### PR TITLE
Refactor talon-core: structured keys, block forms, BackendStore

### DIFF
--- a/crates/talon-coordinator/src/placement.rs
+++ b/crates/talon-coordinator/src/placement.rs
@@ -2,12 +2,12 @@
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use talon_core::{CacheKey, NodeId, NodeInfo};
+use talon_core::{BlockId, NodeId, NodeInfo};
 
-/// Decides which node should hold a given key.
+/// Decides which node should hold a given block.
 pub trait Placement {
-    /// Return the node responsible for `key`, given the current node set.
-    fn locate(&self, key: &CacheKey, nodes: &[NodeInfo]) -> Option<NodeId>;
+    /// Return the node responsible for `block`, given the current node set.
+    fn locate(&self, block: &BlockId, nodes: &[NodeInfo]) -> Option<NodeId>;
 }
 
 /// Rendezvous (highest random weight) hashing placement.
@@ -17,19 +17,19 @@ pub trait Placement {
 pub struct RendezvousPlacement;
 
 impl RendezvousPlacement {
-    fn weight(key: &CacheKey, node: &NodeId) -> u64 {
+    fn weight(block: &BlockId, node: &NodeId) -> u64 {
         let mut hasher = DefaultHasher::new();
-        key.as_str().hash(&mut hasher);
+        block.hash(&mut hasher);
         node.0.hash(&mut hasher);
         hasher.finish()
     }
 }
 
 impl Placement for RendezvousPlacement {
-    fn locate(&self, key: &CacheKey, nodes: &[NodeInfo]) -> Option<NodeId> {
+    fn locate(&self, block: &BlockId, nodes: &[NodeInfo]) -> Option<NodeId> {
         nodes
             .iter()
-            .max_by_key(|n| Self::weight(key, &n.id))
+            .max_by_key(|n| Self::weight(block, &n.id))
             .map(|n| n.id.clone())
     }
 }

--- a/crates/talon-core/src/backend.rs
+++ b/crates/talon-core/src/backend.rs
@@ -1,0 +1,34 @@
+//! The backend (origin) store abstraction.
+//!
+//! [`BackendStore`] is the durable source a worker fetches from on a cache miss:
+//! S3, GCS, or Azure Blob. It is deliberately separate from
+//! [`ObjectStore`](crate::ObjectStore) (the local cache): different lifecycle,
+//! different failure modes, and it is driven off the data-plane ring by the
+//! loader thread pool (see `DESIGN.md`).
+
+use crate::{ObjectId, Result, Version};
+use async_trait::async_trait;
+use bytes::Bytes;
+
+/// Metadata about a source object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectStat {
+    /// Total size of the object in bytes.
+    pub len: u64,
+    /// Current version/etag of the object.
+    pub version: Version,
+}
+
+/// A durable blob backend that workers load blocks/pages from on cache miss.
+#[async_trait]
+pub trait BackendStore: Send + Sync {
+    /// Fetch a byte range `[offset, offset + len)` of a source object.
+    ///
+    /// Used for both whole-block and page-level loads; the caller chooses the
+    /// range. Bytes land in a `Vec`/`Bytes` (unlike the cache read path), so a
+    /// checksum can be computed here.
+    async fn fetch_range(&self, obj: &ObjectId, offset: u64, len: u64) -> Result<Bytes>;
+
+    /// Fetch object metadata (size + version) without transferring data.
+    async fn head(&self, obj: &ObjectId) -> Result<ObjectStat>;
+}

--- a/crates/talon-core/src/block.rs
+++ b/crates/talon-core/src/block.rs
@@ -1,0 +1,150 @@
+//! Block materialization forms.
+//!
+//! A block has a fixed logical size (256MB in v1) but two physical forms,
+//! chosen at LOAD time via a [`LoadHint`]:
+//!
+//! - [`BlockForm::Whole`]: the entire block is cached as one unit (best for
+//!   sequential scans + readahead).
+//! - [`BlockForm::Paged`]: only hot pages are materialized on demand (best for
+//!   point queries), tracked by a [`PresentBitmap`].
+//!
+//! See `DESIGN.md` §3 for the full rationale.
+
+use crate::{BlockId, PageIndex};
+use serde::{Deserialize, Serialize};
+
+/// The hint supplied at LOAD time that selects a block's physical form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LoadHint {
+    /// Materialize the whole block as a single unit.
+    Whole,
+    /// Materialize pages on demand with the given page size (bytes).
+    Paged {
+        /// Page size in bytes (256KB–4MB in v1).
+        page_size: u32,
+    },
+}
+
+/// A compact presence bitset over the pages of a paged block.
+///
+/// Backed by `u64` words; 1024 pages (256KB pages over a 256MB block) fit in 16
+/// words = 128 bytes. Hand-rolled to avoid an external dependency.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PresentBitmap {
+    words: Vec<u64>,
+    len: u32,
+}
+
+impl PresentBitmap {
+    /// Create an empty bitmap sized for `page_count` pages.
+    pub fn new(page_count: u32) -> Self {
+        let words = (page_count as usize).div_ceil(64);
+        Self {
+            words: vec![0; words],
+            len: page_count,
+        }
+    }
+
+    /// Total number of pages the bitmap can address.
+    pub fn len(&self) -> u32 {
+        self.len
+    }
+
+    /// Whether the bitmap addresses zero pages.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Mark a page present.
+    pub fn set(&mut self, page: PageIndex) {
+        if page.0 < self.len {
+            self.words[(page.0 / 64) as usize] |= 1u64 << (page.0 % 64);
+        }
+    }
+
+    /// Mark a page absent.
+    pub fn clear(&mut self, page: PageIndex) {
+        if page.0 < self.len {
+            self.words[(page.0 / 64) as usize] &= !(1u64 << (page.0 % 64));
+        }
+    }
+
+    /// Whether a page is present.
+    pub fn is_present(&self, page: PageIndex) -> bool {
+        page.0 < self.len && (self.words[(page.0 / 64) as usize] >> (page.0 % 64)) & 1 == 1
+    }
+
+    /// Whether every page in the half-open range `[start, end)` is present.
+    pub fn range_present(&self, start: PageIndex, end: PageIndex) -> bool {
+        (start.0..end.0).all(|p| self.is_present(PageIndex(p)))
+    }
+
+    /// Count of present pages.
+    pub fn count(&self) -> u32 {
+        self.words.iter().map(|w| w.count_ones()).sum()
+    }
+}
+
+/// The physical materialization form of a cached block.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BlockForm {
+    /// The whole block is cached, backed by a single file.
+    Whole,
+    /// Only the pages marked in `present` are cached, backed by per-page files.
+    Paged {
+        /// Page size in bytes.
+        page_size: u32,
+        /// Which pages are currently materialized.
+        present: PresentBitmap,
+    },
+}
+
+/// A worker block-index entry (shape only; the index itself lives in the
+/// worker crate).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockMeta {
+    /// Identity of the block.
+    pub id: BlockId,
+    /// Physical form and materialization state.
+    pub form: BlockForm,
+    /// Total logical length of the block in bytes (may be < block_size for the
+    /// last block of an object).
+    pub len: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bitmap_set_get_count() {
+        let mut bm = PresentBitmap::new(1024);
+        assert_eq!(bm.len(), 1024);
+        assert_eq!(bm.count(), 0);
+        assert!(!bm.is_present(PageIndex(0)));
+
+        bm.set(PageIndex(0));
+        bm.set(PageIndex(63));
+        bm.set(PageIndex(64));
+        bm.set(PageIndex(1023));
+        assert_eq!(bm.count(), 4);
+        assert!(bm.is_present(PageIndex(64)));
+        assert!(!bm.range_present(PageIndex(0), PageIndex(3)));
+
+        bm.set(PageIndex(1));
+        bm.set(PageIndex(2));
+        assert!(bm.range_present(PageIndex(0), PageIndex(3)));
+
+        bm.clear(PageIndex(1));
+        assert!(!bm.is_present(PageIndex(1)));
+        assert_eq!(bm.count(), 5);
+    }
+
+    #[test]
+    fn out_of_range_is_ignored() {
+        let mut bm = PresentBitmap::new(10);
+        bm.set(PageIndex(100));
+        assert!(!bm.is_present(PageIndex(100)));
+        assert_eq!(bm.count(), 0);
+    }
+}

