### PR TITLE
Add microbenchmark harness with agent-friendly perf feedback loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Build docs
         run: cargo doc --workspace --no-deps --all-features
+
+  bench:
+    name: bench (informational)
+    runs-on: ubuntu-latest
+    # Never blocks a merge: shared runners are too noisy for absolute-time
+    # gating. This posts the baseline diff for visibility only.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - name: Benchmark check vs committed baseline
+        id: bench
+        run: |
+          python3 scripts/bench.py check main --soft | tee bench-report.md
+      - name: Publish report to job summary
+        if: always()
+        run: cat bench-report.md >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Build artifacts
 /target
 
+# Benchmark run output (baselines are committed; per-run results are not)
+/bench/results/
+
 # Editor / OS
 *.swp
 .DS_Store

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,64 @@
+# Benchmarks
+
+Talon uses [Divan](https://docs.rs/divan) microbenchmarks plus a thin harness
+(`scripts/bench.py`) that turns Divan's human-only table into structured JSON and
+diffs a run against a committed baseline. The goal is a fast, machine-readable
+performance signal so that changes — whether made by a human or a coding agent —
+get timely feedback.
+
+## Quick start
+
+```sh
+just bench            # run all benches, write bench/results/latest.json
+just bench-save main  # promote the latest run to the committed baseline
+just bench-check      # run + diff vs baseline; non-zero exit on regression
+```
+
+Scope a run to one crate to iterate faster:
+
+```sh
+just bench -p talon-core
+just bench-check -p talon-coordinator --threshold 15
+```
+
+## The workflow
+
+1. **Establish a baseline.** On a known-good commit: `just bench && just bench-save main`.
+   `bench/baselines/main.json` is committed and is the reference everything
+   compares against.
+2. **Iterate.** After a change, `just bench-check`. It prints a markdown table
+   (`benchmark | baseline | current | Δ | verdict`) and exits non-zero if any
+   benchmark regresses beyond the threshold (default ±10%, above typical
+   microbench noise). Use `--soft` to report without failing.
+3. **Intentional perf change?** Re-run `just bench-save main` to move the
+   baseline, and commit it in the same PR so the diff is reviewable.
+
+## What is measured
+
+Deterministic, CPU-bound hot paths (low variance, good for regression
+detection):
+
+- `talon-core` (`core_benches`): key path ↔ id conversion, `PresentBitmap`
+  operations, `BlockId::page_count`.
+- `talon-coordinator` (`placement_benches`): `RendezvousPlacement::locate`
+  across 8/64/256 nodes — the per-request placement lookup.
+
+The zero-copy data plane (`sendfile`/`splice`) is I/O-bound and higher-variance;
+those benches are added in a separate tier when the transport layer lands.
+
+## For coding agents
+
+- One command surface: `just bench`, `just bench-save`, `just bench-check`.
+- `bench-check` output is a markdown table and its exit code is the verdict
+  (0 = within threshold, 1 = regression). Parse either.
+- `bench/results/latest.json` and `bench/baselines/<name>.json` are stable
+  `{ "binary::name[/arg]": median_ns }` maps for programmatic diffing.
+- Prefer scoping with `-p <crate>` while iterating; run the full suite before
+  saving a baseline.
+
+## CI
+
+The `bench` CI job runs `bench-check --soft` and posts the table to the job
+summary. It is **informational only** (`continue-on-error`) — shared CI runners
+are too noisy for absolute-time gating, so benchmarks never block a merge. The
+committed baseline is the source of truth; refresh it deliberately.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -141,6 +142,37 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
+
+[[package]]
+name = "divan"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a405457ec78b8fe08b0e32b4a3570ab5dff6dd16eb9e76a5ee0a9d9cbd898933"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "errno"
@@ -181,6 +213,12 @@ name = "libc"
 version = "0.2.187"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -312,10 +350,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "scopeguard"
@@ -436,6 +493,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "divan",
  "serde",
  "talon-core",
  "tokio",
@@ -449,6 +507,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "divan",
  "serde",
  "serde_json",
  "thiserror",
@@ -480,6 +539,16 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ serde_json = "1"
 bytes = "1"
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
+divan = "0.1"

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,46 @@
+# Talon task runner. Run `just` to list recipes.
+# The bench recipes are the agent-facing performance feedback loop.
+
+# Show available recipes.
+default:
+    @just --list
+
+# --- build / quality gates (mirror CI) ---
+
+# Format the whole workspace.
+fmt:
+    cargo fmt --all
+
+# Check formatting without modifying files.
+fmt-check:
+    cargo fmt --all --check
+
+# Lint with warnings denied.
+clippy:
+    cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+# Run the test suite.
+test:
+    cargo test --workspace --all-features --locked
+
+# Everything CI checks, in order.
+ci: fmt-check clippy test
+
+# --- benchmarks (performance feedback loop) ---
+
+# Run all microbenchmarks and write bench/results/latest.json.
+bench *ARGS:
+    python3 scripts/bench.py run {{ARGS}}
+
+# Promote the latest run to a committed baseline (default name: main).
+bench-save NAME="main":
+    python3 scripts/bench.py save {{NAME}}
+
+# Run benches and diff against a baseline; exits non-zero on regression.
+# Pass --soft to report without failing, or --threshold N to tune sensitivity.
+bench-check *ARGS:
+    python3 scripts/bench.py check {{ARGS}}
+
+# Print the current committed baseline.
+bench-baseline NAME="main":
+    @cat bench/baselines/{{NAME}}.json

--- a/bench/baselines/main.json
+++ b/bench/baselines/main.json
@@ -1,0 +1,12 @@
+{
+  "core_benches::bitmap_range_present/1024": 648.4,
+  "core_benches::bitmap_range_present/64": 49.78,
+  "core_benches::bitmap_set_all/1024": 1362.0,
+  "core_benches::bitmap_set_all/64": 83.28,
+  "core_benches::block_page_count": 1.553,
+  "core_benches::object_id_from_path": 74.81,
+  "core_benches::object_id_to_path": 119.3,
+  "placement_benches::locate/256": 14030.0,
+  "placement_benches::locate/64": 3316.0,
+  "placement_benches::locate/8": 432.9
+}

--- a/crates/talon-coordinator/Cargo.toml
+++ b/crates/talon-coordinator/Cargo.toml
@@ -20,3 +20,10 @@ tracing-subscriber.workspace = true
 serde.workspace = true
 clap.workspace = true
 async-trait.workspace = true
+
+[dev-dependencies]
+divan.workspace = true
+
+[[bench]]
+name = "placement_benches"
+harness = false

--- a/crates/talon-coordinator/benches/placement_benches.rs
+++ b/crates/talon-coordinator/benches/placement_benches.rs
@@ -1,0 +1,38 @@
+//! Microbenchmarks for the coordinator placement hot path.
+//!
+//! `RendezvousPlacement::locate` runs on every client placement lookup, scaling
+//! with cluster size, so it is benchmarked across representative node counts.
+
+use talon_coordinator::{Placement, RendezvousPlacement};
+use talon_core::{Backend, BlockId, NodeId, NodeInfo, NodeRole, ObjectId, Version};
+
+fn main() {
+    divan::main();
+}
+
+fn nodes(n: u32) -> Vec<NodeInfo> {
+    (0..n)
+        .map(|i| NodeInfo {
+            id: NodeId::new(format!("worker-{i}")),
+            address: format!("10.0.0.{i}:7001"),
+            role: NodeRole::Worker,
+        })
+        .collect()
+}
+
+fn block(i: u64) -> BlockId {
+    BlockId::new(
+        ObjectId::new(Backend::S3, "bucket", format!("obj-{i}")),
+        i * 256 * 1024 * 1024,
+        256 * 1024 * 1024,
+        Version::new("v1"),
+    )
+}
+
+#[divan::bench(args = [8, 64, 256])]
+fn locate(bencher: divan::Bencher, node_count: u32) {
+    let placement = RendezvousPlacement;
+    let nodes = nodes(node_count);
+    let id = block(42);
+    bencher.bench(|| placement.locate(divan::black_box(&id), divan::black_box(&nodes)));
+}

--- a/crates/talon-core/Cargo.toml
+++ b/crates/talon-core/Cargo.toml
@@ -14,3 +14,10 @@ serde_json.workspace = true
 bytes.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+divan.workspace = true
+
+[[bench]]
+name = "core_benches"
+harness = false

--- a/crates/talon-core/benches/core_benches.rs
+++ b/crates/talon-core/benches/core_benches.rs
@@ -1,0 +1,65 @@
+//! Microbenchmarks for `talon-core` hot paths.
+//!
+//! Run with `cargo bench -p talon-core` or via the repo `just bench` harness.
+//! These target deterministic, CPU-bound code (no I/O), so they are low-variance
+//! and suitable for regression detection.
+
+use talon_core::block::PresentBitmap;
+use talon_core::{Backend, BlockId, ObjectId, PageIndex, Version};
+
+fn main() {
+    divan::main();
+}
+
+fn sample_block() -> BlockId {
+    BlockId::new(
+        ObjectId::new(Backend::S3, "my-bucket", "data/checkpoint-000042.bin"),
+        256 * 1024 * 1024 * 7,
+        256 * 1024 * 1024,
+        Version::new("etag-abc123"),
+    )
+}
+
+// ---- key path <-> id ----
+
+#[divan::bench]
+fn object_id_to_path(bencher: divan::Bencher) {
+    let obj = sample_block().object;
+    bencher.bench(|| divan::black_box(&obj).to_path());
+}
+
+#[divan::bench]
+fn object_id_from_path(bencher: divan::Bencher) {
+    let path = sample_block().object.to_path();
+    bencher.bench(|| ObjectId::from_path(divan::black_box(&path)).unwrap());
+}
+
+// ---- present bitmap ----
+
+#[divan::bench(args = [64, 1024])]
+fn bitmap_set_all(bencher: divan::Bencher, pages: u32) {
+    bencher.bench(|| {
+        let mut bm = PresentBitmap::new(pages);
+        for p in 0..pages {
+            bm.set(PageIndex(divan::black_box(p)));
+        }
+        bm.count()
+    });
+}
+
+#[divan::bench(args = [64, 1024])]
+fn bitmap_range_present(bencher: divan::Bencher, pages: u32) {
+    let mut bm = PresentBitmap::new(pages);
+    for p in 0..pages {
+        bm.set(PageIndex(p));
+    }
+    bencher.bench(|| bm.range_present(PageIndex(0), PageIndex(divan::black_box(pages))));
+}
+
+// ---- block id ----
+
+#[divan::bench]
+fn block_page_count(bencher: divan::Bencher) {
+    let id = sample_block();
+    bencher.bench(|| divan::black_box(&id).page_count(divan::black_box(256 * 1024)));
+}

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Talon microbenchmark harness.
+
+Runs Divan benchmarks, parses their (human-only) table output into structured
+JSON, and diffs a run against a committed baseline with an explicit per-bench
+verdict. Designed to give humans *and* coding agents a fast, machine-readable
+performance signal.
+
+Subcommands:
+  run     Run benches, write results/latest.json, print the parsed table.
+  save    Promote results/latest.json to baselines/<name>.json (the committed
+          reference). Run this deliberately when a perf change is intended.
+  check   Run benches and diff vs a baseline; print a markdown table with Δ% and
+          a verdict per bench. Exit non-zero on regression (unless --soft).
+
+Divan emits no JSON (as of 0.1.21), so we parse its tree table. The parser keys
+off value+unit tokens (e.g. "648.4 ns") rather than the box-drawing column
+separators, which are ambiguous with tree-indent glyphs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+BASELINE_DIR = REPO / "bench" / "baselines"
+RESULTS_DIR = REPO / "bench" / "results"
+LATEST = RESULTS_DIR / "latest.json"
+
+# Default regression/improvement threshold, percent. Set above typical
+# microbench run-to-run noise on shared hardware to limit false positives.
+DEFAULT_THRESHOLD = 10.0
+
+UNIT_TO_NS = {"ns": 1.0, "us": 1e3, "µs": 1e3, "ms": 1e6, "s": 1e9}
+
+# A value like "648.4 ns" / "1.322 µs" / "13.94 µs".
+VALUE_RE = re.compile(r"(\d+\.?\d*)\s*(ns|µs|us|ms|s)\b")
+# Leading box-drawing / whitespace we strip from a name cell.
+TREE_CHARS = "│├╰┬─╭╮╯╰┐└┌ \t"
+# The "Running .../<binary>.rs" line that precedes each bench binary's table.
+RUNNING_RE = re.compile(r"Running .*/([A-Za-z0-9_]+)-[0-9a-f]+")
+
+
+def to_ns(value: str, unit: str) -> float:
+    return float(value) * UNIT_TO_NS[unit]
+
+
+def strip_name(cell: str) -> str:
+    return cell.strip(TREE_CHARS).strip()
+
+
+def is_nested(line: str) -> bool:
+    """True if a row is an args-child (indented under a group header)."""
+    for ch in line:
+        if ch in "├╰":  # first branch glyph reached
+            # Anything before it (│ or spaces) means it's nested.
+            return line.index(ch) > 0
+        if ch not in "│ \t":
+            return False
+    return False
+
+
+def parse_divan(output: str) -> dict[str, float]:
+    """Parse Divan table output into {bench_name: median_ns}."""
+    results: dict[str, float] = {}
+    binary = "bench"
+    parent: str | None = None
+
+    for raw in output.splitlines():
+        run = RUNNING_RE.search(raw)
+        if run:
+            binary = run.group(1)
+            parent = None
+            continue
+
+        line = raw.rstrip()
+        if not line or "fastest" in line and "median" in line:
+            # Column header row.
+            continue
+        if line.startswith("Timer precision"):
+            continue
+
+        values = VALUE_RE.findall(line)
+        # Name cell = text before the first value token (or whole line).
+        if values:
+            name_cell = line[: line.index(values_first_span(line))]
+        else:
+            name_cell = line
+        name = strip_name(name_cell)
+        if not name:
+            continue
+
+        if not values:
+            # Group header row (no measurements): its children are args.
+            parent = name
+            continue
+
+        # Leaf row with measurements: median is the 3rd value column.
+        if len(values) < 3:
+            continue
+        median_ns = to_ns(*values[2])
+
+        if is_nested(line) and parent:
+            full = f"{binary}::{parent}/{name}"
+        else:
+            parent = None
+            full = f"{binary}::{name}"
+        results[full] = median_ns
+
+    return results
+
+
+def values_first_span(line: str) -> str:
+    m = VALUE_RE.search(line)
+    return m.group(0) if m else line
+
+
+def run_benches(packages: list[str] | None) -> str:
+    cmd = ["cargo", "bench"]
+    if packages:
+        for p in packages:
+            cmd += ["-p", p]
+    else:
+        cmd.append("--workspace")
+    proc = subprocess.run(cmd, cwd=REPO, stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT, text=True)
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stdout)
+        sys.exit(f"cargo bench failed (exit {proc.returncode})")
+    return proc.stdout
+
+
+def fmt_ns(ns: float) -> str:
+    for unit, scale in (("s", 1e9), ("ms", 1e6), ("µs", 1e3), ("ns", 1.0)):
+        if ns >= scale:
+            return f"{ns / scale:.3g} {unit}"
+    return f"{ns:.3g} ns"
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    output = run_benches(args.package)
+    results = parse_divan(output)
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    LATEST.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n")
+    print(f"Parsed {len(results)} benchmarks -> {LATEST.relative_to(REPO)}\n")
+    for name in sorted(results):
+        print(f"  {name:<48} {fmt_ns(results[name])}")
+    return 0
+
+
+def cmd_save(args: argparse.Namespace) -> int:
+    if not LATEST.exists():
+        sys.exit("no results/latest.json — run `just bench` first")
+    BASELINE_DIR.mkdir(parents=True, exist_ok=True)
+    dest = BASELINE_DIR / f"{args.name}.json"
+    dest.write_text(LATEST.read_text())
+    print(f"Saved baseline {dest.relative_to(REPO)}")
+    return 0
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    baseline_path = BASELINE_DIR / f"{args.name}.json"
+    if not baseline_path.exists():
+        sys.exit(
+            f"no baseline {baseline_path.relative_to(REPO)} — "
+            f"run `just bench && just bench-save {args.name}`"
+        )
+    baseline = json.loads(baseline_path.read_text())
+    output = run_benches(args.package)
+    current = parse_divan(output)
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    LATEST.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n")
+
+    threshold = args.threshold
+    rows = []
+    regressions = 0
+    for name in sorted(set(baseline) | set(current)):
+        base = baseline.get(name)
+        cur = current.get(name)
+        if base is None:
+            rows.append((name, "—", fmt_ns(cur), "—", "new"))
+            continue
+        if cur is None:
+            rows.append((name, fmt_ns(base), "—", "—", "missing"))
+            continue
+        delta = (cur - base) / base * 100.0
+        if delta > threshold:
+            verdict = "REGRESSION"
+            regressions += 1
+        elif delta < -threshold:
+            verdict = "improved"
+        else:
+            verdict = "ok"
+        rows.append((name, fmt_ns(base), fmt_ns(cur), f"{delta:+.1f}%", verdict))
+
+    # Markdown table — friendly to PR comments and agent parsing.
+    print(f"\n### Benchmark check vs `{args.name}` (threshold ±{threshold:.0f}%)\n")
+    print("| benchmark | baseline | current | Δ | verdict |")
+    print("|---|---:|---:|---:|---|")
+    for name, base, cur, delta, verdict in rows:
+        print(f"| `{name}` | {base} | {cur} | {delta} | {verdict} |")
+    print()
+
+    if regressions:
+        msg = f"{regressions} regression(s) beyond ±{threshold:.0f}%"
+        if args.soft:
+            print(f"NOTE: {msg} (soft mode, not failing)")
+            return 0
+        print(f"FAIL: {msg}")
+        return 1
+    print("All benchmarks within threshold.")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Talon microbenchmark harness")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def add_common(sp):
+        sp.add_argument(
+            "-p", "--package", action="append",
+            help="restrict to a cargo package (repeatable); default: whole workspace",
+        )
+
+    r = sub.add_parser("run", help="run benches and write latest.json")
+    add_common(r)
+    r.set_defaults(func=cmd_run)
+
+    s = sub.add_parser("save", help="promote latest.json to a committed baseline")
+    s.add_argument("name", nargs="?", default="main", help="baseline name (default: main)")
+    s.set_defaults(func=cmd_save)
+
+    c = sub.add_parser("check", help="run and diff vs a baseline")
+    add_common(c)
+    c.add_argument("name", nargs="?", default="main", help="baseline name (default: main)")
+    c.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD)
+    c.add_argument("--soft", action="store_true", help="never exit non-zero")
+    c.set_defaults(func=cmd_check)
+
+    args = p.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
A tight, machine-readable performance feedback loop so changes — human or agent — get timely perf signal. Built on **Divan** microbenchmarks + a thin harness that structures Divan's output and diffs against a committed baseline.

