### PR TITLE
feat(coordinator): add cluster state store contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,7 @@ dependencies = [
  "serde",
  "talon-core",
  "talon-transport",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/talon-coordinator/Cargo.toml
+++ b/crates/talon-coordinator/Cargo.toml
@@ -11,6 +11,9 @@ description = "Cluster coordinator: metadata, membership, and object placement f
 name = "talon-coordinator"
 path = "src/main.rs"
 
+[features]
+state-store-testkit = []
+
 [dependencies]
 talon-core.workspace = true
 talon-transport.workspace = true
@@ -21,6 +24,7 @@ tracing-subscriber.workspace = true
 serde.workspace = true
 clap.workspace = true
 async-trait.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 divan.workspace = true

--- a/crates/talon-coordinator/src/lib.rs
+++ b/crates/talon-coordinator/src/lib.rs
@@ -8,9 +8,16 @@ pub mod load;
 pub mod membership;
 pub mod placement;
 pub mod service;
+pub mod state_store;
 
 pub use heartbeat::{HeartbeatConfig, HeartbeatTracker, Inventory};
 pub use load::{plan_load, split_into_blocks, LoadAssignment, LoadProgress};
 pub use membership::{K8sSelector, KubernetesMembership, Membership, MembershipSource};
 pub use placement::{Epoch, Placement, RendezvousPlacement};
 pub use service::{PlacementResult, PlacementService};
+pub use state_store::{
+    BackendHealth, ClusterSnapshot, ClusterStateConfig, ClusterStateStore, ClusterStateWatch,
+    ConfigError as ClusterStateConfigError, MemoryStateStore, NodeEvent, NodeEventKind,
+    StateBackend, StateStoreError, StateStoreResult, StoreRevision, TimeSource, WriteDisposition,
+    WriteResult,
+};

--- a/crates/talon-coordinator/src/state_store/config.rs
+++ b/crates/talon-coordinator/src/state_store/config.rs
@@ -1,0 +1,235 @@
+//! Cluster-state backend and lease timing configuration.
+
+use std::fmt;
+use std::str::FromStr;
+
+use clap::ValueEnum;
+use serde::Deserialize;
+
+/// Shared-state backend selected by a coordinator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum StateBackend {
+    /// Single-process development and tests only.
+    Memory,
+    /// External etcd v3 cluster.
+    Etcd,
+    /// Kubernetes API using namespaced Lease resources.
+    #[value(alias = "k8s")]
+    #[serde(alias = "k8s")]
+    Kubernetes,
+}
+
+impl fmt::Display for StateBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Memory => "memory",
+            Self::Etcd => "etcd",
+            Self::Kubernetes => "kubernetes",
+        })
+    }
+}
+
+impl FromStr for StateBackend {
+    type Err = ConfigError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "memory" => Ok(Self::Memory),
+            "etcd" => Ok(Self::Etcd),
+            "kubernetes" | "k8s" => Ok(Self::Kubernetes),
+            _ => Err(ConfigError::UnknownBackend(value.to_string())),
+        }
+    }
+}
+
+/// Backend-neutral cluster-state configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ClusterStateConfig {
+    /// Selected backend.
+    pub backend: StateBackend,
+    /// Whether active-active coordinator behavior is requested.
+    pub ha_enabled: bool,
+    /// Expected coordinator replica count.
+    pub coordinator_replicas: u16,
+    /// Node heartbeat interval in milliseconds.
+    pub heartbeat_interval_ms: u64,
+    /// Silence interval after which a node is unhealthy.
+    pub unhealthy_after_ms: u64,
+    /// Silence interval after which the node lease expires.
+    pub lease_ttl_ms: u64,
+    /// Deadline for one authoritative backend operation.
+    pub request_timeout_ms: u64,
+}
+
+impl Default for ClusterStateConfig {
+    fn default() -> Self {
+        Self {
+            backend: StateBackend::Memory,
+            ha_enabled: false,
+            coordinator_replicas: 1,
+            heartbeat_interval_ms: 5_000,
+            unhealthy_after_ms: 15_000,
+            lease_ttl_ms: 30_000,
+            request_timeout_ms: 3_000,
+        }
+    }
+}
+
+impl ClusterStateConfig {
+    /// Validate HA/backend selection and lease timing relationships.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.coordinator_replicas == 0 {
+            return Err(ConfigError::ZeroReplicas);
+        }
+        if self.request_timeout_ms == 0 {
+            return Err(ConfigError::ZeroRequestTimeout);
+        }
+        if self.heartbeat_interval_ms == 0
+            || self.heartbeat_interval_ms >= self.unhealthy_after_ms
+            || self.unhealthy_after_ms >= self.lease_ttl_ms
+        {
+            return Err(ConfigError::InvalidLeaseTiming {
+                heartbeat_interval_ms: self.heartbeat_interval_ms,
+                unhealthy_after_ms: self.unhealthy_after_ms,
+                lease_ttl_ms: self.lease_ttl_ms,
+            });
+        }
+        if self.backend == StateBackend::Memory
+            && (self.ha_enabled || self.coordinator_replicas > 1)
+        {
+            return Err(ConfigError::MemoryBackendWithHa {
+                ha_enabled: self.ha_enabled,
+                coordinator_replicas: self.coordinator_replicas,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Invalid cluster-state configuration.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ConfigError {
+    /// Backend selector was not recognized.
+    #[error("unknown cluster-state backend {0:?}; expected memory, etcd, or kubernetes")]
+    UnknownBackend(String),
+    /// At least one coordinator replica is required.
+    #[error("coordinator_replicas must be greater than zero")]
+    ZeroReplicas,
+    /// Authoritative operations require a positive timeout.
+    #[error("request_timeout_ms must be greater than zero")]
+    ZeroRequestTimeout,
+    /// Heartbeat, unhealthy, and expiry timing were not strictly increasing.
+    #[error(
+        "lease timing must satisfy heartbeat_interval_ms < unhealthy_after_ms < lease_ttl_ms; \
+         got {heartbeat_interval_ms} < {unhealthy_after_ms} < {lease_ttl_ms}"
+    )]
+    InvalidLeaseTiming {
+        /// Configured heartbeat interval.
+        heartbeat_interval_ms: u64,
+        /// Configured unhealthy threshold.
+        unhealthy_after_ms: u64,
+        /// Configured lease expiry.
+        lease_ttl_ms: u64,
+    },
+    /// The in-memory backend cannot coordinate multiple processes.
+    #[error(
+        "memory state backend is development-only and cannot run HA \
+         (ha_enabled={ha_enabled}, coordinator_replicas={coordinator_replicas})"
+    )]
+    MemoryBackendWithHa {
+        /// Whether HA mode was explicitly enabled.
+        ha_enabled: bool,
+        /// Requested coordinator replica count.
+        coordinator_replicas: u16,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_selector_parses_supported_names() {
+        assert_eq!("memory".parse(), Ok(StateBackend::Memory));
+        assert_eq!("etcd".parse(), Ok(StateBackend::Etcd));
+        assert_eq!("kubernetes".parse(), Ok(StateBackend::Kubernetes));
+        assert_eq!("k8s".parse(), Ok(StateBackend::Kubernetes));
+        assert!(matches!(
+            "consul".parse::<StateBackend>(),
+            Err(ConfigError::UnknownBackend(_))
+        ));
+    }
+
+    #[test]
+    fn defaults_are_valid_for_single_process_development() {
+        ClusterStateConfig::default().validate().unwrap();
+    }
+
+    #[test]
+    fn memory_backend_is_rejected_for_ha() {
+        let config = ClusterStateConfig {
+            ha_enabled: true,
+            ..Default::default()
+        };
+        assert!(matches!(
+            config.validate(),
+            Err(ConfigError::MemoryBackendWithHa { .. })
+        ));
+
+        let config = ClusterStateConfig {
+            coordinator_replicas: 2,
+            ..Default::default()
+        };
+        assert!(matches!(
+            config.validate(),
+            Err(ConfigError::MemoryBackendWithHa { .. })
+        ));
+    }
+
+    #[test]
+    fn production_backends_accept_ha() {
+        for backend in [StateBackend::Etcd, StateBackend::Kubernetes] {
+            ClusterStateConfig {
+                backend,
+                ha_enabled: true,
+                coordinator_replicas: 3,
+                ..Default::default()
+            }
+            .validate()
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn lease_timing_and_timeout_are_validated() {
+        for config in [
+            ClusterStateConfig {
+                heartbeat_interval_ms: 0,
+                ..Default::default()
+            },
+            ClusterStateConfig {
+                unhealthy_after_ms: 5_000,
+                ..Default::default()
+            },
+            ClusterStateConfig {
+                lease_ttl_ms: 15_000,
+                ..Default::default()
+            },
+        ] {
+            assert!(matches!(
+                config.validate(),
+                Err(ConfigError::InvalidLeaseTiming { .. })
+            ));
+        }
+        assert_eq!(
+            ClusterStateConfig {
+                request_timeout_ms: 0,
+                ..Default::default()
+            }
+            .validate(),
+            Err(ConfigError::ZeroRequestTimeout)
+        );
+    }
+}

--- a/crates/talon-coordinator/src/state_store/memory.rs
+++ b/crates/talon-coordinator/src/state_store/memory.rs
@@ -1,0 +1,527 @@
+//! Deterministic in-memory state backend for development and contract tests.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use talon_core::{NodeId, NodeStatus};
+use tokio::sync::broadcast;
+
+use super::{
+    BackendHealth, ClusterSnapshot, ClusterStateStore, ClusterStateWatch, NodeEvent, NodeEventKind,
+    StateBackend, StateStoreError, StateStoreResult, StoreRevision, WriteDisposition, WriteResult,
+};
+
+const DEFAULT_EVENT_HISTORY: usize = 1_024;
+
+/// Time source used for lease expiry.
+pub trait TimeSource: Send + Sync {
+    /// Current Unix time in milliseconds.
+    fn now_unix_ms(&self) -> u64;
+}
+
+#[derive(Debug)]
+struct SystemTimeSource;
+
+impl TimeSource for SystemTimeSource {
+    fn now_unix_ms(&self) -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RecordKey {
+    cluster_id: String,
+    node_id: NodeId,
+}
+
+#[derive(Debug, Clone)]
+struct StoredRecord {
+    status: NodeStatus,
+    expires_at_unix_ms: u64,
+}
+
+#[derive(Debug, Default)]
+struct Inner {
+    revision: u64,
+    records: HashMap<RecordKey, StoredRecord>,
+    history: VecDeque<NodeEvent>,
+}
+
+/// Single-process backend with injected time, bounded watch history, and fault
+/// injection.
+pub struct MemoryStateStore {
+    clock: Arc<dyn TimeSource>,
+    history_limit: usize,
+    available: AtomicBool,
+    events: broadcast::Sender<NodeEvent>,
+    inner: Mutex<Inner>,
+}
+
+impl Default for MemoryStateStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MemoryStateStore {
+    /// Create a store using wall-clock time and the default event history.
+    pub fn new() -> Self {
+        Self::with_time_source(Arc::new(SystemTimeSource), DEFAULT_EVENT_HISTORY)
+    }
+
+    /// Create a store with injectable time and bounded watch history.
+    pub fn with_time_source(clock: Arc<dyn TimeSource>, history_limit: usize) -> Self {
+        let history_limit = history_limit.max(1);
+        let (events, _) = broadcast::channel(history_limit);
+        Self {
+            clock,
+            history_limit,
+            available: AtomicBool::new(true),
+            events,
+            inner: Mutex::new(Inner::default()),
+        }
+    }
+
+    /// Toggle deterministic backend availability for tests and local fault
+    /// injection.
+    pub fn set_available(&self, available: bool) {
+        self.available.store(available, Ordering::Release);
+    }
+
+    fn ensure_available(&self) -> StateStoreResult<()> {
+        if self.available.load(Ordering::Acquire) {
+            Ok(())
+        } else {
+            Err(StateStoreError::Unavailable {
+                backend: StateBackend::Memory,
+                detail: "fault injection is active".into(),
+            })
+        }
+    }
+
+    fn revision(value: u64) -> StoreRevision {
+        StoreRevision::new(format!("memory:{value}")).expect("memory revision is never empty")
+    }
+
+    fn parse_revision(revision: &StoreRevision) -> StateStoreResult<u64> {
+        revision
+            .as_str()
+            .strip_prefix("memory:")
+            .and_then(|value| value.parse().ok())
+            .ok_or_else(|| StateStoreError::InvalidRevision {
+                backend: Some(StateBackend::Memory),
+                revision: revision.to_string(),
+                detail: "expected memory:<u64>",
+            })
+    }
+
+    fn publish_locked(&self, inner: &mut Inner, mut event: NodeEvent) {
+        inner.revision = inner.revision.saturating_add(1);
+        event.revision = Self::revision(inner.revision);
+        inner.history.push_back(event.clone());
+        while inner.history.len() > self.history_limit {
+            inner.history.pop_front();
+        }
+        let _ = self.events.send(event);
+    }
+
+    fn prune_expired_locked(&self, inner: &mut Inner, now_unix_ms: u64) {
+        let expired: Vec<_> = inner
+            .records
+            .iter()
+            .filter(|(_, record)| record.expires_at_unix_ms <= now_unix_ms)
+            .map(|(key, _)| key.clone())
+            .collect();
+        for key in expired {
+            inner.records.remove(&key);
+            self.publish_locked(
+                inner,
+                NodeEvent {
+                    cluster_id: key.cluster_id,
+                    node_id: key.node_id,
+                    kind: NodeEventKind::Removed,
+                    status: None,
+                    revision: Self::revision(0),
+                    observed_at_unix_ms: now_unix_ms,
+                },
+            );
+        }
+    }
+
+    fn ttl_ms(ttl: Duration) -> StateStoreResult<u64> {
+        if ttl.is_zero() {
+            return Err(StateStoreError::InvalidLeaseTtl(ttl));
+        }
+        let ttl_ms =
+            u64::try_from(ttl.as_millis()).map_err(|_| StateStoreError::InvalidLeaseTtl(ttl))?;
+        if ttl_ms == 0 {
+            return Err(StateStoreError::InvalidLeaseTtl(ttl));
+        }
+        Ok(ttl_ms)
+    }
+}
+
+#[async_trait]
+impl ClusterStateStore for MemoryStateStore {
+    fn backend(&self) -> StateBackend {
+        StateBackend::Memory
+    }
+
+    async fn upsert_node(
+        &self,
+        status: NodeStatus,
+        lease_ttl: Duration,
+    ) -> StateStoreResult<WriteResult> {
+        self.ensure_available()?;
+        status.validate()?;
+        let ttl_ms = Self::ttl_ms(lease_ttl)?;
+        let now = self.clock.now_unix_ms();
+        let key = RecordKey {
+            cluster_id: status.cluster_id.clone(),
+            node_id: status.node.id.clone(),
+        };
+        let mut inner = self.inner.lock().unwrap();
+        self.prune_expired_locked(&mut inner, now);
+
+        if let Some(current) = inner.records.get(&key) {
+            let disposition = if current.status.incarnation_id == status.incarnation_id {
+                match status.heartbeat_seq.cmp(&current.status.heartbeat_seq) {
+                    std::cmp::Ordering::Less => Some(WriteDisposition::Stale),
+                    std::cmp::Ordering::Equal => Some(WriteDisposition::Duplicate),
+                    std::cmp::Ordering::Greater => None,
+                }
+            } else if status.started_at_unix_ms < current.status.started_at_unix_ms
+                || (status.started_at_unix_ms == current.status.started_at_unix_ms
+                    && status.reported_at_unix_ms <= current.status.reported_at_unix_ms)
+            {
+                Some(WriteDisposition::Stale)
+            } else {
+                None
+            };
+            if let Some(disposition) = disposition {
+                return Ok(WriteResult {
+                    disposition,
+                    revision: Self::revision(inner.revision),
+                });
+            }
+        }
+
+        inner.records.insert(
+            key,
+            StoredRecord {
+                status: status.clone(),
+                expires_at_unix_ms: now.saturating_add(ttl_ms),
+            },
+        );
+        self.publish_locked(
+            &mut inner,
+            NodeEvent {
+                cluster_id: status.cluster_id.clone(),
+                node_id: status.node.id.clone(),
+                kind: NodeEventKind::Upserted,
+                status: Some(status),
+                revision: Self::revision(0),
+                observed_at_unix_ms: now,
+            },
+        );
+        Ok(WriteResult {
+            disposition: WriteDisposition::Applied,
+            revision: Self::revision(inner.revision),
+        })
+    }
+
+    async fn remove_node(
+        &self,
+        cluster_id: &str,
+        node_id: &NodeId,
+        incarnation_id: &str,
+    ) -> StateStoreResult<WriteResult> {
+        self.ensure_available()?;
+        let now = self.clock.now_unix_ms();
+        let key = RecordKey {
+            cluster_id: cluster_id.to_string(),
+            node_id: node_id.clone(),
+        };
+        let mut inner = self.inner.lock().unwrap();
+        self.prune_expired_locked(&mut inner, now);
+        let Some(record) = inner.records.get(&key) else {
+            return Ok(WriteResult {
+                disposition: WriteDisposition::NotFound,
+                revision: Self::revision(inner.revision),
+            });
+        };
+        if record.status.incarnation_id != incarnation_id {
+            return Ok(WriteResult {
+                disposition: WriteDisposition::Stale,
+                revision: Self::revision(inner.revision),
+            });
+        }
+
+        inner.records.remove(&key);
+        self.publish_locked(
+            &mut inner,
+            NodeEvent {
+                cluster_id: cluster_id.to_string(),
+                node_id: node_id.clone(),
+                kind: NodeEventKind::Removed,
+                status: None,
+                revision: Self::revision(0),
+                observed_at_unix_ms: now,
+            },
+        );
+        Ok(WriteResult {
+            disposition: WriteDisposition::Applied,
+            revision: Self::revision(inner.revision),
+        })
+    }
+
+    async fn snapshot(&self, cluster_id: &str) -> StateStoreResult<ClusterSnapshot> {
+        self.ensure_available()?;
+        let now = self.clock.now_unix_ms();
+        let mut inner = self.inner.lock().unwrap();
+        self.prune_expired_locked(&mut inner, now);
+        let mut nodes: Vec<_> = inner
+            .records
+            .iter()
+            .filter(|(key, _)| key.cluster_id == cluster_id)
+            .map(|(_, record)| record.status.clone())
+            .collect();
+        nodes.sort_by(|a, b| a.node.id.0.cmp(&b.node.id.0));
+        Ok(ClusterSnapshot {
+            nodes,
+            revision: Self::revision(inner.revision),
+            observed_at_unix_ms: now,
+        })
+    }
+
+    async fn watch(
+        &self,
+        cluster_id: &str,
+        after_revision: Option<&StoreRevision>,
+    ) -> StateStoreResult<Box<dyn ClusterStateWatch>> {
+        self.ensure_available()?;
+        let now = self.clock.now_unix_ms();
+        let mut inner = self.inner.lock().unwrap();
+        self.prune_expired_locked(&mut inner, now);
+        let after = match after_revision {
+            Some(revision) => Self::parse_revision(revision)?,
+            None => inner.revision,
+        };
+        if after > inner.revision {
+            return Err(StateStoreError::InvalidRevision {
+                backend: Some(StateBackend::Memory),
+                revision: Self::revision(after).to_string(),
+                detail: "revision is newer than current state",
+            });
+        }
+        if let Some(oldest) = inner.history.front().map(|event| {
+            Self::parse_revision(&event.revision).expect("memory history has memory revisions")
+        }) {
+            if after.saturating_add(1) < oldest {
+                return Err(StateStoreError::Compacted {
+                    requested: Self::revision(after),
+                    oldest: Self::revision(oldest),
+                });
+            }
+        }
+
+        let backlog = inner
+            .history
+            .iter()
+            .filter(|event| {
+                event.cluster_id == cluster_id
+                    && Self::parse_revision(&event.revision).is_ok_and(|revision| revision > after)
+            })
+            .cloned()
+            .collect();
+        let receiver = self.events.subscribe();
+        Ok(Box::new(MemoryWatch {
+            cluster_id: cluster_id.to_string(),
+            backlog,
+            receiver,
+            last_revision: Self::revision(after),
+        }))
+    }
+
+    async fn check_ready(&self) -> StateStoreResult<BackendHealth> {
+        self.ensure_available()?;
+        let now = self.clock.now_unix_ms();
+        let mut inner = self.inner.lock().unwrap();
+        self.prune_expired_locked(&mut inner, now);
+        Ok(BackendHealth {
+            backend: StateBackend::Memory,
+            checked_at_unix_ms: now,
+            revision: Some(Self::revision(inner.revision)),
+        })
+    }
+}
+
+struct MemoryWatch {
+    cluster_id: String,
+    backlog: VecDeque<NodeEvent>,
+    receiver: broadcast::Receiver<NodeEvent>,
+    last_revision: StoreRevision,
+}
+
+#[async_trait]
+impl ClusterStateWatch for MemoryWatch {
+    async fn next(&mut self) -> StateStoreResult<NodeEvent> {
+        if let Some(event) = self.backlog.pop_front() {
+            self.last_revision = event.revision.clone();
+            return Ok(event);
+        }
+        loop {
+            match self.receiver.recv().await {
+                Ok(event) => {
+                    self.last_revision = event.revision.clone();
+                    if event.cluster_id == self.cluster_id {
+                        return Ok(event);
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    return Err(StateStoreError::WatchLagged {
+                        after: self.last_revision.clone(),
+                        skipped,
+                    });
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    return Err(StateStoreError::Unavailable {
+                        backend: StateBackend::Memory,
+                        detail: "watch channel closed".into(),
+                    });
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+    use crate::state_store::testkit::{assert_store_contract, StoreContractHarness};
+
+    #[derive(Debug, Default)]
+    struct ManualTime {
+        now_ms: AtomicU64,
+    }
+
+    impl ManualTime {
+        fn advance(&self, duration: Duration) {
+            self.now_ms
+                .fetch_add(duration.as_millis() as u64, Ordering::SeqCst);
+        }
+    }
+
+    impl TimeSource for ManualTime {
+        fn now_unix_ms(&self) -> u64 {
+            self.now_ms.load(Ordering::SeqCst)
+        }
+    }
+
+    struct MemoryHarness {
+        store: Arc<MemoryStateStore>,
+        clock: Arc<ManualTime>,
+    }
+
+    #[async_trait]
+    impl StoreContractHarness for MemoryHarness {
+        fn store(&self) -> Arc<dyn ClusterStateStore> {
+            self.store.clone()
+        }
+
+        fn lease_ttl(&self) -> Duration {
+            Duration::from_millis(100)
+        }
+
+        async fn elapse(&self, duration: Duration) {
+            self.clock.advance(duration);
+        }
+    }
+
+    #[tokio::test]
+    async fn reusable_store_contract_passes() {
+        let clock = Arc::new(ManualTime::default());
+        let harness = MemoryHarness {
+            store: Arc::new(MemoryStateStore::with_time_source(clock.clone(), 64)),
+            clock,
+        };
+        assert_store_contract(&harness).await;
+    }
+
+    #[tokio::test]
+    async fn compacted_and_foreign_revisions_are_rejected() {
+        let clock = Arc::new(ManualTime::default());
+        let store = MemoryStateStore::with_time_source(clock, 2);
+        for seq in 0..3 {
+            let mut status = crate::state_store::testkit::worker_status("w1", "inc-1", seq);
+            status.reported_at_unix_ms += seq;
+            store
+                .upsert_node(status, Duration::from_secs(30))
+                .await
+                .unwrap();
+        }
+
+        assert!(matches!(
+            store
+                .watch("contract", Some(&StoreRevision::new("memory:0").unwrap()))
+                .await,
+            Err(StateStoreError::Compacted { .. })
+        ));
+        assert!(matches!(
+            store
+                .watch("contract", Some(&StoreRevision::new("etcd:7").unwrap()))
+                .await,
+            Err(StateStoreError::InvalidRevision { .. })
+        ));
+        assert!(matches!(
+            store
+                .watch("contract", Some(&StoreRevision::new("memory:99").unwrap()))
+                .await,
+            Err(StateStoreError::InvalidRevision { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn unavailable_backend_fails_without_mutating_state() {
+        let store = MemoryStateStore::new();
+        store.set_available(false);
+        assert!(matches!(
+            store.snapshot("contract").await,
+            Err(StateStoreError::Unavailable { .. })
+        ));
+        assert!(matches!(
+            store.check_ready().await,
+            Err(StateStoreError::Unavailable { .. })
+        ));
+        assert!(StateStoreError::Unavailable {
+            backend: StateBackend::Memory,
+            detail: "test".into()
+        }
+        .is_retryable());
+
+        store.set_available(true);
+        assert!(store.snapshot("contract").await.unwrap().nodes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn sub_millisecond_lease_is_rejected() {
+        let store = MemoryStateStore::new();
+        assert!(matches!(
+            store
+                .upsert_node(
+                    crate::state_store::testkit::worker_status("w1", "inc-1", 0),
+                    Duration::from_nanos(1)
+                )
+                .await,
+            Err(StateStoreError::InvalidLeaseTtl(_))
+        ));
+    }
+}

--- a/crates/talon-coordinator/src/state_store/mod.rs
+++ b/crates/talon-coordinator/src/state_store/mod.rs
@@ -1,0 +1,252 @@
+//! Backend-neutral shared cluster-state contract.
+//!
+//! Coordinators use this API for leased node status, consistent snapshots, and
+//! resumable watches. Backend revisions are deliberately opaque: etcd happens
+//! to use integers while Kubernetes resource versions must not be parsed or
+//! ordered by clients.
+
+mod config;
+mod memory;
+
+#[cfg(any(test, feature = "state-store-testkit"))]
+#[doc(hidden)]
+pub mod testkit;
+
+use std::fmt;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use talon_core::{NodeId, NodeStatus, NodeStatusError};
+
+pub use config::{ClusterStateConfig, ConfigError, StateBackend};
+pub use memory::{MemoryStateStore, TimeSource};
+
+/// Result alias for cluster-state operations.
+pub type StateStoreResult<T> = Result<T, StateStoreError>;
+
+/// Opaque backend revision used for watch resume and diagnostics.
+///
+/// The type intentionally does not implement `Ord` or `PartialOrd`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StoreRevision(String);
+
+impl StoreRevision {
+    /// Construct a revision from a non-empty backend token.
+    pub fn new(value: impl Into<String>) -> StateStoreResult<Self> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(StateStoreError::InvalidRevision {
+                backend: None,
+                revision: value,
+                detail: "revision must not be empty",
+            });
+        }
+        Ok(Self(value))
+    }
+
+    /// Borrow the backend token without interpreting it.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for StoreRevision {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Outcome of an idempotent state mutation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteDisposition {
+    /// The record changed and a new revision was committed.
+    Applied,
+    /// The same heartbeat sequence was already accepted.
+    Duplicate,
+    /// The write belongs to an older sequence or process incarnation.
+    Stale,
+    /// The requested record did not exist.
+    NotFound,
+}
+
+/// Result of an upsert or explicit removal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriteResult {
+    /// Whether the mutation changed shared state.
+    pub disposition: WriteDisposition,
+    /// Backend revision after evaluating the mutation.
+    pub revision: StoreRevision,
+}
+
+/// One consistent cluster snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClusterSnapshot {
+    /// Non-expired node records in stable node-id order.
+    pub nodes: Vec<NodeStatus>,
+    /// Opaque revision at which the snapshot was observed.
+    pub revision: StoreRevision,
+    /// Backend/client observation time as Unix milliseconds.
+    pub observed_at_unix_ms: u64,
+}
+
+/// Kind of event emitted by a cluster watch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeEventKind {
+    /// A node was inserted or refreshed with newer status.
+    Upserted,
+    /// A node was explicitly removed or its lease expired.
+    Removed,
+}
+
+/// Ordered node event emitted after a snapshot revision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeEvent {
+    /// Logical cluster containing the node.
+    pub cluster_id: String,
+    /// Stable node identity.
+    pub node_id: NodeId,
+    /// Event type.
+    pub kind: NodeEventKind,
+    /// Status for an upsert; absent for removal.
+    pub status: Option<NodeStatus>,
+    /// Opaque revision committed with the event.
+    pub revision: StoreRevision,
+    /// Observation time as Unix milliseconds.
+    pub observed_at_unix_ms: u64,
+}
+
+/// Successful backend readiness result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendHealth {
+    /// Selected backend implementation.
+    pub backend: StateBackend,
+    /// Time the readiness check completed, as Unix milliseconds.
+    pub checked_at_unix_ms: u64,
+    /// Latest revision if the backend returned one cheaply.
+    pub revision: Option<StoreRevision>,
+}
+
+/// Resumable stream of ordered cluster events.
+#[async_trait]
+pub trait ClusterStateWatch: Send {
+    /// Wait for the next event.
+    async fn next(&mut self) -> StateStoreResult<NodeEvent>;
+}
+
+/// Strongly consistent, lease-oriented storage used by active-active
+/// coordinators.
+#[async_trait]
+pub trait ClusterStateStore: Send + Sync {
+    /// Backend implementation represented by this store.
+    fn backend(&self) -> StateBackend;
+
+    /// Insert or refresh a node status for `lease_ttl`.
+    ///
+    /// Implementations reject duplicate/out-of-order heartbeat sequences
+    /// without refreshing the lease.
+    async fn upsert_node(
+        &self,
+        status: NodeStatus,
+        lease_ttl: Duration,
+    ) -> StateStoreResult<WriteResult>;
+
+    /// Remove a node only if `incarnation_id` still owns the current record.
+    async fn remove_node(
+        &self,
+        cluster_id: &str,
+        node_id: &NodeId,
+        incarnation_id: &str,
+    ) -> StateStoreResult<WriteResult>;
+
+    /// Return a linearizable snapshot for one cluster.
+    async fn snapshot(&self, cluster_id: &str) -> StateStoreResult<ClusterSnapshot>;
+
+    /// Watch events strictly after `after_revision`.
+    ///
+    /// `None` starts after the backend's current revision. A compacted revision
+    /// returns [`StateStoreError::Compacted`], prompting a fresh snapshot.
+    async fn watch(
+        &self,
+        cluster_id: &str,
+        after_revision: Option<&StoreRevision>,
+    ) -> StateStoreResult<Box<dyn ClusterStateWatch>>;
+
+    /// Verify the backend can serve authoritative requests.
+    async fn check_ready(&self) -> StateStoreResult<BackendHealth>;
+}
+
+/// Backend-neutral state-store failures.
+#[derive(Debug, thiserror::Error)]
+pub enum StateStoreError {
+    /// A status record violated the shared schema contract.
+    #[error("invalid node status: {0}")]
+    InvalidRecord(#[from] NodeStatusError),
+    /// A lease duration was zero or could not be represented.
+    #[error("invalid lease TTL: {0:?}")]
+    InvalidLeaseTtl(Duration),
+    /// A revision token was empty, malformed, or belonged to another backend.
+    #[error("invalid revision {revision:?}: {detail}")]
+    InvalidRevision {
+        /// Backend that rejected the token, when known.
+        backend: Option<StateBackend>,
+        /// Rejected opaque token.
+        revision: String,
+        /// Stable diagnostic detail without credentials.
+        detail: &'static str,
+    },
+    /// A watch can no longer resume from the requested revision.
+    #[error("revision {requested} was compacted; oldest available is {oldest}")]
+    Compacted {
+        /// Requested resume revision.
+        requested: StoreRevision,
+        /// Oldest revision retained by the backend.
+        oldest: StoreRevision,
+    },
+    /// A live watch receiver fell behind its bounded event buffer.
+    #[error("state watch lagged by {skipped} events after revision {after}")]
+    WatchLagged {
+        /// Last revision delivered to the caller.
+        after: StoreRevision,
+        /// Number of skipped events reported by the backend/client.
+        skipped: u64,
+    },
+    /// Backend authentication failed.
+    #[error("{backend} state backend authentication failed")]
+    Authentication {
+        /// Selected backend.
+        backend: StateBackend,
+    },
+    /// Backend authorization denied the requested operation.
+    #[error("{backend} state backend permission denied")]
+    PermissionDenied {
+        /// Selected backend.
+        backend: StateBackend,
+    },
+    /// A backend operation exceeded its configured deadline.
+    #[error("{backend} state backend operation timed out")]
+    Timeout {
+        /// Selected backend.
+        backend: StateBackend,
+    },
+    /// The backend or watch transport is unavailable.
+    #[error("{backend} state backend unavailable: {detail}")]
+    Unavailable {
+        /// Selected backend.
+        backend: StateBackend,
+        /// Sanitized diagnostic detail.
+        detail: String,
+    },
+}
+
+impl StateStoreError {
+    /// Whether retrying after backoff or relisting can recover the operation.
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::Compacted { .. }
+                | Self::WatchLagged { .. }
+                | Self::Timeout { .. }
+                | Self::Unavailable { .. }
+        )
+    }
+}

--- a/crates/talon-coordinator/src/state_store/testkit.rs
+++ b/crates/talon-coordinator/src/state_store/testkit.rs
@@ -1,0 +1,154 @@
+//! Reusable behavioral contract for production state-store implementations.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use talon_core::{
+    NodeHealth, NodeId, NodeInfo, NodeMetricsSnapshot, NodeRole, NodeStatus,
+    NODE_STATUS_SCHEMA_VERSION,
+};
+
+use super::{ClusterStateStore, NodeEventKind, StoreRevision, WriteDisposition};
+
+#[async_trait]
+pub trait StoreContractHarness {
+    fn store(&self) -> Arc<dyn ClusterStateStore>;
+    fn lease_ttl(&self) -> Duration;
+    async fn elapse(&self, duration: Duration);
+}
+
+pub fn worker_status(node_id: &str, incarnation: &str, seq: u64) -> NodeStatus {
+    NodeStatus {
+        schema_version: NODE_STATUS_SCHEMA_VERSION,
+        cluster_id: "contract".into(),
+        node: NodeInfo {
+            id: NodeId::new(node_id),
+            address: format!("{node_id}:7001"),
+            role: NodeRole::Worker,
+        },
+        incarnation_id: incarnation.into(),
+        admin_address: Some(format!("{node_id}:8001")),
+        build_version: "test".into(),
+        started_at_unix_ms: if incarnation == "inc-1" { 1_000 } else { 2_000 },
+        reported_at_unix_ms: if incarnation == "inc-1" {
+            1_000 + seq
+        } else {
+            2_000 + seq
+        },
+        heartbeat_seq: seq,
+        health: NodeHealth::Healthy,
+        ready: true,
+        metrics: NodeMetricsSnapshot {
+            requests_total: seq,
+            block_count: seq,
+            ..Default::default()
+        },
+        labels: BTreeMap::new(),
+    }
+}
+
+pub async fn assert_store_contract<H: StoreContractHarness>(harness: &H) {
+    let store = harness.store();
+    let ttl = harness.lease_ttl();
+
+    let first = store
+        .upsert_node(worker_status("w1", "inc-1", 0), ttl)
+        .await
+        .unwrap();
+    assert_eq!(first.disposition, WriteDisposition::Applied);
+    let duplicate = store
+        .upsert_node(worker_status("w1", "inc-1", 0), ttl)
+        .await
+        .unwrap();
+    assert_eq!(duplicate.disposition, WriteDisposition::Duplicate);
+    assert_eq!(duplicate.revision, first.revision);
+
+    let snapshot = store.snapshot("contract").await.unwrap();
+    assert_eq!(snapshot.nodes.len(), 1);
+    assert_eq!(snapshot.nodes[0].heartbeat_seq, 0);
+    let mut watch = store
+        .watch("contract", Some(&snapshot.revision))
+        .await
+        .unwrap();
+
+    let newer = store
+        .upsert_node(worker_status("w1", "inc-1", 2), ttl)
+        .await
+        .unwrap();
+    assert_eq!(newer.disposition, WriteDisposition::Applied);
+    let stale = store
+        .upsert_node(worker_status("w1", "inc-1", 1), ttl)
+        .await
+        .unwrap();
+    assert_eq!(stale.disposition, WriteDisposition::Stale);
+    assert_eq!(stale.revision, newer.revision);
+
+    let event = watch.next().await.unwrap();
+    assert_eq!(event.kind, NodeEventKind::Upserted);
+    assert_eq!(event.status.unwrap().heartbeat_seq, 2);
+
+    let mut tasks = Vec::new();
+    for seq in 3..=16 {
+        let store = Arc::clone(&store);
+        tasks.push(tokio::spawn(async move {
+            store
+                .upsert_node(worker_status("w1", "inc-1", seq), ttl)
+                .await
+                .unwrap()
+        }));
+    }
+    for task in tasks {
+        task.await.unwrap();
+    }
+    assert_eq!(
+        store.snapshot("contract").await.unwrap().nodes[0].heartbeat_seq,
+        16
+    );
+
+    let restarted = store
+        .upsert_node(worker_status("w1", "inc-2", 0), ttl)
+        .await
+        .unwrap();
+    assert_eq!(restarted.disposition, WriteDisposition::Applied);
+    let old_incarnation = store
+        .upsert_node(worker_status("w1", "inc-1", 99), ttl)
+        .await
+        .unwrap();
+    assert_eq!(old_incarnation.disposition, WriteDisposition::Stale);
+
+    let wrong_owner = store
+        .remove_node("contract", &NodeId::new("w1"), "inc-1")
+        .await
+        .unwrap();
+    assert_eq!(wrong_owner.disposition, WriteDisposition::Stale);
+    let removed = store
+        .remove_node("contract", &NodeId::new("w1"), "inc-2")
+        .await
+        .unwrap();
+    assert_eq!(removed.disposition, WriteDisposition::Applied);
+    assert!(store.snapshot("contract").await.unwrap().nodes.is_empty());
+
+    store
+        .upsert_node(worker_status("expiring", "inc-1", 0), ttl)
+        .await
+        .unwrap();
+    let before_expiry = store.snapshot("contract").await.unwrap();
+    let mut expiry_watch = store
+        .watch("contract", Some(&before_expiry.revision))
+        .await
+        .unwrap();
+    harness.elapse(ttl + Duration::from_millis(1)).await;
+    assert!(store.snapshot("contract").await.unwrap().nodes.is_empty());
+    let expired = expiry_watch.next().await.unwrap();
+    assert_eq!(expired.kind, NodeEventKind::Removed);
+    assert_eq!(expired.node_id, NodeId::new("expiring"));
+
+    let health = store.check_ready().await.unwrap();
+    assert_eq!(health.backend, store.backend());
+    assert!(health.revision.is_some());
+
+    let empty = StoreRevision::new("");
+    assert!(empty.is_err());
+}


### PR DESCRIPTION
## Summary
- add a backend-neutral async ClusterStateStore contract with opaque revisions, snapshots, watches, readiness, and retryable error taxonomy
- add a deterministic in-memory lease backend with idempotent ordered writes, TTL expiry, bounded watch history, and fault injection
- add backend/HA configuration validation and a reusable contract testkit for etcd and Kubernetes implementations

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo build --workspace --all-targets --all-features --locked
- cargo test --workspace --all-features --locked
- git diff --check

Parent: #72
Closes #75