### PR TITLE
feat(config): layered configuration resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,10 +191,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -424,6 +446,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +542,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "toml",
  "tracing",
 ]
 
@@ -616,6 +648,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,6 +786,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 bytes = "1"
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }

--- a/crates/talon-core/Cargo.toml
+++ b/crates/talon-core/Cargo.toml
@@ -11,6 +11,7 @@ description = "Shared types, traits, and protocol definitions for Talon distribu
 thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+toml.workspace = true
 bytes.workspace = true
 async-trait.workspace = true
 tracing.workspace = true

--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -1,0 +1,264 @@
+//! Layered configuration resolution.
+//!
+//! Configuration is resolved from four layers, highest precedence first:
+//!
+//! 1. **CLI flags** — debugging / one-off overrides.
+//! 2. **Environment** — deployment injection, secrets, node identity.
+//! 3. **Config file** (TOML) — stable parameters (ports, block size, cache
+//!    dirs, capacity, backend).
+//! 4. **Defaults** — compiled-in fallbacks.
+//!
+//! Each concrete config type pairs a fully-resolved struct (e.g.
+//! [`WorkerConfig`]) with a *patch* struct whose fields are all optional. A
+//! patch is produced from each layer and folded onto the defaults in
+//! precedence order via [`Patch::merge`]; the result is [`validate`]d.
+//!
+//! Secrets are read only from the environment and are never serialized or
+//! logged.
+//!
+//! [`validate`]: WorkerConfig::validate
+
+use serde::Deserialize;
+use std::path::PathBuf;
+
+use crate::{Error, Result};
+
+/// A configuration patch: a set of optionally-present overrides.
+///
+/// Higher-precedence patches are merged *onto* lower-precedence values so that
+/// only explicitly-set fields override what came before.
+pub trait Patch {
+    /// Overlay `self` onto `base`, letting `self`'s set fields win.
+    fn merge(self, base: Self) -> Self;
+}
+
+/// Fully-resolved worker configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkerConfig {
+    /// Address the worker's RPC service binds to.
+    pub listen: String,
+    /// Address of the coordinator to register with.
+    pub coordinator: String,
+    /// Logical block size in bytes (256 MiB default).
+    pub block_size: u32,
+    /// One or more cache directory roots on local NVMe.
+    pub cache_dirs: Vec<PathBuf>,
+    /// Total cache capacity in bytes across all cache dirs.
+    pub capacity_bytes: u64,
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            listen: "127.0.0.1:7001".into(),
+            coordinator: "127.0.0.1:7000".into(),
+            block_size: 256 << 20,
+            cache_dirs: vec![PathBuf::from("/var/cache/talon")],
+            capacity_bytes: 64 << 30,
+        }
+    }
+}
+
+/// An optional-field overlay for [`WorkerConfig`].
+///
+/// Deserialized from the config file, and also assembled from env and CLI
+/// layers. Every field is optional so a layer only overrides what it sets.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkerConfigPatch {
+    /// Override for [`WorkerConfig::listen`].
+    pub listen: Option<String>,
+    /// Override for [`WorkerConfig::coordinator`].
+    pub coordinator: Option<String>,
+    /// Override for [`WorkerConfig::block_size`].
+    pub block_size: Option<u32>,
+    /// Override for [`WorkerConfig::cache_dirs`].
+    pub cache_dirs: Option<Vec<PathBuf>>,
+    /// Override for [`WorkerConfig::capacity_bytes`].
+    pub capacity_bytes: Option<u64>,
+}
+
+impl Patch for WorkerConfigPatch {
+    fn merge(self, base: Self) -> Self {
+        Self {
+            listen: self.listen.or(base.listen),
+            coordinator: self.coordinator.or(base.coordinator),
+            block_size: self.block_size.or(base.block_size),
+            cache_dirs: self.cache_dirs.or(base.cache_dirs),
+            capacity_bytes: self.capacity_bytes.or(base.capacity_bytes),
+        }
+    }
+}
+
+impl WorkerConfigPatch {
+    /// Parse a patch from a TOML config-file string.
+    pub fn from_toml(s: &str) -> Result<Self> {
+        toml::from_str(s).map_err(|e| Error::Other(format!("invalid config file: {e}")))
+    }
+
+    /// Read a patch from a TOML file path. A missing file yields an empty patch.
+    pub fn from_file(path: &std::path::Path) -> Result<Self> {
+        match std::fs::read_to_string(path) {
+            Ok(s) => Self::from_toml(&s),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Assemble a patch from `TALON_WORKER_*` environment variables.
+    ///
+    /// Recognized keys: `TALON_WORKER_LISTEN`, `TALON_WORKER_COORDINATOR`,
+    /// `TALON_WORKER_BLOCK_SIZE`, `TALON_WORKER_CACHE_DIRS` (`:`-separated),
+    /// `TALON_WORKER_CAPACITY_BYTES`.
+    pub fn from_env() -> Result<Self> {
+        Self::from_env_with(|k| std::env::var(k).ok())
+    }
+
+    /// Like [`from_env`](Self::from_env) but with an injectable lookup, for
+    /// tests.
+    pub fn from_env_with(get: impl Fn(&str) -> Option<String>) -> Result<Self> {
+        let parse_u32 = |v: String, k: &str| {
+            v.parse::<u32>()
+                .map_err(|_| Error::Other(format!("{k}: invalid u32: {v:?}")))
+        };
+        let parse_u64 = |v: String, k: &str| {
+            v.parse::<u64>()
+                .map_err(|_| Error::Other(format!("{k}: invalid u64: {v:?}")))
+        };
+        Ok(Self {
+            listen: get("TALON_WORKER_LISTEN"),
+            coordinator: get("TALON_WORKER_COORDINATOR"),
+            block_size: get("TALON_WORKER_BLOCK_SIZE")
+                .map(|v| parse_u32(v, "TALON_WORKER_BLOCK_SIZE"))
+                .transpose()?,
+            cache_dirs: get("TALON_WORKER_CACHE_DIRS")
+                .map(|v| v.split(':').map(PathBuf::from).collect()),
+            capacity_bytes: get("TALON_WORKER_CAPACITY_BYTES")
+                .map(|v| parse_u64(v, "TALON_WORKER_CAPACITY_BYTES"))
+                .transpose()?,
+        })
+    }
+}
+
+impl WorkerConfig {
+    /// Resolve config across all layers: defaults < file < env < CLI.
+    ///
+    /// `cli` is the highest-precedence patch (assembled from parsed CLI flags);
+    /// `env` and `file` are lower. Any layer may be [`WorkerConfigPatch::default`]
+    /// (empty) to skip it.
+    pub fn resolve(
+        file: WorkerConfigPatch,
+        env: WorkerConfigPatch,
+        cli: WorkerConfigPatch,
+    ) -> Result<Self> {
+        // Fold highest-first onto lower layers, then onto defaults.
+        let merged = cli.merge(env).merge(file);
+        let d = WorkerConfig::default();
+        let cfg = WorkerConfig {
+            listen: merged.listen.unwrap_or(d.listen),
+            coordinator: merged.coordinator.unwrap_or(d.coordinator),
+            block_size: merged.block_size.unwrap_or(d.block_size),
+            cache_dirs: merged.cache_dirs.unwrap_or(d.cache_dirs),
+            capacity_bytes: merged.capacity_bytes.unwrap_or(d.capacity_bytes),
+        };
+        cfg.validate()?;
+        Ok(cfg)
+    }
+
+    /// Fail fast on invalid configuration with an actionable message.
+    pub fn validate(&self) -> Result<()> {
+        if self.listen.is_empty() {
+            return Err(Error::Other("listen address must not be empty".into()));
+        }
+        if self.coordinator.is_empty() {
+            return Err(Error::Other("coordinator address must not be empty".into()));
+        }
+        if self.block_size == 0 {
+            return Err(Error::Other("block_size must be > 0".into()));
+        }
+        if self.cache_dirs.is_empty() {
+            return Err(Error::Other("at least one cache_dir is required".into()));
+        }
+        if self.capacity_bytes < self.block_size as u64 {
+            return Err(Error::Other(format!(
+                "capacity_bytes ({}) must be >= block_size ({})",
+                self.capacity_bytes, self.block_size
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_valid() {
+        WorkerConfig::default().validate().unwrap();
+    }
+
+    #[test]
+    fn precedence_cli_over_env_over_file_over_default() {
+        // block_size only in file; coordinator in file+env; listen in all three.
+        let file = WorkerConfigPatch {
+            listen: Some("file:1".into()),
+            coordinator: Some("file-coord".into()),
+            block_size: Some(1 << 20),
+            ..Default::default()
+        };
+        let env = WorkerConfigPatch {
+            listen: Some("env:1".into()),
+            coordinator: Some("env-coord".into()),
+            ..Default::default()
+        };
+        let cli = WorkerConfigPatch {
+            listen: Some("cli:1".into()),
+            ..Default::default()
+        };
+
+        let cfg = WorkerConfig::resolve(file, env, cli).unwrap();
+        assert_eq!(cfg.listen, "cli:1"); // CLI wins
+        assert_eq!(cfg.coordinator, "env-coord"); // env beats file
+        assert_eq!(cfg.block_size, 1 << 20); // file beats default
+        assert_eq!(cfg.capacity_bytes, WorkerConfig::default().capacity_bytes); // default
+    }
+
+    #[test]
+    fn from_toml_parses_and_rejects_unknown() {
+        let patch = WorkerConfigPatch::from_toml(
+            "listen = \"0.0.0.0:9000\"\ncache_dirs = [\"/a\", \"/b\"]\n",
+        )
+        .unwrap();
+        assert_eq!(patch.listen.as_deref(), Some("0.0.0.0:9000"));
+        assert_eq!(patch.cache_dirs.unwrap().len(), 2);
+        assert!(WorkerConfigPatch::from_toml("bogus_key = 1").is_err());
+    }
+
+    #[test]
+    fn from_env_parses_typed_fields() {
+        let map = |k: &str| match k {
+            "TALON_WORKER_BLOCK_SIZE" => Some("1048576".to_string()),
+            "TALON_WORKER_CACHE_DIRS" => Some("/x:/y:/z".to_string()),
+            _ => None,
+        };
+        let patch = WorkerConfigPatch::from_env_with(map).unwrap();
+        assert_eq!(patch.block_size, Some(1 << 20));
+        assert_eq!(patch.cache_dirs.as_ref().unwrap().len(), 3);
+        assert!(patch.listen.is_none());
+
+        let bad = |k: &str| (k == "TALON_WORKER_BLOCK_SIZE").then(|| "notanum".to_string());
+        assert!(WorkerConfigPatch::from_env_with(bad).is_err());
+    }
+
+    #[test]
+    fn invalid_config_fails_fast() {
+        let cli = WorkerConfigPatch {
+            capacity_bytes: Some(1),
+            ..Default::default()
+        };
+        // capacity < block_size
+        let err = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
+        assert!(err.to_string().contains("capacity_bytes"));
+    }
+}

--- a/crates/talon-core/src/lib.rs
+++ b/crates/talon-core/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod backend;
 pub mod block;
+pub mod config;
 pub mod error;
 pub mod key;
 pub mod node;
@@ -12,6 +13,7 @@ pub mod store;
 
 pub use backend::{BackendStore, ObjectStat};
 pub use block::{BlockForm, BlockMeta, LoadHint, PresentBitmap};
+pub use config::{Patch, WorkerConfig, WorkerConfigPatch};
 pub use error::{Error, Result};
 pub use key::{Backend, BlockId, ObjectId, PageIndex, Version};
 pub use node::{NodeId, NodeInfo, NodeRole};

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -1,18 +1,43 @@
 //! Talon worker entry point.
 
 use clap::Parser;
+use std::path::PathBuf;
+use talon_core::{WorkerConfig, WorkerConfigPatch};
 
 /// Command-line arguments for a Talon worker.
+///
+/// Flags are the highest-precedence configuration layer (CLI > env > file >
+/// default). Unset flags fall through to the lower layers.
 #[derive(Debug, Parser)]
 #[command(name = "talon-worker", version, about)]
 struct Args {
+    /// Path to a TOML config file.
+    #[arg(long)]
+    config: Option<PathBuf>,
+
     /// Address to bind the worker RPC service to.
-    #[arg(long, default_value = "127.0.0.1:7001")]
-    listen: String,
+    #[arg(long)]
+    listen: Option<String>,
 
     /// Address of the coordinator to register with.
-    #[arg(long, default_value = "127.0.0.1:7000")]
-    coordinator: String,
+    #[arg(long)]
+    coordinator: Option<String>,
+
+    /// Logical block size in bytes.
+    #[arg(long)]
+    block_size: Option<u32>,
+}
+
+impl Args {
+    fn into_patch(self) -> WorkerConfigPatch {
+        WorkerConfigPatch {
+            listen: self.listen,
+            coordinator: self.coordinator,
+            block_size: self.block_size,
+            cache_dirs: None,
+            capacity_bytes: None,
+        }
+    }
 }
 
 #[tokio::main]
@@ -24,9 +49,21 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let args = Args::parse();
+
+    let file = match &args.config {
+        Some(path) => WorkerConfigPatch::from_file(path)?,
+        None => WorkerConfigPatch::default(),
+    };
+    let env = WorkerConfigPatch::from_env()?;
+    let cli = args.into_patch();
+    let cfg = WorkerConfig::resolve(file, env, cli)?;
+
     tracing::info!(
-        listen = %args.listen,
-        coordinator = %args.coordinator,
+        listen = %cfg.listen,
+        coordinator = %cfg.coordinator,
+        block_size = cfg.block_size,
+        cache_dirs = ?cfg.cache_dirs,
+        capacity_bytes = cfg.capacity_bytes,
         "starting talon-worker"
     );
 


### PR DESCRIPTION
## Summary
- Add `talon-core::config` with a `Patch`-based layered resolver.
- Concrete `WorkerConfig` / `WorkerConfigPatch`: TOML file + `TALON_WORKER_*` env + CLI flags folded onto compiled defaults in precedence order (CLI > env > file > default).
- Fail-fast `validate()` with actionable messages (empty addrs, zero block size, no cache dir, capacity < block size).
- Wire `talon-worker`'s `main` to resolve through all four layers.

## Design alignment
DESIGN.md §5 (Configuration precedence). Secrets come only from env and are never serialized/logged. Underpins worker capacity (#17) and backend creds (#19-#21).

## Test plan
- [x] defaults valid
- [x] CLI > env > file > default precedence across a shared key set
- [x] TOML parse + unknown-key rejection
- [x] typed env parsing incl. invalid-value error
- [x] invalid config (capacity < block_size) fails fast

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)