### PR TITLE
fix(coordinator): seed placement epoch from wall clock across restarts

### DIFF
--- a/crates/talon-coordinator/src/membership.rs
+++ b/crates/talon-coordinator/src/membership.rs
@@ -17,21 +17,43 @@ use talon_core::{NodeId, NodeInfo};
 use crate::Epoch;
 
 /// An in-memory registry of known cluster nodes, versioned by an epoch.
-#[derive(Default)]
 pub struct Membership {
     inner: RwLock<Inner>,
 }
 
-#[derive(Default)]
+impl Default for Membership {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 struct Inner {
     nodes: HashMap<NodeId, NodeInfo>,
     epoch: Epoch,
 }
 
 impl Membership {
-    /// Create an empty membership registry at epoch 0.
+    /// Create an empty membership registry seeded from the process start time.
+    ///
+    /// The epoch base comes from [`Epoch::seeded_now`] rather than `0` so that
+    /// this coordinator's epochs outrank any earlier process's, keeping client
+    /// placement caches correct across a coordinator restart (issue #69).
     pub fn new() -> Self {
-        Self::default()
+        Self::with_epoch_base(Epoch::seeded_now())
+    }
+
+    /// Create an empty registry starting at a specific epoch base.
+    ///
+    /// Production uses [`Membership::new`] (wall-clock seed); this constructor
+    /// lets tests pin a deterministic base (e.g. `Epoch(0)`) or simulate a
+    /// restart by seeding a second instance at a strictly larger base.
+    pub fn with_epoch_base(base: Epoch) -> Self {
+        Self {
+            inner: RwLock::new(Inner {
+                nodes: HashMap::new(),
+                epoch: base,
+            }),
+        }
     }
 
     /// Register or update a node. Bumps the epoch if this changed the set.
@@ -158,7 +180,9 @@ mod tests {
 
     #[test]
     fn reconcile_bumps_epoch_only_on_change() {
-        let m = Membership::new();
+        // Pin a deterministic base so we can assert exact epoch values; the
+        // +1-on-change semantics are what matter here, not the base.
+        let m = Membership::with_epoch_base(Epoch(0));
         assert_eq!(m.epoch(), Epoch(0));
 
         assert!(m.reconcile(vec![worker("a", "1"), worker("b", "2")]));
@@ -181,7 +205,7 @@ mod tests {
 
     #[test]
     fn register_and_remove_track_epoch() {
-        let m = Membership::new();
+        let m = Membership::with_epoch_base(Epoch(0));
         m.register(worker("a", "1"));
         assert_eq!(m.epoch(), Epoch(1));
         // Re-register identical -> no change.
@@ -191,6 +215,38 @@ mod tests {
         assert_eq!(m.epoch(), Epoch(2));
         m.remove(&NodeId::new("a")); // absent -> no bump
         assert_eq!(m.epoch(), Epoch(2));
+    }
+
+    #[test]
+    fn new_seeds_nonzero_epoch_base() {
+        // A production Membership seeds from the wall clock, so its base is far
+        // above 0 and — critically — above the low-counter range a prior
+        // process would have reached (issue #69).
+        let m = Membership::new();
+        assert!(m.epoch().0 > 0, "epoch base must be seeded, not 0");
+        // The seed lives in the high 32 bits; the low counter starts at 0.
+        assert_eq!(m.epoch().0 & 0xFFFF_FFFF, 0);
+    }
+
+    #[test]
+    fn restarted_coordinator_outranks_prior_process() {
+        // Simulate: an earlier process seeded at second T1 that then churned
+        // through many membership changes, vs. a later process seeded at a
+        // strictly greater second T2. The later process's *initial* epoch must
+        // already exceed the earlier one's *final* epoch, so clients refresh.
+        let t1 = 1_000u64;
+        let t2 = 1_001u64; // one second later
+        let old = Membership::with_epoch_base(Epoch(t1 << 32));
+        for i in 0..10_000 {
+            old.register(worker(&format!("w{i}"), "a"));
+        }
+        let new = Membership::with_epoch_base(Epoch(t2 << 32));
+        assert!(
+            new.epoch() > old.epoch(),
+            "restarted coordinator epoch {:?} must outrank prior {:?}",
+            new.epoch(),
+            old.epoch()
+        );
     }
 
     #[test]
@@ -210,7 +266,7 @@ mod tests {
             })
         });
 
-        let m = Membership::new();
+        let m = Membership::with_epoch_base(Epoch(0));
 
         assert!(m.reconcile(source.poll().unwrap()));
         assert_eq!(m.snapshot().len(), 1);

--- a/crates/talon-coordinator/src/placement.rs
+++ b/crates/talon-coordinator/src/placement.rs
@@ -14,6 +14,27 @@ use talon_core::{BlockId, NodeId, NodeInfo};
 ///
 /// The coordinator bumps the epoch whenever membership changes so that clients
 /// and workers can detect stale placement decisions and refresh.
+///
+/// # Monotonicity across restarts
+///
+/// Clients only refresh cached placement when they observe an epoch **strictly
+/// greater** than the one they hold, so the epoch must never move backwards —
+/// including across a coordinator process restart. A plain in-memory counter
+/// from `0` breaks this: a restarted coordinator would re-advertise low epochs
+/// that clients (holding a higher pre-restart epoch) silently ignore, pinning
+/// them to a stale replica list forever (see issue #69).
+///
+/// To stay monotonic without external state, the epoch is seeded from the
+/// process **start time**: the wall-clock second occupies the high 32 bits and
+/// an in-process counter the low 32 bits. A later process always starts from a
+/// larger seed than any earlier one produced, so its epochs outrank them.
+///
+/// This keeps the coordinator free of unrebuildable persistent state (a v1
+/// design invariant). The residual edge — two restarts within the *same* second
+/// where the later process observes fewer membership changes — is negligible in
+/// practice (pod restarts take seconds). A future revision may instead derive
+/// the epoch from the Kubernetes `resourceVersion` of the worker endpoints,
+/// which is monotonic by construction (tracked for v1.5).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct Epoch(pub u64);
 
@@ -21,6 +42,19 @@ impl Epoch {
     /// Return the next epoch (this + 1).
     pub fn next(self) -> Self {
         Epoch(self.0 + 1)
+    }
+
+    /// A fresh epoch seeded from the current wall-clock second in the high 32
+    /// bits, with a zero low counter. Used as the base for a newly started
+    /// coordinator so its epochs outrank any earlier process's (see the type
+    /// docs for the monotonicity rationale).
+    pub fn seeded_now() -> Self {
+        let secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        // Clamp to 32 bits (good past year 2106) and shift into the high half.
+        Epoch((secs & 0xFFFF_FFFF) << 32)
     }
 }
 
@@ -160,5 +194,16 @@ mod tests {
         assert_eq!(e.0, 0);
         assert_eq!(e.next().0, 1);
         assert!(e < e.next());
+    }
+
+    #[test]
+    fn seeded_now_puts_time_in_high_bits() {
+        let e = Epoch::seeded_now();
+        // High 32 bits carry a nonzero wall-clock second; low 32 start clear.
+        assert!(e.0 >> 32 > 0, "seed must occupy the high bits");
+        assert_eq!(e.0 & 0xFFFF_FFFF, 0, "low counter starts at 0");
+        // A seed leaves ample low-bit headroom before it could collide with the
+        // next second's seed (2^32 counter increments per second).
+        assert!(e.next().0 > e.0);
     }
 }

--- a/crates/talon-coordinator/src/service.rs
+++ b/crates/talon-coordinator/src/service.rs
@@ -103,7 +103,9 @@ mod tests {
     }
 
     fn svc(ids: &[&str]) -> PlacementService<RendezvousPlacement> {
-        let m = Membership::new();
+        // Pin a deterministic epoch base so exact-value assertions below hold;
+        // production seeds from the wall clock (see Epoch::seeded_now).
+        let m = Membership::with_epoch_base(Epoch(0));
         for id in ids {
             m.register(NodeInfo {
                 id: NodeId::new(*id),

--- a/crates/talon-fuse/src/placement_cache.rs
+++ b/crates/talon-fuse/src/placement_cache.rs
@@ -208,4 +208,34 @@ mod tests {
         assert!(c.observe_epoch(&block(3), 6));
         assert!(c.get(&block(3), 0).is_none());
     }
+
+    #[test]
+    fn coordinator_restart_invalidates_stale_cache() {
+        // Regression for issue #69: a client caches placement at a high epoch
+        // produced by one coordinator process; that coordinator restarts and,
+        // because epochs are now seeded from the process start time (wall-clock
+        // second in the high 32 bits), the restarted process advertises a
+        // *larger* epoch — so the client's pre-restart cache is invalidated.
+        //
+        // Before the fix, the restarted coordinator restarted its counter at 0,
+        // `cached_epoch < 0` was false, and the stale entry lived forever.
+        let seed = |secs: u64, counter: u64| (secs << 32) | counter;
+
+        // Pre-restart: coordinator seeded at second T1, churned to counter 37.
+        let pre_restart = seed(1_000, 37);
+        let c = PlacementCache::new(10_000);
+        c.insert(block(7), cached(pre_restart, &["w3"]), 0);
+
+        // Post-restart: a fresh process seeded at a later second T2. Its very
+        // first advertised epoch already exceeds the pre-restart one.
+        let post_restart = seed(1_001, 0);
+        assert!(
+            post_restart > pre_restart,
+            "restart epoch must outrank pre-restart"
+        );
+
+        // The stale entry pinning the client to the now-dead w3 is dropped.
+        assert!(c.observe_epoch(&block(7), post_restart));
+        assert!(c.get(&block(7), 0).is_none());
+    }
 }


### PR DESCRIPTION
Fixes #69.

## Problem
The placement `Epoch` was an in-memory counter starting at `0`, bumped only
while a single coordinator process lived. On restart it reset to `0`. Because
clients refresh cached placement only on a **strictly greater** epoch
(`placement_cache.rs`: `cached.epoch < observed_epoch`), a restarted coordinator
advertising low epochs was silently ignored — clients stayed pinned to a stale
replica list (routing to dead workers) until they themselves restarted. This is
deterministic, not a race.

## Fix
Seed the epoch base from the **process start time**: wall-clock second in the
high 32 bits, in-process counter in the low 32. A later process always starts
from a larger seed than any earlier one produced, so its epochs outrank them —
with no persisted/unrebuildable coordinator state (a v1 design invariant). The
client-side compare logic is unchanged (it was correct given true monotonicity).

Deriving the epoch from the K8s worker-endpoints `resourceVersion` (monotonic by
construction) is noted as a more fundamental v1.5 follow-up.

## Changes
- `placement.rs`: `Epoch::seeded_now()` + rationale docs; unit test.
- `membership.rs`: `new()` seeds from it; `with_epoch_base(..)` for deterministic
  tests; `new_seeds_nonzero_epoch_base` + `restarted_coordinator_outranks_prior_process`.
- `service.rs`: pin test base to `Epoch(0)` so exact-value assertions hold.
- `placement_cache.rs` (fuse): `coordinator_restart_invalidates_stale_cache`
  regression — a post-restart epoch drops a pre-restart entry (the bug scenario).

## Acceptance criteria (from #69)
- [x] Epoch advertised after restart is `>=` max epoch any client could have cached.
- [x] Regression test simulates a restart and asserts the pre-restart cache **is**
      invalidated by the post-restart epoch.

## Test plan
- [x] `cargo test --workspace` green (incl. new tests by name)
- [x] `cargo clippy -p talon-coordinator -p talon-fuse --all-targets` clean
- [x] `RUSTDOCFLAGS=-D warnings cargo doc` clean