### PR TITLE
feat: multi-process control+data path with real Azure backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -79,6 +79,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,16 +106,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cc"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
 
 [[package]]
 name = "clap"
@@ -159,6 +204,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "divan"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,7 +261,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-util"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "rand_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -212,6 +352,207 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +561,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -232,6 +579,17 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -252,6 +610,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +629,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -289,7 +659,7 @@ checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -298,7 +668,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -337,10 +707,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -352,12 +737,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -393,6 +866,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,8 +933,55 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -464,6 +1042,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +1061,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -481,6 +1077,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -495,14 +1097,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -527,13 +1141,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "talon-backend"
 version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "reqwest",
  "talon-core",
  "tokio",
+]
+
+[[package]]
+name = "talon-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "talon-core",
+ "talon-transport",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -601,7 +1249,9 @@ dependencies = [
  "bytes",
  "clap",
  "libc",
+ "talon-backend",
  "talon-core",
+ "talon-transport",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -615,7 +1265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -648,6 +1298,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,7 +1336,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -673,6 +1348,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -715,6 +1400,51 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -778,10 +1508,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -796,16 +1556,118 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -817,6 +1679,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,10 +1752,99 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/talon-fuse",
     "crates/talon-transport",
     "crates/talon-backend",
+    "crates/talon-client",
 ]
 
 [workspace.package]

--- a/crates/talon-backend/Cargo.toml
+++ b/crates/talon-backend/Cargo.toml
@@ -11,6 +11,7 @@ description = "Blob-store BackendStore implementations (S3/GCS/Azure) for Talon"
 talon-core.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/talon-backend/src/lib.rs
+++ b/crates/talon-backend/src/lib.rs
@@ -9,9 +9,11 @@
 pub mod azure;
 pub mod gcs;
 pub mod http;
+pub mod reqwest_client;
 pub mod s3;
 
 pub use azure::{AzureBackend, AzureConfig};
 pub use gcs::{GcsBackend, GcsConfig};
 pub use http::{HttpClient, HttpRequest, HttpResponse, Method};
+pub use reqwest_client::ReqwestClient;
 pub use s3::{S3Backend, S3Config, S3Credentials};

--- a/crates/talon-backend/src/reqwest_client.rs
+++ b/crates/talon-backend/src/reqwest_client.rs
@@ -1,0 +1,68 @@
+//! A concrete [`HttpClient`] backed by [`reqwest`] (rustls TLS).
+//!
+//! The backends ([`AzureBackend`](crate::AzureBackend) etc.) are generic over
+//! [`HttpClient`] so they stay offline-testable with a mock; this is the real
+//! networked implementation wired in production. It performs a ranged GET or a
+//! HEAD over HTTPS and maps the response into the crate's transport-agnostic
+//! [`HttpResponse`].
+//!
+//! Only the pieces the backends need are implemented (GET/HEAD, request headers,
+//! status + response headers + body). Auth is expected to be baked into the URL
+//! (e.g. an Azure SAS query string) or carried in `HttpRequest::headers`; this
+//! client does no signing of its own.
+
+use async_trait::async_trait;
+
+use crate::http::{HttpClient, HttpRequest, HttpResponse, Method};
+
+/// A `reqwest`-backed HTTP client.
+pub struct ReqwestClient {
+    inner: reqwest::Client,
+}
+
+impl ReqwestClient {
+    /// Build a client with sensible pooled defaults.
+    pub fn new() -> Self {
+        Self {
+            inner: reqwest::Client::new(),
+        }
+    }
+
+    /// Build over a pre-configured [`reqwest::Client`] (timeouts, proxies, etc.).
+    pub fn with_client(inner: reqwest::Client) -> Self {
+        Self { inner }
+    }
+}
+
+impl Default for ReqwestClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl HttpClient for ReqwestClient {
+    async fn execute(&self, req: HttpRequest) -> Result<HttpResponse, String> {
+        let method = match req.method {
+            Method::Get => reqwest::Method::GET,
+            Method::Head => reqwest::Method::HEAD,
+        };
+        let mut builder = self.inner.request(method, &req.url);
+        for (k, v) in &req.headers {
+            builder = builder.header(k.as_str(), v.as_str());
+        }
+        let resp = builder.send().await.map_err(|e| e.to_string())?;
+        let status = resp.status().as_u16();
+        let headers = resp
+            .headers()
+            .iter()
+            .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
+            .collect();
+        let body = resp.bytes().await.map_err(|e| e.to_string())?;
+        Ok(HttpResponse {
+            status,
+            headers,
+            body,
+        })
+    }
+}

--- a/crates/talon-client/Cargo.toml
+++ b/crates/talon-client/Cargo.toml
@@ -1,26 +1,21 @@
 [package]
-name = "talon-worker"
+name = "talon-client"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "Worker node: stores and serves cached object data for Talon"
+description = "CLI client that reads Talon cache objects via the coordinator + workers"
 
 [[bin]]
-name = "talon-worker"
+name = "talon-client"
 path = "src/main.rs"
 
 [dependencies]
 talon-core.workspace = true
 talon-transport.workspace = true
-talon-backend = { path = "../talon-backend" }
 anyhow.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-bytes.workspace = true
-async-trait.workspace = true
 clap.workspace = true
-xxhash-rust.workspace = true
-libc.workspace = true

