### PR TITLE
feat(fuse): add replica fallback and epoch reconciliation

### DIFF
--- a/crates/talon-fuse/src/block_reader.rs
+++ b/crates/talon-fuse/src/block_reader.rs
@@ -12,19 +12,20 @@
 //! client actually dials), derived by resolving the coordinator's owner
 //! [`NodeId`](talon_core::NodeId)s through the membership snapshot. Storing the
 //! dialable address keeps the hot path allocation-light and makes replica
-//! fallback (a future step, issue #97) a simple walk down the ordered list.
+//! fallback a simple walk down the ordered list.
 //!
-//! This step (issue #94) implements the **single-block, primary-owner** path:
-//! it reads from the first (highest-weight) owner. Multi-block splitting
-//! (#95), readahead (#96), and replica fallback / epoch reconciliation (#97)
-//! build on this without changing the cache shape.
+//! On a fetch failure the reader walks the cached replicas in order; if all are
+//! exhausted it invalidates the entry and performs one coordinator refresh
+//! before giving up. [`BlockReader::observe_epoch`] reconciles the cache when a
+//! newer placement epoch is seen. Multi-block splitting is handled by
+//! [`crate::read_plan`] and readahead by [`crate::prefetch`].
 
 use std::sync::Arc;
 
 use talon_core::{BlockId, ObjectId, Version};
 
 use crate::coordinator_client::{CoordinatorClient, CoordinatorError};
-use crate::placement_cache::{Cached, PlacementCache};
+use crate::placement_cache::{Cached, PlacementCache, RefreshReason};
 use crate::read_plan::plan_read;
 use crate::worker_client::{WorkerClient, WorkerError};
 
@@ -43,6 +44,9 @@ pub enum BlockReadError {
     /// An owner id had no resolvable worker address in membership.
     #[error("owner has no known worker address")]
     UnresolvedOwner,
+    /// Every replica failed, including after a coordinator refresh.
+    #[error("all replicas failed after refresh")]
+    AllReplicasFailed,
 }
 
 /// The coordinates of an open file needed to plan a read: its object identity,
