### PR TITLE
feat(coordinator): add production observability endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,13 +1272,16 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "clap",
  "divan",
  "serde",
+ "serde_json",
  "talon-core",
  "talon-transport",
  "thiserror",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/talon-coordinator/Cargo.toml
+++ b/crates/talon-coordinator/Cargo.toml
@@ -25,6 +25,9 @@ serde.workspace = true
 clap.workspace = true
 async-trait.workspace = true
 thiserror.workspace = true
+serde_json.workspace = true
+toml.workspace = true
+axum.workspace = true
 
 [dev-dependencies]
 divan.workspace = true

--- a/crates/talon-coordinator/src/config.rs
+++ b/crates/talon-coordinator/src/config.rs
@@ -1,0 +1,287 @@
+//! Layered coordinator configuration.
+
+use std::path::Path;
+
+use serde::Deserialize;
+use talon_core::{Patch, MAX_STATUS_FIELD_BYTES};
+
+use crate::{ClusterStateConfig, StateBackend};
+
+/// Fully resolved coordinator configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoordinatorConfig {
+    /// Control-plane bind address.
+    pub listen: String,
+    /// Administration HTTP bind address.
+    pub admin_listen: String,
+    /// Administration address advertised in node status.
+    pub admin_advertise: String,
+    /// Logical cluster identity.
+    pub cluster_id: String,
+    /// Stable coordinator node identity.
+    pub node_id: String,
+    /// Shared-state and lease settings.
+    pub state: ClusterStateConfig,
+}
+
+impl Default for CoordinatorConfig {
+    fn default() -> Self {
+        Self {
+            listen: "127.0.0.1:7000".into(),
+            admin_listen: "127.0.0.1:8000".into(),
+            admin_advertise: "127.0.0.1:8000".into(),
+            cluster_id: "default".into(),
+            node_id: "127.0.0.1:7000".into(),
+            state: ClusterStateConfig::default(),
+        }
+    }
+}
+
+/// Optional coordinator configuration overrides.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CoordinatorConfigPatch {
+    /// Override for [`CoordinatorConfig::listen`].
+    pub listen: Option<String>,
+    /// Override for [`CoordinatorConfig::admin_listen`].
+    pub admin_listen: Option<String>,
+    /// Override for [`CoordinatorConfig::admin_advertise`].
+    pub admin_advertise: Option<String>,
+    /// Override for [`CoordinatorConfig::cluster_id`].
+    pub cluster_id: Option<String>,
+    /// Override for [`CoordinatorConfig::node_id`].
+    pub node_id: Option<String>,
+    /// Shared-state backend selector.
+    pub state_backend: Option<StateBackend>,
+    /// Whether active-active coordinator mode is requested.
+    pub ha_enabled: Option<bool>,
+    /// Expected coordinator replica count.
+    pub coordinator_replicas: Option<u16>,
+    /// Node heartbeat interval.
+    pub heartbeat_interval_ms: Option<u64>,
+    /// Node unhealthy threshold.
+    pub unhealthy_after_ms: Option<u64>,
+    /// Node lease TTL.
+    pub lease_ttl_ms: Option<u64>,
+    /// Shared-state request timeout.
+    pub request_timeout_ms: Option<u64>,
+}
+
+impl Patch for CoordinatorConfigPatch {
+    fn merge(self, base: Self) -> Self {
+        Self {
+            listen: self.listen.or(base.listen),
+            admin_listen: self.admin_listen.or(base.admin_listen),
+            admin_advertise: self.admin_advertise.or(base.admin_advertise),
+            cluster_id: self.cluster_id.or(base.cluster_id),
+            node_id: self.node_id.or(base.node_id),
+            state_backend: self.state_backend.or(base.state_backend),
+            ha_enabled: self.ha_enabled.or(base.ha_enabled),
+            coordinator_replicas: self.coordinator_replicas.or(base.coordinator_replicas),
+            heartbeat_interval_ms: self.heartbeat_interval_ms.or(base.heartbeat_interval_ms),
+            unhealthy_after_ms: self.unhealthy_after_ms.or(base.unhealthy_after_ms),
+            lease_ttl_ms: self.lease_ttl_ms.or(base.lease_ttl_ms),
+            request_timeout_ms: self.request_timeout_ms.or(base.request_timeout_ms),
+        }
+    }
+}
+
+impl CoordinatorConfigPatch {
+    /// Parse a TOML patch.
+    pub fn from_toml(value: &str) -> anyhow::Result<Self> {
+        Ok(toml::from_str(value)?)
+    }
+
+    /// Load a TOML patch; a missing path is treated as an empty layer.
+    pub fn from_file(path: &Path) -> anyhow::Result<Self> {
+        match std::fs::read_to_string(path) {
+            Ok(value) => Self::from_toml(&value),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    /// Read `TALON_COORDINATOR_*` environment variables.
+    pub fn from_env() -> anyhow::Result<Self> {
+        Self::from_env_with(|key| std::env::var(key).ok())
+    }
+
+    /// Injectable environment parser used by tests.
+    pub fn from_env_with(get: impl Fn(&str) -> Option<String>) -> anyhow::Result<Self> {
+        fn parse<T: std::str::FromStr>(value: String, key: &str) -> anyhow::Result<T> {
+            value
+                .parse()
+                .map_err(|_| anyhow::anyhow!("{key}: invalid value {value:?}"))
+        }
+
+        Ok(Self {
+            listen: get("TALON_COORDINATOR_LISTEN"),
+            admin_listen: get("TALON_COORDINATOR_ADMIN_LISTEN"),
+            admin_advertise: get("TALON_COORDINATOR_ADMIN_ADVERTISE"),
+            cluster_id: get("TALON_COORDINATOR_CLUSTER_ID"),
+            node_id: get("TALON_COORDINATOR_NODE_ID"),
+            state_backend: get("TALON_COORDINATOR_STATE_BACKEND")
+                .map(|value| parse(value, "TALON_COORDINATOR_STATE_BACKEND"))
+                .transpose()?,
+            ha_enabled: get("TALON_COORDINATOR_HA_ENABLED")
+                .map(|value| parse(value, "TALON_COORDINATOR_HA_ENABLED"))
+                .transpose()?,
+            coordinator_replicas: get("TALON_COORDINATOR_REPLICAS")
+                .map(|value| parse(value, "TALON_COORDINATOR_REPLICAS"))
+                .transpose()?,
+            heartbeat_interval_ms: get("TALON_COORDINATOR_HEARTBEAT_INTERVAL_MS")
+                .map(|value| parse(value, "TALON_COORDINATOR_HEARTBEAT_INTERVAL_MS"))
+                .transpose()?,
+            unhealthy_after_ms: get("TALON_COORDINATOR_UNHEALTHY_AFTER_MS")
+                .map(|value| parse(value, "TALON_COORDINATOR_UNHEALTHY_AFTER_MS"))
+                .transpose()?,
+            lease_ttl_ms: get("TALON_COORDINATOR_LEASE_TTL_MS")
+                .map(|value| parse(value, "TALON_COORDINATOR_LEASE_TTL_MS"))
+                .transpose()?,
+            request_timeout_ms: get("TALON_COORDINATOR_REQUEST_TIMEOUT_MS")
+                .map(|value| parse(value, "TALON_COORDINATOR_REQUEST_TIMEOUT_MS"))
+                .transpose()?,
+        })
+    }
+}
+
+impl CoordinatorConfig {
+    /// Resolve defaults, file, environment, and CLI layers.
+    pub fn resolve(
+        file: CoordinatorConfigPatch,
+        env: CoordinatorConfigPatch,
+        cli: CoordinatorConfigPatch,
+    ) -> anyhow::Result<Self> {
+        let merged = cli.merge(env).merge(file);
+        let defaults = Self::default();
+        let default_state = defaults.state;
+        let listen = merged.listen.unwrap_or(defaults.listen);
+        let admin_listen = merged.admin_listen.unwrap_or(defaults.admin_listen);
+        let config = Self {
+            node_id: merged.node_id.unwrap_or_else(|| listen.clone()),
+            admin_advertise: merged
+                .admin_advertise
+                .unwrap_or_else(|| admin_listen.clone()),
+            listen,
+            admin_listen,
+            cluster_id: merged.cluster_id.unwrap_or(defaults.cluster_id),
+            state: ClusterStateConfig {
+                backend: merged.state_backend.unwrap_or(default_state.backend),
+                ha_enabled: merged.ha_enabled.unwrap_or(default_state.ha_enabled),
+                coordinator_replicas: merged
+                    .coordinator_replicas
+                    .unwrap_or(default_state.coordinator_replicas),
+                heartbeat_interval_ms: merged
+                    .heartbeat_interval_ms
+                    .unwrap_or(default_state.heartbeat_interval_ms),
+                unhealthy_after_ms: merged
+                    .unhealthy_after_ms
+                    .unwrap_or(default_state.unhealthy_after_ms),
+                lease_ttl_ms: merged.lease_ttl_ms.unwrap_or(default_state.lease_ttl_ms),
+                request_timeout_ms: merged
+                    .request_timeout_ms
+                    .unwrap_or(default_state.request_timeout_ms),
+            },
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Validate addresses, bounded identity fields, and state timing.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        for (name, value) in [
+            ("listen", self.listen.as_str()),
+            ("admin_listen", self.admin_listen.as_str()),
+            ("admin_advertise", self.admin_advertise.as_str()),
+            ("cluster_id", self.cluster_id.as_str()),
+            ("node_id", self.node_id.as_str()),
+        ] {
+            if value.is_empty() {
+                anyhow::bail!("{name} must not be empty");
+            }
+            if value.len() > MAX_STATUS_FIELD_BYTES {
+                anyhow::bail!(
+                    "{name} is {} bytes; maximum is {MAX_STATUS_FIELD_BYTES}",
+                    value.len()
+                );
+            }
+        }
+        self.state.validate()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn precedence_and_advertise_fallback_are_resolved() {
+        let file = CoordinatorConfigPatch {
+            listen: Some("file:7000".into()),
+            admin_listen: Some("file:8000".into()),
+            ..Default::default()
+        };
+        let env = CoordinatorConfigPatch {
+            admin_listen: Some("env:8000".into()),
+            cluster_id: Some("prod".into()),
+            ..Default::default()
+        };
+        let cli = CoordinatorConfigPatch {
+            listen: Some("cli:7000".into()),
+            admin_advertise: Some("public:8000".into()),
+            ..Default::default()
+        };
+        let config = CoordinatorConfig::resolve(file, env, cli).unwrap();
+        assert_eq!(config.listen, "cli:7000");
+        assert_eq!(config.admin_listen, "env:8000");
+        assert_eq!(config.admin_advertise, "public:8000");
+        assert_eq!(config.node_id, "cli:7000");
+        assert_eq!(config.cluster_id, "prod");
+    }
+
+    #[test]
+    fn environment_and_toml_are_typed() {
+        let patch = CoordinatorConfigPatch::from_toml(
+            "admin_listen = \"0.0.0.0:8000\"\nstate_backend = \"memory\"\n",
+        )
+        .unwrap();
+        assert_eq!(patch.admin_listen.as_deref(), Some("0.0.0.0:8000"));
+        assert_eq!(patch.state_backend, Some(StateBackend::Memory));
+
+        let patch = CoordinatorConfigPatch::from_env_with(|key| match key {
+            "TALON_COORDINATOR_REPLICAS" => Some("3".into()),
+            "TALON_COORDINATOR_HA_ENABLED" => Some("true".into()),
+            _ => None,
+        })
+        .unwrap();
+        assert_eq!(patch.coordinator_replicas, Some(3));
+        assert_eq!(patch.ha_enabled, Some(true));
+    }
+
+    #[test]
+    fn invalid_identity_and_state_config_fail_fast() {
+        let config = CoordinatorConfig {
+            node_id: String::new(),
+            ..Default::default()
+        };
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("node_id"));
+
+        let config = CoordinatorConfig {
+            state: ClusterStateConfig {
+                request_timeout_ms: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("request_timeout_ms"));
+    }
+}

--- a/crates/talon-coordinator/src/lib.rs
+++ b/crates/talon-coordinator/src/lib.rs
@@ -3,16 +3,23 @@
 //! The coordinator tracks cluster membership and decides which worker holds
 //! each object. It exposes a routing layer that clients use to locate data.
 
+pub mod config;
 pub mod heartbeat;
 pub mod load;
 pub mod membership;
+pub mod observability;
 pub mod placement;
 pub mod service;
 pub mod state_store;
 
+pub use config::{CoordinatorConfig, CoordinatorConfigPatch};
 pub use heartbeat::{HeartbeatConfig, HeartbeatTracker, Inventory};
 pub use load::{plan_load, split_into_blocks, LoadAssignment, LoadProgress};
 pub use membership::{K8sSelector, KubernetesMembership, Membership, MembershipSource};
+pub use observability::{
+    serve_admin as serve_coordinator_admin, ControlOperation, CoordinatorMetrics,
+    CoordinatorObservability,
+};
 pub use placement::{Epoch, Placement, RendezvousPlacement};
 pub use service::{PlacementResult, PlacementService};
 pub use state_store::{

--- a/crates/talon-coordinator/src/main.rs
+++ b/crates/talon-coordinator/src/main.rs
@@ -1,95 +1,151 @@
-//! Talon coordinator entry point.
-//!
-//! Runs the real control-plane serve loop: workers `Register` and `Heartbeat`,
-//! clients issue `PlacementLookup` and `MembershipQuery`. Each accepted
-//! connection carries one framed [`ControlMessage`] request and receives one
-//! framed reply (see [`talon_transport::codec`]).
+//! Talon coordinator control and administration servers.
 
+use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use clap::Parser;
-use talon_coordinator::{Membership, PlacementService, RendezvousPlacement};
+use talon_coordinator::{
+    serve_coordinator_admin, ClusterStateStore, CoordinatorConfig, CoordinatorConfigPatch,
+    CoordinatorObservability, Membership, MemoryStateStore, PlacementService, RendezvousPlacement,
+    StateBackend, WriteDisposition,
+};
+use talon_core::{NodeInfo, NodeRole};
 use talon_transport::frame::HEADER_LEN;
 use talon_transport::{codec, ControlMessage, FrameHeader};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
-/// Command-line arguments for the Talon coordinator.
 #[derive(Debug, Parser)]
 #[command(name = "talon-coordinator", version, about)]
 struct Args {
-    /// Address to bind the coordinator RPC service to.
-    #[arg(long, default_value = "127.0.0.1:7000")]
-    listen: String,
+    /// Path to a TOML configuration file.
+    #[arg(long)]
+    config: Option<PathBuf>,
+    /// Control-plane bind address.
+    #[arg(long)]
+    listen: Option<String>,
+    /// Administration HTTP bind address.
+    #[arg(long)]
+    admin_listen: Option<String>,
+    /// Administration address advertised in coordinator status.
+    #[arg(long)]
+    admin_advertise: Option<String>,
+    /// Logical cluster identity.
+    #[arg(long)]
+    cluster_id: Option<String>,
+    /// Stable coordinator node identity.
+    #[arg(long)]
+    node_id: Option<String>,
+    /// Shared-state backend.
+    #[arg(long, value_enum)]
+    state_backend: Option<StateBackend>,
+    /// Enable active-active coordinator mode.
+    #[arg(long)]
+    ha_enabled: Option<bool>,
+    /// Expected coordinator replica count.
+    #[arg(long)]
+    coordinator_replicas: Option<u16>,
+    /// Node heartbeat interval in milliseconds.
+    #[arg(long)]
+    heartbeat_interval_ms: Option<u64>,
+    /// Node unhealthy threshold in milliseconds.
+    #[arg(long)]
+    unhealthy_after_ms: Option<u64>,
+    /// Node lease TTL in milliseconds.
+    #[arg(long)]
+    lease_ttl_ms: Option<u64>,
+    /// Shared-state request timeout in milliseconds.
+    #[arg(long)]
+    request_timeout_ms: Option<u64>,
 }
 
-/// Shared coordinator state behind the serve loop.
+impl Args {
+    fn into_patch(self) -> CoordinatorConfigPatch {
+        CoordinatorConfigPatch {
+            listen: self.listen,
+            admin_listen: self.admin_listen,
+            admin_advertise: self.admin_advertise,
+            cluster_id: self.cluster_id,
+            node_id: self.node_id,
+            state_backend: self.state_backend,
+            ha_enabled: self.ha_enabled,
+            coordinator_replicas: self.coordinator_replicas,
+            heartbeat_interval_ms: self.heartbeat_interval_ms,
+            unhealthy_after_ms: self.unhealthy_after_ms,
+            lease_ttl_ms: self.lease_ttl_ms,
+            request_timeout_ms: self.request_timeout_ms,
+        }
+    }
+}
+
 struct Coordinator {
     service: PlacementService<RendezvousPlacement>,
+    observability: Arc<CoordinatorObservability>,
+    lease_ttl: Duration,
 }
 
 impl Coordinator {
-    fn new() -> Arc<Self> {
-        let service = PlacementService::new(Membership::new(), RendezvousPlacement);
-        Arc::new(Self { service })
+    fn new(observability: Arc<CoordinatorObservability>, lease_ttl: Duration) -> Arc<Self> {
+        Arc::new(Self {
+            service: PlacementService::new(Membership::new(), RendezvousPlacement),
+            observability,
+            lease_ttl,
+        })
     }
-}
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
-        )
-        .init();
-
-    let args = Args::parse();
-    tracing::info!(listen = %args.listen, "starting talon-coordinator");
-
-    let state = Coordinator::new();
-
-    let listener = TcpListener::bind(&args.listen).await?;
-    loop {
-        let (stream, peer) = listener.accept().await?;
-        let state = Arc::clone(&state);
-        tokio::spawn(async move {
-            if let Err(e) = handle_conn(stream, state).await {
-                tracing::debug!(%peer, error = %e, "coordinator: connection ended");
-            }
-        });
-    }
-}
-
-/// Read one framed control request, dispatch it, and write one framed reply.
-async fn handle_conn(mut stream: TcpStream, state: Arc<Coordinator>) -> anyhow::Result<()> {
-    loop {
-        let Some((_header, msg)) = read_control(&mut stream).await? else {
-            return Ok(()); // clean EOF
-        };
-        let reply = state.dispatch(msg);
-        let buf = codec::encode(0, &reply)?;
-        stream.write_all(&buf).await?;
-        stream.flush().await?;
-    }
-}
-
-impl Coordinator {
-    /// Handle one decoded control message, returning the reply message.
-    fn dispatch(&self, msg: ControlMessage) -> ControlMessage {
-        match msg {
+    async fn dispatch(&self, message: ControlMessage) -> ControlMessage {
+        match message {
             ControlMessage::Register { node } => {
                 tracing::info!(id = %node.id, address = %node.address, "worker registered");
                 self.service.membership().register(node);
+                self.observability.metrics().record_registration(true);
                 ControlMessage::Ack {
                     ok: true,
                     detail: None,
                 }
             }
             ControlMessage::Heartbeat { node, block_count } => {
-                tracing::debug!(%node, block_count, "heartbeat");
+                tracing::debug!(%node, block_count, "legacy heartbeat");
+                self.observability.metrics().record_heartbeat(false, true);
                 ControlMessage::Ack {
                     ok: true,
                     detail: None,
+                }
+            }
+            ControlMessage::NodeStatusHeartbeat { status } => {
+                if status.cluster_id != self.observability.cluster_id() {
+                    self.observability.metrics().record_heartbeat(true, false);
+                    return ControlMessage::Ack {
+                        ok: false,
+                        detail: Some("node status belongs to another cluster".into()),
+                    };
+                }
+                let node = status.node.clone();
+                match self
+                    .observability
+                    .upsert_status(*status, self.lease_ttl)
+                    .await
+                {
+                    Ok(result) => {
+                        if result.disposition == WriteDisposition::Applied
+                            && node.role == NodeRole::Worker
+                        {
+                            self.service.membership().register(node);
+                        }
+                        self.observability.metrics().record_heartbeat(true, true);
+                        ControlMessage::Ack {
+                            ok: true,
+                            detail: None,
+                        }
+                    }
+                    Err(error) => {
+                        self.observability.metrics().record_heartbeat(true, false);
+                        ControlMessage::Ack {
+                            ok: false,
+                            detail: Some(error.to_string()),
+                        }
+                    }
                 }
             }
             lookup @ ControlMessage::PlacementLookup { .. } => self.service.handle(lookup),
@@ -104,23 +160,223 @@ impl Coordinator {
     }
 }
 
-/// Read a full framed control message (header + payload). `Ok(None)` on clean
-/// EOF before any bytes of a new frame.
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let args = Args::parse();
+    let file = match &args.config {
+        Some(path) => CoordinatorConfigPatch::from_file(path)?,
+        None => CoordinatorConfigPatch::default(),
+    };
+    let config =
+        CoordinatorConfig::resolve(file, CoordinatorConfigPatch::from_env()?, args.into_patch())?;
+    if config.state.backend != StateBackend::Memory {
+        anyhow::bail!(
+            "{} state backend is configured but its implementation is not installed",
+            config.state.backend
+        );
+    }
+
+    tracing::info!(
+        listen = %config.listen,
+        admin_listen = %config.admin_listen,
+        admin_advertise = %config.admin_advertise,
+        cluster_id = %config.cluster_id,
+        node_id = %config.node_id,
+        state_backend = %config.state.backend,
+        "starting talon-coordinator"
+    );
+
+    let store: Arc<dyn ClusterStateStore> = Arc::new(MemoryStateStore::new());
+    let node = NodeInfo {
+        id: talon_core::NodeId::new(config.node_id.clone()),
+        address: config.listen.clone(),
+        role: NodeRole::Coordinator,
+    };
+    let observability = Arc::new(CoordinatorObservability::new(
+        config.cluster_id.clone(),
+        node,
+        config.admin_advertise.clone(),
+        Duration::from_millis(config.state.request_timeout_ms),
+        store,
+    )?);
+    observability.check_ready().await?;
+    let state = Coordinator::new(
+        Arc::clone(&observability),
+        Duration::from_millis(config.state.lease_ttl_ms),
+    );
+
+    let admin_listener = TcpListener::bind(&config.admin_listen).await?;
+    let admin_state = Arc::clone(&observability);
+    tokio::spawn(async move {
+        if let Err(error) = serve_coordinator_admin(admin_listener, admin_state).await {
+            tracing::error!(%error, "coordinator administration server stopped");
+        }
+    });
+    spawn_self_heartbeat(
+        Arc::clone(&observability),
+        Duration::from_millis(config.state.heartbeat_interval_ms),
+        Duration::from_millis(config.state.lease_ttl_ms),
+    );
+
+    let listener = TcpListener::bind(&config.listen).await?;
+    tracing::info!(listen = %config.listen, "coordinator serving control plane");
+    loop {
+        let (stream, peer) = listener.accept().await?;
+        let state = Arc::clone(&state);
+        tokio::spawn(async move {
+            if let Err(error) = handle_conn(stream, state).await {
+                tracing::debug!(%peer, %error, "coordinator connection ended");
+            }
+        });
+    }
+}
+
+fn spawn_self_heartbeat(
+    observability: Arc<CoordinatorObservability>,
+    interval: Duration,
+    lease_ttl: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            ticker.tick().await;
+            if let Err(error) = observability
+                .upsert_status(observability.status(), lease_ttl)
+                .await
+            {
+                tracing::warn!(%error, "coordinator status heartbeat failed");
+            }
+        }
+    })
+}
+
+async fn handle_conn(mut stream: TcpStream, state: Arc<Coordinator>) -> anyhow::Result<()> {
+    let _connection = state.observability.metrics().track_connection();
+    loop {
+        let message = match read_control(&mut stream).await {
+            Ok(Some((_header, message))) => message,
+            Ok(None) => return Ok(()),
+            Err(error) => {
+                state.observability.metrics().record_protocol_error();
+                return Err(error);
+            }
+        };
+        let operation = talon_coordinator::ControlOperation::from_message(&message);
+        let started = Instant::now();
+        let reply = state.dispatch(message).await;
+        let error = matches!(&reply, ControlMessage::Ack { ok: false, .. });
+        state
+            .observability
+            .metrics()
+            .record_control(operation, error, started.elapsed());
+        if matches!(operation, talon_coordinator::ControlOperation::Placement) {
+            state
+                .observability
+                .metrics()
+                .record_placement(error, started.elapsed());
+        }
+        let buffer = codec::encode(0, &reply)?;
+        stream.write_all(&buffer).await?;
+        stream.flush().await?;
+    }
+}
+
 async fn read_control(
     stream: &mut TcpStream,
 ) -> anyhow::Result<Option<(FrameHeader, ControlMessage)>> {
-    let mut header_buf = [0u8; HEADER_LEN];
-    match stream.read_exact(&mut header_buf).await {
+    let mut header_buffer = [0u8; HEADER_LEN];
+    match stream.read_exact(&mut header_buffer).await {
         Ok(_) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
-        Err(e) => return Err(e.into()),
+        Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(error) => return Err(error.into()),
     }
-    let header = FrameHeader::decode(&header_buf)?;
+    let header = FrameHeader::decode(&header_buffer)?;
     let mut payload = vec![0u8; header.length as usize];
     stream.read_exact(&mut payload).await?;
     let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
-    full.extend_from_slice(&header_buf);
+    full.extend_from_slice(&header_buffer);
     full.extend_from_slice(&payload);
-    let (h, msg) = codec::decode(&full)?;
-    Ok(Some((h, msg)))
+    let (header, message) = codec::decode(&full)?;
+    Ok(Some((header, message)))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use talon_coordinator::MemoryStateStore;
+    use talon_core::{
+        NodeHealth, NodeId, NodeMetricsSnapshot, NodeStatus, NODE_STATUS_SCHEMA_VERSION,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn status_heartbeat_updates_store_and_worker_membership() {
+        let store: Arc<dyn ClusterStateStore> = Arc::new(MemoryStateStore::new());
+        let observability = Arc::new(
+            CoordinatorObservability::new(
+                "cluster-a".into(),
+                NodeInfo {
+                    id: NodeId::new("coordinator-1"),
+                    address: "127.0.0.1:7000".into(),
+                    role: NodeRole::Coordinator,
+                },
+                "127.0.0.1:8000".into(),
+                Duration::from_secs(1),
+                store,
+            )
+            .unwrap(),
+        );
+        observability.check_ready().await.unwrap();
+        let coordinator = Coordinator::new(Arc::clone(&observability), Duration::from_secs(30));
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        let status = NodeStatus {
+            schema_version: NODE_STATUS_SCHEMA_VERSION,
+            cluster_id: "cluster-a".into(),
+            node: NodeInfo {
+                id: NodeId::new("worker-1"),
+                address: "127.0.0.1:7001".into(),
+                role: NodeRole::Worker,
+            },
+            incarnation_id: "worker-incarnation".into(),
+            admin_address: Some("127.0.0.1:8001".into()),
+            build_version: "test".into(),
+            started_at_unix_ms: now,
+            reported_at_unix_ms: now,
+            heartbeat_seq: 0,
+            health: NodeHealth::Healthy,
+            ready: true,
+            metrics: NodeMetricsSnapshot::default(),
+            labels: BTreeMap::new(),
+        };
+
+        let reply = coordinator
+            .dispatch(ControlMessage::NodeStatusHeartbeat {
+                status: Box::new(status),
+            })
+            .await;
+        assert!(matches!(reply, ControlMessage::Ack { ok: true, .. }));
+        assert_eq!(coordinator.service.membership().snapshot().len(), 1);
+        assert_eq!(
+            observability
+                .store()
+                .snapshot("cluster-a")
+                .await
+                .unwrap()
+                .nodes
+                .len(),
+            1
+        );
+    }
 }

--- a/crates/talon-coordinator/src/observability.rs
+++ b/crates/talon-coordinator/src/observability.rs
@@ -1,0 +1,792 @@
+//! Coordinator metrics, shared-state readiness, and administration HTTP API.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::fs::File;
+use std::io::Read;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use axum::extract::State;
+use axum::http::{header, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use talon_core::metrics::labels;
+use talon_core::{
+    Counter, Gauge, Histogram, Metrics, NodeHealth, NodeInfo, NodeMetricsSnapshot, NodeRole,
+    NodeStatus, NODE_STATUS_SCHEMA_VERSION,
+};
+use talon_transport::ControlMessage;
+use tokio::net::TcpListener;
+
+use crate::{ClusterSnapshot, ClusterStateStore, StateStoreError, StateStoreResult, WriteResult};
+
+/// Bounded control operation label.
+#[derive(Debug, Clone, Copy)]
+#[repr(usize)]
+pub enum ControlOperation {
+    /// Worker registration.
+    Register,
+    /// Legacy worker heartbeat.
+    Heartbeat,
+    /// Versioned node status heartbeat.
+    StatusHeartbeat,
+    /// Placement lookup.
+    Placement,
+    /// Membership query.
+    Membership,
+    /// Other control message.
+    Other,
+}
+
+impl ControlOperation {
+    /// Classify a control message before dispatch.
+    pub fn from_message(message: &ControlMessage) -> Self {
+        match message {
+            ControlMessage::Register { .. } => Self::Register,
+            ControlMessage::Heartbeat { .. } => Self::Heartbeat,
+            ControlMessage::NodeStatusHeartbeat { .. } => Self::StatusHeartbeat,
+            ControlMessage::PlacementLookup { .. } => Self::Placement,
+            ControlMessage::MembershipQuery {} => Self::Membership,
+            _ => Self::Other,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Register => "register",
+            Self::Heartbeat => "heartbeat",
+            Self::StatusHeartbeat => "status_heartbeat",
+            Self::Placement => "placement_lookup",
+            Self::Membership => "membership_query",
+            Self::Other => "other",
+        }
+    }
+}
+
+#[derive(Clone)]
+struct OperationMetric {
+    requests: Counter,
+    errors: Counter,
+    duration: Histogram,
+}
+
+/// Pre-registered coordinator metric handles.
+#[derive(Clone)]
+pub struct CoordinatorMetrics {
+    registry: Metrics,
+    operations: Arc<Vec<OperationMetric>>,
+    protocol_errors: Counter,
+    registration_accepted: Counter,
+    registration_rejected: Counter,
+    heartbeat_legacy_accepted: Counter,
+    heartbeat_legacy_rejected: Counter,
+    heartbeat_status_accepted: Counter,
+    heartbeat_status_rejected: Counter,
+    placement_duration: Histogram,
+    placement_errors: Counter,
+    state_readiness_duration: Histogram,
+    state_snapshot_duration: Histogram,
+    state_upsert_duration: Histogram,
+    active_count: Arc<AtomicU64>,
+    active_connections: Gauge,
+    ready: Gauge,
+    uptime: Gauge,
+    snapshot_age_seconds: Gauge,
+    snapshot_age_value: Arc<AtomicU64>,
+}
+
+/// RAII guard for coordinator control connections.
+pub struct CoordinatorConnectionGuard {
+    count: Arc<AtomicU64>,
+}
+
+impl Drop for CoordinatorConnectionGuard {
+    fn drop(&mut self) {
+        self.count.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+impl CoordinatorMetrics {
+    /// Create all coordinator metric families.
+    pub fn new() -> Self {
+        let registry = Metrics::new();
+        registry
+            .gauge(
+                "talon_coordinator_build_info",
+                "Coordinator build information.",
+                labels(&[("version", env!("CARGO_PKG_VERSION"))]),
+            )
+            .set(1.0);
+        let operations = [
+            ControlOperation::Register,
+            ControlOperation::Heartbeat,
+            ControlOperation::StatusHeartbeat,
+            ControlOperation::Placement,
+            ControlOperation::Membership,
+            ControlOperation::Other,
+        ]
+        .into_iter()
+        .map(|operation| {
+            let operation_labels = labels(&[("operation", operation.label())]);
+            OperationMetric {
+                requests: registry.counter(
+                    "talon_coordinator_control_requests_total",
+                    "Decoded control requests by operation.",
+                    operation_labels.clone(),
+                ),
+                errors: registry.counter(
+                    "talon_coordinator_control_errors_total",
+                    "Control requests returning an error by operation.",
+                    operation_labels.clone(),
+                ),
+                duration: registry.histogram(
+                    "talon_coordinator_control_duration_seconds",
+                    "Control request latency in seconds by operation.",
+                    operation_labels,
+                ),
+            }
+        })
+        .collect();
+        let result_counter =
+            |name: &str, help: &str, pairs| registry.counter(name, help, labels(pairs));
+        let active_connections = registry.gauge(
+            "talon_coordinator_active_connections",
+            "Control-plane connections currently open.",
+            BTreeMap::new(),
+        );
+        let ready = registry.gauge(
+            "talon_coordinator_ready",
+            "Whether authoritative shared state is ready.",
+            BTreeMap::new(),
+        );
+        let uptime = registry.gauge(
+            "talon_coordinator_process_uptime_seconds",
+            "Coordinator process uptime in seconds.",
+            BTreeMap::new(),
+        );
+        let snapshot_age_seconds = registry.gauge(
+            "talon_coordinator_state_snapshot_age_seconds",
+            "Age of the latest successful shared-state snapshot in seconds.",
+            BTreeMap::new(),
+        );
+        Self {
+            protocol_errors: registry.counter(
+                "talon_coordinator_protocol_errors_total",
+                "Control frames rejected before dispatch.",
+                BTreeMap::new(),
+            ),
+            registration_accepted: result_counter(
+                "talon_coordinator_registration_total",
+                "Worker registrations by outcome.",
+                &[("result", "accepted")],
+            ),
+            registration_rejected: result_counter(
+                "talon_coordinator_registration_total",
+                "Worker registrations by outcome.",
+                &[("result", "rejected")],
+            ),
+            heartbeat_legacy_accepted: registry.counter(
+                "talon_coordinator_heartbeat_total",
+                "Node heartbeats by kind and outcome.",
+                labels(&[("kind", "legacy"), ("result", "accepted")]),
+            ),
+            heartbeat_legacy_rejected: registry.counter(
+                "talon_coordinator_heartbeat_total",
+                "Node heartbeats by kind and outcome.",
+                labels(&[("kind", "legacy"), ("result", "rejected")]),
+            ),
+            heartbeat_status_accepted: registry.counter(
+                "talon_coordinator_heartbeat_total",
+                "Node heartbeats by kind and outcome.",
+                labels(&[("kind", "status"), ("result", "accepted")]),
+            ),
+            heartbeat_status_rejected: registry.counter(
+                "talon_coordinator_heartbeat_total",
+                "Node heartbeats by kind and outcome.",
+                labels(&[("kind", "status"), ("result", "rejected")]),
+            ),
+            placement_duration: registry.histogram(
+                "talon_coordinator_placement_duration_seconds",
+                "Placement lookup latency in seconds.",
+                BTreeMap::new(),
+            ),
+            placement_errors: registry.counter(
+                "talon_coordinator_placement_errors_total",
+                "Placement lookup failures.",
+                BTreeMap::new(),
+            ),
+            state_readiness_duration: registry.histogram(
+                "talon_coordinator_state_store_duration_seconds",
+                "Shared-state operation latency in seconds.",
+                labels(&[("operation", "readiness")]),
+            ),
+            state_snapshot_duration: registry.histogram(
+                "talon_coordinator_state_store_duration_seconds",
+                "Shared-state operation latency in seconds.",
+                labels(&[("operation", "snapshot")]),
+            ),
+            state_upsert_duration: registry.histogram(
+                "talon_coordinator_state_store_duration_seconds",
+                "Shared-state operation latency in seconds.",
+                labels(&[("operation", "upsert")]),
+            ),
+            registry,
+            operations: Arc::new(operations),
+            active_count: Arc::new(AtomicU64::new(0)),
+            active_connections,
+            ready,
+            uptime,
+            snapshot_age_seconds,
+            snapshot_age_value: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    fn operation(&self, operation: ControlOperation) -> &OperationMetric {
+        &self.operations[operation as usize]
+    }
+
+    /// Record one decoded control request.
+    pub fn record_control(&self, operation: ControlOperation, error: bool, elapsed: Duration) {
+        let metric = self.operation(operation);
+        metric.requests.inc();
+        if error {
+            metric.errors.inc();
+        }
+        metric.duration.observe(elapsed.as_secs_f64());
+    }
+
+    /// Record a protocol decode failure.
+    pub fn record_protocol_error(&self) {
+        self.protocol_errors.inc();
+    }
+
+    /// Record a registration outcome.
+    pub fn record_registration(&self, accepted: bool) {
+        if accepted {
+            self.registration_accepted.inc();
+        } else {
+            self.registration_rejected.inc();
+        }
+    }
+
+    /// Record a legacy or status heartbeat outcome.
+    pub fn record_heartbeat(&self, status: bool, accepted: bool) {
+        match (status, accepted) {
+            (false, true) => self.heartbeat_legacy_accepted.inc(),
+            (false, false) => self.heartbeat_legacy_rejected.inc(),
+            (true, true) => self.heartbeat_status_accepted.inc(),
+            (true, false) => self.heartbeat_status_rejected.inc(),
+        }
+    }
+
+    /// Record placement-specific latency and failure.
+    pub fn record_placement(&self, error: bool, elapsed: Duration) {
+        if error {
+            self.placement_errors.inc();
+        }
+        self.placement_duration.observe(elapsed.as_secs_f64());
+    }
+
+    /// Track one active control connection.
+    pub fn track_connection(&self) -> CoordinatorConnectionGuard {
+        self.active_count.fetch_add(1, Ordering::Relaxed);
+        CoordinatorConnectionGuard {
+            count: Arc::clone(&self.active_count),
+        }
+    }
+
+    fn record_state<T>(
+        &self,
+        operation: &'static str,
+        result: &StateStoreResult<T>,
+        elapsed: Duration,
+    ) {
+        match operation {
+            "readiness" => &self.state_readiness_duration,
+            "snapshot" => &self.state_snapshot_duration,
+            "upsert" => &self.state_upsert_duration,
+            _ => unreachable!("state operation labels are fixed"),
+        }
+        .observe(elapsed.as_secs_f64());
+        if let Err(error) = result {
+            self.registry
+                .counter(
+                    "talon_coordinator_state_store_errors_total",
+                    "Shared-state operation failures by operation and kind.",
+                    labels(&[("operation", operation), ("kind", state_error_kind(error))]),
+                )
+                .inc();
+        }
+    }
+
+    fn refresh(&self, started: Instant, ready: bool) {
+        self.active_connections
+            .set(self.active_count.load(Ordering::Relaxed) as f64);
+        self.ready.set(u8::from(ready) as f64);
+        self.uptime.set(started.elapsed().as_secs_f64());
+        self.snapshot_age_seconds
+            .set(self.snapshot_age_value.load(Ordering::Relaxed) as f64 / 1000.0);
+    }
+
+    fn update_snapshot(&self, snapshot: &ClusterSnapshot) {
+        let now = now_unix_ms();
+        self.snapshot_age_value.store(
+            now.saturating_sub(snapshot.observed_at_unix_ms),
+            Ordering::Relaxed,
+        );
+        for role in [NodeRole::Coordinator, NodeRole::Worker] {
+            for health in [
+                NodeHealth::Healthy,
+                NodeHealth::Degraded,
+                NodeHealth::Unhealthy,
+                NodeHealth::Unknown,
+            ] {
+                let count = snapshot
+                    .nodes
+                    .iter()
+                    .filter(|node| node.node.role == role && node.health == health)
+                    .count();
+                self.registry
+                    .gauge(
+                        "talon_coordinator_live_nodes",
+                        "Live leased nodes by role and reported health.",
+                        labels(&[("role", role_label(role)), ("health", health_label(health))]),
+                    )
+                    .set(count as f64);
+            }
+        }
+    }
+
+    fn totals(&self) -> (u64, u64) {
+        self.operations
+            .iter()
+            .fold((0, 0), |(requests, errors), op| {
+                (requests + op.requests.get(), errors + op.errors.get())
+            })
+    }
+
+    /// Render the Prometheus registry.
+    pub fn render(&self) -> String {
+        self.registry.render()
+    }
+}
+
+impl Default for CoordinatorMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Shared coordinator observability and state-store access.
+pub struct CoordinatorObservability {
+    cluster_id: String,
+    node: NodeInfo,
+    admin_address: String,
+    incarnation_id: String,
+    started_at_unix_ms: u64,
+    started: Instant,
+    sequence: AtomicU64,
+    ready: AtomicBool,
+    shutting_down: AtomicBool,
+    request_timeout: Duration,
+    metrics: CoordinatorMetrics,
+    store: Arc<dyn ClusterStateStore>,
+}
+
+impl CoordinatorObservability {
+    /// Create observability state over the selected shared-state backend.
+    pub fn new(
+        cluster_id: String,
+        node: NodeInfo,
+        admin_address: String,
+        request_timeout: Duration,
+        store: Arc<dyn ClusterStateStore>,
+    ) -> std::io::Result<Self> {
+        Ok(Self {
+            cluster_id,
+            node,
+            admin_address,
+            incarnation_id: generate_incarnation_id()?,
+            started_at_unix_ms: now_unix_ms(),
+            started: Instant::now(),
+            sequence: AtomicU64::new(0),
+            ready: AtomicBool::new(false),
+            shutting_down: AtomicBool::new(false),
+            request_timeout,
+            metrics: CoordinatorMetrics::new(),
+            store,
+        })
+    }
+
+    /// Coordinator metric handles.
+    pub fn metrics(&self) -> &CoordinatorMetrics {
+        &self.metrics
+    }
+
+    /// Selected state store.
+    pub fn store(&self) -> &Arc<dyn ClusterStateStore> {
+        &self.store
+    }
+
+    /// Logical cluster accepted by status heartbeats.
+    pub fn cluster_id(&self) -> &str {
+        &self.cluster_id
+    }
+
+    /// Whether authoritative shared state is currently ready.
+    pub fn is_ready(&self) -> bool {
+        self.ready.load(Ordering::Acquire) && !self.shutting_down.load(Ordering::Acquire)
+    }
+
+    /// Read-only readiness check with deadline.
+    pub async fn check_ready(&self) -> StateStoreResult<()> {
+        let started = Instant::now();
+        let result =
+            match tokio::time::timeout(self.request_timeout, self.store.check_ready()).await {
+                Ok(result) => result.map(|_| ()),
+                Err(_) => Err(StateStoreError::Timeout {
+                    backend: self.store.backend(),
+                }),
+            };
+        self.metrics
+            .record_state("readiness", &result, started.elapsed());
+        self.ready.store(result.is_ok(), Ordering::Release);
+        result
+    }
+
+    /// Upsert a leased node status with metrics and deadline.
+    pub async fn upsert_status(
+        &self,
+        status: NodeStatus,
+        lease_ttl: Duration,
+    ) -> StateStoreResult<WriteResult> {
+        let started = Instant::now();
+        let result = match tokio::time::timeout(
+            self.request_timeout,
+            self.store.upsert_node(status, lease_ttl),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(StateStoreError::Timeout {
+                backend: self.store.backend(),
+            }),
+        };
+        self.metrics
+            .record_state("upsert", &result, started.elapsed());
+        if result.is_err() {
+            self.ready.store(false, Ordering::Release);
+        }
+        result
+    }
+
+    /// Refresh live-node and snapshot-age gauges.
+    pub async fn refresh_snapshot(&self) -> StateStoreResult<()> {
+        let started = Instant::now();
+        let result =
+            match tokio::time::timeout(self.request_timeout, self.store.snapshot(&self.cluster_id))
+                .await
+            {
+                Ok(result) => result,
+                Err(_) => Err(StateStoreError::Timeout {
+                    backend: self.store.backend(),
+                }),
+            };
+        self.metrics
+            .record_state("snapshot", &result, started.elapsed());
+        match result {
+            Ok(snapshot) => {
+                self.metrics.update_snapshot(&snapshot);
+                self.ready.store(true, Ordering::Release);
+                Ok(())
+            }
+            Err(error) => {
+                self.ready.store(false, Ordering::Release);
+                Err(error)
+            }
+        }
+    }
+
+    /// Build the coordinator's own leased status record.
+    pub fn status(&self) -> NodeStatus {
+        let (requests_total, errors_total) = self.metrics.totals();
+        NodeStatus {
+            schema_version: NODE_STATUS_SCHEMA_VERSION,
+            cluster_id: self.cluster_id.clone(),
+            node: self.node.clone(),
+            incarnation_id: self.incarnation_id.clone(),
+            admin_address: Some(self.admin_address.clone()),
+            build_version: env!("CARGO_PKG_VERSION").into(),
+            started_at_unix_ms: self.started_at_unix_ms,
+            reported_at_unix_ms: now_unix_ms().max(self.started_at_unix_ms),
+            heartbeat_seq: self.sequence.fetch_add(1, Ordering::Relaxed),
+            health: if self.is_ready() {
+                NodeHealth::Healthy
+            } else {
+                NodeHealth::Degraded
+            },
+            ready: self.is_ready(),
+            metrics: NodeMetricsSnapshot {
+                requests_total,
+                errors_total,
+                state_snapshot_age_ms: self.metrics.snapshot_age_value.load(Ordering::Relaxed),
+                ..Default::default()
+            },
+            labels: BTreeMap::new(),
+        }
+    }
+}
+
+/// Serve coordinator health, readiness, and metrics endpoints.
+pub async fn serve_admin(
+    listener: TcpListener,
+    state: Arc<CoordinatorObservability>,
+) -> std::io::Result<()> {
+    axum::serve(
+        listener,
+        Router::new()
+            .route("/metrics", get(metrics_handler))
+            .route("/healthz", get(health_handler))
+            .route("/readyz", get(readiness_handler))
+            .with_state(state),
+    )
+    .await
+}
+
+async fn metrics_handler(State(state): State<Arc<CoordinatorObservability>>) -> impl IntoResponse {
+    let _ = state.refresh_snapshot().await;
+    state.metrics.refresh(state.started, state.is_ready());
+    (
+        [(
+            header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        state.metrics.render(),
+    )
+}
+
+async fn health_handler(State(state): State<Arc<CoordinatorObservability>>) -> Response {
+    let live = !state.shutting_down.load(Ordering::Acquire);
+    (
+        if live {
+            StatusCode::OK
+        } else {
+            StatusCode::SERVICE_UNAVAILABLE
+        },
+        Json(serde_json::json!({"status": if live { "ok" } else { "shutting_down" }})),
+    )
+        .into_response()
+}
+
+async fn readiness_handler(State(state): State<Arc<CoordinatorObservability>>) -> Response {
+    match state.check_ready().await {
+        Ok(()) => (StatusCode::OK, Json(serde_json::json!({"ready": true}))).into_response(),
+        Err(error) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "ready": false,
+                "reason": state_error_kind(&error),
+            })),
+        )
+            .into_response(),
+    }
+}
+
+fn state_error_kind(error: &StateStoreError) -> &'static str {
+    match error {
+        StateStoreError::Authentication { .. } => "authentication",
+        StateStoreError::PermissionDenied { .. } => "permission_denied",
+        StateStoreError::Timeout { .. } => "timeout",
+        StateStoreError::Unavailable { .. } => "unavailable",
+        StateStoreError::Compacted { .. } => "compacted",
+        StateStoreError::WatchLagged { .. } => "watch_lagged",
+        StateStoreError::InvalidRecord(_)
+        | StateStoreError::InvalidLeaseTtl(_)
+        | StateStoreError::InvalidRevision { .. } => "invalid",
+    }
+}
+
+fn role_label(role: NodeRole) -> &'static str {
+    match role {
+        NodeRole::Coordinator => "coordinator",
+        NodeRole::Worker => "worker",
+    }
+}
+
+fn health_label(health: NodeHealth) -> &'static str {
+    match health {
+        NodeHealth::Healthy => "healthy",
+        NodeHealth::Degraded => "degraded",
+        NodeHealth::Unhealthy => "unhealthy",
+        NodeHealth::Unknown => "unknown",
+    }
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn generate_incarnation_id() -> std::io::Result<String> {
+    let mut bytes = [0u8; 16];
+    File::open("/dev/urandom")?.read_exact(&mut bytes)?;
+    let mut id = String::with_capacity(32);
+    for byte in bytes {
+        write!(id, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    Ok(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use talon_core::{NodeId, NodeMetricsSnapshot};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    use super::*;
+    use crate::MemoryStateStore;
+
+    fn observability() -> (Arc<CoordinatorObservability>, Arc<MemoryStateStore>) {
+        let store = Arc::new(MemoryStateStore::new());
+        let state_store: Arc<dyn ClusterStateStore> = store.clone();
+        let observability = Arc::new(
+            CoordinatorObservability::new(
+                "cluster-a".into(),
+                NodeInfo {
+                    id: NodeId::new("coordinator-1"),
+                    address: "127.0.0.1:7000".into(),
+                    role: NodeRole::Coordinator,
+                },
+                "127.0.0.1:8000".into(),
+                Duration::from_millis(100),
+                state_store,
+            )
+            .unwrap(),
+        );
+        (observability, store)
+    }
+
+    fn worker_status() -> NodeStatus {
+        let now = now_unix_ms();
+        NodeStatus {
+            schema_version: NODE_STATUS_SCHEMA_VERSION,
+            cluster_id: "cluster-a".into(),
+            node: NodeInfo {
+                id: NodeId::new("worker-1"),
+                address: "127.0.0.1:7001".into(),
+                role: NodeRole::Worker,
+            },
+            incarnation_id: "worker-incarnation".into(),
+            admin_address: Some("127.0.0.1:8001".into()),
+            build_version: "test".into(),
+            started_at_unix_ms: now,
+            reported_at_unix_ms: now,
+            heartbeat_seq: 0,
+            health: NodeHealth::Healthy,
+            ready: true,
+            metrics: NodeMetricsSnapshot::default(),
+            labels: BTreeMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn readiness_and_status_use_shared_state() {
+        let (observability, store) = observability();
+        observability.check_ready().await.unwrap();
+        assert!(observability.is_ready());
+
+        let status = observability.status();
+        status.validate().unwrap();
+        assert!(status.ready);
+        observability
+            .upsert_status(status, Duration::from_secs(30))
+            .await
+            .unwrap();
+        observability
+            .upsert_status(worker_status(), Duration::from_secs(30))
+            .await
+            .unwrap();
+        observability.refresh_snapshot().await.unwrap();
+
+        let rendered = observability.metrics.render();
+        assert!(rendered
+            .contains("talon_coordinator_live_nodes{health=\"healthy\",role=\"coordinator\"} 1"));
+        assert!(
+            rendered.contains("talon_coordinator_live_nodes{health=\"healthy\",role=\"worker\"} 1")
+        );
+
+        store.set_available(false);
+        assert!(observability.check_ready().await.is_err());
+        assert!(!observability.is_ready());
+        assert!(observability.metrics.render().contains(
+            "talon_coordinator_state_store_errors_total{kind=\"unavailable\",operation=\"readiness\"} 1"
+        ));
+    }
+
+    #[test]
+    fn control_instrumentation_is_atomic_and_bounded() {
+        let (observability, _) = observability();
+        let guard = observability.metrics.track_connection();
+        observability.metrics.record_control(
+            ControlOperation::Placement,
+            true,
+            Duration::from_millis(2),
+        );
+        observability
+            .metrics
+            .record_placement(true, Duration::from_millis(2));
+        observability.metrics.refresh(observability.started, false);
+        let rendered = observability.metrics.render();
+        assert!(rendered.contains("talon_coordinator_active_connections 1"));
+        assert!(rendered.contains(
+            "talon_coordinator_control_requests_total{operation=\"placement_lookup\"} 1"
+        ));
+        assert!(rendered.contains("talon_coordinator_placement_errors_total 1"));
+        drop(guard);
+    }
+
+    #[tokio::test]
+    async fn admin_endpoints_report_health_readiness_metrics_and_failure() {
+        let (observability, store) = observability();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(serve_admin(listener, Arc::clone(&observability)));
+
+        let health = request(address, "/healthz").await;
+        assert!(health.starts_with("HTTP/1.1 200 OK"));
+        let ready = request(address, "/readyz").await;
+        assert!(ready.starts_with("HTTP/1.1 200 OK"));
+        let metrics = request(address, "/metrics").await;
+        assert!(metrics.contains("talon_coordinator_build_info{version=\"0.1.0\"} 1"));
+        assert!(metrics.contains("talon_coordinator_ready 1"));
+        assert!(metrics.contains("talon_coordinator_state_snapshot_age_seconds"));
+
+        store.set_available(false);
+        let ready = request(address, "/readyz").await;
+        assert!(ready.starts_with("HTTP/1.1 503 Service Unavailable"));
+        assert!(ready.contains("\"reason\":\"unavailable\""));
+
+        server.abort();
+    }
+
+    async fn request(address: std::net::SocketAddr, path: &str) -> String {
+        let mut stream = tokio::net::TcpStream::connect(address).await.unwrap();
+        stream
+            .write_all(
+                format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+                    .as_bytes(),
+            )
+            .await
+            .unwrap();
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+        String::from_utf8(response).unwrap()
+    }
+}


### PR DESCRIPTION
## Summary
- add layered coordinator CLI/environment/TOML configuration for control and administration listen/advertise addresses plus shared-state timing
- expose `/metrics`, `/healthz`, and read-only `/readyz` backed by `ClusterStateStore::check_ready()`
- instrument control operations, connections, registration/heartbeat outcomes, placement, state-store operations, snapshot age, live nodes, uptime, build info, and readiness
- accept versioned node status heartbeats into leased shared state and publish the coordinator own status record

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo build --workspace --all-targets --all-features --locked
- cargo test --workspace --all-features --locked
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
- git diff --check

Parent: #72
Closes #77