--- a/crates/talon-client/src/main.rs
+++ b/crates/talon-client/src/main.rs
@@ -1,0 +1,182 @@
+//! Talon CLI client.
+//!
+//! Runs the same read path a FUSE mount would, without a kernel mount (this
+//! sandbox has no `/dev/fuse`):
+//!
+//! 1. Parse `/az/<container>/<blob>` into an [`ObjectId`].
+//! 2. Ask the coordinator (`PlacementLookup`) which worker owns the block.
+//! 3. Resolve that owner id to an address (`MembershipQuery`).
+//! 4. Send a data-plane [`RangeRequest`] to the worker and read the raw bytes.
+//!
+//! Prints byte count + elapsed time; writes the bytes to `--out` when given so
+//! the caller can `cmp` two reads for byte-exactness.
+
+use std::time::Instant;
+
+use clap::Parser;
+use talon_core::{BlockId, ObjectId, Version};
+use talon_transport::data::{self, RangeRequest};
+use talon_transport::frame::{Flags, HEADER_LEN};
+use talon_transport::{codec, ControlMessage, FrameHeader};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// Block size used only to compute the placement key (must match the worker's
+/// so HRW selects the same owner; with a single worker any value works).
+const PLACEMENT_BLOCK_SIZE: u32 = 256 << 20;
+/// Placeholder version matching the worker's block identity.
+const PLACEHOLDER_VERSION: &str = "e2e-v1";
+
+/// Command-line arguments for the Talon client.
+#[derive(Debug, Parser)]
+#[command(name = "talon-client", version, about)]
+struct Args {
+    /// Address of the coordinator to query for placement.
+    #[arg(long, default_value = "127.0.0.1:7000")]
+    coordinator: String,
+    /// Object path, e.g. `/az/<container>/<blob>`.
+    #[arg(long)]
+    path: String,
+    /// Byte offset to start reading at.
+    #[arg(long, default_value_t = 0)]
+    offset: u64,
+    /// Number of bytes to read.
+    #[arg(long)]
+    len: u64,
+    /// Optional output file for the fetched bytes.
+    #[arg(long)]
+    out: Option<std::path::PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let args = Args::parse();
+    let object = ObjectId::from_path(&args.path)?;
+    let block = BlockId::new(
+        object.clone(),
+        (args.offset / PLACEMENT_BLOCK_SIZE as u64) * PLACEMENT_BLOCK_SIZE as u64,
+        PLACEMENT_BLOCK_SIZE,
+        Version::new(PLACEHOLDER_VERSION),
+    );
+
+    // 1. Placement lookup: which worker owns this block?
+    let owners = placement_lookup(&args.coordinator, &block).await?;
+    let owner = owners
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("no worker owns this block (empty cluster?)"))?;
+    tracing::info!(owner = %owner, "resolved owner");
+
+    // 2. Resolve the owner id to a worker address.
+    let worker_addr = resolve_address(&args.coordinator, owner).await?;
+    tracing::info!(%worker_addr, "resolved worker address");
+
+    // 3. Fetch the range from the worker.
+    let start = Instant::now();
+    let bytes = fetch_range(&worker_addr, &object, args.offset, args.len).await?;
+    let elapsed = start.elapsed();
+
+    println!(
+        "read {} bytes from {} in {:.1?}",
+        bytes.len(),
+        worker_addr,
+        elapsed
+    );
+    if let Some(out) = &args.out {
+        tokio::fs::write(out, &bytes).await?;
+        println!("wrote {} bytes to {}", bytes.len(), out.display());
+    } else {
+        let n = bytes.len().min(64);
+        println!("first {n} bytes (hex): {}", hex_prefix(&bytes[..n]));
+    }
+    Ok(())
+}
+
+/// Send a `PlacementLookup` and return the ordered owner ids.
+async fn placement_lookup(coordinator: &str, block: &BlockId) -> anyhow::Result<Vec<String>> {
+    let req = ControlMessage::PlacementLookup {
+        block: block.clone(),
+        k: 1,
+    };
+    match request_control(coordinator, &req).await? {
+        ControlMessage::PlacementResponse { owners, .. } => {
+            Ok(owners.into_iter().map(|n| n.0).collect())
+        }
+        other => anyhow::bail!("unexpected placement reply: {other:?}"),
+    }
+}
+
+/// Send a `MembershipQuery` and resolve `owner_id` to its worker address.
+async fn resolve_address(coordinator: &str, owner_id: &str) -> anyhow::Result<String> {
+    match request_control(coordinator, &ControlMessage::MembershipQuery {}).await? {
+        ControlMessage::MembershipList { nodes } => nodes
+            .into_iter()
+            .find(|n| n.id.0 == owner_id)
+            .map(|n| n.address)
+            .ok_or_else(|| anyhow::anyhow!("owner {owner_id} not in membership list")),
+        other => anyhow::bail!("unexpected membership reply: {other:?}"),
+    }
+}
+
+/// Send a control request over a fresh connection and read one reply.
+async fn request_control(addr: &str, msg: &ControlMessage) -> anyhow::Result<ControlMessage> {
+    let mut stream = TcpStream::connect(addr).await?;
+    let buf = codec::encode(0, msg)?;
+    stream.write_all(&buf).await?;
+    stream.flush().await?;
+
+    let mut header_buf = [0u8; HEADER_LEN];
+    stream.read_exact(&mut header_buf).await?;
+    let header = FrameHeader::decode(&header_buf)?;
+    let mut payload = vec![0u8; header.length as usize];
+    stream.read_exact(&mut payload).await?;
+    let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
+    full.extend_from_slice(&header_buf);
+    full.extend_from_slice(&payload);
+    let (_h, reply) = codec::decode(&full)?;
+    Ok(reply)
+}
+
+/// Send a `RangeRequest` to a worker and read the raw response bytes.
+async fn fetch_range(
+    worker_addr: &str,
+    object: &ObjectId,
+    offset: u64,
+    len: u64,
+) -> anyhow::Result<Vec<u8>> {
+    let mut stream = TcpStream::connect(worker_addr).await?;
+    let req = RangeRequest {
+        object: object.clone(),
+        offset,
+        len,
+    };
+    let buf = data::encode_request(0, &req)?;
+    stream.write_all(&buf).await?;
+    stream.flush().await?;
+
+    let mut header_buf = [0u8; HEADER_LEN];
+    stream.read_exact(&mut header_buf).await?;
+    let header = FrameHeader::decode(&header_buf)?;
+    let mut payload = vec![0u8; header.length as usize];
+    stream.read_exact(&mut payload).await?;
+
+    if header.flags.contains(Flags::ERROR) {
+        anyhow::bail!("worker error: {}", String::from_utf8_lossy(&payload));
+    }
+    Ok(payload)
+}
+
+/// Render bytes as a space-free hex string.
+fn hex_prefix(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}

