### PR TITLE
feat(fuse): mount lifecycle in main (config, mount, SIGINT unmount)

### DIFF
--- a/crates/talon-fuse/src/main.rs
+++ b/crates/talon-fuse/src/main.rs
@@ -1,18 +1,51 @@
 //! Talon FUSE client entry point.
+//!
+//! Resolves [`FuseConfig`] (defaults < file < env < CLI), builds the read-path
+//! components (coordinator client, placement cache, [`BlockReader`]), populates
+//! the namespace from a coordinator listing, and — when built with the `mount`
+//! feature — mounts the read-only filesystem, serving until SIGINT triggers a
+//! clean unmount.
+//!
+//! Without the `mount` feature the binary performs all the setup and validation
+//! but prints a clear message instead of mounting, so it still builds and runs
+//! in environments without `/dev/fuse` or libfuse.
+
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use clap::Parser;
+use talon_core::{FuseConfig, FuseConfigPatch};
+use talon_fuse::{BlockReader, CoordinatorClient, PlacementCache, ReadOnlyFs};
 
 /// Command-line arguments for the Talon FUSE mount.
 #[derive(Debug, Parser)]
 #[command(name = "talon-fuse", version, about)]
 struct Args {
+    /// Path to a TOML config file.
+    #[arg(long)]
+    config: Option<PathBuf>,
     /// Directory to mount the Talon filesystem at.
     #[arg(long)]
-    mountpoint: String,
-
+    mountpoint: Option<PathBuf>,
     /// Address of the coordinator to connect to.
-    #[arg(long, default_value = "127.0.0.1:7000")]
-    coordinator: String,
+    #[arg(long)]
+    coordinator: Option<String>,
+    /// Logical block size in bytes.
+    #[arg(long)]
+    block_size: Option<u32>,
+}
+
+impl Args {
+    /// Assemble the highest-precedence (CLI) config patch from parsed flags.
+    fn to_patch(&self) -> FuseConfigPatch {
+        FuseConfigPatch {
+            mountpoint: self.mountpoint.clone(),
+            coordinator: self.coordinator.clone(),
+            block_size: self.block_size,
+            placement_ttl_ms: None,
+            readahead_blocks: None,
+        }
+    }
 }
 
 #[tokio::main]
@@ -24,13 +57,86 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let args = Args::parse();
+    let file = match &args.config {
+        Some(path) => FuseConfigPatch::from_file(path)?,
+        None => FuseConfigPatch::default(),
+    };
+    let env = FuseConfigPatch::from_env()?;
+    let cfg = FuseConfig::resolve(file, env, args.to_patch())?;
+
     tracing::info!(
-        mountpoint = %args.mountpoint,
-        coordinator = %args.coordinator,
+        mountpoint = %cfg.mountpoint.display(),
+        coordinator = %cfg.coordinator,
+        block_size = cfg.block_size,
+        placement_ttl_ms = cfg.placement_ttl_ms,
+        readahead_blocks = cfg.readahead_blocks,
         "starting talon-fuse"
     );
 
-    // TODO: connect to the cluster and mount the FUSE filesystem.
+    // Read-path components, shared by the metadata and data callbacks.
+    let coordinator = CoordinatorClient::new(cfg.coordinator.clone());
+    let cache = Arc::new(PlacementCache::new(cfg.placement_ttl_ms));
+    let reader = BlockReader::new(coordinator.clone(), cache, 1);
 
+    // Populate the namespace from a coordinator listing (best-effort: a listing
+    // failure logs and yields an empty tree rather than aborting the mount).
+    let fs = Arc::new(ReadOnlyFs::new());
+    match coordinator.list_objects("").await {
+        Ok(entries) => {
+            let n = fs.populate_from_listing(entries.iter().map(|e| (e.path.as_str(), e.size)));
+            tracing::info!(objects = n, "populated namespace from coordinator listing");
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "coordinator listing failed; mounting an empty namespace");
+        }
+    }
+
+    run_mount(cfg, fs, reader).await
+}
+
+/// Mount and serve until SIGINT (built with `--features mount`).
+#[cfg(feature = "mount")]
+async fn run_mount(
+    cfg: FuseConfig,
+    fs: Arc<ReadOnlyFs>,
+    reader: BlockReader,
+) -> anyhow::Result<()> {
+    use fuser::MountOption;
+    use talon_fuse::mount::TalonFuse;
+
+    let version = talon_core::Version::new("v1");
+    let handle = tokio::runtime::Handle::current();
+    let adapter = TalonFuse::new(fs, reader, handle, cfg.block_size, version);
+
+    let options = vec![
+        MountOption::RO,
+        MountOption::FSName("talon".to_string()),
+        MountOption::DefaultPermissions,
+    ];
+
+    // spawn_mount2 runs the session on a background thread and returns a guard;
+    // dropping the guard (or an explicit unmount) tears the mount down.
+    let session = fuser::spawn_mount2(adapter, &cfg.mountpoint, &options)?;
+    tracing::info!(mountpoint = %cfg.mountpoint.display(), "mounted; press Ctrl-C to unmount");
+
+    tokio::signal::ctrl_c().await?;
+    tracing::info!("SIGINT received; unmounting");
+    // Dropping the BackgroundSession unmounts and joins the session thread.
+    drop(session);
+    Ok(())
+}
+
+/// Built without the `mount` feature: set everything up but do not mount.
+#[cfg(not(feature = "mount"))]
+async fn run_mount(
+    cfg: FuseConfig,
+    _fs: Arc<ReadOnlyFs>,
+    _reader: BlockReader,
+) -> anyhow::Result<()> {
+    tracing::warn!(
+        mountpoint = %cfg.mountpoint.display(),
+        "built without the `mount` feature: not mounting. \
+         Rebuild with `--features mount` to enable the kernel FUSE mount."
+    );
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Replaces the parse-and-exit stub with the real client bootstrap: resolve `FuseConfig` (defaults < file < env < CLI), build `CoordinatorClient` + `PlacementCache` + `BlockReader`, and populate the namespace from a coordinator listing (best-effort — a failure logs and mounts an empty tree).
- With `--features mount`: builds `TalonFuse` and calls `fuser::spawn_mount2` (read-only options), serving until SIGINT triggers a clean unmount (dropping `BackgroundSession` unmounts + joins).
- Without the feature: full setup + validation, then logs "not mounting; rebuild with --features mount" — so it still builds/runs where `/dev/fuse`/libfuse are absent.

## Testing
- `cargo build -p talon-fuse` (default) and `--features mount` both green.
- `build --workspace --all-features --locked`, clippy (both feature sets), doc, fmt clean.

Part of #88. Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)