## Command surface (agent-facing)
```
just bench              # run all, write bench/results/latest.json
just bench-save main    # promote latest -> committed baseline
just bench-check        # run + diff vs baseline; nonzero exit on regression
```
Scope while iterating: `just bench -p talon-core`, tune with `--threshold N`, report-only with `--soft`.

## What's measured
Deterministic, CPU-bound hot paths (low variance → good for regression detection):
- **talon-core** (`core_benches`): key path ↔ id conversion, `PresentBitmap` ops, `BlockId::page_count`.
- **talon-coordinator** (`placement_benches`): `RendezvousPlacement::locate` across 8/64/256 nodes.

The zero-copy data plane (`sendfile`/`splice`) is I/O-bound; those benches come in a separate tier when the transport layer lands.

## Harness (`scripts/bench.py`)
- Divan has **no JSON output** (0.1.21), so the parser reads the tree table by value+unit tokens (robust against box-drawing separators) → `{ "binary::name[/arg]": median_ns }`.
- `check` emits a **markdown verdict table** (baseline / current / Δ% / verdict) and its **exit code is the verdict** (0 ok, 1 regression). Default threshold ±10% (above observed microbench noise).

## CI
New `bench` job runs `bench-check --soft`, posts the table to the **job summary**, and is **informational only** (`continue-on-error`) — shared runners are too noisy to gate on absolute time. Never blocks a merge.

## Design notes
- Committed baseline (`bench/baselines/main.json`) is the source of truth; per-run `bench/results/` is gitignored.
- Docs in `BENCHMARKS.md`, including a section for coding agents.

## Test plan
- [x] `just bench` parses 10/10 benchmarks with correctly qualified names
- [x] `just bench-check` produces the verdict table + correct exit codes (hard/soft)
- [x] `cargo fmt --check`, `clippy --all-targets` (incl. benches), `test --locked` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)