### PR TITLE
feat(transport): bincode control-plane message codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +572,9 @@ dependencies = [
 name = "talon-transport"
 version = "0.1.0"
 dependencies = [
+ "bincode",
+ "serde",
+ "talon-core",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,6 @@ serde_json = "1"
 toml = "0.8"
 bytes = "1"
 async-trait = "0.1"
+bincode = "1.3"
 clap = { version = "4", features = ["derive"] }
 divan = "0.1"

--- a/crates/talon-transport/Cargo.toml
+++ b/crates/talon-transport/Cargo.toml
@@ -7,6 +7,9 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+talon-core.workspace = true
 thiserror.workspace = true
+serde.workspace = true
+bincode.workspace = true
 
 [dev-dependencies]

--- a/crates/talon-transport/src/codec.rs
+++ b/crates/talon-transport/src/codec.rs
@@ -1,9 +1,8 @@
 //! Control-plane message codec.
 //!
 //! Control messages are a versioned [`ControlMessage`] enum, serialized with
-//! **bincode** and framed by a [`FrameHeader`](crate::FrameHeader) whose
-//! `msg_type` is [`MsgType::Control`](crate::MsgType). No JSON is used on the
-//! wire.
+//! **bincode** and framed by a [`FrameHeader`] whose `msg_type` is
+//! [`Control`](crate::MsgType::Control). No JSON is used on the wire.
 //!
 //! [`encode`] produces `header || bincode(msg)` as a single buffer;
 //! [`decode`] validates the header, checks the declared length against the

--- a/crates/talon-transport/src/codec.rs
+++ b/crates/talon-transport/src/codec.rs
@@ -1,0 +1,272 @@
+//! Control-plane message codec.
+//!
+//! Control messages are a versioned [`ControlMessage`] enum, serialized with
+//! **bincode** and framed by a [`FrameHeader`](crate::FrameHeader) whose
+//! `msg_type` is [`MsgType::Control`](crate::MsgType). No JSON is used on the
+//! wire.
+//!
+//! [`encode`] produces `header || bincode(msg)` as a single buffer;
+//! [`decode`] validates the header, checks the declared length against the
+//! remaining bytes, and deserializes. Unknown or newer message shapes surface a
+//! [`CodecError`] rather than panicking.
+
+use serde::{Deserialize, Serialize};
+use talon_core::{BlockId, NodeId, NodeInfo, ObjectId};
+
+use crate::frame::{FrameError, FrameHeader, MsgType, HEADER_LEN};
+
+/// Wire schema version for the control message set.
+///
+/// Bumped when [`ControlMessage`] changes in an incompatible way. Carried in
+/// the envelope so a peer can reject a mismatched schema instead of
+/// misinterpreting bytes.
+pub const CONTROL_SCHEMA_VERSION: u16 = 1;
+
+/// A single control-plane message.
+///
+/// Deliberately minimal for v1; extend per consumer (membership, placement,
+/// load). `#[non_exhaustive]` so adding a variant is not a breaking change for
+/// matchers that already have a wildcard arm.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ControlMessage {
+    /// Worker → coordinator: announce presence and address.
+    Register {
+        /// Identity of the registering node.
+        node: NodeInfo,
+    },
+    /// Worker → coordinator: periodic liveness + block-count summary.
+    Heartbeat {
+        /// The reporting worker.
+        node: NodeId,
+        /// Number of blocks currently resident.
+        block_count: u64,
+    },
+    /// Client → coordinator: where does this block live?
+    PlacementLookup {
+        /// The block being located.
+        block: BlockId,
+        /// Number of replicas requested (RF=1 → 1 in v1).
+        k: u8,
+    },
+    /// Coordinator → client: ordered owners + the epoch they were computed at.
+    PlacementResponse {
+        /// Ordered replica node ids (highest weight first).
+        owners: Vec<NodeId>,
+        /// Placement epoch these owners were computed against.
+        epoch: u64,
+    },
+    /// Coordinator → worker: prewarm/load an object range.
+    Load {
+        /// The source object to load from.
+        object: ObjectId,
+        /// Byte offset to begin loading at.
+        offset: u64,
+        /// Number of bytes to load.
+        len: u64,
+    },
+    /// Coordinator → all: the placement epoch advanced.
+    EpochBump {
+        /// The new epoch value.
+        epoch: u64,
+    },
+    /// Generic acknowledgement / error reply.
+    Ack {
+        /// True on success; false carries `detail`.
+        ok: bool,
+        /// Optional human-readable detail (error text).
+        detail: Option<String>,
+    },
+}
+
+/// The framed control envelope actually written to the wire.
+///
+/// Wraps a [`ControlMessage`] with the schema version so the receiver can
+/// reject an incompatible schema before trusting the payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct Envelope {
+    schema: u16,
+    message: ControlMessage,
+}
+
+/// Errors from control-message encode/decode.
+#[derive(Debug, thiserror::Error)]
+pub enum CodecError {
+    /// The framing header was invalid.
+    #[error("frame error: {0}")]
+    Frame(#[from] FrameError),
+    /// A non-control frame was handed to the control codec.
+    #[error("expected a Control frame, got {0:?}")]
+    NotControl(MsgType),
+    /// The header's declared length did not match the available payload bytes.
+    #[error("length mismatch: header says {declared}, have {actual}")]
+    LengthMismatch {
+        /// Length advertised by the frame header.
+        declared: usize,
+        /// Bytes actually present after the header.
+        actual: usize,
+    },
+    /// The message schema version is not understood.
+    #[error("unsupported control schema {got} (this build speaks {ours})")]
+    UnsupportedSchema {
+        /// Schema version seen on the wire.
+        got: u16,
+        /// Schema version this build supports.
+        ours: u16,
+    },
+    /// bincode failed to (de)serialize the message body.
+    #[error("bincode error: {0}")]
+    Bincode(#[from] bincode::Error),
+}
+
+/// Encode a control message into `header || bincode(envelope)`.
+pub fn encode(request_id: u32, message: &ControlMessage) -> Result<Vec<u8>, CodecError> {
+    let env = Envelope {
+        schema: CONTROL_SCHEMA_VERSION,
+        message: message.clone(),
+    };
+    let body = bincode::serialize(&env)?;
+    let header = FrameHeader::new(MsgType::Control, request_id, body.len() as u32);
+    let mut buf = Vec::with_capacity(HEADER_LEN + body.len());
+    buf.extend_from_slice(&header.encode());
+    buf.extend_from_slice(&body);
+    Ok(buf)
+}
+
+/// Decode a full framed control buffer into its header and message.
+///
+/// Validates magic/version/type/length via [`FrameHeader::decode`], ensures the
+/// frame is [`MsgType::Control`], checks the declared payload length against the
+/// bytes present, and rejects an unknown schema version.
+pub fn decode(buf: &[u8]) -> Result<(FrameHeader, ControlMessage), CodecError> {
+    let header = FrameHeader::decode(buf)?;
+    if header.msg_type != MsgType::Control {
+        return Err(CodecError::NotControl(header.msg_type));
+    }
+    let declared = header.length as usize;
+    let body = &buf[HEADER_LEN..];
+    if body.len() != declared {
+        return Err(CodecError::LengthMismatch {
+            declared,
+            actual: body.len(),
+        });
+    }
+    let env: Envelope = bincode::deserialize(body)?;
+    if env.schema != CONTROL_SCHEMA_VERSION {
+        return Err(CodecError::UnsupportedSchema {
+            got: env.schema,
+            ours: CONTROL_SCHEMA_VERSION,
+        });
+    }
+    Ok((header, env.message))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use talon_core::{Backend, NodeRole, Version};
+
+    fn sample_messages() -> Vec<ControlMessage> {
+        let node = NodeInfo {
+            id: NodeId::new("worker-1"),
+            address: "10.0.0.1:7001".into(),
+            role: NodeRole::Worker,
+        };
+        let block = BlockId::new(
+            ObjectId::new(Backend::S3, "bkt", "path/obj.bin"),
+            256 << 20,
+            256 << 20,
+            Version::new("etag-xyz"),
+        );
+        vec![
+            ControlMessage::Register { node: node.clone() },
+            ControlMessage::Heartbeat {
+                node: node.id.clone(),
+                block_count: 42,
+            },
+            ControlMessage::PlacementLookup {
+                block: block.clone(),
+                k: 1,
+            },
+            ControlMessage::PlacementResponse {
+                owners: vec![NodeId::new("a"), NodeId::new("b")],
+                epoch: 7,
+            },
+            ControlMessage::Load {
+                object: block.object.clone(),
+                offset: 0,
+                len: 1 << 20,
+            },
+            ControlMessage::EpochBump { epoch: 8 },
+            ControlMessage::Ack {
+                ok: false,
+                detail: Some("nope".into()),
+            },
+        ]
+    }
+
+    #[test]
+    fn every_variant_round_trips() {
+        for (i, msg) in sample_messages().into_iter().enumerate() {
+            let buf = encode(i as u32, &msg).unwrap();
+            let (header, back) = decode(&buf).unwrap();
+            assert_eq!(header.msg_type, MsgType::Control);
+            assert_eq!(header.request_id, i as u32);
+            assert_eq!(header.length as usize, buf.len() - HEADER_LEN);
+            assert_eq!(back, msg);
+        }
+    }
+
+    #[test]
+    fn non_control_frame_rejected() {
+        // Hand-build a Get frame with a control-looking body.
+        let body = bincode::serialize(&Envelope {
+            schema: CONTROL_SCHEMA_VERSION,
+            message: ControlMessage::EpochBump { epoch: 1 },
+        })
+        .unwrap();
+        let mut buf = FrameHeader::new(MsgType::Get, 0, body.len() as u32)
+            .encode()
+            .to_vec();
+        buf.extend_from_slice(&body);
+        assert!(matches!(
+            decode(&buf),
+            Err(CodecError::NotControl(MsgType::Get))
+        ));
+    }
+
+    #[test]
+    fn truncated_body_rejected() {
+        let mut buf = encode(1, &ControlMessage::EpochBump { epoch: 5 }).unwrap();
+        buf.pop(); // drop a payload byte; header length now disagrees
+        assert!(matches!(
+            decode(&buf),
+            Err(CodecError::LengthMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn unknown_schema_rejected_not_panicked() {
+        // Encode with a bumped schema and confirm decode reports it cleanly.
+        let env = Envelope {
+            schema: 999,
+            message: ControlMessage::EpochBump { epoch: 1 },
+        };
+        let body = bincode::serialize(&env).unwrap();
+        let mut buf = FrameHeader::new(MsgType::Control, 0, body.len() as u32)
+            .encode()
+            .to_vec();
+        buf.extend_from_slice(&body);
+        assert!(matches!(
+            decode(&buf),
+            Err(CodecError::UnsupportedSchema { got: 999, ours: 1 })
+        ));
+    }
+
+    #[test]
+    fn garbage_body_errors_gracefully() {
+        let mut buf = FrameHeader::new(MsgType::Control, 0, 3).encode().to_vec();
+        buf.extend_from_slice(&[0xFF, 0xFF, 0xFF]);
+        assert!(decode(&buf).is_err());
+    }
+}

--- a/crates/talon-transport/src/lib.rs
+++ b/crates/talon-transport/src/lib.rs
@@ -2,14 +2,16 @@
 //!
 //! Wire-protocol primitives shared by Talon's control and data planes.
 //!
-//! The only thing defined here in this first cut is the [`FrameHeader`]: a
-//! compact, versioned, fixed-size header that prefixes every frame on both
-//! planes. The control plane follows the header with a bincode-encoded message;
-//! the data plane follows it with raw payload bytes (never wrapped), so the hot
-//! path can `sendfile`/`splice` straight from a file into the socket.
+//! [`FrameHeader`] is the compact, versioned, fixed-size header that prefixes
+//! every frame on both planes. The control plane follows the header with a
+//! bincode-encoded [`ControlMessage`] (see [`codec`]); the data plane follows
+//! it with raw payload bytes (never wrapped), so the hot path can
+//! `sendfile`/`splice` straight from a file into the socket.
 //!
 //! See [`frame`] for the byte layout.
 
+pub mod codec;
 pub mod frame;
 
+pub use codec::{decode, encode, CodecError, ControlMessage, CONTROL_SCHEMA_VERSION};
 pub use frame::{Flags, FrameError, FrameHeader, MsgType, HEADER_LEN, MAGIC, PROTOCOL_VERSION};


### PR DESCRIPTION
## Summary
- Add `ControlMessage` enum: register, heartbeat, placement lookup/response, load, epoch bump, ack. `#[non_exhaustive]` for forward compat.
- Versioned bincode codec (`encode`/`decode`) framed by the #7 `FrameHeader` (`MsgType::Control`); no JSON on the wire.
- `decode` validates header, enforces Control msg-type, checks declared length vs payload, and rejects unknown schema versions gracefully (no panic).

## Design alignment
DESIGN.md §1 / Serialization. Replaces the placeholder serde_json intent. Depends on #7.

## Test plan
- [x] every variant round-trips through header+bincode
- [x] non-control frame rejected
- [x] truncated body → LengthMismatch
- [x] unknown schema reported, not panicked
- [x] garbage body errors gracefully

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)