### PR TITLE
feat(fuse): split multi-block reads into per-block segments

### DIFF
--- a/crates/talon-fuse/src/block_reader.rs
+++ b/crates/talon-fuse/src/block_reader.rs
@@ -21,10 +21,11 @@
 
 use std::sync::Arc;
 
-use talon_core::BlockId;
+use talon_core::{BlockId, ObjectId, Version};
 
 use crate::coordinator_client::{CoordinatorClient, CoordinatorError};
 use crate::placement_cache::{Cached, PlacementCache};
+use crate::read_plan::plan_read;
 use crate::worker_client::{WorkerClient, WorkerError};
 
 /// Errors from a block read.
@@ -42,6 +43,23 @@ pub enum BlockReadError {
     /// An owner id had no resolvable worker address in membership.
     #[error("owner has no known worker address")]
     UnresolvedOwner,
+}
+
+/// The coordinates of an open file needed to plan a read: its object identity,
+/// logical block size, source version/etag, and total size (for EOF clamping).
+///
+/// Grouping these keeps [`BlockReader::read`] to a small argument list and
+/// mirrors what a `getattr`/HEAD lookup yields for an open handle.
+#[derive(Debug, Clone)]
+pub struct FileView<'a> {
+    /// The object being read.
+    pub object: &'a ObjectId,
+    /// Logical block size in bytes.
+    pub block_size: u32,
+    /// Source version/etag guarding the blocks.
+    pub version: &'a Version,
+    /// Total object length, used to clamp reads at EOF.
+    pub size: u64,
 }
 
 /// Orchestrates block reads against the coordinator + workers with caching.
@@ -89,6 +107,39 @@ impl BlockReader {
             .fetch_range(&block.object, abs_offset, len as u64)
             .await?;
         Ok(bytes)
+    }
+
+    /// Read `[offset, offset+len)` of a file, spanning block boundaries.
+    ///
+    /// Splits the request into per-block segments via
+    /// [`crate::read_plan::plan_read`] (clamped to `file.size` at EOF),
+    /// fetches each segment through [`read_block`](Self::read_block) — so each
+    /// segment independently benefits from the placement cache — and
+    /// concatenates the results in order. A read at or past EOF returns an empty
+    /// buffer (POSIX short read).
+    pub async fn read(
+        &self,
+        file: &FileView<'_>,
+        offset: u64,
+        len: u64,
+        now_ms: u64,
+    ) -> Result<Vec<u8>, BlockReadError> {
+        let plan = plan_read(
+            file.object,
+            offset,
+            len,
+            file.block_size,
+            file.version,
+            file.size,
+        );
+        let mut out = Vec::with_capacity(plan.iter().map(|s| s.len as usize).sum());
+        for seg in plan {
+            let bytes = self
+                .read_block(&seg.block, seg.offset_in_block, seg.len, now_ms)
+                .await?;
+            out.extend_from_slice(&bytes);
+        }
+        Ok(out)
     }
 
     /// Look the block up via the coordinator and insert the resolved,
@@ -308,5 +359,60 @@ mod tests {
             err,
             BlockReadError::Worker(WorkerError::Remote(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn multi_block_read_stitches_in_order() {
+        // Small block size so a modest read spans several blocks.
+        let hits = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let worker_addr = mock_worker(Arc::clone(&hits)).await;
+        let coord_addr = mock_coordinator(worker_addr).await;
+        let cache = Arc::new(PlacementCache::new(10_000));
+        let reader = BlockReader::new(CoordinatorClient::new(coord_addr), Arc::clone(&cache), 1);
+
+        let obj = ObjectId::new(Backend::S3, "b", "o/1");
+        let ver = Version::new("v1");
+        let bs = 1024u32;
+        let size = 100_000u64;
+        // Read 900..900+2300 → spans 4 blocks (tail, full, full, head).
+        let offset = 900u64;
+        let len = 2300u64;
+        let file = FileView {
+            object: &obj,
+            block_size: bs,
+            version: &ver,
+            size,
+        };
+        let bytes = reader.read(&file, offset, len, 0).await.unwrap();
+        assert_eq!(bytes.len() as u64, len);
+        // The mock worker fills each byte with (absolute_offset % 256); the
+        // stitched buffer must be contiguous across block boundaries.
+        for (i, b) in bytes.iter().enumerate() {
+            assert_eq!(*b, ((offset + i as u64) % 256) as u8, "byte {i} mismatch");
+        }
+        // Four distinct blocks were fetched (one worker call each).
+        assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 4);
+        assert_eq!(cache.len(), 4, "each block's placement cached");
+    }
+
+    #[tokio::test]
+    async fn read_past_eof_is_empty_without_fetch() {
+        let hits = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let worker_addr = mock_worker(Arc::clone(&hits)).await;
+        let coord_addr = mock_coordinator(worker_addr).await;
+        let cache = Arc::new(PlacementCache::new(10_000));
+        let reader = BlockReader::new(CoordinatorClient::new(coord_addr), cache, 1);
+
+        let obj = ObjectId::new(Backend::S3, "b", "o/1");
+        let ver = Version::new("v1");
+        let file = FileView {
+            object: &obj,
+            block_size: 1024,
+            version: &ver,
+            size: 1500,
+        };
+        let bytes = reader.read(&file, 5000, 10, 0).await.unwrap();
+        assert!(bytes.is_empty());
+        assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 0);
     }
 }