--- a/crates/talon-client/tests/control_path.rs
+++ b/crates/talon-client/tests/control_path.rs
@@ -1,0 +1,107 @@
+//! Integration test: the coordinator serve loop over real TCP.
+//!
+//! Launches the built `talon-coordinator` binary, registers a mock worker via
+//! the real control protocol, then exercises the two client-side lookups
+//! (`PlacementLookup` + `MembershipQuery`) and asserts the owner id resolves
+//! back to the worker's address. This covers the whole control path end-to-end
+//! without needing Azure credentials or a running worker/data plane.
+
+use std::process::{Child, Command};
+use std::time::Duration;
+
+use talon_core::{Backend, BlockId, NodeId, NodeInfo, NodeRole, ObjectId, Version};
+use talon_transport::frame::HEADER_LEN;
+use talon_transport::{codec, ControlMessage, FrameHeader};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// Kill the coordinator child on drop so a failing assert can't leak it.
+struct Killer(Child);
+impl Drop for Killer {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Locate the sibling `talon-coordinator` binary next to this test's target
+/// dir (`.../target/<profile>/deps/<test>` → `.../target/<profile>/`).
+fn coordinator_bin() -> std::path::PathBuf {
+    let mut dir = std::env::current_exe().unwrap();
+    dir.pop(); // drop test exe name
+    if dir.ends_with("deps") {
+        dir.pop();
+    }
+    let exe = if cfg!(windows) {
+        "talon-coordinator.exe"
+    } else {
+        "talon-coordinator"
+    };
+    dir.join(exe)
+}
+
+async fn round_trip(addr: &str, msg: &ControlMessage) -> ControlMessage {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let buf = codec::encode(0, msg).unwrap();
+    stream.write_all(&buf).await.unwrap();
+    stream.flush().await.unwrap();
+
+    let mut header_buf = [0u8; HEADER_LEN];
+    stream.read_exact(&mut header_buf).await.unwrap();
+    let header = FrameHeader::decode(&header_buf).unwrap();
+    let mut payload = vec![0u8; header.length as usize];
+    stream.read_exact(&mut payload).await.unwrap();
+    let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
+    full.extend_from_slice(&header_buf);
+    full.extend_from_slice(&payload);
+    codec::decode(&full).unwrap().1
+}
+
+#[tokio::test]
+async fn control_path_register_lookup_resolve() {
+    let addr = "127.0.0.1:7411";
+    let bin = coordinator_bin();
+    let child = Command::new(&bin).args(["--listen", addr]).spawn().unwrap();
+    let _killer = Killer(child);
+
+    // Wait for the listener to come up.
+    let mut connected = false;
+    for _ in 0..50 {
+        if TcpStream::connect(addr).await.is_ok() {
+            connected = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(connected, "coordinator did not start listening");
+
+    // A mock worker registers itself.
+    let node = NodeInfo {
+        id: NodeId::new("127.0.0.1:9999"),
+        address: "127.0.0.1:9999".into(),
+        role: NodeRole::Worker,
+    };
+    let ack = round_trip(addr, &ControlMessage::Register { node: node.clone() }).await;
+    assert!(matches!(ack, ControlMessage::Ack { ok: true, .. }));
+
+    // Placement lookup should now name our worker as the owner.
+    let block = BlockId::new(
+        ObjectId::new(Backend::Azure, "container", "path/blob.bin"),
+        0,
+        256 << 20,
+        Version::new("e2e-v1"),
+    );
+    let owners = match round_trip(addr, &ControlMessage::PlacementLookup { block, k: 1 }).await {
+        ControlMessage::PlacementResponse { owners, .. } => owners,
+        other => panic!("expected PlacementResponse, got {other:?}"),
+    };
+    assert_eq!(owners, vec![NodeId::new("127.0.0.1:9999")]);
+
+    // Membership query resolves that id back to the worker's address.
+    let nodes = match round_trip(addr, &ControlMessage::MembershipQuery {}).await {
+        ControlMessage::MembershipList { nodes } => nodes,
+        other => panic!("expected MembershipList, got {other:?}"),
+    };
+    let resolved = nodes.iter().find(|n| n.id == node.id).unwrap();
+    assert_eq!(resolved.address, "127.0.0.1:9999");
+}

--- a/crates/talon-coordinator/src/main.rs
+++ b/crates/talon-coordinator/src/main.rs
@@ -1,6 +1,18 @@
 //! Talon coordinator entry point.
+//!
+//! Runs the real control-plane serve loop: workers `Register` and `Heartbeat`,
+//! clients issue `PlacementLookup` and `MembershipQuery`. Each accepted
+//! connection carries one framed [`ControlMessage`] request and receives one
+//! framed reply (see [`talon_transport::codec`]).
+
+use std::sync::Arc;
 
 use clap::Parser;
+use talon_coordinator::{Membership, PlacementService, RendezvousPlacement};
+use talon_transport::frame::HEADER_LEN;
+use talon_transport::{codec, ControlMessage, FrameHeader};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
 
 /// Command-line arguments for the Talon coordinator.
 #[derive(Debug, Parser)]
@@ -9,6 +21,18 @@ struct Args {
     /// Address to bind the coordinator RPC service to.
     #[arg(long, default_value = "127.0.0.1:7000")]
     listen: String,
+}
+
+/// Shared coordinator state behind the serve loop.
+struct Coordinator {
+    service: PlacementService<RendezvousPlacement>,
+}
+
+impl Coordinator {
+    fn new() -> Arc<Self> {
+        let service = PlacementService::new(Membership::new(), RendezvousPlacement);
+        Arc::new(Self { service })
+    }
 }
 
 #[tokio::main]
@@ -22,7 +46,81 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     tracing::info!(listen = %args.listen, "starting talon-coordinator");
 
-    // TODO: start RPC server, membership gossip, and placement service.
+    let state = Coordinator::new();
 
-    Ok(())
+    let listener = TcpListener::bind(&args.listen).await?;
+    loop {
+        let (stream, peer) = listener.accept().await?;
+        let state = Arc::clone(&state);
+        tokio::spawn(async move {
+            if let Err(e) = handle_conn(stream, state).await {
+                tracing::debug!(%peer, error = %e, "coordinator: connection ended");
+            }
+        });
+    }
+}
+
+/// Read one framed control request, dispatch it, and write one framed reply.
+async fn handle_conn(mut stream: TcpStream, state: Arc<Coordinator>) -> anyhow::Result<()> {
+    loop {
+        let Some((_header, msg)) = read_control(&mut stream).await? else {
+            return Ok(()); // clean EOF
+        };
+        let reply = state.dispatch(msg);
+        let buf = codec::encode(0, &reply)?;
+        stream.write_all(&buf).await?;
+        stream.flush().await?;
+    }
+}
+
+impl Coordinator {
+    /// Handle one decoded control message, returning the reply message.
+    fn dispatch(&self, msg: ControlMessage) -> ControlMessage {
+        match msg {
+            ControlMessage::Register { node } => {
+                tracing::info!(id = %node.id, address = %node.address, "worker registered");
+                self.service.membership().register(node);
+                ControlMessage::Ack {
+                    ok: true,
+                    detail: None,
+                }
+            }
+            ControlMessage::Heartbeat { node, block_count } => {
+                tracing::debug!(%node, block_count, "heartbeat");
+                ControlMessage::Ack {
+                    ok: true,
+                    detail: None,
+                }
+            }
+            lookup @ ControlMessage::PlacementLookup { .. } => self.service.handle(lookup),
+            ControlMessage::MembershipQuery {} => ControlMessage::MembershipList {
+                nodes: self.service.membership().snapshot(),
+            },
+            other => ControlMessage::Ack {
+                ok: false,
+                detail: Some(format!("unexpected control message: {other:?}")),
+            },
+        }
+    }
+}
+
+/// Read a full framed control message (header + payload). `Ok(None)` on clean
+/// EOF before any bytes of a new frame.
+async fn read_control(
+    stream: &mut TcpStream,
+) -> anyhow::Result<Option<(FrameHeader, ControlMessage)>> {
+    let mut header_buf = [0u8; HEADER_LEN];
+    match stream.read_exact(&mut header_buf).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e.into()),
+    }
+    let header = FrameHeader::decode(&header_buf)?;
+    let mut payload = vec![0u8; header.length as usize];
+    stream.read_exact(&mut payload).await?;
+    let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
+    full.extend_from_slice(&header_buf);
+    full.extend_from_slice(&payload);
+    let (h, msg) = codec::decode(&full)?;
+    Ok(Some((h, msg)))
 }