--- a/crates/talon-core/src/error.rs
+++ b/crates/talon-core/src/error.rs
@@ -16,6 +16,19 @@ pub enum Error {
     #[error("node unavailable: {0}")]
     NodeUnavailable(String),
 
+    /// A backend (origin store) operation failed.
+    #[error("backend error: {0}")]
+    Backend(String),
+
+    /// The source version/etag did not match the expected value.
+    #[error("version mismatch: expected {expected}, found {found}")]
+    VersionMismatch {
+        /// The version the caller expected.
+        expected: String,
+        /// The version the backend reported.
+        found: String,
+    },
+
     /// Serialization or deserialization failed.
     #[error("serialization error: {0}")]
     Serialization(String),

--- a/crates/talon-core/src/key.rs
+++ b/crates/talon-core/src/key.rs
@@ -1,32 +1,243 @@
-//! Cache key definitions.
+//! Structured, reversible cache keys.
+//!
+//! The logical addressing unit is a fixed-size **block** (256MB in v1). A
+//! [`BlockId`] identifies one block of a source object and is the unit used for
+//! placement, the worker block index, and the cache key. Keys are reversible to
+//! and from a hierarchical filesystem path (e.g. `/s3/<bucket>/<object>`), which
+//! the FUSE client uses.
 
+use crate::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::str::FromStr;
 
-/// A key identifying an object in the cache.
+/// A supported blob-storage backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Backend {
+    /// Amazon S3 (and S3-compatible stores).
+    S3,
+    /// Google Cloud Storage.
+    Gcs,
+    /// Azure Blob Storage.
+    Azure,
+}
+
+impl Backend {
+    /// The path prefix used in the FUSE namespace (without slashes).
+    pub fn prefix(&self) -> &'static str {
+        match self {
+            Backend::S3 => "s3",
+            Backend::Gcs => "gcs",
+            Backend::Azure => "az",
+        }
+    }
+}
+
+impl fmt::Display for Backend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.prefix())
+    }
+}
+
+impl FromStr for Backend {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "s3" => Ok(Backend::S3),
+            "gcs" => Ok(Backend::Gcs),
+            "az" | "azure" => Ok(Backend::Azure),
+            other => Err(Error::Other(format!("unknown backend: {other}"))),
+        }
+    }
+}
+
+/// An etag / version guard for a source object.
+///
+/// Included in a [`BlockId`] so that a source update never causes a stale block
+/// to be served: a changed version yields a different key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct CacheKey(pub String);
+pub struct Version(pub String);
 
