### PR TITLE
feat(fuse): add object listing to populate the readdir namespace

### DIFF
--- a/crates/talon-fuse/src/coordinator_client.rs
+++ b/crates/talon-fuse/src/coordinator_client.rs
@@ -123,6 +123,26 @@ impl CoordinatorClient {
         }
     }
 
+    /// List objects under `prefix` (mount-relative) for `readdir`.
+    ///
+    /// Returns `(path, size)` entries the caller can feed into a
+    /// [`ReadOnlyFs`](crate::ops::ReadOnlyFs) to synthesize the namespace tree.
+    pub async fn list_objects(
+        &self,
+        prefix: &str,
+    ) -> Result<Vec<talon_transport::ObjectEntry>, CoordinatorError> {
+        let req = ControlMessage::ListObjects {
+            prefix: prefix.to_string(),
+        };
+        match self.round_trip(req, "ListObjects").await? {
+            ControlMessage::ObjectList { entries } => Ok(entries),
+            other => Err(CoordinatorError::Unexpected {
+                expected: "ListObjects",
+                got: Box::new(other),
+            }),
+        }
+    }
+
     /// Locate `block` and resolve the primary owner to a worker address.
     /// Combines [`placement_lookup`](Self::placement_lookup) with a
     /// [`membership`](Self::membership) resolution so a caller gets a directly
@@ -306,6 +326,28 @@ mod tests {
             .unwrap();
         assert_eq!(stat.size, 2_500_000_000);
         assert_eq!(stat.version, "etag-9");
+    }
+
+    #[tokio::test]
+    async fn list_objects_parses_entries() {
+        let addr = mock_coordinator(ControlMessage::ObjectList {
+            entries: vec![
+                talon_transport::ObjectEntry {
+                    path: "s3/b/dir/a.bin".into(),
+                    size: 10,
+                },
+                talon_transport::ObjectEntry {
+                    path: "s3/b/dir/c.bin".into(),
+                    size: 30,
+                },
+            ],
+        })
+        .await;
+        let client = CoordinatorClient::new(addr);
+        let entries = client.list_objects("s3/b/dir").await.unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].path, "s3/b/dir/a.bin");
+        assert_eq!(entries[1].size, 30);
     }
 
     #[tokio::test]

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -157,6 +157,24 @@ impl ReadOnlyFs {
         parent
     }
 
+    /// Bulk-register `(path, size)` listing entries, synthesizing directories.
+    ///
+    /// Convenience over [`insert_object`](Self::insert_object) for populating the
+    /// namespace from a coordinator `ObjectList`. Idempotent: re-inserting an
+    /// existing object is a no-op for the tree shape (the path already resolves).
+    /// Returns the number of entries processed.
+    pub fn populate_from_listing<'a, I>(&self, entries: I) -> usize
+    where
+        I: IntoIterator<Item = (&'a str, u64)>,
+    {
+        let mut n = 0;
+        for (path, size) in entries {
+            self.insert_object(path, size);
+            n += 1;
+        }
+        n
+    }
+
     fn attr_of(node: &Node) -> Attr {
         let perm = match node.kind {
             FileKind::Directory => 0o555,
@@ -321,5 +339,46 @@ mod tests {
     fn mutating_ops_are_read_only() {
         let fs = fs();
         assert_eq!(fs.mutate(), FsError::ReadOnly);
+    }
+
+    #[test]
+    fn populate_from_listing_builds_tree_and_readdir() {
+        let fs = ReadOnlyFs::new();
+        let n = fs.populate_from_listing([
+            ("s3/bkt/dir/a.bin", 10u64),
+            ("s3/bkt/dir/b.bin", 20u64),
+            ("s3/bkt/other.bin", 5u64),
+        ]);
+        assert_eq!(n, 3);
+
+        // Root shows the single backend dir.
+        let root: Vec<String> = fs
+            .readdir(ROOT_INO)
+            .unwrap()
+            .into_iter()
+            .map(|e| e.name)
+            .collect();
+        assert_eq!(root, vec!["s3"]);
+
+        // Walk into the synthesized directories.
+        let s3 = fs.lookup(ROOT_INO, "s3").unwrap();
+        let bkt = fs.lookup(s3.ino, "bkt").unwrap();
+        let bkt_children: Vec<String> = fs
+            .readdir(bkt.ino)
+            .unwrap()
+            .into_iter()
+            .map(|e| e.name)
+            .collect();
+        assert_eq!(bkt_children, vec!["dir", "other.bin"]);
+
+        let dir = fs.lookup(bkt.ino, "dir").unwrap();
+        let a = fs.lookup(dir.ino, "a.bin").unwrap();
+        assert_eq!(a.kind, FileKind::File);
+        assert_eq!(a.size, 10);
+
+        // Idempotent: re-inserting keeps the same inode / shape.
+        let a_ino = a.ino;
+        fs.populate_from_listing([("s3/bkt/dir/a.bin", 10u64)]);
+        assert_eq!(fs.lookup(dir.ino, "a.bin").unwrap().ino, a_ino);
     }
 }

--- a/crates/talon-transport/src/codec.rs
+++ b/crates/talon-transport/src/codec.rs
@@ -115,6 +115,29 @@ pub enum ControlMessage {
         /// Current source version/etag of the object.
         version: String,
     },
+    /// Client → coordinator: list objects under a mount-relative prefix.
+    ///
+    /// Backs FUSE `readdir`: the client asks for the objects beneath a
+    /// directory prefix (e.g. `s3/bucket/dir`) and synthesizes the namespace
+    /// tree from the returned paths. Schema v2.
+    ListObjects {
+        /// Mount-relative prefix to list under (may be empty for the root).
+        prefix: String,
+    },
+    /// Coordinator → client: object entries matching a `ListObjects` prefix.
+    ObjectList {
+        /// Matching objects as `(mount-relative path, size in bytes)` pairs.
+        entries: Vec<ObjectEntry>,
+    },
+}
+
+/// One object listing entry: its mount-relative path and byte size.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObjectEntry {
+    /// Mount-relative object path, e.g. `s3/bucket/dir/file.bin`.
+    pub path: String,
+    /// Object size in bytes.
+    pub size: u64,
 }
 
 impl ControlMessage {
@@ -123,6 +146,7 @@ impl ControlMessage {
         match self {
             Self::NodeStatusHeartbeat { .. } => 2,
             Self::StatObject { .. } | Self::ObjectStat { .. } => 2,
+            Self::ListObjects { .. } | Self::ObjectList { .. } => 2,
             _ => MIN_CONTROL_SCHEMA_VERSION,
         }
     }
@@ -372,6 +396,21 @@ mod tests {
                 size: 2_500_000_000,
                 version: "etag-xyz".into(),
             },
+            ControlMessage::ListObjects {
+                prefix: "s3/bkt/dir".into(),
+            },
+            ControlMessage::ObjectList {
+                entries: vec![
+                    ObjectEntry {
+                        path: "s3/bkt/dir/a.bin".into(),
+                        size: 10,
+                    },
+                    ObjectEntry {
+                        path: "s3/bkt/dir/b.bin".into(),
+                        size: 20,
+                    },
+                ],
+            },
         ]
     }
 