--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -45,6 +45,23 @@ pub struct WorkerConfig {
     pub cache_dirs: Vec<PathBuf>,
     /// Total cache capacity in bytes across all cache dirs.
     pub capacity_bytes: u64,
+    /// Azure Blob storage account for the backend origin (`None` if unset).
+    ///
+    /// The container is taken per-object from the request path; the SAS token is
+    /// **not** stored here — it is read from the environment at use time (see
+    /// [`azure_sas_from_env`]) so a secret never lands in a config struct or log.
+    pub azure_account: Option<String>,
+}
+
+/// Read the Azure SAS token from the environment (`TALON_WORKER_AZURE_SAS`).
+///
+/// Returned as an opaque string and intended for immediate use; it is
+/// deliberately kept out of [`WorkerConfig`] so it is never serialized, printed
+/// via `Debug`, or logged.
+pub fn azure_sas_from_env() -> Option<String> {
+    std::env::var("TALON_WORKER_AZURE_SAS")
+        .ok()
+        .filter(|s| !s.is_empty())
 }
 
 impl Default for WorkerConfig {
@@ -55,6 +72,7 @@ impl Default for WorkerConfig {
             block_size: 256 << 20,
             cache_dirs: vec![PathBuf::from("/var/cache/talon")],
             capacity_bytes: 64 << 30,
+            azure_account: None,
         }
     }
 }
@@ -76,6 +94,8 @@ pub struct WorkerConfigPatch {
     pub cache_dirs: Option<Vec<PathBuf>>,
     /// Override for [`WorkerConfig::capacity_bytes`].
     pub capacity_bytes: Option<u64>,
+    /// Override for [`WorkerConfig::azure_account`].
+    pub azure_account: Option<String>,
 }
 
 impl Patch for WorkerConfigPatch {
@@ -86,6 +106,7 @@ impl Patch for WorkerConfigPatch {
             block_size: self.block_size.or(base.block_size),
             cache_dirs: self.cache_dirs.or(base.cache_dirs),
             capacity_bytes: self.capacity_bytes.or(base.capacity_bytes),
+            azure_account: self.azure_account.or(base.azure_account),
         }
     }
 }
@@ -136,6 +157,7 @@ impl WorkerConfigPatch {
             capacity_bytes: get("TALON_WORKER_CAPACITY_BYTES")
                 .map(|v| parse_u64(v, "TALON_WORKER_CAPACITY_BYTES"))
                 .transpose()?,
+            azure_account: get("TALON_WORKER_AZURE_ACCOUNT"),
         })
     }
 }
@@ -160,6 +182,7 @@ impl WorkerConfig {
             block_size: merged.block_size.unwrap_or(d.block_size),
             cache_dirs: merged.cache_dirs.unwrap_or(d.cache_dirs),
             capacity_bytes: merged.capacity_bytes.unwrap_or(d.capacity_bytes),
+            azure_account: merged.azure_account.or(d.azure_account),
         };
         cfg.validate()?;
         Ok(cfg)

--- a/crates/talon-core/src/lib.rs
+++ b/crates/talon-core/src/lib.rs
@@ -15,7 +15,7 @@ pub mod trace;
 
 pub use backend::{BackendStore, ObjectStat};
 pub use block::{BlockForm, BlockMeta, LoadHint, PresentBitmap};
-pub use config::{Patch, WorkerConfig, WorkerConfigPatch};
+pub use config::{azure_sas_from_env, Patch, WorkerConfig, WorkerConfigPatch};
 pub use error::{Error, Result};
 pub use key::{Backend, BlockId, ObjectId, PageIndex, Version};
 pub use metrics::{Counter, Gauge, Histogram, Metrics};

--- a/crates/talon-transport/src/codec.rs
+++ b/crates/talon-transport/src/codec.rs
@@ -69,6 +69,16 @@ pub enum ControlMessage {
         /// The new epoch value.
         epoch: u64,
     },