-impl CacheKey {
-    /// Create a new cache key.
-    pub fn new(key: impl Into<String>) -> Self {
-        Self(key.into())
+impl Version {
+    /// Create a new version token.
+    pub fn new(v: impl Into<String>) -> Self {
+        Self(v.into())
     }
 
-    /// Return the key as a string slice.
+    /// Return the version as a string slice.
     pub fn as_str(&self) -> &str {
         &self.0
     }
 }
 
-impl fmt::Display for CacheKey {
+impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        f.write_str(&self.0)
     }
 }
 
-impl From<&str> for CacheKey {
-    fn from(s: &str) -> Self {
-        Self(s.to_string())
+/// Identifies a source object in a backend.
+///
+/// `bucket` is the S3/GCS bucket or the Azure `account/container` scope. The
+/// `object_path` is the remaining key within that scope.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ObjectId {
+    /// The backing store this object lives in.
+    pub backend: Backend,
+    /// Bucket (S3/GCS) or account/container scope (Azure).
+    pub bucket: String,
+    /// Object key/path within the bucket.
+    pub object_path: String,
+}
+
+impl ObjectId {
+    /// Create a new object id.
+    pub fn new(backend: Backend, bucket: impl Into<String>, object_path: impl Into<String>) -> Self {
+        Self {
+            backend,
+            bucket: bucket.into(),
+            object_path: object_path.into(),
+        }
+    }
+
+    /// Render as a hierarchical namespace path: `/<prefix>/<bucket>/<object_path>`.
+    pub fn to_path(&self) -> String {
+        format!(
+            "/{}/{}/{}",
+            self.backend.prefix(),
+            self.bucket,
+            self.object_path
+        )
+    }
+
+    /// Parse an [`ObjectId`] from a namespace path produced by [`to_path`].
+    ///
+    /// [`to_path`]: ObjectId::to_path
+    pub fn from_path(path: &str) -> Result<Self> {
+        let trimmed = path.trim_start_matches('/');
+        let mut parts = trimmed.splitn(3, '/');
+        let prefix = parts
+            .next()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| Error::Other(format!("missing backend in path: {path}")))?;
+        let bucket = parts
+            .next()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| Error::Other(format!("missing bucket in path: {path}")))?;
+        let object_path = parts
+            .next()
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| Error::Other(format!("missing object path in path: {path}")))?;
+        Ok(ObjectId::new(prefix.parse::<Backend>()?, bucket, object_path))
+    }
+}
+
+impl fmt::Display for ObjectId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_path())
+    }
+}
+
+/// A page index within a paged block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct PageIndex(pub u32);
+
+/// Identifies one fixed-size block of a source object.
+///
+/// This is the logical addressing unit for placement, the worker block index,
+/// and the cache. Two blocks are equal iff they share object, offset, block
+/// size, and version — so a version change produces a distinct key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BlockId {
+    /// The source object this block belongs to.
+    pub object: ObjectId,
+    /// Byte offset of the block within the object.
+    pub offset: u64,
+    /// Block size in bytes (256MB in v1).
+    pub block_size: u32,
+    /// Source version/etag guard.
+    pub version: Version,
+}
+
+impl BlockId {
+    /// Create a new block id.
+    pub fn new(object: ObjectId, offset: u64, block_size: u32, version: Version) -> Self {
+        Self {
+            object,
+            offset,
+            block_size,
+            version,
+        }
+    }
+
+    /// Zero-based index of this block within its object.
+    pub fn block_index(&self) -> u64 {
+        if self.block_size == 0 {
+            0
+        } else {
+            self.offset / self.block_size as u64
+        }
+    }
+
+    /// Number of pages this block holds for the given page size.
+    ///
+    /// Returns 0 if `page_size` is 0. The last page may be shorter than
+    /// `page_size`; it is still counted.
+    pub fn page_count(&self, page_size: u32) -> u32 {
+        if page_size == 0 {
+            return 0;
+        }
+        self.block_size.div_ceil(page_size)
+    }
+}
+
+impl fmt::Display for BlockId {
+    /// Render as `<object-path>@<version>#<offset>+<block_size>`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}@{}#{}+{}",
+            self.object.to_path(),
+            self.version,
+            self.offset,
+            self.block_size
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn object_path_roundtrips_all_backends() {
+        for (backend, path) in [
+            (Backend::S3, "/s3/my-bucket/data/checkpoint.bin"),
+            (Backend::Gcs, "/gcs/my-bucket/data/checkpoint.bin"),
+            (Backend::Azure, "/az/acct-container/data/checkpoint.bin"),
+        ] {
+            let obj = ObjectId::from_path(path).unwrap();
+            assert_eq!(obj.backend, backend);
+            assert_eq!(obj.to_path(), path);
+        }
+    }
+
+    #[test]
+    fn from_path_rejects_incomplete() {
+        assert!(ObjectId::from_path("/s3/only-bucket").is_err());
+        assert!(ObjectId::from_path("/unknown/b/o").is_err());
+        assert!(ObjectId::from_path("/").is_err());
+    }
+
+    #[test]
+    fn page_count_and_block_index() {
+        let obj = ObjectId::new(Backend::S3, "b", "o");
+        let block_size = 256 * 1024 * 1024; // 256 MiB
+        let id = BlockId::new(obj, block_size as u64 * 3, block_size, Version::new("v1"));
+        assert_eq!(id.block_index(), 3);
+        assert_eq!(id.page_count(256 * 1024), 1024);
+        assert_eq!(id.page_count(4 * 1024 * 1024), 64);
+        assert_eq!(id.page_count(0), 0);
     }
 }

