### PR TITLE
feat(transport): add StatObject/ObjectStat messages for getattr

### DIFF
--- a/crates/talon-fuse/src/coordinator_client.rs
+++ b/crates/talon-fuse/src/coordinator_client.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashMap;
 
-use talon_core::{BlockId, NodeId, NodeInfo};
+use talon_core::{BlockId, NodeId, NodeInfo, ObjectId};
 use talon_transport::frame::{FrameHeader, MsgType, HEADER_LEN};
 use talon_transport::ControlMessage;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -31,6 +31,15 @@ pub struct Placement {
     pub owners: Vec<NodeId>,
     /// Placement epoch these owners were computed against.
     pub epoch: u64,
+}
+
+/// An object's metadata as answered by the coordinator, for `getattr`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectStat {
+    /// Total object length in bytes (the file size reported to FUSE).
+    pub size: u64,
+    /// Current source version/etag, used to address the object's blocks.
+    pub version: String,
 }
 
 /// Errors from a coordinator round-trip.
@@ -100,8 +109,21 @@ impl CoordinatorClient {
         }
     }
 
+    /// Fetch an object's size + version for `getattr` / block addressing.
+    pub async fn stat_object(&self, object: &ObjectId) -> Result<ObjectStat, CoordinatorError> {
+        let req = ControlMessage::StatObject {
+            object: object.clone(),
+        };
+        match self.round_trip(req, "StatObject").await? {
+            ControlMessage::ObjectStat { size, version } => Ok(ObjectStat { size, version }),
+            other => Err(CoordinatorError::Unexpected {
+                expected: "StatObject",
+                got: Box::new(other),
+            }),
+        }
+    }
+
     /// Locate `block` and resolve the primary owner to a worker address.
-    ///
     /// Combines [`placement_lookup`](Self::placement_lookup) with a
     /// [`membership`](Self::membership) resolution so a caller gets a directly
     /// dialable `host:port` for the highest-weight owner. Returns `Ok(None)`
@@ -268,6 +290,22 @@ mod tests {
         let nodes = client.membership().await.unwrap();
         assert_eq!(nodes.len(), 2);
         assert_eq!(nodes[0].address, "10.0.0.1:7001");
+    }
+
+    #[tokio::test]
+    async fn stat_object_parses_response() {
+        let addr = mock_coordinator(ControlMessage::ObjectStat {
+            size: 2_500_000_000,
+            version: "etag-9".into(),
+        })
+        .await;
+        let client = CoordinatorClient::new(addr);
+        let stat = client
+            .stat_object(&ObjectId::new(Backend::S3, "b", "o/1"))
+            .await
+            .unwrap();
+        assert_eq!(stat.size, 2_500_000_000);
+        assert_eq!(stat.version, "etag-9");
     }
 
     #[tokio::test]

--- a/crates/talon-fuse/src/lib.rs
+++ b/crates/talon-fuse/src/lib.rs
@@ -18,7 +18,9 @@ pub mod worker_client;
 
 pub use block_reader::{BlockReadError, BlockReader, FileView};
 pub use bridge::{spawn_bridge, BridgeClient, BridgeError};
-pub use coordinator_client::{CoordinatorClient, CoordinatorError, Placement, ResolvedPlacement};
+pub use coordinator_client::{
+    CoordinatorClient, CoordinatorError, ObjectStat, Placement, ResolvedPlacement,
+};
 pub use fs::TalonFs;
 pub use mapping::{object_to_path, path_to_object, resolve_read, ReadTarget};
 pub use ops::{Attr, DirEntry, FileKind, FsError, ReadOnlyFs, ROOT_INO};

--- a/crates/talon-transport/src/codec.rs
+++ b/crates/talon-transport/src/codec.rs
@@ -99,6 +99,22 @@ pub enum ControlMessage {
         /// Bounded, versioned status snapshot.
         status: Box<NodeStatus>,
     },
+    /// Client → coordinator: what is this object's size and version?
+    ///
+    /// Backs FUSE `getattr`: the client needs the object length to report file
+    /// size and the version/etag to address blocks. Schema v2. The coordinator
+    /// answers from the backend `HEAD` (or its index).
+    StatObject {
+        /// The object to stat.
+        object: ObjectId,
+    },
+    /// Coordinator → client: an object's size and version.
+    ObjectStat {
+        /// Total object length in bytes.
+        size: u64,
+        /// Current source version/etag of the object.
+        version: String,
+    },
 }
 
 impl ControlMessage {
@@ -106,6 +122,7 @@ impl ControlMessage {
     pub fn minimum_schema(&self) -> u16 {
         match self {
             Self::NodeStatusHeartbeat { .. } => 2,
+            Self::StatObject { .. } | Self::ObjectStat { .. } => 2,
             _ => MIN_CONTROL_SCHEMA_VERSION,
         }
     }
@@ -348,6 +365,13 @@ mod tests {
             ControlMessage::NodeStatusHeartbeat {
                 status: Box::new(sample_status(node)),
             },
+            ControlMessage::StatObject {
+                object: block.object.clone(),
+            },
+            ControlMessage::ObjectStat {
+                size: 2_500_000_000,
+                version: "etag-xyz".into(),
+            },
         ]
     }
 
@@ -410,6 +434,36 @@ mod tests {
                 selected: 1
             })
         ));
+    }
+
+    #[test]
+    fn stat_object_and_object_stat_are_v2() {
+        let stat_req = ControlMessage::StatObject {
+            object: ObjectId::new(Backend::S3, "bkt", "path/obj.bin"),
+        };
+        let stat_resp = ControlMessage::ObjectStat {
+            size: 2_500_000_000,
+            version: "etag-xyz".into(),
+        };
+        for msg in [stat_req, stat_resp] {
+            let buf = encode(1, &msg).unwrap();
+            // Encoded at schema v2 and round-trips.
+            assert_eq!(peek_schema(&buf[HEADER_LEN..]).unwrap(), 2);
+            assert_eq!(decode(&buf).unwrap().1, msg);
+            // An old v1-only peer rejects it cleanly rather than misreading it.
+            assert!(matches!(
+                decode_with_max_schema(&buf, 1),
+                Err(CodecError::UnsupportedSchema { got: 2, ours: 1 })
+            ));
+            // Forcing v1 on encode is refused.
+            assert!(matches!(
+                encode_for_schema(1, &msg, 1),
+                Err(CodecError::MessageRequiresSchema {
+                    required: 2,
+                    selected: 1
+                })
+            ));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds two schema-v2 control messages for FUSE `getattr`: `StatObject { object }` (client asks) and `ObjectStat { size, version }` (coordinator replies with length + version/etag).
- Additive and `non_exhaustive`; v1-only peers reject them cleanly (`UnsupportedSchema`) rather than misreading bytes.
- Wires `CoordinatorClient::stat_object` returning a typed `ObjectStat`.

## Testing
- Both messages round-trip and encode at schema v2, are rejected by a v1 peer, and can't be mislabeled as v1.
- Client parses `ObjectStat`.
- `cargo test --workspace`, `clippy -D warnings`, `doc`, `fmt --check` clean.

Coordinator-side answering (from backend HEAD/index) lands with the serve loop in #103.

Part of #88. Closes #98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)