### PR TITLE
feat(backend): GCS BackendStore implementation

### DIFF
--- a/crates/talon-backend/src/gcs.rs
+++ b/crates/talon-backend/src/gcs.rs
@@ -1,0 +1,255 @@
+//! Google Cloud Storage [`BackendStore`] implementation.
+//!
+//! Uses the GCS XML/JSON download endpoint: a ranged GET on
+//! `storage.googleapis.com/<bucket>/<object>` for block/page loads and a HEAD
+//! (or metadata GET) for size + generation. The object **generation** maps to a
+//! [`Version`] so a source overwrite yields a distinct cache key, analogous to
+//! an S3 ETag.
+//!
+//! Like [`crate::s3`], the store is generic over an [`HttpClient`] so request
+//! construction and response parsing are unit-testable offline; a real OAuth2
+//! bearer-token client is injected in production.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use talon_core::{BackendStore, Error, ObjectId, ObjectStat, Result, Version};
+
+use crate::http::{HttpClient, HttpRequest, Method};
+
+/// GCS endpoint configuration.
+#[derive(Debug, Clone)]
+pub struct GcsConfig {
+    /// Download host; defaults to `storage.googleapis.com`.
+    pub endpoint: String,
+    /// `https` when true.
+    pub tls: bool,
+}
+
+impl Default for GcsConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: "storage.googleapis.com".into(),
+            tls: true,
+        }
+    }
+}
+
+/// A GCS `BackendStore` over a pluggable HTTP client.
+pub struct GcsBackend {
+    config: GcsConfig,
+    /// OAuth2 bearer token (short-lived; refreshed by the caller).
+    bearer_token: Option<String>,
+    http: Arc<dyn HttpClient>,
+}
+
+impl GcsBackend {
+    /// Construct a backend from config, an optional bearer token, and a client.
+    pub fn new(config: GcsConfig, bearer_token: Option<String>, http: Arc<dyn HttpClient>) -> Self {
+        Self {
+            config,
+            bearer_token,
+            http,
+        }
+    }
+
+    /// Build the object download URL (`scheme://host/bucket/object`).
+    pub fn object_url(&self, obj: &ObjectId) -> String {
+        let scheme = if self.config.tls { "https" } else { "http" };
+        let key = obj.object_path.trim_start_matches('/');
+        format!("{scheme}://{}/{}/{}", self.config.endpoint, obj.bucket, key)
+    }
+
+    /// Format an inclusive HTTP `Range` header for `[offset, offset+len)`.
+    pub fn range_header(offset: u64, len: u64) -> String {
+        format!("bytes={offset}-{}", offset + len - 1)
+    }
+
+    fn auth_headers(&self) -> Vec<(String, String)> {
+        match &self.bearer_token {
+            Some(t) => vec![("Authorization".to_string(), format!("Bearer {t}"))],
+            None => Vec::new(),
+        }
+    }
+
+    /// Build the ranged GET request (exposed for testing).
+    pub fn build_get(&self, obj: &ObjectId, offset: u64, len: u64) -> HttpRequest {
+        let mut headers = self.auth_headers();
+        headers.push(("Range".to_string(), Self::range_header(offset, len)));
+        HttpRequest {
+            method: Method::Get,
+            url: self.object_url(obj),
+            headers,
+        }
+    }
+
+    /// Build the HEAD request (exposed for testing).
+    pub fn build_head(&self, obj: &ObjectId) -> HttpRequest {
+        HttpRequest {
+            method: Method::Head,
+            url: self.object_url(obj),
+            headers: self.auth_headers(),
+        }
+    }
+}
+
+#[async_trait]
+impl BackendStore for GcsBackend {
+    async fn fetch_range(&self, obj: &ObjectId, offset: u64, len: u64) -> Result<bytes::Bytes> {
+        if len == 0 {
+            return Ok(bytes::Bytes::new());
+        }
+        let resp = self
+            .http
+            .execute(self.build_get(obj, offset, len))
+            .await
+            .map_err(Error::Backend)?;
+        match resp.status {
+            200 | 206 => Ok(resp.body),
+            404 => Err(Error::NotFound(obj.to_path())),
+            s => Err(Error::Backend(format!(
+                "GCS GET {} -> HTTP {s}",
+                obj.to_path()
+            ))),
+        }
+    }
+
+    async fn head(&self, obj: &ObjectId) -> Result<ObjectStat> {
+        let resp = self
+            .http
+            .execute(self.build_head(obj))
+            .await
+            .map_err(Error::Backend)?;
+        if resp.status == 404 {
+            return Err(Error::NotFound(obj.to_path()));
+        }
+        if !resp.is_success() {
+            return Err(Error::Backend(format!(
+                "GCS HEAD {} -> HTTP {}",
+                obj.to_path(),
+                resp.status
+            )));
+        }
+        let len = resp
+            .header("content-length")
+            .and_then(|v| v.parse::<u64>().ok())
+            .ok_or_else(|| Error::Backend("GCS HEAD missing/invalid Content-Length".into()))?;
+        // Prefer the immutable generation; fall back to the goog-hash ETag.
+        let version = resp
+            .header("x-goog-generation")
+            .or_else(|| resp.header("etag"))
+            .map(|v| Version::new(v.trim_matches('"').to_string()))
+            .unwrap_or_else(|| Version::new(""));
+        Ok(ObjectStat { len, version })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::HttpResponse;
+    use std::sync::Mutex;
+    use talon_core::Backend;
+
+    struct MockHttp {
+        last: Mutex<Option<HttpRequest>>,
+        response: HttpResponse,
+    }
+
+    impl MockHttp {
+        fn new(response: HttpResponse) -> Arc<Self> {
+            Arc::new(Self {
+                last: Mutex::new(None),
+                response,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl HttpClient for MockHttp {
+        async fn execute(&self, req: HttpRequest) -> std::result::Result<HttpResponse, String> {
+            *self.last.lock().unwrap() = Some(req);
+            Ok(self.response.clone())
+        }
+    }
+
+    fn obj() -> ObjectId {
+        ObjectId::new(Backend::Gcs, "my-bucket", "data/checkpoint.bin")
+    }
+
+    #[test]
+    fn url_and_range() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![],
+            body: bytes::Bytes::new(),
+        });
+        let g = GcsBackend::new(GcsConfig::default(), None, http);
+        assert_eq!(
+            g.object_url(&obj()),
+            "https://storage.googleapis.com/my-bucket/data/checkpoint.bin"
+        );
+        assert_eq!(GcsBackend::range_header(0, 64), "bytes=0-63");
+    }
+
+    #[tokio::test]
+    async fn fetch_range_sends_bearer_and_range() {
+        let http = MockHttp::new(HttpResponse {
+            status: 206,
+            headers: vec![],
+            body: bytes::Bytes::from_static(b"gcs-bytes"),
+        });
+        let g = GcsBackend::new(GcsConfig::default(), Some("tok".into()), http.clone());
+        let got = g.fetch_range(&obj(), 4, 5).await.unwrap();
+        assert_eq!(got, bytes::Bytes::from_static(b"gcs-bytes"));
+        let req = http.last.lock().unwrap().clone().unwrap();
+        assert_eq!(req.header("Authorization"), Some("Bearer tok"));
+        assert_eq!(req.header("Range"), Some("bytes=4-8"));
+    }
+
+    #[tokio::test]
+    async fn head_uses_generation_as_version() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![
+                ("Content-Length".into(), "2048".into()),
+                ("x-goog-generation".into(), "1699999999".into()),
+                ("ETag".into(), "\"fallback\"".into()),
+            ],
+            body: bytes::Bytes::new(),
+        });
+        let g = GcsBackend::new(GcsConfig::default(), None, http);
+        let stat = g.head(&obj()).await.unwrap();
+        assert_eq!(stat.len, 2048);
+        assert_eq!(stat.version, Version::new("1699999999"));
+    }
+
+    #[tokio::test]
+    async fn missing_generation_falls_back_to_etag() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![
+                ("Content-Length".into(), "1".into()),
+                ("ETag".into(), "\"abc\"".into()),
+            ],
+            body: bytes::Bytes::new(),
+        });
+        let g = GcsBackend::new(GcsConfig::default(), None, http);
+        assert_eq!(g.head(&obj()).await.unwrap().version, Version::new("abc"));
+    }
+
+    #[tokio::test]
+    async fn not_found_maps_through() {
+        let http = MockHttp::new(HttpResponse {
+            status: 404,
+            headers: vec![],
+            body: bytes::Bytes::new(),
+        });
+        let g = GcsBackend::new(GcsConfig::default(), None, http);
+        assert!(matches!(
+            g.fetch_range(&obj(), 0, 8).await,
+            Err(Error::NotFound(_))
+        ));
+        assert!(matches!(g.head(&obj()).await, Err(Error::NotFound(_))));
+    }
+}

