### PR TITLE
feat(transport): add versioned node status heartbeat

### DIFF
--- a/crates/talon-core/src/lib.rs
+++ b/crates/talon-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod error;
 pub mod key;
 pub mod metrics;
 pub mod node;
+pub mod status;
 pub mod store;
 pub mod trace;
 
@@ -20,5 +21,10 @@ pub use error::{Error, Result};
 pub use key::{Backend, BlockId, ObjectId, PageIndex, Version};
 pub use metrics::{Counter, Gauge, Histogram, Metrics};
 pub use node::{NodeId, NodeInfo, NodeRole};
+pub use status::{
+    NodeHealth, NodeMetricsSnapshot, NodeStatus, NodeStatusError, MAX_NODE_STATUS_BYTES,
+    MAX_STATUS_FIELD_BYTES, MAX_STATUS_LABELS, MAX_STATUS_LABEL_KEY_BYTES,
+    MAX_STATUS_LABEL_VALUE_BYTES, NODE_STATUS_SCHEMA_VERSION,
+};
 pub use store::{BlockHandle, ObjectStore};
 pub use trace::{init_tracing, RequestId};

--- a/crates/talon-core/src/status.rs
+++ b/crates/talon-core/src/status.rs
@@ -1,0 +1,328 @@
+//! Bounded runtime status shared by workers, coordinators, and management APIs.
+//!
+//! A [`NodeStatus`] is a latest-value snapshot, not a time-series sample. It is
+//! small enough to carry in a control heartbeat and persist in either etcd or a
+//! Kubernetes Lease annotation. Prometheus remains the source for histograms
+//! and historical metrics.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::NodeInfo;
+
+/// Current node-status value schema.
+pub const NODE_STATUS_SCHEMA_VERSION: u16 = 1;
+
+/// Maximum size of an encoded node-status value.
+pub const MAX_NODE_STATUS_BYTES: usize = 16 * 1024;
+
+/// Maximum UTF-8 byte length of an identity, version, or address field.
+pub const MAX_STATUS_FIELD_BYTES: usize = 256;
+
+/// Maximum number of deployment labels attached to a node.
+pub const MAX_STATUS_LABELS: usize = 16;
+
+/// Maximum UTF-8 byte length of a deployment-label key.
+pub const MAX_STATUS_LABEL_KEY_BYTES: usize = 63;
+
+/// Maximum UTF-8 byte length of a deployment-label value.
+pub const MAX_STATUS_LABEL_VALUE_BYTES: usize = 256;
+
+/// Health reported by a process in its latest status heartbeat.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeHealth {
+    /// The process and its required dependencies are operating normally.
+    Healthy,
+    /// The process is serving, but a dependency or subsystem is impaired.
+    Degraded,
+    /// The process cannot safely serve normal traffic.
+    Unhealthy,
+    /// The process has not made a health determination yet.
+    Unknown,
+}
+
+/// Bounded latest-value counters and gauges needed by the management UI.
+///
+/// Histograms are intentionally excluded; they remain available through each
+/// process's Prometheus endpoint.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeMetricsSnapshot {
+    /// Requests accepted since process start.
+    pub requests_total: u64,
+    /// Requests completed with an error since process start.
+    pub errors_total: u64,
+    /// Bytes returned to clients since process start.
+    pub bytes_served_total: u64,
+    /// Worker cache hits since process start.
+    pub cache_hits_total: u64,
+    /// Worker cache misses since process start.
+    pub cache_misses_total: u64,
+    /// Worker backend fetch failures since process start.
+    pub backend_errors_total: u64,
+    /// Worker evictions since process start.
+    pub evictions_total: u64,
+    /// Loads currently in flight.
+    pub inflight_loads: u64,
+    /// Blocks currently indexed by a worker.
+    pub block_count: u64,
+    /// Materialized pages currently indexed by a worker.
+    pub page_count: u64,
+    /// Bytes currently resident on a worker.
+    pub resident_bytes: u64,
+    /// Configured worker cache capacity in bytes.
+    pub capacity_bytes: u64,
+    /// Age of the coordinator's latest shared-state snapshot in milliseconds.
+    pub state_snapshot_age_ms: u64,
+}
+
+/// Versioned status sent by a coordinator or worker.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeStatus {
+    /// Schema version of this status value.
+    pub schema_version: u16,
+    /// Logical Talon cluster containing the node.
+    pub cluster_id: String,
+    /// Stable node identity, role, and service address.
+    pub node: NodeInfo,
+    /// Random process-incarnation identity generated at process start.
+    pub incarnation_id: String,
+    /// HTTP administration address, if enabled and advertised.
+    pub admin_address: Option<String>,
+    /// Talon package/build version.
+    pub build_version: String,
+    /// Process start time as Unix milliseconds.
+    pub started_at_unix_ms: u64,
+    /// Time this heartbeat snapshot was created, as Unix milliseconds.
+    pub reported_at_unix_ms: u64,
+    /// Monotonically increasing sequence within this process incarnation.
+    pub heartbeat_seq: u64,
+    /// Current process health.
+    pub health: NodeHealth,
+    /// Whether the process is ready to receive normal service traffic.
+    pub ready: bool,
+    /// Latest bounded metric snapshot.
+    pub metrics: NodeMetricsSnapshot,
+    /// Bounded deployment metadata such as region, zone, pod, or host.
+    pub labels: BTreeMap<String, String>,
+}
+
+impl NodeStatus {
+    /// Validate schema, field lengths, timestamps, and label cardinality.
+    pub fn validate(&self) -> Result<(), NodeStatusError> {
+        if self.schema_version != NODE_STATUS_SCHEMA_VERSION {
+            return Err(NodeStatusError::UnsupportedSchema {
+                got: self.schema_version,
+                supported: NODE_STATUS_SCHEMA_VERSION,
+            });
+        }
+
+        validate_required("cluster_id", &self.cluster_id, MAX_STATUS_FIELD_BYTES)?;
+        validate_required("node.id", &self.node.id.0, MAX_STATUS_FIELD_BYTES)?;
+        validate_required("node.address", &self.node.address, MAX_STATUS_FIELD_BYTES)?;
+        validate_required(
+            "incarnation_id",
+            &self.incarnation_id,
+            MAX_STATUS_FIELD_BYTES,
+        )?;
+        validate_required("build_version", &self.build_version, MAX_STATUS_FIELD_BYTES)?;
+        if let Some(address) = &self.admin_address {
+            validate_required("admin_address", address, MAX_STATUS_FIELD_BYTES)?;
+        }
+        if self.reported_at_unix_ms < self.started_at_unix_ms {
+            return Err(NodeStatusError::ReportBeforeStart {
+                started_at_unix_ms: self.started_at_unix_ms,
+                reported_at_unix_ms: self.reported_at_unix_ms,
+            });
+        }
+        if self.labels.len() > MAX_STATUS_LABELS {
+            return Err(NodeStatusError::TooManyLabels {
+                got: self.labels.len(),
+                max: MAX_STATUS_LABELS,
+            });
+        }
+        for (key, value) in &self.labels {
+            validate_required("label key", key, MAX_STATUS_LABEL_KEY_BYTES)?;
+            validate_length("label value", value, MAX_STATUS_LABEL_VALUE_BYTES)?;
+        }
+        Ok(())
+    }
+}
+
+fn validate_required(field: &'static str, value: &str, max: usize) -> Result<(), NodeStatusError> {
+    if value.is_empty() {
+        return Err(NodeStatusError::EmptyField { field });
+    }
+    validate_length(field, value, max)
+}
+
+fn validate_length(field: &'static str, value: &str, max: usize) -> Result<(), NodeStatusError> {
+    let got = value.len();
+    if got > max {
+        return Err(NodeStatusError::FieldTooLong { field, got, max });
+    }
+    Ok(())
+}
+
+/// Validation failure for a [`NodeStatus`] snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum NodeStatusError {
+    /// The value uses an unsupported status schema.
+    #[error("unsupported node-status schema {got} (supported: {supported})")]
+    UnsupportedSchema {
+        /// Version found in the value.
+        got: u16,
+        /// Version understood by this build.
+        supported: u16,
+    },
+    /// A required string field was empty.
+    #[error("node-status field {field} must not be empty")]
+    EmptyField {
+        /// Name of the invalid field.
+        field: &'static str,
+    },
+    /// A bounded string exceeded its UTF-8 byte limit.
+    #[error("node-status field {field} is {got} bytes; maximum is {max}")]
+    FieldTooLong {
+        /// Name of the invalid field.
+        field: &'static str,
+        /// Observed UTF-8 byte length.
+        got: usize,
+        /// Maximum UTF-8 byte length.
+        max: usize,
+    },
+    /// Too many deployment labels were provided.
+    #[error("node status has {got} labels; maximum is {max}")]
+    TooManyLabels {
+        /// Observed number of labels.
+        got: usize,
+        /// Maximum number of labels.
+        max: usize,
+    },
+    /// The report timestamp predates process start.
+    #[error(
+        "node status reported_at_unix_ms {reported_at_unix_ms} is before \
+         started_at_unix_ms {started_at_unix_ms}"
+    )]
+    ReportBeforeStart {
+        /// Process start time in Unix milliseconds.
+        started_at_unix_ms: u64,
+        /// Snapshot creation time in Unix milliseconds.
+        reported_at_unix_ms: u64,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{NodeId, NodeRole};
+
+    fn sample_status() -> NodeStatus {
+        NodeStatus {
+            schema_version: NODE_STATUS_SCHEMA_VERSION,
+            cluster_id: "cluster-a".into(),
+            node: NodeInfo {
+                id: NodeId::new("worker-1"),
+                address: "10.0.0.1:7001".into(),
+                role: NodeRole::Worker,
+            },
+            incarnation_id: "01J2ABCDEF".into(),
+            admin_address: Some("10.0.0.1:8001".into()),
+            build_version: "0.1.0".into(),
+            started_at_unix_ms: 1_000,
+            reported_at_unix_ms: 2_000,
+            heartbeat_seq: 7,
+            health: NodeHealth::Healthy,
+            ready: true,
+            metrics: NodeMetricsSnapshot {
+                requests_total: 12,
+                resident_bytes: 1024,
+                capacity_bytes: 4096,
+                ..Default::default()
+            },
+            labels: BTreeMap::from([
+                ("region".into(), "us-west".into()),
+                ("zone".into(), "us-west-1a".into()),
+            ]),
+        }
+    }
+
+    #[test]
+    fn valid_status_round_trips_as_json() {
+        let status = sample_status();
+        status.validate().unwrap();
+        let encoded = serde_json::to_string(&status).unwrap();
+        assert_eq!(
+            serde_json::from_str::<NodeStatus>(&encoded).unwrap(),
+            status
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_schema_and_invalid_timestamps() {
+        let mut status = sample_status();
+        status.schema_version += 1;
+        assert!(matches!(
+            status.validate(),
+            Err(NodeStatusError::UnsupportedSchema { .. })
+        ));
+
+        let mut status = sample_status();
+        status.reported_at_unix_ms = status.started_at_unix_ms - 1;
+        assert!(matches!(
+            status.validate(),
+            Err(NodeStatusError::ReportBeforeStart { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_empty_and_oversized_fields() {
+        let mut status = sample_status();
+        status.cluster_id.clear();
+        assert_eq!(
+            status.validate(),
+            Err(NodeStatusError::EmptyField {
+                field: "cluster_id"
+            })
+        );
+
+        let mut status = sample_status();
+        status.node.address = "x".repeat(MAX_STATUS_FIELD_BYTES + 1);
+        assert!(matches!(
+            status.validate(),
+            Err(NodeStatusError::FieldTooLong {
+                field: "node.address",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn label_limits_are_enforced_in_utf8_bytes() {
+        let mut status = sample_status();
+        status.labels = (0..=MAX_STATUS_LABELS)
+            .map(|i| (format!("k{i}"), "v".into()))
+            .collect();
+        assert_eq!(
+            status.validate(),
+            Err(NodeStatusError::TooManyLabels {
+                got: MAX_STATUS_LABELS + 1,
+                max: MAX_STATUS_LABELS
+            })
+        );
+
+        let mut status = sample_status();
+        status.labels = BTreeMap::from([(
+            "region".into(),
+            "界".repeat(MAX_STATUS_LABEL_VALUE_BYTES / 3 + 1),
+        )]);
+        assert!(matches!(
+            status.validate(),
+            Err(NodeStatusError::FieldTooLong {
+                field: "label value",
+                ..
+            })
+        ));
+    }
+}

--- a/crates/talon-transport/src/codec.rs
+++ b/crates/talon-transport/src/codec.rs
@@ -10,7 +10,9 @@
 //! [`CodecError`] rather than panicking.
 
 use serde::{Deserialize, Serialize};
-use talon_core::{BlockId, NodeId, NodeInfo, ObjectId};
+use talon_core::{
+    BlockId, NodeId, NodeInfo, NodeStatus, NodeStatusError, ObjectId, MAX_NODE_STATUS_BYTES,
+};
 
 use crate::frame::{FrameError, FrameHeader, MsgType, HEADER_LEN};
 
@@ -19,7 +21,10 @@ use crate::frame::{FrameError, FrameHeader, MsgType, HEADER_LEN};
 /// Bumped when [`ControlMessage`] changes in an incompatible way. Carried in
 /// the envelope so a peer can reject a mismatched schema instead of
 /// misinterpreting bytes.
-pub const CONTROL_SCHEMA_VERSION: u16 = 1;
+pub const CONTROL_SCHEMA_VERSION: u16 = 2;
+
+/// Oldest control schema this build can decode.
+pub const MIN_CONTROL_SCHEMA_VERSION: u16 = 1;
 
 /// A single control-plane message.
 ///
@@ -86,6 +91,24 @@ pub enum ControlMessage {
         /// Optional human-readable detail (error text).
         detail: Option<String>,
     },
+    /// Node → coordinator: complete runtime status and metric snapshot.
+    ///
+    /// This is the first schema-v2 message. The legacy [`Heartbeat`](Self::Heartbeat)
+    /// remains available during rolling upgrades.
+    NodeStatusHeartbeat {
+        /// Bounded, versioned status snapshot.
+        status: Box<NodeStatus>,
+    },
+}
+
+impl ControlMessage {
+    /// Oldest control schema that can represent this message.
+    pub fn minimum_schema(&self) -> u16 {
+        match self {
+            Self::NodeStatusHeartbeat { .. } => 2,
+            _ => MIN_CONTROL_SCHEMA_VERSION,
+        }
+    }
 }
 
 /// The framed control envelope actually written to the wire.
@@ -123,6 +146,25 @@ pub enum CodecError {
         /// Schema version this build supports.
         ours: u16,
     },
+    /// The selected schema predates the requested message.
+    #[error("control message requires schema {required}, but schema {selected} was selected")]
+    MessageRequiresSchema {
+        /// Oldest schema that supports the message.
+        required: u16,
+        /// Schema selected by the caller or envelope.
+        selected: u16,
+    },
+    /// A node status failed its bounded-field validation.
+    #[error("invalid node status: {0}")]
+    InvalidNodeStatus(#[from] NodeStatusError),
+    /// A valid node status exceeded the encoded-value limit.
+    #[error("encoded node status is {got} bytes; maximum is {max}")]
+    NodeStatusTooLarge {
+        /// Encoded status size.
+        got: usize,
+        /// Maximum encoded status size.
+        max: usize,
+    },
     /// bincode failed to (de)serialize the message body.
     #[error("bincode error: {0}")]
     Bincode(#[from] bincode::Error),
@@ -130,8 +172,22 @@ pub enum CodecError {
 
 /// Encode a control message into `header || bincode(envelope)`.
 pub fn encode(request_id: u32, message: &ControlMessage) -> Result<Vec<u8>, CodecError> {
+    encode_for_schema(request_id, message, message.minimum_schema())
+}
+
+/// Encode with an explicitly selected supported schema.
+///
+/// Existing v1 messages can be forced to v1 or v2. A v2-only message returns
+/// [`CodecError::MessageRequiresSchema`] when v1 is selected.
+pub fn encode_for_schema(
+    request_id: u32,
+    message: &ControlMessage,
+    schema: u16,
+) -> Result<Vec<u8>, CodecError> {
+    validate_schema(schema, CONTROL_SCHEMA_VERSION)?;
+    validate_message(message, schema)?;
     let env = Envelope {
-        schema: CONTROL_SCHEMA_VERSION,
+        schema,
         message: message.clone(),
     };
     let body = bincode::serialize(&env)?;
@@ -148,6 +204,13 @@ pub fn encode(request_id: u32, message: &ControlMessage) -> Result<Vec<u8>, Code
 /// frame is [`MsgType::Control`], checks the declared payload length against the
 /// bytes present, and rejects an unknown schema version.
 pub fn decode(buf: &[u8]) -> Result<(FrameHeader, ControlMessage), CodecError> {
+    decode_with_max_schema(buf, CONTROL_SCHEMA_VERSION)
+}
+
+fn decode_with_max_schema(
+    buf: &[u8],
+    max_schema: u16,
+) -> Result<(FrameHeader, ControlMessage), CodecError> {
     let header = FrameHeader::decode(buf)?;
     if header.msg_type != MsgType::Control {
         return Err(CodecError::NotControl(header.msg_type));
@@ -160,20 +223,87 @@ pub fn decode(buf: &[u8]) -> Result<(FrameHeader, ControlMessage), CodecError> {
             actual: body.len(),
         });
     }
+    // The schema is the first field in the fixed-int bincode envelope. Check it
+    // before deserializing the message so an older peer rejects a newer enum
+    // shape cleanly rather than reporting a misleading bincode failure.
+    let schema = peek_schema(body)?;
+    validate_schema(schema, max_schema)?;
     let env: Envelope = bincode::deserialize(body)?;
-    if env.schema != CONTROL_SCHEMA_VERSION {
+    validate_message(&env.message, env.schema)?;
+    Ok((header, env.message))
+}
+
+fn peek_schema(body: &[u8]) -> Result<u16, CodecError> {
+    if body.len() < std::mem::size_of::<u16>() {
+        // Preserve the established bincode error classification for a
+        // truncated envelope.
+        let _: Envelope = bincode::deserialize(body)?;
+        unreachable!("deserializing a truncated envelope cannot succeed");
+    }
+    Ok(u16::from_le_bytes([body[0], body[1]]))
+}
+
+fn validate_schema(schema: u16, max_schema: u16) -> Result<(), CodecError> {
+    if !(MIN_CONTROL_SCHEMA_VERSION..=max_schema).contains(&schema) {
         return Err(CodecError::UnsupportedSchema {
-            got: env.schema,
-            ours: CONTROL_SCHEMA_VERSION,
+            got: schema,
+            ours: max_schema,
         });
     }
-    Ok((header, env.message))
+    Ok(())
+}
+
+fn validate_message(message: &ControlMessage, schema: u16) -> Result<(), CodecError> {
+    let required = message.minimum_schema();
+    if schema < required {
+        return Err(CodecError::MessageRequiresSchema {
+            required,
+            selected: schema,
+        });
+    }
+    if let ControlMessage::NodeStatusHeartbeat { status } = message {
+        status.validate()?;
+        let got = bincode::serialized_size(status)? as usize;
+        if got > MAX_NODE_STATUS_BYTES {
+            return Err(CodecError::NodeStatusTooLarge {
+                got,
+                max: MAX_NODE_STATUS_BYTES,
+            });
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use talon_core::{Backend, NodeRole, Version};
+    use std::collections::BTreeMap;
+    use talon_core::{
+        Backend, NodeHealth, NodeMetricsSnapshot, NodeRole, Version, NODE_STATUS_SCHEMA_VERSION,
+    };
+
+    fn sample_status(node: NodeInfo) -> NodeStatus {
+        NodeStatus {
+            schema_version: NODE_STATUS_SCHEMA_VERSION,
+            cluster_id: "cluster-a".into(),
+            node,
+            incarnation_id: "incarnation-1".into(),
+            admin_address: Some("10.0.0.1:8001".into()),
+            build_version: "0.1.0".into(),
+            started_at_unix_ms: 1_000,
+            reported_at_unix_ms: 2_000,
+            heartbeat_seq: 3,
+            health: NodeHealth::Healthy,
+            ready: true,
+            metrics: NodeMetricsSnapshot {
+                block_count: 42,
+                resident_bytes: 1024,
+                capacity_bytes: 4096,
+                ..Default::default()
+            },
+            labels: BTreeMap::from([("zone".into(), "us-west-1a".into())]),
+        }
+    }
 
     fn sample_messages() -> Vec<ControlMessage> {
         let node = NodeInfo {
@@ -215,6 +345,9 @@ mod tests {
                 ok: false,
                 detail: Some("nope".into()),
             },
+            ControlMessage::NodeStatusHeartbeat {
+                status: Box::new(sample_status(node)),
+            },
         ]
     }
 
@@ -228,6 +361,125 @@ mod tests {
             assert_eq!(header.length as usize, buf.len() - HEADER_LEN);
             assert_eq!(back, msg);
         }
+    }
+
+    #[test]
+    fn existing_messages_default_to_v1_during_rolling_upgrade() {
+        let msg = ControlMessage::Heartbeat {
+            node: NodeId::new("worker-1"),
+            block_count: 42,
+        };
+        let buf = encode(1, &msg).unwrap();
+        assert_eq!(peek_schema(&buf[HEADER_LEN..]).unwrap(), 1);
+        assert_eq!(decode_with_max_schema(&buf, 1).unwrap().1, msg);
+    }
+
+    #[test]
+    fn new_status_heartbeat_uses_v2_and_old_peer_rejects_cleanly() {
+        let node = NodeInfo {
+            id: NodeId::new("worker-1"),
+            address: "10.0.0.1:7001".into(),
+            role: NodeRole::Worker,
+        };
+        let msg = ControlMessage::NodeStatusHeartbeat {
+            status: Box::new(sample_status(node)),
+        };
+        let buf = encode(1, &msg).unwrap();
+        assert_eq!(peek_schema(&buf[HEADER_LEN..]).unwrap(), 2);
+        assert!(matches!(
+            decode_with_max_schema(&buf, 1),
+            Err(CodecError::UnsupportedSchema { got: 2, ours: 1 })
+        ));
+        assert_eq!(decode(&buf).unwrap().1, msg);
+    }
+
+    #[test]
+    fn v2_message_cannot_be_mislabeled_as_v1() {
+        let node = NodeInfo {
+            id: NodeId::new("worker-1"),
+            address: "10.0.0.1:7001".into(),
+            role: NodeRole::Worker,
+        };
+        let msg = ControlMessage::NodeStatusHeartbeat {
+            status: Box::new(sample_status(node)),
+        };
+        assert!(matches!(
+            encode_for_schema(1, &msg, 1),
+            Err(CodecError::MessageRequiresSchema {
+                required: 2,
+                selected: 1
+            })
+        ));
+    }
+
+    #[test]
+    fn malformed_node_status_is_rejected_on_encode_and_decode() {
+        let node = NodeInfo {
+            id: NodeId::new("worker-1"),
+            address: "10.0.0.1:7001".into(),
+            role: NodeRole::Worker,
+        };
+        let mut status = sample_status(node);
+        status.cluster_id.clear();
+        let msg = ControlMessage::NodeStatusHeartbeat {
+            status: Box::new(status),
+        };
+        assert!(matches!(
+            encode(1, &msg),
+            Err(CodecError::InvalidNodeStatus(NodeStatusError::EmptyField {
+                field: "cluster_id"
+            }))
+        ));
+
+        let body = bincode::serialize(&Envelope {
+            schema: 2,
+            message: msg,
+        })
+        .unwrap();
+        let mut buf = FrameHeader::new(MsgType::Control, 1, body.len() as u32)
+            .encode()
+            .to_vec();
+        buf.extend_from_slice(&body);
+        assert!(matches!(
+            decode(&buf),
+            Err(CodecError::InvalidNodeStatus(_))
+        ));
+    }
+
+    #[test]
+    fn maximal_bounded_status_fits_the_wire_limit() {
+        let node = NodeInfo {
+            id: NodeId::new("n".repeat(talon_core::MAX_STATUS_FIELD_BYTES)),
+            address: "a".repeat(talon_core::MAX_STATUS_FIELD_BYTES),
+            role: NodeRole::Worker,
+        };
+        let mut status = sample_status(node);
+        status.cluster_id = "c".repeat(talon_core::MAX_STATUS_FIELD_BYTES);
+        status.incarnation_id = "i".repeat(talon_core::MAX_STATUS_FIELD_BYTES);
+        status.admin_address = Some("m".repeat(talon_core::MAX_STATUS_FIELD_BYTES));
+        status.build_version = "v".repeat(talon_core::MAX_STATUS_FIELD_BYTES);
+        status.labels = (0..talon_core::MAX_STATUS_LABELS)
+            .map(|i| {
+                (
+                    format!(
+                        "{i:02}{}",
+                        "k".repeat(talon_core::MAX_STATUS_LABEL_KEY_BYTES - 2)
+                    ),
+                    "x".repeat(talon_core::MAX_STATUS_LABEL_VALUE_BYTES),
+                )
+            })
+            .collect();
+
+        status.validate().unwrap();
+        let encoded_size = bincode::serialized_size(&status).unwrap() as usize;
+        assert!(
+            encoded_size <= MAX_NODE_STATUS_BYTES,
+            "{encoded_size} exceeds {MAX_NODE_STATUS_BYTES}"
+        );
+        let msg = ControlMessage::NodeStatusHeartbeat {
+            status: Box::new(status),
+        };
+        assert_eq!(decode(&encode(1, &msg).unwrap()).unwrap().1, msg);
     }
 
     #[test]
@@ -272,7 +524,7 @@ mod tests {
         buf.extend_from_slice(&body);
         assert!(matches!(
             decode(&buf),
-            Err(CodecError::UnsupportedSchema { got: 999, ours: 1 })
+            Err(CodecError::UnsupportedSchema { got: 999, ours: 2 })
         ));
     }
 

--- a/crates/talon-transport/src/lib.rs
+++ b/crates/talon-transport/src/lib.rs
@@ -16,7 +16,10 @@ pub mod frame;
 pub mod pool;
 pub mod runtime;
 
-pub use codec::{decode, encode, CodecError, ControlMessage, CONTROL_SCHEMA_VERSION};
+pub use codec::{
+    decode, encode, encode_for_schema, CodecError, ControlMessage, CONTROL_SCHEMA_VERSION,
+    MIN_CONTROL_SCHEMA_VERSION,
+};
 pub use data::{
     decode_request, encode_error, encode_request, response_header_ok, DataError, RangeRequest,
 };


### PR DESCRIPTION
## Summary

- add bounded, validated coordinator/worker runtime status types in `talon-core`
- include identity, role, service/admin endpoints, build and heartbeat metadata, health/readiness, deployment labels, capacity/inventory, and UI counter snapshots
- add control schema v2 with `NodeStatusHeartbeat` while preserving all existing message variants as schema v1
- encode each message with its minimum compatible schema so existing traffic remains rolling-upgrade compatible
- reject unsupported schemas before decoding newer enum shapes and validate status limits on encode/decode

## Compatibility

- v2 peers decode both schema v1 and v2
- existing Register/Heartbeat/Placement/Membership messages continue to encode as v1
- an old v1 peer rejects `NodeStatusHeartbeat` cleanly as unsupported schema v2
- callers can explicitly select a schema with `encode_for_schema`; a v2-only message cannot be mislabeled as v1

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --all-targets --all-features --locked`
- `cargo test --workspace --all-features --locked`
- `git diff --check`

Parent: #72
Closes #74