--- a/crates/talon-fuse/src/lib.rs
+++ b/crates/talon-fuse/src/lib.rs
@@ -11,15 +11,17 @@ pub mod fs;
 pub mod mapping;
 pub mod ops;
 pub mod placement_cache;
+pub mod read_plan;
 pub mod readahead;
 pub mod worker_client;
 
-pub use block_reader::{BlockReadError, BlockReader};
+pub use block_reader::{BlockReadError, BlockReader, FileView};
 pub use bridge::{spawn_bridge, BridgeClient, BridgeError};
 pub use coordinator_client::{CoordinatorClient, CoordinatorError, Placement, ResolvedPlacement};
 pub use fs::TalonFs;
 pub use mapping::{object_to_path, path_to_object, resolve_read, ReadTarget};
 pub use ops::{Attr, DirEntry, FileKind, FsError, ReadOnlyFs, ROOT_INO};
 pub use placement_cache::{Cached, PlacementCache, RefreshReason};
+pub use read_plan::{plan_read, BlockSegment};
 pub use readahead::{ReadaheadConfig, ReadaheadState};
 pub use worker_client::{WorkerClient, WorkerError};

--- a/crates/talon-fuse/src/read_plan.rs
+++ b/crates/talon-fuse/src/read_plan.rs
@@ -1,0 +1,170 @@
+//! Splitting a byte read into per-block fetch segments.
+//!
+//! A single POSIX `read(offset, len)` may span multiple 256 MiB blocks, and the
+//! read path fetches one block at a time. [`plan_read`] turns a request into an
+//! ordered list of [`BlockSegment`]s — each naming the [`BlockId`] to fetch, the
+//! offset *within* that block, and how many bytes to take from it — so a caller
+//! can fetch each segment and concatenate the results in order to reconstruct
+//! the requested range.
+//!
+//! The plan is clamped to the file's `size`: a read starting at or past EOF
+//! yields an empty plan, and a read overrunning EOF is truncated at the last
+//! valid byte (mirroring POSIX short reads). This is pure arithmetic over
+//! [`mapping::resolve_read`](crate::mapping::resolve_read); no I/O happens here.
+
+use talon_core::{BlockId, ObjectId, Version};
+
+use crate::mapping::resolve_read;
+
+/// One block-local slice of a larger read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockSegment {
+    /// The block to fetch this slice from.
+    pub block: BlockId,
+    /// Offset of the slice within the block (`0..block_size`).
+    pub offset_in_block: u32,
+    /// Number of bytes to take from the block starting at `offset_in_block`.
+    pub len: u32,
+}
+
+/// Split `[offset, offset+len)` of `obj` into ordered per-block segments.
+///
+/// - `block_size` is the file's logical block size and `version` its source
+///   version/etag (both from the coordinator/HEAD).
+/// - `size` is the object's total byte length, used to clamp at EOF.
+///
+/// Returns segments in ascending offset order. The concatenation of every
+/// segment's `len` equals `min(len, size.saturating_sub(offset))`.
+pub fn plan_read(
+    obj: &ObjectId,
+    offset: u64,
+    len: u64,
+    block_size: u32,
+    version: &Version,
+    size: u64,
+) -> Vec<BlockSegment> {
+    if block_size == 0 || len == 0 || offset >= size {
+        return Vec::new();
+    }
+    // Clamp the read to the end of the object (POSIX short read at EOF).
+    let end = offset.saturating_add(len).min(size);
+    let bs = block_size as u64;
+
+    let mut segments = Vec::new();
+    let mut pos = offset;
+    while pos < end {
+        // The block covering `pos`, plus the offset of `pos` within it.
+        let target = match resolve_read(obj, pos, block_size, version) {
+            Ok(t) => t,
+            Err(_) => break, // block_size==0 guarded above; defensive.
+        };
+        let block_start = target.block.offset;
+        let block_end = block_start + bs;
+        // Take up to the block boundary or the clamped read end, whichever first.
+        let seg_end = block_end.min(end);
+        let seg_len = (seg_end - pos) as u32;
+        segments.push(BlockSegment {
+            block: target.block,
+            offset_in_block: target.offset_in_block,
+            len: seg_len,
+        });
+        pos = seg_end;
+    }
+    segments
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use talon_core::Backend;
+
+    fn obj() -> ObjectId {
+        ObjectId::new(Backend::S3, "b", "o")
+    }
+
+    fn v() -> Version {
+        Version::new("etag-1")
+    }
+
+    /// Total bytes covered by a plan.
+    fn total(plan: &[BlockSegment]) -> u64 {
+        plan.iter().map(|s| s.len as u64).sum()
+    }
+
+    #[test]
+    fn single_block_read_is_one_segment() {
+        let bs = 1024u32;
+        let plan = plan_read(&obj(), 100, 200, bs, &v(), 10_000);
+        assert_eq!(plan.len(), 1);
+        assert_eq!(plan[0].block.offset, 0);
+        assert_eq!(plan[0].offset_in_block, 100);
+        assert_eq!(plan[0].len, 200);
+    }
+
+    #[test]
+    fn read_spanning_two_blocks_splits_at_boundary() {
+        let bs = 1024u32;
+        // Start 100 before the boundary, run 300 bytes → 100 in block0, 200 in block1.
+        let plan = plan_read(&obj(), 924, 300, bs, &v(), 10_000);
+        assert_eq!(plan.len(), 2);
+        assert_eq!(plan[0].block.offset, 0);
+        assert_eq!(plan[0].offset_in_block, 924);
+        assert_eq!(plan[0].len, 100);
+        assert_eq!(plan[1].block.offset, 1024);
+        assert_eq!(plan[1].offset_in_block, 0);
+        assert_eq!(plan[1].len, 200);
+        assert_eq!(total(&plan), 300);
+    }
+
+    #[test]
+    fn read_spanning_many_blocks_has_full_middle_segments() {
+        let bs = 1024u32;
+        // 900..3200 → block0 tail(124), block1 full(1024), block2 full(1024),
+        // block3 head(128).
+        let plan = plan_read(&obj(), 900, 2300, bs, &v(), 100_000);
+        assert_eq!(plan.len(), 4);
+        assert_eq!(plan[0].len, 124); // 1024-900
+        assert_eq!(plan[1].offset_in_block, 0);
+        assert_eq!(plan[1].len, 1024); // full middle block
+        assert_eq!(plan[2].block.offset, 2048);
+        assert_eq!(plan[2].offset_in_block, 0);
+        assert_eq!(plan[2].len, 1024); // full middle block
+        assert_eq!(plan[3].block.offset, 3072);
+        assert_eq!(plan[3].offset_in_block, 0);
+        assert_eq!(plan[3].len, 128); // 3200-3072
+        assert_eq!(total(&plan), 2300);
+    }
+
+    #[test]
+    fn read_clamped_at_eof() {
+        let bs = 1024u32;
+        // File is 1500 bytes; read 1400..1400+400 overruns → clamped to 100 bytes.
+        let plan = plan_read(&obj(), 1400, 400, bs, &v(), 1500);
+        assert_eq!(total(&plan), 100);
+        assert_eq!(plan.last().unwrap().block.offset, 1024);
+    }
+
+    #[test]
+    fn read_at_or_past_eof_is_empty() {
+        let bs = 1024u32;
+        assert!(plan_read(&obj(), 1500, 10, bs, &v(), 1500).is_empty());
+        assert!(plan_read(&obj(), 5000, 10, bs, &v(), 1500).is_empty());
+    }
+
+    #[test]
+    fn zero_len_or_zero_block_size_is_empty() {
+        assert!(plan_read(&obj(), 0, 0, 1024, &v(), 1000).is_empty());
+        assert!(plan_read(&obj(), 0, 10, 0, &v(), 1000).is_empty());
+    }
+
+    #[test]
+    fn exact_block_aligned_read() {
+        let bs = 1024u32;
+        // Exactly two full blocks starting at a boundary.
+        let plan = plan_read(&obj(), 1024, 2048, bs, &v(), 10_000);
+        assert_eq!(plan.len(), 2);
+        assert!(plan.iter().all(|s| s.offset_in_block == 0 && s.len == 1024));
+        assert_eq!(plan[0].block.offset, 1024);
+        assert_eq!(plan[1].block.offset, 2048);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `read_plan::plan_read`: turns a `(offset, len)` read spanning several 256 MiB blocks into an ordered list of `BlockSegment`s (block + offset-in-block + length), clamped to object size (empty at/after EOF, truncated on overrun — POSIX short read). Pure arithmetic over `mapping::resolve_read`.
- `BlockReader::read` executes a plan: fetches each segment via `read_block` (each block still hits the placement cache) and stitches results in order. Params grouped into a `FileView` (object/block_size/version/size).

## Testing
- Table-driven plan cases: single block, two-block boundary split, many-block with full middle segments, EOF clamp, past-EOF empty, zero-len/zero-block-size, exact aligned.
- Mock end-to-end multi-block read verifying contiguous stitched bytes and one worker fetch per block; past-EOF returns empty with zero fetches.
- `cargo test --workspace`, `clippy -D warnings`, `doc`, `fmt --check` clean.

Part of #88. Closes #95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)