### PR TITLE
feat(fuse): add fuser behind a 'mount' feature with scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +335,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fuser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e697f6f62c20b6fad1ba0f84ae909f25971cf16e735273524e3977c94604cf8"
+dependencies = [
+ "libc",
+ "log",
+ "memchr",
+ "page_size",
+ "smallvec",
+ "zerocopy",
 ]
 
 [[package]]
@@ -753,6 +773,16 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1305,6 +1335,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "fuser",
  "talon-core",
  "talon-transport",
  "thiserror",
@@ -1745,6 +1776,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +1927,27 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/crates/talon-fuse/Cargo.toml
+++ b/crates/talon-fuse/Cargo.toml
@@ -22,5 +22,14 @@ clap.workspace = true
 async-trait.workspace = true
 thiserror.workspace = true
 
-# Uncomment to implement the actual FUSE mount layer:
-# fuser = "0.14"
+# The kernel mount layer is optional: enabling the `mount` feature pulls in
+# `fuser` and compiles the `fuser::Filesystem` adapter. Default builds (and CI
+# environments without `/dev/fuse` or libfuse) omit it entirely, so the read
+# path stays testable everywhere. `default-features = false` drops fuser's
+# libfuse C dependency (it talks to /dev/fuse directly), so `--features mount`
+# compiles without the libfuse headers installed.
+fuser = { version = "0.14", optional = true, default-features = false }
+
+[features]
+# Compile the kernel FUSE mount adapter (requires fuser).
+mount = ["dep:fuser"]

--- a/crates/talon-fuse/src/block_reader.rs
+++ b/crates/talon-fuse/src/block_reader.rs
@@ -88,6 +88,11 @@ impl BlockReader {
         }
     }
 
+    /// The coordinator address this reader resolves placement against.
+    pub fn coordinator_addr(&self) -> &str {
+        self.coordinator.addr()
+    }
+
     /// Read `len` bytes at `offset_in_block` within `block`.
     ///
     /// Resolves placement (cache hit, else coordinator lookup that populates the

--- a/crates/talon-fuse/src/lib.rs
+++ b/crates/talon-fuse/src/lib.rs
@@ -9,6 +9,8 @@ pub mod bridge;
 pub mod coordinator_client;
 pub mod fs;
 pub mod mapping;
+#[cfg(feature = "mount")]
+pub mod mount;
 pub mod ops;
 pub mod placement_cache;
 pub mod prefetch;
@@ -23,6 +25,8 @@ pub use coordinator_client::{
 };
 pub use fs::TalonFs;
 pub use mapping::{object_to_path, path_to_object, resolve_read, ReadTarget};
+#[cfg(feature = "mount")]
+pub use mount::TalonFuse;
 pub use ops::{Attr, DirEntry, FileKind, FsError, ReadOnlyFs, ROOT_INO};
 pub use placement_cache::{Cached, PlacementCache, RefreshReason};
 pub use prefetch::Prefetcher;