--- a/crates/talon-core/src/lib.rs
+++ b/crates/talon-core/src/lib.rs
@@ -3,12 +3,16 @@
 //! Shared types, traits, and protocol definitions for the Talon distributed
 //! object store cache. All other Talon crates depend on this crate.
 
+pub mod backend;
+pub mod block;
 pub mod error;
 pub mod key;
 pub mod node;
 pub mod store;
 
+pub use backend::{BackendStore, ObjectStat};
+pub use block::{BlockForm, BlockMeta, LoadHint, PresentBitmap};
 pub use error::{Error, Result};
-pub use key::CacheKey;
+pub use key::{Backend, BlockId, ObjectId, PageIndex, Version};
 pub use node::{NodeId, NodeInfo, NodeRole};
-pub use store::ObjectStore;
+pub use store::{BlockHandle, ObjectStore};

--- a/crates/talon-core/src/store.rs
+++ b/crates/talon-core/src/store.rs
@@ -1,28 +1,71 @@
-//! The core object store abstraction.
+//! The cache-side object store abstraction.
+//!
+//! [`ObjectStore`] is the worker's local cache surface. Hot reads return a
+//! [`BlockHandle`] — an fd plus offset/len — so the transport layer can serve
+//! bytes with `sendfile` without copying them through userspace. A small
+//! `get_bytes` path exists for the optional in-memory (L1) tier.
 
