### PR TITLE
feat(fuse): add read-path metrics and tracing

### DIFF
--- a/crates/talon-fuse/src/block_reader.rs
+++ b/crates/talon-fuse/src/block_reader.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 use talon_core::{BlockId, ObjectId, Version};
 
 use crate::coordinator_client::{CoordinatorClient, CoordinatorError};
+use crate::metrics::ReadStats;
 use crate::placement_cache::{Cached, PlacementCache, RefreshReason};
 use crate::read_plan::plan_read;
 use crate::worker_client::{WorkerClient, WorkerError};
@@ -73,6 +74,8 @@ pub struct BlockReader {
     cache: Arc<PlacementCache>,
     /// Number of replicas to request from the coordinator (RF=1 → 1 in v1).
     replicas_k: u8,
+    /// Read-path counters (cache hit/miss, worker fetches, bytes served).
+    stats: ReadStats,
 }
 
 impl BlockReader {
@@ -80,17 +83,37 @@ impl BlockReader {
     ///
     /// `replicas_k` is how many owners to request per placement lookup; with
     /// RF=1 this is `1`, but requesting more reserves an ordered fallback list.
+    /// Metrics are collected into a fresh [`ReadStats`]; use
+    /// [`with_stats`](Self::with_stats) to share an existing one.
     pub fn new(coordinator: CoordinatorClient, cache: Arc<PlacementCache>, replicas_k: u8) -> Self {
+        Self::with_stats(coordinator, cache, replicas_k, ReadStats::new())
+    }
+
+    /// Like [`new`](Self::new) but records metrics into the provided
+    /// [`ReadStats`], so a caller (e.g. the mount layer) can observe the same
+    /// counters this reader bumps.
+    pub fn with_stats(
+        coordinator: CoordinatorClient,
+        cache: Arc<PlacementCache>,
+        replicas_k: u8,
+        stats: ReadStats,
+    ) -> Self {
         Self {
             coordinator,
             cache,
             replicas_k: replicas_k.max(1),
+            stats,
         }
     }
 
     /// The coordinator address this reader resolves placement against.
     pub fn coordinator_addr(&self) -> &str {
         self.coordinator.addr()
+    }
+
+    /// The read-path counters this reader updates.
+    pub fn stats(&self) -> &ReadStats {
+        &self.stats
     }
 
     /// Read `len` bytes at `offset_in_block` within `block`.
@@ -118,8 +141,14 @@ impl BlockReader {
         now_ms: u64,
     ) -> Result<Vec<u8>, BlockReadError> {
         let cached = match self.cache.get(block, now_ms) {
-            Some(c) => c,
-            None => self.resolve_and_cache(block, now_ms).await?,
+            Some(c) => {
+                self.stats.record_cache_hit();
+                c
+            }
+            None => {
+                self.stats.record_cache_miss();
+                self.resolve_and_cache(block, now_ms).await?
+            }
         };
         let abs_offset = block.offset + offset_in_block as u64;
 
@@ -128,18 +157,26 @@ impl BlockReader {
             .try_replicas(block, &cached.replicas, abs_offset, len)
             .await
         {
-            Ok(bytes) => return Ok(bytes),
+            Ok(bytes) => {
+                self.stats.add_bytes_served(bytes.len() as u64);
+                return Ok(bytes);
+            }
             Err(reason) => {
                 // Every cached replica failed; drop the stale placement and do a
                 // single coordinator refresh before giving up.
+                tracing::debug!(%block, ?reason, "all cached replicas failed; refreshing placement");
                 self.cache.invalidate(block, reason);
+                self.stats.record_coordinator_refresh();
             }
         }
 
         let fresh = self.resolve_and_cache(block, now_ms).await?;
-        self.try_replicas(block, &fresh.replicas, abs_offset, len)
+        let bytes = self
+            .try_replicas(block, &fresh.replicas, abs_offset, len)
             .await
-            .map_err(|_| BlockReadError::AllReplicasFailed)
+            .map_err(|_| BlockReadError::AllReplicasFailed)?;
+        self.stats.add_bytes_served(bytes.len() as u64);
+        Ok(bytes)
     }
 
     /// Try each replica address in order; return the first success, or the
@@ -161,16 +198,21 @@ impl BlockReader {
         let mut last = RefreshReason::WrongOwner;
         for addr in replicas {
             let worker = WorkerClient::new(addr.clone());
+            self.stats.record_worker_fetch();
             match worker
                 .fetch_range(&block.object, abs_offset, len as u64)
                 .await
             {
                 Ok(bytes) => return Ok(bytes),
-                Err(WorkerError::Io(_)) => last = RefreshReason::ConnectFailure,
-                Err(WorkerError::Remote(_)) => last = RefreshReason::WrongOwner,
-                // A framing/encode error is not a placement problem; surface it
-                // as a wrong-owner refresh so we still try to recover.
-                Err(_) => last = RefreshReason::WrongOwner,
+                Err(e) => {
+                    self.stats.record_worker_failure();
+                    last = match e {
+                        WorkerError::Io(_) => RefreshReason::ConnectFailure,
+                        // A framing/encode error is not a placement problem, but
+                        // treat it as a wrong-owner refresh so we still recover.
+                        _ => RefreshReason::WrongOwner,
+                    };
+                }
             }
         }
         Err(last)
@@ -470,6 +512,15 @@ mod tests {
         // Second read: cache hit (still 1 entry), worker serves again.
         let _ = reader.read_block(&blk, 0, 16, 1).await.unwrap();
         assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 2);
+
+        // Metrics reflect one miss then one hit, two worker fetches, bytes served.
+        let snap = reader.stats().snapshot();
+        assert_eq!(snap.cache_misses, 1);
+        assert_eq!(snap.cache_hits, 1);
+        assert_eq!(snap.worker_fetches, 2);
+        assert_eq!(snap.worker_failures, 0);
+        assert_eq!(snap.bytes_served, 64 + 16);
+        assert_eq!(snap.hit_ratio(), 0.5);
     }
 
     #[tokio::test]

--- a/crates/talon-fuse/src/lib.rs
+++ b/crates/talon-fuse/src/lib.rs
@@ -9,6 +9,7 @@ pub mod bridge;
 pub mod coordinator_client;
 pub mod fs;
 pub mod mapping;
+pub mod metrics;
 #[cfg(feature = "mount")]
 pub mod mount;
 pub mod ops;
@@ -25,6 +26,7 @@ pub use coordinator_client::{
 };
 pub use fs::TalonFs;
 pub use mapping::{object_to_path, path_to_object, resolve_read, ReadTarget};
+pub use metrics::{ReadStats, ReadStatsSnapshot};
 #[cfg(feature = "mount")]
 pub use mount::TalonFuse;
 pub use ops::{Attr, DirEntry, FileKind, FsError, ReadOnlyFs, ROOT_INO};

--- a/crates/talon-fuse/src/main.rs
+++ b/crates/talon-fuse/src/main.rs
@@ -106,6 +106,7 @@ async fn run_mount(
 
     let version = talon_core::Version::new("v1");
     let handle = tokio::runtime::Handle::current();
+    let stats = reader.stats().clone();
     let adapter = TalonFuse::new(fs, reader, handle, cfg.block_size, version);
 
     let options = vec![
@@ -123,6 +124,17 @@ async fn run_mount(
     tracing::info!("SIGINT received; unmounting");
     // Dropping the BackgroundSession unmounts and joins the session thread.
     drop(session);
+    let s = stats.snapshot();
+    tracing::info!(
+        cache_hits = s.cache_hits,
+        cache_misses = s.cache_misses,
+        hit_ratio = s.hit_ratio(),
+        worker_fetches = s.worker_fetches,
+        worker_failures = s.worker_failures,
+        coordinator_refreshes = s.coordinator_refreshes,
+        bytes_served = s.bytes_served,
+        "read-path metrics at unmount"
+    );
     Ok(())
 }
 

--- a/crates/talon-fuse/src/metrics.rs
+++ b/crates/talon-fuse/src/metrics.rs
@@ -1,0 +1,160 @@
+//! Read-path metrics.
+//!
+//! [`ReadStats`] is a small bundle of atomic counters the read path bumps as it
+//! serves blocks: placement-cache hits and misses, coordinator refreshes,
+//! per-replica worker fetch attempts and failures, and bytes served. It is
+//! cheap to share (all `Relaxed` atomics behind an `Arc`) and lets the mount
+//! layer expose live read-path health without threading a metrics facade
+//! through every call.
+//!
+//! Counters are monotonic; a caller samples them into a [`ReadStatsSnapshot`]
+//! (e.g. for a `/metrics` line or a periodic `tracing` log) and diffs snapshots
+//! over time for rates.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// Shared, cheaply-clonable read-path counters.
+#[derive(Debug, Clone, Default)]
+pub struct ReadStats {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug, Default)]
+struct Inner {
+    cache_hits: AtomicU64,
+    cache_misses: AtomicU64,
+    coordinator_refreshes: AtomicU64,
+    worker_fetches: AtomicU64,
+    worker_failures: AtomicU64,
+    bytes_served: AtomicU64,
+}
+
+impl ReadStats {
+    /// Create a fresh, zeroed counter set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a placement-cache hit (owners served from cache).
+    pub fn record_cache_hit(&self) {
+        self.inner.cache_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a placement-cache miss (a coordinator lookup was needed).
+    pub fn record_cache_miss(&self) {
+        self.inner.cache_misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a coordinator refresh after all cached replicas failed.
+    pub fn record_coordinator_refresh(&self) {
+        self.inner
+            .coordinator_refreshes
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a single worker fetch attempt (one replica dial).
+    pub fn record_worker_fetch(&self) {
+        self.inner.worker_fetches.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record a failed worker fetch attempt.
+    pub fn record_worker_failure(&self) {
+        self.inner.worker_failures.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Add to the count of bytes successfully served to the caller.
+    pub fn add_bytes_served(&self, n: u64) {
+        self.inner.bytes_served.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Take a consistent-enough snapshot of the current counter values.
+    pub fn snapshot(&self) -> ReadStatsSnapshot {
+        ReadStatsSnapshot {
+            cache_hits: self.inner.cache_hits.load(Ordering::Relaxed),
+            cache_misses: self.inner.cache_misses.load(Ordering::Relaxed),
+            coordinator_refreshes: self.inner.coordinator_refreshes.load(Ordering::Relaxed),
+            worker_fetches: self.inner.worker_fetches.load(Ordering::Relaxed),
+            worker_failures: self.inner.worker_failures.load(Ordering::Relaxed),
+            bytes_served: self.inner.bytes_served.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// A point-in-time copy of [`ReadStats`] counters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ReadStatsSnapshot {
+    /// Placement-cache hits.
+    pub cache_hits: u64,
+    /// Placement-cache misses (coordinator lookups triggered).
+    pub cache_misses: u64,
+    /// Coordinator refreshes after all cached replicas failed.
+    pub coordinator_refreshes: u64,
+    /// Worker fetch attempts (per-replica dials).
+    pub worker_fetches: u64,
+    /// Failed worker fetch attempts.
+    pub worker_failures: u64,
+    /// Bytes successfully served to callers.
+    pub bytes_served: u64,
+}
+
+impl ReadStatsSnapshot {
+    /// Cache hit ratio in `[0.0, 1.0]`, or `0.0` if there were no lookups.
+    pub fn hit_ratio(&self) -> f64 {
+        let total = self.cache_hits + self.cache_misses;
+        if total == 0 {
+            0.0
+        } else {
+            self.cache_hits as f64 / total as f64
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counters_accumulate_and_snapshot() {
+        let s = ReadStats::new();
+        s.record_cache_hit();
+        s.record_cache_hit();
+        s.record_cache_miss();
+        s.record_coordinator_refresh();
+        s.record_worker_fetch();
+        s.record_worker_fetch();
+        s.record_worker_failure();
+        s.add_bytes_served(4096);
+        s.add_bytes_served(96);
+
+        let snap = s.snapshot();
+        assert_eq!(snap.cache_hits, 2);
+        assert_eq!(snap.cache_misses, 1);
+        assert_eq!(snap.coordinator_refreshes, 1);
+        assert_eq!(snap.worker_fetches, 2);
+        assert_eq!(snap.worker_failures, 1);
+        assert_eq!(snap.bytes_served, 4192);
+    }
+
+    #[test]
+    fn hit_ratio_handles_empty_and_typical() {
+        assert_eq!(ReadStatsSnapshot::default().hit_ratio(), 0.0);
+        let snap = ReadStatsSnapshot {
+            cache_hits: 3,
+            cache_misses: 1,
+            ..Default::default()
+        };
+        assert_eq!(snap.hit_ratio(), 0.75);
+    }
+
+    #[test]
+    fn clones_share_the_same_counters() {
+        let a = ReadStats::new();
+        let b = a.clone();
+        a.record_cache_hit();
+        b.record_cache_hit();
+        // Both handles point at the same underlying counters.
+        assert_eq!(a.snapshot().cache_hits, 2);
+        assert_eq!(b.snapshot().cache_hits, 2);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `metrics::ReadStats`: cheaply-shared atomic counters (`Arc<Inner>`) for placement-cache hits/misses, coordinator refreshes, per-replica worker fetches/failures, and bytes served.
- `BlockReader` records into a `ReadStats` (fresh via `new()`, shared via `with_stats`), exposes it via `stats()`, and emits a debug tracing line when all cached replicas fail and a refresh is triggered.
- The mount binary logs a structured `ReadStatsSnapshot` (hit ratio, fetches, failures, refreshes, bytes) at unmount. `ReadStatsSnapshot::hit_ratio()` helps diff over time.

## Testing
- Counters accumulate + snapshot; `hit_ratio` empty + typical; clones share counters; miss-then-hit read records 1 miss / 1 hit / 2 fetches / bytes served.
- `cargo test -p talon-fuse` (57) and `--features mount` (60); clippy (both feature sets), doc, fmt clean.

Part of #88. Closes #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)