@@ -87,9 +91,20 @@ impl BlockReader {
     /// Read `len` bytes at `offset_in_block` within `block`.
     ///
     /// Resolves placement (cache hit, else coordinator lookup that populates the
-    /// cache at `now_ms`), then fetches the sub-range from the primary owner.
-    /// The absolute object offset handed to the worker is
+    /// cache at `now_ms`), then fetches the sub-range from an owner. The
+    /// absolute object offset handed to the worker is
     /// `block.offset + offset_in_block`.
+    ///
+    /// # Replica fallback & refresh
+    ///
+    /// A worker that is unreachable ([`WorkerError::Io`], a
+    /// [`RefreshReason::ConnectFailure`]) or that no longer holds the block
+    /// ([`WorkerError::Remote`], a [`RefreshReason::WrongOwner`]) does not fail
+    /// the read outright: the reader walks the ordered replica list from the
+    /// cached placement. If every cached replica is exhausted, it invalidates
+    /// the entry and performs **one** coordinator refresh (which may return a
+    /// newer epoch / different owners), then retries against the fresh primary.
+    /// Only if that also fails does the error propagate.
     pub async fn read_block(
         &self,
         block: &BlockId,
@@ -101,13 +116,70 @@ impl BlockReader {
             Some(c) => c,
             None => self.resolve_and_cache(block, now_ms).await?,
         };
-        let addr = cached.primary().ok_or(BlockReadError::NoOwners)?;
-        let worker = WorkerClient::new(addr);
         let abs_offset = block.offset + offset_in_block as u64;
-        let bytes = worker
-            .fetch_range(&block.object, abs_offset, len as u64)
-            .await?;
-        Ok(bytes)
+
+        // First pass: walk the cached replica list in order.
+        match self
+            .try_replicas(block, &cached.replicas, abs_offset, len)
+            .await
+        {
+            Ok(bytes) => return Ok(bytes),
+            Err(reason) => {
+                // Every cached replica failed; drop the stale placement and do a
+                // single coordinator refresh before giving up.
+                self.cache.invalidate(block, reason);
+            }
+        }
+
+        let fresh = self.resolve_and_cache(block, now_ms).await?;
+        self.try_replicas(block, &fresh.replicas, abs_offset, len)
+            .await
+            .map_err(|_| BlockReadError::AllReplicasFailed)
+    }
+
+    /// Try each replica address in order; return the first success, or the
+    /// [`RefreshReason`] describing why the whole list failed.
+    ///
+    /// A connect failure or a remote "not present" is retryable against the next
+    /// replica; the returned reason reflects the last failure so the caller can
+    /// record an accurate invalidation cause.
+    async fn try_replicas(
+        &self,
+        block: &BlockId,
+        replicas: &[String],
+        abs_offset: u64,
+        len: u32,
+    ) -> Result<Vec<u8>, RefreshReason> {
+        if replicas.is_empty() {
+            return Err(RefreshReason::WrongOwner);
+        }
+        let mut last = RefreshReason::WrongOwner;
+        for addr in replicas {
+            let worker = WorkerClient::new(addr.clone());
+            match worker
+                .fetch_range(&block.object, abs_offset, len as u64)
+                .await
+            {
+                Ok(bytes) => return Ok(bytes),
+                Err(WorkerError::Io(_)) => last = RefreshReason::ConnectFailure,
+                Err(WorkerError::Remote(_)) => last = RefreshReason::WrongOwner,
+                // A framing/encode error is not a placement problem; surface it
+                // as a wrong-owner refresh so we still try to recover.
+                Err(_) => last = RefreshReason::WrongOwner,
+            }
+        }
+        Err(last)
+    }
+
+    /// Reconcile the cache against an observed epoch.
+    ///
+    /// When a response (placement or otherwise) carries a newer epoch than a
+    /// cached entry, that entry is dropped so the next read re-looks-up. This is
+    /// the client half of the coordinator's epoch bump: a membership change
+    /// advances the epoch, and any client holding an older placement refreshes.
+    /// Returns `true` if the entry was invalidated.
+    pub fn observe_epoch(&self, block: &BlockId, observed_epoch: u64) -> bool {
+        self.cache.observe_epoch(block, observed_epoch)
     }
 
     /// Read `[offset, offset+len)` of a file, spanning block boundaries.
@@ -283,6 +355,95 @@ mod tests {
         addr
     }
 
+    /// A mock worker that always replies with an ERROR frame ("not present"),
+    /// counting how many requests it saw. Loops so it survives retries.
+    async fn spawn_erroring_worker(count: Arc<std::sync::atomic::AtomicU32>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            loop {
+                let (mut s, _) = match listener.accept().await {
+                    Ok(v) => v,
+                    Err(_) => return,
+                };
+                let count = Arc::clone(&count);
+                tokio::spawn(async move {
+                    let mut hdr = [0u8; HEADER_LEN];
+                    if s.read_exact(&mut hdr).await.is_err() {
+                        return;
+                    }
+                    let h = FrameHeader::decode(&hdr).unwrap();
+                    let mut body = vec![0u8; h.length as usize];
+                    s.read_exact(&mut body).await.unwrap();
+                    count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    s.write_all(&encode_error(0, "block not present"))
+                        .await
+                        .unwrap();
+                    s.flush().await.unwrap();
+                });
+            }
+        });
+        addr
+    }
+
+    /// A mock coordinator that returns two ordered owners (w1, w2) and resolves
+    /// their addresses via membership.
+    async fn mock_coordinator_two(w1: String, w2: String) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            loop {
+                let (mut s, _) = match listener.accept().await {
+                    Ok(v) => v,
+                    Err(_) => return,
+                };
+                let (w1, w2) = (w1.clone(), w2.clone());
+                tokio::spawn(async move {
+                    let mut hdr = [0u8; HEADER_LEN];
+                    if s.read_exact(&mut hdr).await.is_err() {
+                        return;
+                    }
+                    let h = FrameHeader::decode(&hdr).unwrap();
+                    let mut body = vec![0u8; h.length as usize];
+                    s.read_exact(&mut body).await.unwrap();
+                    let mut full = hdr.to_vec();
+                    full.extend_from_slice(&body);
+                    let (_h, msg) = talon_transport::decode(&full).unwrap();
+                    let reply = match msg {
+                        ControlMessage::PlacementLookup { .. } => {
+                            ControlMessage::PlacementResponse {
+                                owners: vec![NodeId::new("w1"), NodeId::new("w2")],
+                                epoch: 3,
+                            }
+                        }
+                        ControlMessage::MembershipQuery {} => ControlMessage::MembershipList {
+                            nodes: vec![
+                                NodeInfo {
+                                    id: NodeId::new("w1"),
+                                    address: w1.clone(),
+                                    role: NodeRole::Worker,
+                                },
+                                NodeInfo {
+                                    id: NodeId::new("w2"),
+                                    address: w2.clone(),
+                                    role: NodeRole::Worker,
+                                },
+                            ],
+                        },
+                        _ => ControlMessage::Ack {
+                            ok: false,
+                            detail: None,
+                        },
+                    };
+                    let out = talon_transport::encode(0, &reply).unwrap();
+                    s.write_all(&out).await.unwrap();
+                    s.flush().await.unwrap();
+                });
+            }
+        });
+        addr
+    }
+
     #[tokio::test]
     async fn miss_then_hit_fetches_correct_range() {
         let hits = Arc::new(std::sync::atomic::AtomicU32::new(0));
@@ -334,7 +495,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn worker_error_propagates() {
+    async fn all_replicas_failing_errors_after_refresh() {
+        // Single owner whose worker serves exactly one error then closes. The
+        // reader tries it, refreshes (same owner), and on the second attempt the
+        // worker is gone → connect failure → AllReplicasFailed.
         let worker_addr = {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             let a = listener.local_addr().unwrap().to_string();
@@ -356,10 +520,55 @@ mod tests {
         let cache = Arc::new(PlacementCache::new(10_000));
         let reader = BlockReader::new(CoordinatorClient::new(coord_addr), cache, 1);
         let err = reader.read_block(&block(), 0, 16, 0).await.unwrap_err();
-        assert!(matches!(
-            err,
-            BlockReadError::Worker(WorkerError::Remote(_))
-        ));
+        assert!(matches!(err, BlockReadError::AllReplicasFailed));
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_second_replica_on_wrong_owner() {
+        // Primary w1 always errors "not present"; secondary w2 serves the bytes.
+        // The reader must walk from w1 to w2 within the cached list — no refresh.
+        let bad = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let good = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let w1 = spawn_erroring_worker(Arc::clone(&bad)).await;
+        let w2 = mock_worker(Arc::clone(&good)).await;
+        let coord = mock_coordinator_two(w1, w2).await;
+        let cache = Arc::new(PlacementCache::new(10_000));
+        // Request k=2 so both owners are cached.
+        let reader = BlockReader::new(CoordinatorClient::new(coord), Arc::clone(&cache), 2);
+
+        let bytes = reader.read_block(&block(), 0, 32, 0).await.unwrap();
+        assert_eq!(bytes.len(), 32);
+        assert_eq!(
+            bad.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "primary tried"
+        );
+        assert_eq!(
+            good.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "fell back to w2"
+        );
+        // Placement stays cached (fallback within the list, no invalidation).
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn observe_epoch_invalidates_stale_entry() {
+        let hits = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let worker_addr = mock_worker(Arc::clone(&hits)).await;
+        let coord_addr = mock_coordinator(worker_addr).await;
+        let cache = Arc::new(PlacementCache::new(10_000));
+        let reader = BlockReader::new(CoordinatorClient::new(coord_addr), Arc::clone(&cache), 1);
+
+        // Warm the cache (mock_coordinator answers epoch=3).
+        let _ = reader.read_block(&block(), 0, 8, 0).await.unwrap();
+        assert_eq!(cache.len(), 1);
+        // An older/equal epoch does not invalidate.
+        assert!(!reader.observe_epoch(&block(), 3));
+        assert_eq!(cache.len(), 1);
+        // A newer epoch drops the entry so the next read re-looks-up.
+        assert!(reader.observe_epoch(&block(), 4));
+        assert_eq!(cache.len(), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- `read_block` now walks the cached ordered replica list on a fetch failure instead of failing: a connect failure (`WorkerError::Io`) or remote "not present" (`WorkerError::Remote`) advances to the next replica.
- When all cached replicas are exhausted, the entry is invalidated with the right `RefreshReason` and a single coordinator refresh is performed (may carry a newer epoch / owners) before the read errors with `AllReplicasFailed`.
- Adds `BlockReader::observe_epoch` — the client half of the coordinator epoch bump: a strictly newer observed epoch drops the stale cache entry so the next read re-looks-up.

## Testing
- Fall back from a wrong-owner primary to a healthy secondary within the cached list (no refresh, placement retained).
- All-replicas-fail → `AllReplicasFailed` after refresh.
- `observe_epoch` invalidates only on a strictly newer epoch.
- `cargo test --workspace` (50 fuse tests), `clippy -D warnings`, `doc`, `fmt --check` clean.

Part of #88. Closes #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)