--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -1,0 +1,95 @@
+//! Kernel FUSE mount adapter (`mount` feature).
+//!
+//! This module is compiled only with `--features mount`; it pulls in `fuser`
+//! and defines [`TalonFuse`], the type that implements [`fuser::Filesystem`] by
+//! delegating to the runtime-independent read-path logic ([`ReadOnlyFs`],
+//! [`BlockReader`]). Keeping it behind a feature means `cargo build`/`test
+//! --workspace` — including CI without `/dev/fuse` or libfuse — never needs the
+//! kernel bindings, while the mount binary opts in explicitly.
+//!
+//! This step ([#100]) is the **scaffold**: it wires the struct, its
+//! construction, and a `fuser::Filesystem` impl with the six read ops present
+//! but not yet dispatching (metadata callbacks land in #101, data in #102).
+//! Every method compiles and is ready to be filled in without touching the
+//! feature plumbing again.
+//!
+//! [#100]: https://github.com/milvus-io/talon/issues/100
+
+use std::sync::Arc;
+
+use crate::block_reader::BlockReader;
+use crate::ops::ReadOnlyFs;
+
+/// A mountable Talon filesystem: the `fuser` adapter over the read path.
+///
+/// Holds the namespace tree ([`ReadOnlyFs`]) that answers metadata ops and the
+/// [`BlockReader`] that serves data ops. A Tokio [`Handle`](tokio::runtime::Handle)
+/// is retained so the synchronous `fuser` callbacks can drive the async read
+/// path (via the bridge) once the data callbacks are implemented.
+pub struct TalonFuse {
+    /// Synthesized namespace tree for lookup/getattr/readdir.
+    fs: Arc<ReadOnlyFs>,
+    /// Read-path orchestrator for open/read.
+    reader: BlockReader,
+    /// Handle to the async runtime the callbacks dispatch onto.
+    runtime: tokio::runtime::Handle,
+}
+
+impl TalonFuse {
+    /// Build the adapter over a populated namespace and a read-path reader.
+    ///
+    /// `runtime` is the handle the synchronous FUSE callbacks use to run async
+    /// work; typically `tokio::runtime::Handle::current()` on the mounting
+    /// thread.
+    pub fn new(fs: Arc<ReadOnlyFs>, reader: BlockReader, runtime: tokio::runtime::Handle) -> Self {
+        Self {
+            fs,
+            reader,
+            runtime,
+        }
+    }
+
+    /// The namespace tree backing metadata ops.
+    pub fn namespace(&self) -> &Arc<ReadOnlyFs> {
+        &self.fs
+    }
+
+    /// The read-path orchestrator backing data ops.
+    pub fn reader(&self) -> &BlockReader {
+        &self.reader
+    }
+
+    /// The runtime handle the callbacks dispatch async work onto.
+    pub fn runtime(&self) -> &tokio::runtime::Handle {
+        &self.runtime
+    }
+}
+
+impl fuser::Filesystem for TalonFuse {
+    // Metadata ops (lookup, getattr, readdir) are implemented in #101; data ops
+    // (open, read, release) in #102. The trait's default methods return ENOSYS,
+    // so an unimplemented op fails cleanly rather than misbehaving; the scaffold
+    // deliberately does not override them yet.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coordinator_client::CoordinatorClient;
+    use crate::placement_cache::PlacementCache;
+
+    #[tokio::test]
+    async fn constructs_over_read_path_components() {
+        let fs = Arc::new(ReadOnlyFs::new());
+        fs.insert_object("s3/b/o.bin", 123);
+        let reader = BlockReader::new(
+            CoordinatorClient::new("127.0.0.1:7000"),
+            Arc::new(PlacementCache::new(1000)),
+            1,
+        );
+        let mounted = TalonFuse::new(Arc::clone(&fs), reader, tokio::runtime::Handle::current());
+        // The adapter exposes its components for the callbacks to use.
+        assert_eq!(mounted.namespace().getattr(1).unwrap().ino, 1);
+        assert_eq!(mounted.reader().coordinator_addr(), "127.0.0.1:7000");
+    }
+}


### PR DESCRIPTION
## Summary
- Reinstates `fuser` as an **optional** dep gated by a new `mount` cargo feature; adds the `TalonFuse` adapter that will implement `fuser::Filesystem`.
- Default builds (`cargo build/test --workspace`) omit `fuser`, so CI/sandboxes without `/dev/fuse` or libfuse still compile the read path. The mount binary opts in with `--features mount`.
- `fuser` is pulled with `default-features = false`, dropping its libfuse C dependency (it talks to `/dev/fuse` directly), so `--features mount` compiles without libfuse headers — verified.
- Scaffold only: `TalonFuse` holds the `ReadOnlyFs`, `BlockReader`, and a runtime `Handle`, and impls `fuser::Filesystem` with no overrides yet (default ENOSYS). Metadata callbacks → #101, data → #102. Adds `BlockReader::coordinator_addr`.

## Testing
- `cargo test -p talon-fuse` (default, 53) and `--features mount` (54) both green.
- `cargo build --workspace --all-features --locked` (as CI runs) green. clippy/doc/fmt clean under `--all-features`.

Part of #88. Closes #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)