+    /// Client → coordinator: list the currently-known live nodes.
+    ///
+    /// A placement lookup returns owner [`NodeId`]s; the client resolves those
+    /// ids to worker addresses with this query.
+    MembershipQuery {},
+    /// Coordinator → client: the current membership snapshot (id + address).
+    MembershipList {
+        /// All nodes the coordinator currently knows about.
+        nodes: Vec<NodeInfo>,
+    },
     /// Generic acknowledgement / error reply.
     Ack {
         /// True on success; false carries `detail`.
@@ -197,6 +207,10 @@ mod tests {
                 len: 1 << 20,
             },
             ControlMessage::EpochBump { epoch: 8 },
+            ControlMessage::MembershipQuery {},
+            ControlMessage::MembershipList {
+                nodes: vec![node.clone()],
+            },
             ControlMessage::Ack {
                 ok: false,
                 detail: Some("nope".into()),

--- a/crates/talon-transport/src/data.rs
+++ b/crates/talon-transport/src/data.rs
@@ -1,0 +1,157 @@
+//! Data-plane range request/response framing.
+//!
+//! Unlike the control plane (a bincode [`ControlMessage`](crate::ControlMessage)
+//! envelope), a data-plane fetch is a [`MsgType::GetRange`] frame whose payload
+//! is a small bincode [`RangeRequest`] naming the object + byte range. The
+//! worker replies with a `GetRange` frame carrying the **raw bytes** of the
+//! range (no envelope), or the [`Flags::ERROR`] bit set and a UTF-8 error string
+//! as the payload.
+//!
+//! Keeping the request body tiny and the response body raw means the hot read
+//! path can be served straight from a file (`sendfile`) in production; this
+//! module only handles the request encode/decode and the response header shape.
+
+use serde::{Deserialize, Serialize};
+use talon_core::ObjectId;
+
+use crate::frame::{Flags, FrameError, FrameHeader, MsgType, HEADER_LEN};
+
+/// A client→worker request to read `[offset, offset+len)` of an object.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RangeRequest {
+    /// The source object whose bytes are requested.
+    pub object: ObjectId,
+    /// Byte offset within the object to start reading at.
+    pub offset: u64,
+    /// Number of bytes to read.
+    pub len: u64,
+}
+
+/// Errors from data-plane range encode/decode.
+#[derive(Debug, thiserror::Error)]
+pub enum DataError {
+    /// The framing header was invalid.
+    #[error("frame error: {0}")]
+    Frame(#[from] FrameError),
+    /// A non-`GetRange` frame was handed to the data codec.
+    #[error("expected a GetRange frame, got {0:?}")]
+    NotGetRange(MsgType),
+    /// The header's declared length did not match the available payload bytes.
+    #[error("length mismatch: header says {declared}, have {actual}")]
+    LengthMismatch {
+        /// Length advertised by the frame header.
+        declared: usize,
+        /// Bytes actually present after the header.
+        actual: usize,
+    },
+    /// bincode failed to (de)serialize the request body.
+    #[error("bincode error: {0}")]
+    Bincode(#[from] bincode::Error),
+}
+
+/// Encode a [`RangeRequest`] into `header || bincode(req)`.
+pub fn encode_request(request_id: u32, req: &RangeRequest) -> Result<Vec<u8>, DataError> {
+    let body = bincode::serialize(req)?;
+    let header = FrameHeader::new(MsgType::GetRange, request_id, body.len() as u32);
+    let mut buf = Vec::with_capacity(HEADER_LEN + body.len());
+    buf.extend_from_slice(&header.encode());
+    buf.extend_from_slice(&body);
+    Ok(buf)
+}
+
+/// Decode a framed [`RangeRequest`] buffer into its header and request.
+pub fn decode_request(buf: &[u8]) -> Result<(FrameHeader, RangeRequest), DataError> {
+    let header = FrameHeader::decode(buf)?;
+    if header.msg_type != MsgType::GetRange {
+        return Err(DataError::NotGetRange(header.msg_type));
+    }
+    let declared = header.length as usize;
+    let body = &buf[HEADER_LEN..];
+    if body.len() != declared {
+        return Err(DataError::LengthMismatch {
+            declared,
+            actual: body.len(),
+        });
+    }
+    let req: RangeRequest = bincode::deserialize(body)?;
+    Ok((header, req))
+}
+
+/// Build a successful data response header for `len` raw payload bytes.
+///
+/// The caller writes this 16-byte header followed by exactly `len` bytes (the
+/// range contents).
+pub fn response_header_ok(request_id: u32, len: u32) -> [u8; HEADER_LEN] {
+    FrameHeader::new(MsgType::GetRange, request_id, len).encode()
+}
+
+/// Build an error response header + body (`ERROR` flag set, UTF-8 message).
+pub fn encode_error(request_id: u32, message: &str) -> Vec<u8> {
+    let body = message.as_bytes();
+    let mut header = FrameHeader::new(MsgType::GetRange, request_id, body.len() as u32);
+    header.flags = Flags(Flags::ERROR);
+    let mut buf = Vec::with_capacity(HEADER_LEN + body.len());
+    buf.extend_from_slice(&header.encode());
+    buf.extend_from_slice(body);
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use talon_core::Backend;
+
+    fn req() -> RangeRequest {
+        RangeRequest {
+            object: ObjectId::new(Backend::Azure, "container", "path/to/blob.bin"),
+            offset: 1 << 20,
+            len: 4096,
+        }
+    }
+
+    #[test]
+    fn request_round_trips() {
+        let buf = encode_request(11, &req()).unwrap();
+        let (header, back) = decode_request(&buf).unwrap();
+        assert_eq!(header.msg_type, MsgType::GetRange);
+        assert_eq!(header.request_id, 11);
+        assert_eq!(back, req());
+    }
+
+    #[test]
+    fn non_get_range_frame_rejected() {
+        let mut buf = FrameHeader::new(MsgType::Control, 0, 0).encode().to_vec();
+        buf.truncate(HEADER_LEN);
+        assert!(matches!(
+            decode_request(&buf),
+            Err(DataError::NotGetRange(MsgType::Control))
+        ));
+    }
+
+    #[test]
+    fn truncated_body_rejected() {
+        let mut buf = encode_request(1, &req()).unwrap();
+        buf.pop();
+        assert!(matches!(
+            decode_request(&buf),
+            Err(DataError::LengthMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn error_response_sets_error_flag() {
+        let buf = encode_error(7, "boom");
+        let header = FrameHeader::decode(&buf).unwrap();
+        assert!(header.flags.contains(Flags::ERROR));
+        assert_eq!(header.request_id, 7);
+        assert_eq!(&buf[HEADER_LEN..], b"boom");
+    }
+
+    #[test]
+    fn ok_response_header_declares_len() {
+        let h = response_header_ok(3, 8192);
+        let header = FrameHeader::decode(&h).unwrap();
+        assert_eq!(header.length, 8192);
+        assert!(!header.flags.contains(Flags::ERROR));
+    }
+}

--- a/crates/talon-transport/src/lib.rs
+++ b/crates/talon-transport/src/lib.rs
@@ -11,11 +11,15 @@
 //! See [`frame`] for the byte layout.
 
 pub mod codec;
+pub mod data;
 pub mod frame;
 pub mod pool;
 pub mod runtime;
 
 pub use codec::{decode, encode, CodecError, ControlMessage, CONTROL_SCHEMA_VERSION};
+pub use data::{
+    decode_request, encode_error, encode_request, response_header_ok, DataError, RangeRequest,
+};
 pub use frame::{Flags, FrameError, FrameHeader, MsgType, HEADER_LEN, MAGIC, PROTOCOL_VERSION};
 pub use pool::{Channel, CheckoutError, Connector, Pool, PoolConfig};
 pub use runtime::{spawn_blocking, Handler, Server, Shutdown};

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -1,28 +1,58 @@
 //! Talon worker entry point.
+//!
+//! Registers with the coordinator, then serves data-plane range requests. On a
+//! miss it fetches the block-aligned range from the configured Azure backend
+//! over real HTTPS, commits it durably to the local block store, and serves the
+//! requested sub-range. A subsequent request for the same block is a local hit.
+//!
+//! # Wiring
+//!
+//! - Control plane (register/heartbeat) reuses [`talon_transport::codec`].
+//! - Data plane uses [`talon_transport::data`]: a [`RangeRequest`] in, raw bytes
+//!   (or an `ERROR`-flagged frame) out.
+//! - Backend fetch is the real [`AzureBackend`] over [`ReqwestClient`]; the SAS
+//!   token is read from the environment and **never logged**.
+//!
+//! The response returns bytes inline for simplicity; the production hot path
+//! serves them zero-copy via `sendfile` from the committed block file
+//! ([`send_file_range`](talon_worker::send_file_range)).
+
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use clap::Parser;
-use std::path::PathBuf;
-use talon_core::{WorkerConfig, WorkerConfigPatch};
+use talon_backend::{AzureBackend, AzureConfig, ReqwestClient};
+use talon_core::{
+    azure_sas_from_env, BackendStore, BlockForm, BlockId, BlockMeta, NodeId, NodeInfo, NodeRole,
+    ObjectId, ObjectStore, PageIndex, Version, WorkerConfig, WorkerConfigPatch,
+};
+use talon_transport::data::{self, RangeRequest};
+use talon_transport::frame::{MsgType, HEADER_LEN};
+use talon_transport::{codec, ControlMessage, FrameHeader};
+use talon_worker::{BlockIndex, InFlightLoads, LoadKey, Presence, WholeBlockStore};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Fixed placeholder version used for block identity in this single-worker e2e.
+///
+/// A production worker would carry the object's real etag (from a coordinator
+/// `HEAD`) so a source overwrite invalidates the key. Here client and worker
+/// agree on a constant so the client need not hold Azure credentials.
+const PLACEHOLDER_VERSION: &str = "e2e-v1";
 
 /// Command-line arguments for a Talon worker.
-///
-/// Flags are the highest-precedence configuration layer (CLI > env > file >
-/// default). Unset flags fall through to the lower layers.
 #[derive(Debug, Parser)]
 #[command(name = "talon-worker", version, about)]
 struct Args {
     /// Path to a TOML config file.
     #[arg(long)]
     config: Option<PathBuf>,
-
     /// Address to bind the worker RPC service to.
     #[arg(long)]
     listen: Option<String>,
-
     /// Address of the coordinator to register with.
     #[arg(long)]
     coordinator: Option<String>,
-
     /// Logical block size in bytes.
     #[arg(long)]
     block_size: Option<u32>,
@@ -36,8 +66,18 @@ impl Args {
             block_size: self.block_size,
             cache_dirs: None,
             capacity_bytes: None,
+            azure_account: None,
         }
     }
+}
+
+/// Everything a request handler needs, shared across connections.
+struct Worker {
+    store: WholeBlockStore,
+    index: BlockIndex,
+    inflight: InFlightLoads,
+    backend: Arc<dyn BackendStore>,
+    block_size: u32,
 }
 
 #[tokio::main]
@@ -49,7 +89,6 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let args = Args::parse();
-
     let file = match &args.config {
         Some(path) => WorkerConfigPatch::from_file(path)?,
         None => WorkerConfigPatch::default(),
@@ -64,10 +103,247 @@ async fn main() -> anyhow::Result<()> {
         block_size = cfg.block_size,
         cache_dirs = ?cfg.cache_dirs,
         capacity_bytes = cfg.capacity_bytes,
+        azure_account = ?cfg.azure_account,
         "starting talon-worker"
     );
 
-    // TODO: register with coordinator and serve the object store over RPC.
+    // Build the Azure backend from account (config/env) + SAS (env only).
+    let account = cfg.azure_account.clone().ok_or_else(|| {
+        anyhow::anyhow!("azure_account is required (set TALON_WORKER_AZURE_ACCOUNT)")
+    })?;
+    let sas = azure_sas_from_env()
+        .ok_or_else(|| anyhow::anyhow!("TALON_WORKER_AZURE_SAS must be set (SAS token)"))?;
+    let http = Arc::new(ReqwestClient::new());
+    let backend: Arc<dyn BackendStore> = Arc::new(AzureBackend::new(
+        AzureConfig::new(account),
+        Some(sas),
+        http,
+    ));
 
+    // Local store stack rooted at the first cache dir.
+    let root = cfg
+        .cache_dirs
+        .first()
+        .cloned()
+        .unwrap_or_else(|| PathBuf::from("/tmp/talon-cache"));
+    std::fs::create_dir_all(&root)?;
+    let store = WholeBlockStore::open(&root)?;
+
+    let worker = Arc::new(Worker {
+        store,
+        index: BlockIndex::new(),
+        inflight: InFlightLoads::new(),
+        backend,
+        block_size: cfg.block_size,
+    });
+
+    // Register with the coordinator and start a heartbeat task.
+    let node = NodeInfo {
+        id: NodeId::new(cfg.listen.clone()),
+        address: cfg.listen.clone(),
+        role: NodeRole::Worker,
+    };
+    register_with_coordinator(&cfg.coordinator, &node).await?;
+    spawn_heartbeat(
+        cfg.coordinator.clone(),
+        node.id.clone(),
+        Arc::clone(&worker),
+    );
+
+    // Serve the data plane.
+    let listener = TcpListener::bind(&cfg.listen).await?;
+    tracing::info!(listen = %cfg.listen, "worker serving data plane");
+    loop {
+        let (stream, peer) = listener.accept().await?;
+        let worker = Arc::clone(&worker);
+        tokio::spawn(async move {
+            if let Err(e) = handle_conn(stream, worker).await {
+                tracing::debug!(%peer, error = %e, "worker: connection ended");
+            }
+        });
+    }
+}
+
+/// Open a control connection to the coordinator and send `Register`.
+async fn register_with_coordinator(coordinator: &str, node: &NodeInfo) -> anyhow::Result<()> {
+    let mut stream = TcpStream::connect(coordinator).await?;
+    let buf = codec::encode(0, &ControlMessage::Register { node: node.clone() })?;
+    stream.write_all(&buf).await?;
+    stream.flush().await?;
+    // Read the Ack (best-effort).
+    if let Some(ControlMessage::Ack { ok, detail }) = read_control(&mut stream).await? {
+        if !ok {
+            anyhow::bail!("coordinator rejected registration: {detail:?}");
+        }
+    }
+    tracing::info!(%coordinator, "registered with coordinator");
     Ok(())
+}
+
+/// Periodically send a `Heartbeat` with the current resident block count.
+fn spawn_heartbeat(coordinator: String, node: NodeId, worker: Arc<Worker>) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(std::time::Duration::from_secs(5));
+        loop {
+            ticker.tick().await;
+            let block_count = worker.index.len() as u64;
+            let msg = ControlMessage::Heartbeat {
+                node: node.clone(),
+                block_count,
+            };
+            if let Err(e) = send_oneshot(&coordinator, &msg).await {
+                tracing::debug!(error = %e, "heartbeat send failed");
+            }
+        }
+    });
+}
+
+/// Connect, send one control message, and drop (fire-and-forget over TCP).
+async fn send_oneshot(addr: &str, msg: &ControlMessage) -> anyhow::Result<()> {
+    let mut stream = TcpStream::connect(addr).await?;
+    let buf = codec::encode(0, msg)?;
+    stream.write_all(&buf).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+/// Serve data-plane range requests on one connection until EOF.
+async fn handle_conn(mut stream: TcpStream, worker: Arc<Worker>) -> anyhow::Result<()> {
+    loop {
+        let mut header_buf = [0u8; HEADER_LEN];
+        match stream.read_exact(&mut header_buf).await {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(()),
+            Err(e) => return Err(e.into()),
+        }
+        let header = FrameHeader::decode(&header_buf)?;
+        let mut payload = vec![0u8; header.length as usize];
+        stream.read_exact(&mut payload).await?;
+
+        if header.msg_type != MsgType::GetRange {
+            let err = data::encode_error(header.request_id, "worker only serves GetRange");
+            stream.write_all(&err).await?;
+            stream.flush().await?;
+            continue;
+        }
+
+        let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
+        full.extend_from_slice(&header_buf);
+        full.extend_from_slice(&payload);
+        let (h, req) = match data::decode_request(&full) {
+            Ok(v) => v,
+            Err(e) => {
+                let err = data::encode_error(header.request_id, &format!("bad request: {e}"));
+                stream.write_all(&err).await?;
+                stream.flush().await?;
+                continue;
+            }
+        };
+
+        match worker.serve_range(&req).await {
+            Ok(bytes) => {
+                let hdr = data::response_header_ok(h.request_id, bytes.len() as u32);
+                stream.write_all(&hdr).await?;
+                stream.write_all(&bytes).await?;
+                stream.flush().await?;
+            }
+            Err(e) => {
+                let err = data::encode_error(h.request_id, &e.to_string());
+                stream.write_all(&err).await?;
+                stream.flush().await?;
+            }
+        }
+    }
+}
+
+impl Worker {
+    /// The block-aligned [`BlockId`] that contains `offset` of `object`.
+    fn block_for(&self, object: &ObjectId, offset: u64) -> BlockId {
+        let bs = self.block_size as u64;
+        let block_start = (offset / bs) * bs;
+        BlockId::new(
+            object.clone(),
+            block_start,
+            self.block_size,
+            Version::new(PLACEHOLDER_VERSION),
+        )
+    }
+
+    /// Serve `[offset, offset+len)` of `object`: local hit, or miss→Azure→commit.
+    async fn serve_range(&self, req: &RangeRequest) -> anyhow::Result<bytes::Bytes> {
+        let block = self.block_for(&req.object, req.offset);
+        let offset_in_block = req.offset - block.offset;
+
+        // Hit path: whole block already resident.
+        if matches!(
+            self.index.presence(&block, PageIndex(0), PageIndex(1)),
+            Presence::Whole
+        ) {
+            tracing::info!(block = %block, "HIT");
+            let bytes = self
+                .store
+                .get_bytes(&block)
+                .await
+                .map_err(|e| anyhow::anyhow!("read committed block: {e}"))?;
+            return slice(&bytes, offset_in_block, req.len);
+        }
+
+        // Miss path: fetch the block-aligned range once, commit, then serve.
+        tracing::info!(block = %block, "MISS -> Azure fetch");
+        let key = LoadKey::Whole(block.clone());
+        // Dedup marker for observability; a real herd would coordinate on this.
+        let _ = self.inflight.admit(key.clone());
+
+        let fetch_len = self.block_size as u64; // whole block-aligned range
+        let fetched = self
+            .backend
+            .fetch_range(&req.object, block.offset, fetch_len)
+            .await;
+        self.inflight.complete(&key);
+        let bytes = fetched?;
+
+        // Commit durably via the store's atomic write (temp file + fsync +
+        // rename), then register the block so future reads are hits.
+        self.store
+            .put(&block, bytes.clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("commit block failed: {e}"))?;
+        self.index.commit(BlockMeta {
+            id: block.clone(),
+            form: BlockForm::Whole,
+            len: bytes.len() as u64,
+        });
+        tracing::info!(block = %block, bytes = bytes.len(), "committed block");
+
+        // Serve the requested sub-range from the freshly fetched bytes.
+        slice(&bytes, offset_in_block, req.len)
+    }
+}
+
+/// Slice `[offset, offset+len)` out of `buf`, clamping `len` to what is present.
+fn slice(buf: &[u8], offset: u64, len: u64) -> anyhow::Result<bytes::Bytes> {
+    let start = offset as usize;
+    if start > buf.len() {
+        anyhow::bail!("offset {offset} beyond block length {} bytes", buf.len());
+    }
+    let end = (start + len as usize).min(buf.len());
+    Ok(bytes::Bytes::copy_from_slice(&buf[start..end]))
+}
+
+/// Read one framed control message (header + payload). `Ok(None)` on clean EOF.
+async fn read_control(stream: &mut TcpStream) -> anyhow::Result<Option<ControlMessage>> {
+    let mut header_buf = [0u8; HEADER_LEN];
+    match stream.read_exact(&mut header_buf).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e.into()),
+    }
+    let header = FrameHeader::decode(&header_buf)?;
+    let mut payload = vec![0u8; header.length as usize];
+    stream.read_exact(&mut payload).await?;
+    let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
+    full.extend_from_slice(&header_buf);
+    full.extend_from_slice(&payload);
+    let (_h, msg) = codec::decode(&full)?;
+    Ok(Some(msg))
 }

--- a/scripts/e2e_azure.sh
+++ b/scripts/e2e_azure.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# End-to-end run: coordinator + worker (real Azure) + client.
+#
+# Prereqs (your Azure account — never committed, never logged):
+#   export TALON_WORKER_AZURE_ACCOUNT=<storage-account>
+#   export TALON_WORKER_AZURE_SAS='<container-scoped SAS query string, no leading ?>'
+#   export TALON_BLOB_PATH=/az/<container>/<blob>      # object to read
+#   export TALON_READ_LEN=1048576                       # bytes to read (default 1 MiB)
+#
+# Proves: first read = MISS -> Azure fetch -> commit; second read = HIT (faster);
+# both reads byte-identical; and (if curl available) matches an independent
+# Azure ranged GET.
+set -euo pipefail
+
+: "${TALON_WORKER_AZURE_ACCOUNT:?set TALON_WORKER_AZURE_ACCOUNT}"
+: "${TALON_WORKER_AZURE_SAS:?set TALON_WORKER_AZURE_SAS}"
+: "${TALON_BLOB_PATH:?set TALON_BLOB_PATH, e.g. /az/mycontainer/data.bin}"
+LEN="${TALON_READ_LEN:-1048576}"
+COORD_ADDR="127.0.0.1:7000"
+WORKER_ADDR="127.0.0.1:7001"
+CACHE_DIR="$(mktemp -d /tmp/talon-cache.XXXXXX)"
+
+cd "$(dirname "$0")/.."
+cargo build --workspace --bins
+
+cleanup() { kill "${COORD_PID:-}" "${WORKER_PID:-}" 2>/dev/null || true; }
+trap cleanup EXIT
+
+./target/debug/talon-coordinator --listen "$COORD_ADDR" >/tmp/talon-coord.log 2>&1 &
+COORD_PID=$!
+sleep 1
+
+TALON_WORKER_CACHE_DIRS="$CACHE_DIR" \
+  ./target/debug/talon-worker \
+  --listen "$WORKER_ADDR" --coordinator "$COORD_ADDR" --block-size 268435456 \
+  >/tmp/talon-worker.log 2>&1 &
+WORKER_PID=$!
+sleep 1
+
+echo "### First read (expect MISS -> Azure fetch -> commit)"
+./target/debug/talon-client --coordinator "$COORD_ADDR" \
+  --path "$TALON_BLOB_PATH" --offset 0 --len "$LEN" --out /tmp/talon-a.bin
+
+echo "### Second read (expect HIT, faster)"
+./target/debug/talon-client --coordinator "$COORD_ADDR" \
+  --path "$TALON_BLOB_PATH" --offset 0 --len "$LEN" --out /tmp/talon-b.bin
+
+echo "### Verify both reads are byte-identical"
+cmp /tmp/talon-a.bin /tmp/talon-b.bin && echo "OK: reads identical"
+
+echo "### Worker log (should show one MISS then one HIT; no SAS token present)"
+grep -E "MISS|HIT|committed" /tmp/talon-worker.log || true
+if grep -q "$TALON_WORKER_AZURE_SAS" /tmp/talon-worker.log; then
+  echo "FAIL: SAS token leaked into worker log" >&2; exit 1
+else
+  echo "OK: SAS token absent from worker log"
+fi
+
+# Optional independent cross-check against Azure directly.
+if command -v curl >/dev/null; then
+  CONTAINER_BLOB="${TALON_BLOB_PATH#/az/}"
+  URL="https://${TALON_WORKER_AZURE_ACCOUNT}.blob.core.windows.net/${CONTAINER_BLOB}?${TALON_WORKER_AZURE_SAS}"
+  END=$((LEN - 1))
+  curl -s -H "x-ms-range: bytes=0-${END}" -H "x-ms-version: 2021-12-02" "$URL" -o /tmp/talon-ref.bin
+  cmp /tmp/talon-a.bin /tmp/talon-ref.bin && echo "OK: matches independent Azure GET"
+fi
+
+echo "### Done."


### PR DESCRIPTION
## Summary
Turns the three parse-and-exit daemon stubs into a working cross-process read path, driven end-to-end against **real Azure Blob Storage**.

- **coordinator** serves the control plane: `Register` / `Heartbeat` / `PlacementLookup` / `MembershipQuery` over real TCP (reuses `PlacementService`, `Membership`, `RendezvousPlacement`).
- **worker** registers with the coordinator, heartbeats, and serves data-plane `RangeRequest`s: local **HIT** from the block store, or **MISS → Azure `fetch_range` over HTTPS → durable commit (`WholeBlockStore::put`, fsync+rename) → serve**.
- **talon-client** (new binary): runs the same read path a FUSE mount would (mapping → placement lookup → membership resolution → worker `GetRange`), since this sandbox has no `/dev/fuse`.
- **talon-backend**: new concrete `ReqwestClient` (rustls) implementing `HttpClient` — first real networked client (backends were mock-only).
- **talon-core**: `azure_account` config + `azure_sas_from_env`; the **SAS token is env-only and never logged/serialized**.
- **talon-transport**: additive `MembershipQuery`/`MembershipList` control messages + data-plane `RangeRequest` framing (`data.rs`), with round-trip tests.

## Design notes
- Each daemon uses a small dedicated async accept loop (reusing `frame`/`codec`) rather than the sync `runtime::Handler`, because the worker must `await` the Azure fetch.
- RF=1 single-worker; block identity uses a fixed placeholder version so the client needs no Azure creds to compute the placement key.
- Data is returned inline (framed bytes); the `sendfile` zero-copy path remains the production optimization (already unit-tested).

## Test plan
- [x] `cargo build/test/clippy/doc` green across the workspace (17 test binaries pass; clippy `-D warnings` + `RUSTDOCFLAGS=-D warnings` clean)
- [x] New `data.rs` round-trip tests + new control-message variants covered
- [x] **Control path integration test over real TCP** (`crates/talon-client/tests/control_path.rs`): launches the real `talon-coordinator` binary, registers a mock worker, and asserts `PlacementLookup` + `MembershipQuery` resolve the owner id back to its address
- [x] Worker credential validation: clean error (no panic) when account/SAS unset; SAS never appears in logs
- [ ] **Live Azure leg** (requires caller's account/SAS — not available in CI/sandbox): run `scripts/e2e_azure.sh` with `TALON_WORKER_AZURE_ACCOUNT`, `TALON_WORKER_AZURE_SAS`, `TALON_BLOB_PATH` set. Asserts MISS-then-HIT, byte-identical reads, and a match against an independent `curl` ranged GET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)