### PR TITLE
feat(fuse): implement metadata FUSE callbacks (lookup/getattr/readdir)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,6 +1336,7 @@ dependencies = [
  "async-trait",
  "clap",
  "fuser",
+ "libc",
  "talon-core",
  "talon-transport",
  "thiserror",

--- a/crates/talon-fuse/Cargo.toml
+++ b/crates/talon-fuse/Cargo.toml
@@ -29,7 +29,8 @@ thiserror.workspace = true
 # libfuse C dependency (it talks to /dev/fuse directly), so `--features mount`
 # compiles without the libfuse headers installed.
 fuser = { version = "0.14", optional = true, default-features = false }
+libc = { version = "0.2", optional = true }
 
 [features]
 # Compile the kernel FUSE mount adapter (requires fuser).
-mount = ["dep:fuser"]
+mount = ["dep:fuser", "dep:libc"]

--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -16,9 +16,58 @@
 //! [#100]: https://github.com/milvus-io/talon/issues/100
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::block_reader::BlockReader;
-use crate::ops::ReadOnlyFs;
+use crate::ops::{Attr, FileKind, FsError, ReadOnlyFs};
+
+/// How long the kernel may cache a metadata reply before re-asking.
+///
+/// The namespace is populated from coordinator listings and is effectively
+/// immutable for a mount session (read-only v1), so a modest TTL avoids a
+/// callback per stat without risking staleness.
+const ATTR_TTL: Duration = Duration::from_secs(1);
+
+/// Map a read-op [`FsError`] to a POSIX errno for a `fuser` reply.
+pub(crate) fn errno(err: FsError) -> i32 {
+    match err {
+        FsError::NotFound => libc::ENOENT,
+        FsError::ReadOnly => libc::EROFS,
+        FsError::Unsupported => libc::ENOSYS,
+        FsError::BadHandle => libc::EBADF,
+    }
+}
+
+/// Convert a synthesized [`Attr`] into a `fuser::FileAttr`.
+///
+/// Times are fixed to the UNIX epoch (the namespace is synthetic and read-only,
+/// so there is no meaningful mtime); links are 1, ownership is left to the
+/// mounting user via `uid`/`gid`. `blocks` is a 512-byte-unit count as POSIX
+/// expects.
+pub(crate) fn to_file_attr(attr: Attr, uid: u32, gid: u32) -> fuser::FileAttr {
+    let kind = match attr.kind {
+        FileKind::Directory => fuser::FileType::Directory,
+        FileKind::File => fuser::FileType::RegularFile,
+    };
+    let epoch = std::time::UNIX_EPOCH;
+    fuser::FileAttr {
+        ino: attr.ino,
+        size: attr.size,
+        blocks: attr.size.div_ceil(512),
+        atime: epoch,
+        mtime: epoch,
+        ctime: epoch,
+        crtime: epoch,
+        kind,
+        perm: attr.perm,
+        nlink: 1,
+        uid,
+        gid,
+        rdev: 0,
+        blksize: 512,
+        flags: 0,
+    }
+}
 
 /// A mountable Talon filesystem: the `fuser` adapter over the read path.
 ///
@@ -66,10 +115,79 @@ impl TalonFuse {
 }
 
 impl fuser::Filesystem for TalonFuse {
-    // Metadata ops (lookup, getattr, readdir) are implemented in #101; data ops
-    // (open, read, release) in #102. The trait's default methods return ENOSYS,
-    // so an unimplemented op fails cleanly rather than misbehaving; the scaffold
-    // deliberately does not override them yet.
+    /// Resolve a child `name` under directory `parent` to its attributes.
+    fn lookup(
+        &mut self,
+        req: &fuser::Request<'_>,
+        parent: u64,
+        name: &std::ffi::OsStr,
+        reply: fuser::ReplyEntry,
+    ) {
+        let name = match name.to_str() {
+            Some(s) => s,
+            None => return reply.error(libc::EINVAL),
+        };
+        match self.fs.lookup(parent, name) {
+            Ok(attr) => {
+                let fa = to_file_attr(attr, req.uid(), req.gid());
+                reply.entry(&ATTR_TTL, &fa, 0);
+            }
+            Err(e) => reply.error(errno(e)),
+        }
+    }
+
+    /// Report attributes for an inode.
+    fn getattr(&mut self, req: &fuser::Request<'_>, ino: u64, reply: fuser::ReplyAttr) {
+        match self.fs.getattr(ino) {
+            Ok(attr) => {
+                let fa = to_file_attr(attr, req.uid(), req.gid());
+                reply.attr(&ATTR_TTL, &fa);
+            }
+            Err(e) => reply.error(errno(e)),
+        }
+    }
+
+    /// List the children of a directory inode.
+    ///
+    /// The kernel drives pagination via `offset`: entries with an index `<=`
+    /// offset were already returned, so we start after it. `add` returns true
+    /// when the reply buffer is full; we stop there and let the kernel re-call
+    /// with a higher offset. The synthetic `.` and `..` entries are emitted
+    /// first (self and parent both map back to `ino` for the read-only tree).
+    fn readdir(
+        &mut self,
+        _req: &fuser::Request<'_>,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        mut reply: fuser::ReplyDirectory,
+    ) {
+        let children = match self.fs.readdir(ino) {
+            Ok(c) => c,
+            Err(e) => return reply.error(errno(e)),
+        };
+        // Prepend `.` and `..` so tools like `ls -a` behave; both point at `ino`
+        // (parent tracking is unnecessary for a read-only synthetic namespace).
+        let mut all: Vec<(u64, fuser::FileType, String)> = vec![
+            (ino, fuser::FileType::Directory, ".".to_string()),
+            (ino, fuser::FileType::Directory, "..".to_string()),
+        ];
+        all.extend(children.into_iter().map(|e| {
+            let kind = match e.kind {
+                FileKind::Directory => fuser::FileType::Directory,
+                FileKind::File => fuser::FileType::RegularFile,
+            };
+            (e.ino, kind, e.name)
+        }));
+
+        for (i, (child_ino, kind, name)) in all.into_iter().enumerate().skip(offset as usize) {
+            // The offset stored per entry is "next index to fetch" = i + 1.
+            if reply.add(child_ino, (i + 1) as i64, kind, name) {
+                break; // buffer full; kernel will re-call from here.
+            }
+        }
+        reply.ok();
+    }
 }
 
 #[cfg(test)]
@@ -91,5 +209,40 @@ mod tests {
         // The adapter exposes its components for the callbacks to use.
         assert_eq!(mounted.namespace().getattr(1).unwrap().ino, 1);
         assert_eq!(mounted.reader().coordinator_addr(), "127.0.0.1:7000");
+    }
+
+    #[test]
+    fn errno_maps_each_fs_error() {
+        assert_eq!(errno(FsError::NotFound), libc::ENOENT);
+        assert_eq!(errno(FsError::ReadOnly), libc::EROFS);
+        assert_eq!(errno(FsError::Unsupported), libc::ENOSYS);
+        assert_eq!(errno(FsError::BadHandle), libc::EBADF);
+    }
+
+    #[test]
+    fn to_file_attr_maps_kind_size_and_perm() {
+        let dir = Attr {
+            ino: 1,
+            kind: FileKind::Directory,
+            size: 0,
+            perm: 0o555,
+        };
+        let fa = to_file_attr(dir, 1000, 1000);
+        assert_eq!(fa.kind, fuser::FileType::Directory);
+        assert_eq!(fa.perm, 0o555);
+        assert_eq!(fa.uid, 1000);
+        assert_eq!(fa.nlink, 1);
+
+        let file = Attr {
+            ino: 7,
+            kind: FileKind::File,
+            size: 1000, // 1000 bytes → ceil(1000/512) = 2 blocks
+            perm: 0o444,
+        };
+        let fa = to_file_attr(file, 0, 0);
+        assert_eq!(fa.kind, fuser::FileType::RegularFile);
+        assert_eq!(fa.size, 1000);
+        assert_eq!(fa.blocks, 2);
+        assert_eq!(fa.blksize, 512);
     }
 }


### PR DESCRIPTION
## Summary
- Behind the `mount` feature, `TalonFuse` implements the three metadata `fuser::Filesystem` callbacks by delegating to `ReadOnlyFs` and mapping `FsError` → errno.
- `lookup`/`getattr` build a `fuser::FileAttr` (synthetic epoch times, nlink=1, 512-byte blocks, caller uid/gid); `readdir` emits synthetic `.`/`..` then sorted children, honoring the kernel's offset pagination and stopping when the reply buffer fills.
- Extracts pure helpers `errno()` and `to_file_attr()` so the mapping is unit-tested without a kernel mount; adds `libc` as a mount-only dep.

## Testing
- `errno` covers every `FsError`; `to_file_attr` maps kind/size/perm/blocks for dir + file.
- `cargo test -p talon-fuse --features mount`, `build --workspace --all-features --locked`, clippy/doc/fmt clean.

Part of #88. Closes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)