@@ -434,6 +473,28 @@ mod tests {
                 selected: 1
             })
         ));
+    }
+
+    #[test]
+    fn list_objects_and_object_list_are_v2() {
+        let req = ControlMessage::ListObjects {
+            prefix: "s3/bkt/dir".into(),
+        };
+        let resp = ControlMessage::ObjectList {
+            entries: vec![ObjectEntry {
+                path: "s3/bkt/dir/a.bin".into(),
+                size: 10,
+            }],
+        };
+        for msg in [req, resp] {
+            let buf = encode(1, &msg).unwrap();
+            assert_eq!(peek_schema(&buf[HEADER_LEN..]).unwrap(), 2);
+            assert_eq!(decode(&buf).unwrap().1, msg);
+            assert!(matches!(
+                decode_with_max_schema(&buf, 1),
+                Err(CodecError::UnsupportedSchema { got: 2, ours: 1 })
+            ));
+        }
     }
 
     #[test]

--- a/crates/talon-transport/src/lib.rs
+++ b/crates/talon-transport/src/lib.rs
@@ -17,8 +17,8 @@ pub mod pool;
 pub mod runtime;
 
 pub use codec::{
-    decode, encode, encode_for_schema, CodecError, ControlMessage, CONTROL_SCHEMA_VERSION,
-    MIN_CONTROL_SCHEMA_VERSION,
+    decode, encode, encode_for_schema, CodecError, ControlMessage, ObjectEntry,
+    CONTROL_SCHEMA_VERSION, MIN_CONTROL_SCHEMA_VERSION,
 };
 pub use data::{
     decode_request, encode_error, encode_request, response_header_ok, DataError, RangeRequest,


### PR DESCRIPTION
## Summary
- Adds schema-v2 `ListObjects { prefix }` / `ObjectList { entries }` control messages (`ObjectEntry { path, size }`) so the client can enumerate objects under a directory prefix for `readdir`.
- `CoordinatorClient::list_objects` wraps the round-trip.
- `ReadOnlyFs::populate_from_listing` bulk-inserts `(path, size)` entries, synthesizing intermediate directories; idempotent on re-insert.

## Testing
- Both messages round-trip at schema v2, rejected by a v1 peer.
- Client parses `ObjectList`; `populate_from_listing` builds the tree, `readdir` returns sorted children across synthesized dirs, re-insert keeps the same inode.
- `cargo test --workspace`, `clippy -D warnings`, `doc`, `fmt --check` clean.

Coordinator-side listing (from backend/index) lands with the serve loop in #103.

Part of #88. Closes #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)