-use crate::{CacheKey, Result};
+use crate::{BlockId, PageIndex, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
+use std::os::fd::OwnedFd;
 
-/// An asynchronous key/value object store.
+/// A zero-copy read source: a file descriptor plus the byte range to serve.
 ///
-/// Implementations back the Talon cache; the worker provides the primary
-/// implementation while the coordinator routes requests to workers.
+/// The transport layer performs `sendfile(fd, socket, offset, len)`. Keeping
+/// this to `std` fd types means `talon-core` carries no transport or syscall
+/// dependency.
+#[derive(Debug)]
+pub struct BlockHandle {
+    /// File descriptor backing the cached block or page.
+    pub fd: OwnedFd,
+    /// Byte offset within the file at which the requested data starts.
+    pub offset: u64,
+    /// Number of bytes to serve from `offset`.
+    pub len: u64,
+}
+
+impl BlockHandle {
+    /// Create a new handle.
+    pub fn new(fd: OwnedFd, offset: u64, len: u64) -> Self {
+        Self { fd, offset, len }
+    }
+}
+
+/// An asynchronous, block-addressed local cache store.
+///
+/// Reads are keyed by [`BlockId`]. Absent whole blocks or pages surface
+/// [`Error::NotFound`](crate::Error::NotFound); callers translate that into a
+/// block- or page-level miss and trigger a backend load.
 #[async_trait]
 pub trait ObjectStore: Send + Sync {
-    /// Fetch an object by key. Returns [`Error::NotFound`](crate::Error::NotFound)
-    /// if the object is absent.
-    async fn get(&self, key: &CacheKey) -> Result<Bytes>;
+    /// Fetch a whole block as a zero-copy handle.
+    async fn get_block(&self, id: &BlockId) -> Result<BlockHandle>;
 
-    /// Insert or overwrite an object.
-    async fn put(&self, key: &CacheKey, value: Bytes) -> Result<()>;
+    /// Fetch a single page of a paged block as a zero-copy handle.
+    async fn get_page(&self, id: &BlockId, page: PageIndex) -> Result<BlockHandle>;
 
-    /// Remove an object. Succeeds even if the key is absent.
-    async fn delete(&self, key: &CacheKey) -> Result<()>;
+    /// Fetch a sub-range of a block as one or more zero-copy handles.
+    ///
+    /// For a whole block this is a single handle over `[offset, offset + len)`.
+    /// For a paged block this returns one handle per covered present page
+    /// (contiguous present pages may be coalesced). If any covered page is
+    /// absent, returns [`Error::NotFound`](crate::Error::NotFound) so the caller
+    /// can perform a page-level load.
+    async fn get_range(&self, id: &BlockId, offset: u64, len: u64) -> Result<Vec<BlockHandle>>;
 
-    /// Return whether an object exists.
-    async fn contains(&self, key: &CacheKey) -> Result<bool> {
-        match self.get(key).await {
+    /// Fetch a small object's bytes directly (optional L1 memory path).
+    async fn get_bytes(&self, id: &BlockId) -> Result<Bytes>;
+
+    /// Insert or overwrite a block's bytes.
+    async fn put(&self, id: &BlockId, value: Bytes) -> Result<()>;
+
+    /// Remove a block. Succeeds even if absent.
+    async fn delete(&self, id: &BlockId) -> Result<()>;
+
+    /// Whether a whole block is present in the cache.
+    async fn contains(&self, id: &BlockId) -> Result<bool> {
+        match self.get_bytes(id).await {
             Ok(_) => Ok(true),
             Err(crate::Error::NotFound(_)) => Ok(false),
             Err(e) => Err(e),

--- a/crates/talon-worker/src/memory_store.rs
+++ b/crates/talon-worker/src/memory_store.rs
@@ -1,15 +1,20 @@
 //! A simple in-memory [`ObjectStore`] implementation.
+//!
+//! This backs the optional L1 memory path and tests. It fully implements the
+//! byte-oriented methods (`get_bytes`/`put`/`delete`/`contains`); the zero-copy
+//! fd methods (`get_block`/`get_page`/`get_range`) are wired in the dedicated
+//! worker-store PR and currently report the block/page as absent.
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use std::collections::HashMap;
 use std::sync::RwLock;
-use talon_core::{CacheKey, Error, ObjectStore, Result};
+use talon_core::{BlockHandle, BlockId, Error, ObjectStore, PageIndex, Result};
 
 /// An in-memory object store backed by a hash map.
 #[derive(Default)]
 pub struct MemoryStore {
-    inner: RwLock<HashMap<CacheKey, Bytes>>,
+    inner: RwLock<HashMap<BlockId, Bytes>>,
 }
 
 impl MemoryStore {
@@ -18,7 +23,7 @@ impl MemoryStore {
         Self::default()
     }
 
-    /// Return the number of stored objects.
+    /// Return the number of stored blocks.
     pub fn len(&self) -> usize {
         self.inner.read().unwrap().len()
     }
@@ -31,22 +36,35 @@ impl MemoryStore {
 
 #[async_trait]
 impl ObjectStore for MemoryStore {
-    async fn get(&self, key: &CacheKey) -> Result<Bytes> {
+    async fn get_block(&self, id: &BlockId) -> Result<BlockHandle> {
+        // Zero-copy fd path is provided by the NVMe-backed worker store.
+        Err(Error::NotFound(id.to_string()))
+    }
+
+    async fn get_page(&self, id: &BlockId, page: PageIndex) -> Result<BlockHandle> {
+        Err(Error::NotFound(format!("{id} page {}", page.0)))
+    }
+
+    async fn get_range(&self, id: &BlockId, _offset: u64, _len: u64) -> Result<Vec<BlockHandle>> {
+        Err(Error::NotFound(id.to_string()))
+    }
+
+    async fn get_bytes(&self, id: &BlockId) -> Result<Bytes> {
         self.inner
             .read()
             .unwrap()
-            .get(key)
+            .get(id)
             .cloned()
-            .ok_or_else(|| Error::NotFound(key.to_string()))
+            .ok_or_else(|| Error::NotFound(id.to_string()))
     }
 
-    async fn put(&self, key: &CacheKey, value: Bytes) -> Result<()> {
-        self.inner.write().unwrap().insert(key.clone(), value);
+    async fn put(&self, id: &BlockId, value: Bytes) -> Result<()> {
+        self.inner.write().unwrap().insert(id.clone(), value);
         Ok(())
     }
 
-    async fn delete(&self, key: &CacheKey) -> Result<()> {
-        self.inner.write().unwrap().remove(key);
+    async fn delete(&self, id: &BlockId) -> Result<()> {
+        self.inner.write().unwrap().remove(id);
         Ok(())
     }
 }
@@ -54,17 +72,27 @@ impl ObjectStore for MemoryStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use talon_core::{Backend, ObjectId, Version};
+
+    fn block(name: &str) -> BlockId {
+        BlockId::new(
+            ObjectId::new(Backend::S3, "bucket", name),
+            0,
+            256 * 1024 * 1024,
+            Version::new("v1"),
+        )
+    }
 
     #[tokio::test]
     async fn put_get_delete_roundtrip() {
         let store = MemoryStore::new();
-        let key = CacheKey::new("hello");
+        let id = block("hello");
 
-        store.put(&key, Bytes::from_static(b"world")).await.unwrap();
-        assert_eq!(store.get(&key).await.unwrap(), Bytes::from_static(b"world"));
-        assert!(store.contains(&key).await.unwrap());
+        store.put(&id, Bytes::from_static(b"world")).await.unwrap();
+        assert_eq!(store.get_bytes(&id).await.unwrap(), Bytes::from_static(b"world"));
+        assert!(store.contains(&id).await.unwrap());
 
-        store.delete(&key).await.unwrap();
-        assert!(!store.contains(&key).await.unwrap());
+        store.delete(&id).await.unwrap();
+        assert!(!store.contains(&id).await.unwrap());
     }
 }


### PR DESCRIPTION
## Summary
Reshapes `talon-core` from the PR #1 placeholders to the v1 design surface (DESIGN.md). Types + traits only — real block-index / backend / worker-store implementations follow in later PRs.

- **key.rs:** structured, reversible keys — `Backend {S3,Gcs,Azure}`, `ObjectId`, `Version`, `BlockId` (the 256MB logical unit), `PageIndex`. Path ↔ key conversion for `/s3`, `/gcs`, `/az`; version guards against stale reads.
- **block.rs (new):** `BlockForm { Whole, Paged { page_size, present } }`, hand-rolled `PresentBitmap` (no new dep), `LoadHint`, `BlockMeta` index-entry shape.
- **store.rs:** `ObjectStore` reshaped to a block-addressed, zero-copy API returning `BlockHandle` (`OwnedFd` + offset + len) for the `sendfile` path, plus a `get_bytes` L1 path. Absent blocks/pages surface `NotFound` to drive misses.
- **backend.rs (new):** `BackendStore` trait (`fetch_range` + `head`/`ObjectStat`), distinct from the cache-side `ObjectStore`.
- **error.rs:** add `Backend` and `VersionMismatch` variants.

Downstream kept green: `MemoryStore` adapts to the new trait (byte methods implemented; fd/page methods return `NotFound`, wired in the worker-store PR); `RendezvousPlacement` locates by `BlockId`.

## Design alignment
- `talon-core` stays free of transport/syscall/monoio deps — `BlockHandle` uses `std::os::fd::OwnedFd`; the transport layer performs the actual `sendfile`.
- Page-level miss semantics baked into `get_range` (NotFound on any absent covered page).

## Test plan
- [x] `cargo build` — workspace compiles
- [x] `cargo clippy --all-targets` — clean, no warnings
- [x] `cargo test` — 6 tests pass (key round-trips ×3, present bitmap ×2, MemoryStore roundtrip ×1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)