--- a/crates/talon-backend/src/lib.rs
+++ b/crates/talon-backend/src/lib.rs
@@ -6,8 +6,10 @@
 //! request construction and response parsing are unit-testable offline; a real
 //! networked client is injected in production.
 
+pub mod gcs;
 pub mod http;
 pub mod s3;
 
+pub use gcs::{GcsBackend, GcsConfig};
 pub use http::{HttpClient, HttpRequest, HttpResponse, Method};
 pub use s3::{S3Backend, S3Config, S3Credentials};


### PR DESCRIPTION
## Summary
- Add `GcsBackend` implementing `BackendStore` over the shared pluggable `HttpClient`.
- Ranged GET on `storage.googleapis.com/<bucket>/<object>` for block/page loads; HEAD for size + object **generation**.
- Generation → `Version` (falls back to ETag) so a source overwrite invalidates the cache key. OAuth2 bearer attached per request.

## Design alignment
DESIGN.md §5 (Backing store): `BackendStore` for GCS. Fans out from the S3 pattern (#19). Errors map to `Error::Backend`; 404 → `NotFound`.

## Test plan
- [x] URL + inclusive range formatting
- [x] fetch_range sends bearer + Range, returns body
- [x] head uses generation as version; falls back to ETag when absent
- [x] 404 → NotFound on both paths

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)