### PR TITLE
feat(coordinator): add etcd ClusterStateStore backend with leases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install toolchain (clippy)
         run: rustup component add clippy
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: Swatinem/rust-cache@v2
       - name: Lint
         run: cargo clippy --workspace --all-targets --all-features
@@ -48,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: Swatinem/rust-cache@v2
       - name: Build
         run: cargo build --workspace --all-targets --all-features --locked
@@ -59,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: Swatinem/rust-cache@v2
       - name: Build docs
         run: cargo doc --workspace --no-deps --all-features
@@ -85,6 +91,8 @@ jobs:
       TALON_ETCD_TEST_ENDPOINT: 127.0.0.1:2379
     steps:
       - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: Swatinem/rust-cache@v2
       - name: Run etcd backend contract tests
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,26 +73,34 @@ jobs:
     name: etcd backend contract
     runs-on: ubuntu-latest
     # Exercises the production etcd ClusterStateStore backend against a real
-    # ephemeral etcd, as required by the state-store contract.
-    services:
-      etcd:
-        image: gcr.io/etcd-development/etcd:v3.5.16
-        ports:
-          - 2379:2379
-        env:
-          ETCD_LISTEN_CLIENT_URLS: http://0.0.0.0:2379
-          ETCD_ADVERTISE_CLIENT_URLS: http://127.0.0.1:2379
-        options: >-
-          --health-cmd "etcdctl endpoint health"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 5
+    # ephemeral etcd, as required by the state-store contract. etcd is launched
+    # explicitly rather than as a service container because that image's
+    # healthcheck is unreliable on GitHub-hosted runners.
     env:
+      ETCD_VERSION: v3.5.16
       TALON_ETCD_TEST_ENDPOINT: 127.0.0.1:2379
     steps:
       - uses: actions/checkout@v4
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Start ephemeral etcd
+        run: |
+          curl -fsSL -o /tmp/etcd.tar.gz \
+            "https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz"
+          tar xzf /tmp/etcd.tar.gz -C /tmp
+          ETCD_DIR="/tmp/etcd-${ETCD_VERSION}-linux-amd64"
+          "$ETCD_DIR/etcd" --data-dir /tmp/etcd-data \
+            --listen-client-urls http://127.0.0.1:2379 \
+            --advertise-client-urls http://127.0.0.1:2379 &
+          echo "ETCD_PID=$!" >> "$GITHUB_ENV"
+          for i in $(seq 1 30); do
+            if "$ETCD_DIR/etcdctl" --endpoints=127.0.0.1:2379 endpoint health; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "etcd did not become healthy" >&2
+          exit 1
       - uses: Swatinem/rust-cache@v2
       - name: Run etcd backend contract tests
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,35 @@ jobs:
       - name: Build docs
         run: cargo doc --workspace --no-deps --all-features
 
+  etcd-contract:
+    name: etcd backend contract
+    runs-on: ubuntu-latest
+    # Exercises the production etcd ClusterStateStore backend against a real
+    # ephemeral etcd, as required by the state-store contract.
+    services:
+      etcd:
+        image: gcr.io/etcd-development/etcd:v3.5.16
+        ports:
+          - 2379:2379
+        env:
+          ETCD_LISTEN_CLIENT_URLS: http://0.0.0.0:2379
+          ETCD_ADVERTISE_CLIENT_URLS: http://127.0.0.1:2379
+        options: >-
+          --health-cmd "etcdctl endpoint health"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    env:
+      TALON_ETCD_TEST_ENDPOINT: 127.0.0.1:2379
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - name: Run etcd backend contract tests
+        run: >-
+          cargo test -p talon-coordinator
+          --features etcd,state-store-testkit
+          --test etcd_contract --locked
+
   bench:
     name: bench (informational)
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -322,14 +322,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -510,6 +510,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcd-client"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5da6e9a6ae89f4a91f80ba1caae45a5a924397a19947e18f5121a43285e9bc"
+dependencies = [
+ "http",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tower",
+ "tower-service",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,10 +549,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -703,6 +739,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +868,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1032,6 +1088,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,9 +1264,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.187"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7743783ea728ef5c31194c6590797eed286449b4a4e87d626d8a51f0a94e732"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1273,6 +1338,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1417,6 +1488,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,12 +1543,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
+ "regex",
+ "syn 2.0.119",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -1870,7 +2035,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2020,9 +2185,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2082,6 +2247,7 @@ dependencies = [
  "axum",
  "clap",
  "divan",
+ "etcd-client",
  "futures",
  "k8s-openapi",
  "kube",
@@ -2092,6 +2258,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "toml",
+ "tonic",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -2173,6 +2340,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,7 +2399,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2295,6 +2475,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2542,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "rustls-native-certs",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.119",
+ "tempfile",
+ "tonic-build",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2358,7 +2619,9 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
  "tokio-util",
@@ -2479,6 +2742,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,10 @@ serde_yaml = "0.9"
 kube = { version = "0.97", default-features = false, features = ["client", "config", "rustls-tls", "runtime"] }
 k8s-openapi = { version = "0.23", default-features = false, features = ["v1_30"] }
 futures = "0.3"
+# etcd v3 client for the production ClusterStateStore backend. `tls-roots`
+# enables TLS via tonic/ring with the platform's native root certificates and
+# avoids a system OpenSSL build dependency.
+etcd-client = { version = "0.19", default-features = false, features = ["tls", "tls-roots"] }
+# gRPC status codes surfaced by etcd-client errors. Pinned to the same tonic
+# major the etcd client depends on so error mapping stays in sync.
+tonic = { version = "0.14", default-features = false }

--- a/crates/talon-coordinator/Cargo.toml
+++ b/crates/talon-coordinator/Cargo.toml
@@ -16,6 +16,9 @@ state-store-testkit = []
 # Production Kubernetes Lease ClusterStateStore backend. Off by default so
 # non-Kubernetes builds do not pull in the kube/k8s-openapi client stack.
 kubernetes = ["dep:kube", "dep:k8s-openapi", "dep:futures"]
+# Production etcd v3 ClusterStateStore backend. Kept off by default so
+# non-etcd builds do not pull in the gRPC/TLS stack.
+etcd = ["dep:etcd-client", "dep:tonic"]
 
 [dependencies]
 talon-core.workspace = true
@@ -35,6 +38,8 @@ xxhash-rust.workspace = true
 kube = { workspace = true, optional = true }
 k8s-openapi = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
+etcd-client = { workspace = true, optional = true }
+tonic = { workspace = true, optional = true }
 
 [dev-dependencies]
 divan.workspace = true

--- a/crates/talon-coordinator/src/lib.rs
+++ b/crates/talon-coordinator/src/lib.rs
@@ -31,3 +31,11 @@ pub use state_store::{
     StateBackend, StateStoreError, StateStoreResult, StoreRevision, TimeSource, WriteDisposition,
     WriteResult,
 };
+#[cfg(feature = "etcd")]
+pub use state_store::{
+    EtcdConfig, EtcdConfigError, EtcdStateStore, EtcdTlsConfig, DEFAULT_ETCD_PREFIX,
+};
+#[cfg(feature = "kubernetes")]
+pub use state_store::{
+    KubernetesConfig, KubernetesConfigError, KubernetesStateStore, DEFAULT_LEASE_LABEL_PREFIX,
+};

--- a/crates/talon-coordinator/src/state_store/etcd.rs
+++ b/crates/talon-coordinator/src/state_store/etcd.rs
@@ -1,0 +1,849 @@
+//! Production etcd v3 [`ClusterStateStore`] backend.
+//!
+//! Node records live under a cluster-scoped prefix and are attached to an etcd
+//! lease, so a crashed coordinator's record disappears automatically once its
+//! heartbeat stops refreshing the lease. Snapshots are linearizable and return
+//! the etcd response revision; watches resume from that revision and recover
+//! from compaction by relisting.
+//!
+//! The incarnation/heartbeat-sequence ordering rule from the backend contract is
+//! enforced with a read then a `mod_revision`-guarded transaction, retried a
+//! bounded number of times under write contention.
+
+use std::fmt;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use etcd_client::{
+    Certificate, Client, Compare, CompareOp, ConnectOptions, EventType, GetOptions, Identity,
+    PutOptions, TlsOptions, Txn, TxnOp, WatchOptions, WatchStream,
+};
+use serde::Deserialize;
+use talon_core::{NodeId, NodeRole, NodeStatus};
+use tokio::time::timeout;
+
+use super::{
+    BackendHealth, ClusterSnapshot, ClusterStateStore, ClusterStateWatch, NodeEvent, NodeEventKind,
+    StateBackend, StateStoreError, StateStoreResult, StoreRevision, WriteDisposition, WriteResult,
+};
+
+/// Default keyspace prefix for all Talon cluster state.
+pub const DEFAULT_ETCD_PREFIX: &str = "/talon";
+
+/// Maximum number of optimistic retries for a single mutation before the write
+/// is reported as unavailable.
+const MAX_WRITE_RETRIES: usize = 32;
+
+const REVISION_BACKEND: StateBackend = StateBackend::Etcd;
+
+/// TLS material for connecting to an etcd cluster.
+#[derive(Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct EtcdTlsConfig {
+    /// PEM-encoded certificate authority used to verify the etcd servers.
+    pub ca_cert_path: Option<PathBuf>,
+    /// PEM-encoded client certificate for mutual TLS.
+    pub client_cert_path: Option<PathBuf>,
+    /// PEM-encoded client private key for mutual TLS.
+    pub client_key_path: Option<PathBuf>,
+    /// Optional domain name override used for certificate verification.
+    pub domain_name: Option<String>,
+}
+
+impl fmt::Debug for EtcdTlsConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EtcdTlsConfig")
+            .field("ca_cert_path", &self.ca_cert_path)
+            .field("client_cert_path", &self.client_cert_path)
+            .field(
+                "client_key_path",
+                &self.client_key_path.as_ref().map(|_| "<redacted>"),
+            )
+            .field("domain_name", &self.domain_name)
+            .finish()
+    }
+}
+
+/// etcd backend connection and keyspace configuration.
+///
+/// `request_timeout` and `lease_ttl` are supplied separately from the shared
+/// [`ClusterStateConfig`](super::ClusterStateConfig) so lease timing stays
+/// backend-neutral.
+#[derive(Clone, PartialEq, Eq, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct EtcdConfig {
+    /// One or more `host:port` etcd endpoints.
+    pub endpoints: Vec<String>,
+    /// Optional username for password authentication.
+    pub username: Option<String>,
+    /// Optional password for password authentication. Never logged.
+    pub password: Option<String>,
+    /// Optional transport security.
+    pub tls: Option<EtcdTlsConfig>,
+    /// Keyspace prefix shared by every Talon record.
+    pub prefix: String,
+}
+
+impl Default for EtcdConfig {
+    fn default() -> Self {
+        Self {
+            endpoints: Vec::new(),
+            username: None,
+            password: None,
+            tls: None,
+            prefix: DEFAULT_ETCD_PREFIX.to_string(),
+        }
+    }
+}
+
+impl fmt::Debug for EtcdConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EtcdConfig")
+            .field("endpoints", &self.endpoints)
+            .field("username", &self.username)
+            .field("password", &self.password.as_ref().map(|_| "<redacted>"))
+            .field("tls", &self.tls)
+            .field("prefix", &self.prefix)
+            .finish()
+    }
+}
+
+/// Invalid etcd backend configuration.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum EtcdConfigError {
+    /// No endpoints were supplied.
+    #[error("etcd backend requires at least one endpoint")]
+    NoEndpoints,
+    /// An endpoint entry was blank.
+    #[error("etcd endpoint must not be empty")]
+    EmptyEndpoint,
+    /// The keyspace prefix was blank.
+    #[error("etcd prefix must not be empty")]
+    EmptyPrefix,
+    /// A username was supplied without a password or vice versa.
+    #[error("etcd authentication requires both a username and a password")]
+    IncompleteCredentials,
+    /// A client certificate was supplied without a matching key or vice versa.
+    #[error("etcd mutual TLS requires both a client certificate and a client key")]
+    IncompleteClientIdentity,
+}
+
+impl EtcdConfig {
+    /// Validate endpoints, prefix, credentials, and TLS material pairing.
+    pub fn validate(&self) -> Result<(), EtcdConfigError> {
+        if self.endpoints.is_empty() {
+            return Err(EtcdConfigError::NoEndpoints);
+        }
+        if self
+            .endpoints
+            .iter()
+            .any(|endpoint| endpoint.trim().is_empty())
+        {
+            return Err(EtcdConfigError::EmptyEndpoint);
+        }
+        if self.prefix.trim().is_empty() {
+            return Err(EtcdConfigError::EmptyPrefix);
+        }
+        if self.username.is_some() != self.password.is_some() {
+            return Err(EtcdConfigError::IncompleteCredentials);
+        }
+        if let Some(tls) = &self.tls {
+            if tls.client_cert_path.is_some() != tls.client_key_path.is_some() {
+                return Err(EtcdConfigError::IncompleteClientIdentity);
+            }
+        }
+        Ok(())
+    }
+
+    fn normalized_prefix(&self) -> String {
+        self.prefix.trim_end_matches('/').to_string()
+    }
+}
+
+/// Strongly consistent etcd-backed [`ClusterStateStore`].
+pub struct EtcdStateStore {
+    client: Client,
+    prefix: String,
+    request_timeout: Duration,
+}
+
+impl EtcdStateStore {
+    /// Connect to etcd and construct a store.
+    ///
+    /// `lease_ttl` and `request_timeout` come from the shared cluster-state
+    /// configuration. Lease TTLs are rounded up to whole seconds because etcd
+    /// lease granularity is one second.
+    pub async fn connect(
+        config: &EtcdConfig,
+        lease_ttl: Duration,
+        request_timeout: Duration,
+    ) -> StateStoreResult<Self> {
+        config
+            .validate()
+            .map_err(|error| StateStoreError::Unavailable {
+                backend: REVISION_BACKEND,
+                detail: error.to_string(),
+            })?;
+        // Fail fast if the configured lease TTL cannot be represented in etcd's
+        // one-second granularity before opening a connection.
+        lease_ttl_to_seconds(lease_ttl)?;
+
+        let options = build_connect_options(config)?;
+        let client = timeout(
+            request_timeout,
+            Client::connect(config.endpoints.clone(), Some(options)),
+        )
+        .await
+        .map_err(|_| StateStoreError::Timeout {
+            backend: REVISION_BACKEND,
+        })?
+        .map_err(map_connect_error)?;
+
+        Ok(Self {
+            client,
+            prefix: config.normalized_prefix(),
+            request_timeout,
+        })
+    }
+
+    /// Build a store from an already-connected client (used by tests).
+    pub fn from_client(
+        client: Client,
+        prefix: impl Into<String>,
+        request_timeout: Duration,
+    ) -> StateStoreResult<Self> {
+        Ok(Self {
+            client,
+            prefix: prefix.into().trim_end_matches('/').to_string(),
+            request_timeout,
+        })
+    }
+
+    fn cluster_prefix(&self, cluster_id: &str) -> String {
+        format!("{}/clusters/{cluster_id}/nodes/", self.prefix)
+    }
+
+    fn node_key(&self, status: &NodeStatus) -> String {
+        self.record_key(&status.cluster_id, status.node.role, &status.node.id)
+    }
+
+    fn record_key(&self, cluster_id: &str, role: NodeRole, node_id: &NodeId) -> String {
+        format!(
+            "{}{}/{}",
+            self.cluster_prefix(cluster_id),
+            role_segment(role),
+            node_id.0
+        )
+    }
+
+    async fn with_timeout<T, F>(&self, future: F) -> StateStoreResult<T>
+    where
+        F: std::future::Future<Output = Result<T, etcd_client::Error>>,
+    {
+        match timeout(self.request_timeout, future).await {
+            Ok(Ok(value)) => Ok(value),
+            Ok(Err(error)) => Err(map_etcd_error(error)),
+            Err(_) => Err(StateStoreError::Timeout {
+                backend: REVISION_BACKEND,
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl ClusterStateStore for EtcdStateStore {
+    fn backend(&self) -> StateBackend {
+        StateBackend::Etcd
+    }
+
+    async fn upsert_node(
+        &self,
+        status: NodeStatus,
+        lease_ttl: Duration,
+    ) -> StateStoreResult<WriteResult> {
+        status.validate()?;
+        let ttl_seconds = lease_ttl_to_seconds(lease_ttl)?;
+        let key = self.node_key(&status);
+        let value = serde_json::to_vec(&status).map_err(|error| StateStoreError::Unavailable {
+            backend: REVISION_BACKEND,
+            detail: format!("failed to encode node status: {error}"),
+        })?;
+
+        let mut client = self.client.clone();
+        for _ in 0..MAX_WRITE_RETRIES {
+            // Linearizable read of the current record and its lease.
+            let current = self.with_timeout(client.get(key.clone(), None)).await?;
+            let header_revision = current
+                .header()
+                .map(|header| header.revision())
+                .unwrap_or_default();
+            let existing = current.kvs().first();
+
+            if let Some(kv) = existing {
+                let current_status: NodeStatus = decode_status(kv.value())?;
+                if let Some(disposition) = disposition_for(&current_status, &status) {
+                    return Ok(WriteResult {
+                        disposition,
+                        revision: revision(header_revision)?,
+                    });
+                }
+            }
+            let observed_mod_revision = existing.map(|kv| kv.mod_revision()).unwrap_or(0);
+            let previous_lease = existing.map(|kv| kv.lease()).unwrap_or(0);
+
+            // Fresh lease for this heartbeat; overwriting the key detaches the
+            // previous lease, which we revoke best-effort after committing.
+            let lease = self
+                .with_timeout(client.lease_grant(ttl_seconds, None))
+                .await?;
+
+            // Guard the write on the record being unchanged since the read so a
+            // concurrent writer cannot clobber a newer sequence.
+            let compare = if observed_mod_revision == 0 {
+                Compare::create_revision(key.clone(), CompareOp::Equal, 0)
+            } else {
+                Compare::mod_revision(key.clone(), CompareOp::Equal, observed_mod_revision)
+            };
+            let txn = Txn::new().when(vec![compare]).and_then(vec![TxnOp::put(
+                key.clone(),
+                value.clone(),
+                Some(PutOptions::new().with_lease(lease.id())),
+            )]);
+            let response = self.with_timeout(client.txn(txn)).await?;
+
+            if response.succeeded() {
+                let committed = response
+                    .header()
+                    .map(|header| header.revision())
+                    .unwrap_or(header_revision);
+                if previous_lease != 0 {
+                    // Best-effort: an orphaned lease would expire on its own.
+                    let _ = client.lease_revoke(previous_lease).await;
+                }
+                return Ok(WriteResult {
+                    disposition: WriteDisposition::Applied,
+                    revision: revision(committed)?,
+                });
+            }
+
+            // Lost the race; drop the unused lease and retry with a fresh read.
+            let _ = client.lease_revoke(lease.id()).await;
+        }
+
+        Err(StateStoreError::Unavailable {
+            backend: REVISION_BACKEND,
+            detail: "exceeded optimistic retry budget under write contention".into(),
+        })
+    }
+
+    async fn remove_node(
+        &self,
+        cluster_id: &str,
+        node_id: &NodeId,
+        incarnation_id: &str,
+    ) -> StateStoreResult<WriteResult> {
+        let mut client = self.client.clone();
+        for _ in 0..MAX_WRITE_RETRIES {
+            // The role is part of the key, so scan the cluster prefix to find
+            // the record regardless of role.
+            let record = self.find_record(&mut client, cluster_id, node_id).await?;
+            let Some((key, kv_value, mod_revision, lease, header_revision)) = record else {
+                let latest = self
+                    .with_timeout(client.get(
+                        self.cluster_prefix(cluster_id),
+                        Some(GetOptions::new().with_prefix().with_count_only()),
+                    ))
+                    .await?;
+                let header_revision = latest
+                    .header()
+                    .map(|header| header.revision())
+                    .unwrap_or_default();
+                return Ok(WriteResult {
+                    disposition: WriteDisposition::NotFound,
+                    revision: revision(header_revision)?,
+                });
+            };
+
+            let current_status: NodeStatus = decode_status(&kv_value)?;
+            if current_status.incarnation_id != incarnation_id {
+                return Ok(WriteResult {
+                    disposition: WriteDisposition::Stale,
+                    revision: revision(header_revision)?,
+                });
+            }
+
+            let txn = Txn::new()
+                .when(vec![Compare::mod_revision(
+                    key.clone(),
+                    CompareOp::Equal,
+                    mod_revision,
+                )])
+                .and_then(vec![TxnOp::delete(key.clone(), None)]);
+            let response = self.with_timeout(client.txn(txn)).await?;
+            if response.succeeded() {
+                let committed = response
+                    .header()
+                    .map(|header| header.revision())
+                    .unwrap_or(header_revision);
+                if lease != 0 {
+                    let _ = client.lease_revoke(lease).await;
+                }
+                return Ok(WriteResult {
+                    disposition: WriteDisposition::Applied,
+                    revision: revision(committed)?,
+                });
+            }
+            // Concurrent change; retry.
+        }
+        Err(StateStoreError::Unavailable {
+            backend: REVISION_BACKEND,
+            detail: "exceeded optimistic retry budget while removing node".into(),
+        })
+    }
+
+    async fn snapshot(&self, cluster_id: &str) -> StateStoreResult<ClusterSnapshot> {
+        let mut client = self.client.clone();
+        let response = self
+            .with_timeout(client.get(
+                self.cluster_prefix(cluster_id),
+                Some(GetOptions::new().with_prefix()),
+            ))
+            .await?;
+        let header_revision = response
+            .header()
+            .map(|header| header.revision())
+            .unwrap_or_default();
+        let mut nodes = Vec::with_capacity(response.kvs().len());
+        for kv in response.kvs() {
+            nodes.push(decode_status(kv.value())?);
+        }
+        nodes.sort_by(|a, b| a.node.id.0.cmp(&b.node.id.0));
+        Ok(ClusterSnapshot {
+            nodes,
+            revision: revision(header_revision)?,
+            observed_at_unix_ms: now_unix_ms(),
+        })
+    }
+
+    async fn watch(
+        &self,
+        cluster_id: &str,
+        after_revision: Option<&StoreRevision>,
+    ) -> StateStoreResult<Box<dyn ClusterStateWatch>> {
+        let mut client = self.client.clone();
+        let start_revision = match after_revision {
+            Some(revision) => parse_revision(revision)?.saturating_add(1),
+            None => {
+                let response = self
+                    .with_timeout(client.get(
+                        self.cluster_prefix(cluster_id),
+                        Some(GetOptions::new().with_prefix().with_count_only()),
+                    ))
+                    .await?;
+                response
+                    .header()
+                    .map(|header| header.revision())
+                    .unwrap_or_default()
+                    .saturating_add(1)
+            }
+        };
+
+        let options = WatchOptions::new()
+            .with_prefix()
+            .with_start_revision(start_revision);
+        let stream = self
+            .with_timeout(client.watch(self.cluster_prefix(cluster_id), Some(options)))
+            .await?;
+        Ok(Box::new(EtcdWatch {
+            cluster_id: cluster_id.to_string(),
+            stream,
+            buffered: Vec::new(),
+        }))
+    }
+
+    async fn check_ready(&self) -> StateStoreResult<BackendHealth> {
+        let mut client = self.client.clone();
+        // A linearizable range read confirms the backend can serve
+        // authoritative requests and yields the current revision cheaply.
+        let response = self
+            .with_timeout(client.get(
+                self.prefix.clone(),
+                Some(GetOptions::new().with_prefix().with_count_only()),
+            ))
+            .await?;
+        let header_revision = response
+            .header()
+            .map(|header| header.revision())
+            .unwrap_or_default();
+        Ok(BackendHealth {
+            backend: StateBackend::Etcd,
+            checked_at_unix_ms: now_unix_ms(),
+            revision: Some(revision(header_revision)?),
+        })
+    }
+}
+
+impl EtcdStateStore {
+    #[allow(clippy::type_complexity)]
+    async fn find_record(
+        &self,
+        client: &mut Client,
+        cluster_id: &str,
+        node_id: &NodeId,
+    ) -> StateStoreResult<Option<(String, Vec<u8>, i64, i64, i64)>> {
+        let response = self
+            .with_timeout(client.get(
+                self.cluster_prefix(cluster_id),
+                Some(GetOptions::new().with_prefix()),
+            ))
+            .await?;
+        let header_revision = response
+            .header()
+            .map(|header| header.revision())
+            .unwrap_or_default();
+        for kv in response.kvs() {
+            let key = String::from_utf8_lossy(kv.key()).to_string();
+            if key.rsplit('/').next() == Some(node_id.0.as_str()) {
+                return Ok(Some((
+                    key,
+                    kv.value().to_vec(),
+                    kv.mod_revision(),
+                    kv.lease(),
+                    header_revision,
+                )));
+            }
+        }
+        Ok(None)
+    }
+}
+
+/// Live etcd watch adapted to the ordered [`ClusterStateWatch`] contract.
+struct EtcdWatch {
+    cluster_id: String,
+    stream: WatchStream,
+    buffered: Vec<NodeEvent>,
+}
+
+#[async_trait]
+impl ClusterStateWatch for EtcdWatch {
+    async fn next(&mut self) -> StateStoreResult<NodeEvent> {
+        loop {
+            if !self.buffered.is_empty() {
+                return Ok(self.buffered.remove(0));
+            }
+            let message = self.stream.message().await.map_err(map_etcd_error)?;
+            let Some(response) = message else {
+                return Err(StateStoreError::Unavailable {
+                    backend: REVISION_BACKEND,
+                    detail: "watch stream closed".into(),
+                });
+            };
+            if response.canceled() {
+                let compact_revision = response.compact_revision();
+                if compact_revision > 0 {
+                    return Err(StateStoreError::Compacted {
+                        requested: revision(compact_revision.saturating_sub(1).max(1))?,
+                        oldest: revision(compact_revision)?,
+                    });
+                }
+                return Err(StateStoreError::Unavailable {
+                    backend: REVISION_BACKEND,
+                    detail: "watch canceled by backend".into(),
+                });
+            }
+            for event in response.events() {
+                let Some(kv) = event.kv() else { continue };
+                let observed_at_unix_ms = now_unix_ms();
+                let event_revision = revision(kv.mod_revision())?;
+                match event.event_type() {
+                    EventType::Put => {
+                        let status: NodeStatus = decode_status(kv.value())?;
+                        self.buffered.push(NodeEvent {
+                            cluster_id: status.cluster_id.clone(),
+                            node_id: status.node.id.clone(),
+                            kind: NodeEventKind::Upserted,
+                            status: Some(status),
+                            revision: event_revision,
+                            observed_at_unix_ms,
+                        });
+                    }
+                    EventType::Delete => {
+                        let key = String::from_utf8_lossy(kv.key());
+                        let node_id = key.rsplit('/').next().unwrap_or_default().to_string();
+                        self.buffered.push(NodeEvent {
+                            cluster_id: self.cluster_id.clone(),
+                            node_id: NodeId::new(node_id),
+                            kind: NodeEventKind::Removed,
+                            status: None,
+                            revision: event_revision,
+                            observed_at_unix_ms,
+                        });
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn role_segment(role: NodeRole) -> &'static str {
+    match role {
+        NodeRole::Coordinator => "coordinator",
+        NodeRole::Worker => "worker",
+    }
+}
+
+/// Reproduce the backend contract's incarnation/sequence ordering rule.
+///
+/// Returns `Some(disposition)` when the write must be rejected as a no-op and
+/// `None` when it should be applied.
+fn disposition_for(current: &NodeStatus, incoming: &NodeStatus) -> Option<WriteDisposition> {
+    if current.incarnation_id == incoming.incarnation_id {
+        match incoming.heartbeat_seq.cmp(&current.heartbeat_seq) {
+            std::cmp::Ordering::Less => Some(WriteDisposition::Stale),
+            std::cmp::Ordering::Equal => Some(WriteDisposition::Duplicate),
+            std::cmp::Ordering::Greater => None,
+        }
+    } else if incoming.started_at_unix_ms < current.started_at_unix_ms
+        || (incoming.started_at_unix_ms == current.started_at_unix_ms
+            && incoming.reported_at_unix_ms <= current.reported_at_unix_ms)
+    {
+        Some(WriteDisposition::Stale)
+    } else {
+        None
+    }
+}
+
+fn decode_status(bytes: &[u8]) -> StateStoreResult<NodeStatus> {
+    serde_json::from_slice(bytes).map_err(|error| StateStoreError::Unavailable {
+        backend: REVISION_BACKEND,
+        detail: format!("failed to decode node status: {error}"),
+    })
+}
+
+fn revision(value: i64) -> StateStoreResult<StoreRevision> {
+    StoreRevision::new(format!("etcd:{value}"))
+}
+
+fn parse_revision(revision: &StoreRevision) -> StateStoreResult<i64> {
+    revision
+        .as_str()
+        .strip_prefix("etcd:")
+        .and_then(|value| value.parse().ok())
+        .ok_or_else(|| StateStoreError::InvalidRevision {
+            backend: Some(StateBackend::Etcd),
+            revision: revision.to_string(),
+            detail: "expected etcd:<i64>",
+        })
+}
+
+fn lease_ttl_to_seconds(ttl: Duration) -> StateStoreResult<i64> {
+    if ttl.is_zero() {
+        return Err(StateStoreError::InvalidLeaseTtl(ttl));
+    }
+    // Round up to whole seconds: etcd lease granularity is one second, and a
+    // shorter effective TTL than requested would expire records too early.
+    let millis = ttl.as_millis();
+    let seconds = millis.div_ceil(1_000);
+    i64::try_from(seconds)
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or(StateStoreError::InvalidLeaseTtl(ttl))
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn build_connect_options(config: &EtcdConfig) -> StateStoreResult<ConnectOptions> {
+    let mut options = ConnectOptions::new();
+    if let (Some(user), Some(password)) = (&config.username, &config.password) {
+        options = options.with_user(user.clone(), password.clone());
+    }
+    if let Some(tls) = &config.tls {
+        let mut tls_options = TlsOptions::new();
+        if let Some(ca_path) = &tls.ca_cert_path {
+            let pem = read_pem(ca_path)?;
+            tls_options = tls_options.ca_certificate(Certificate::from_pem(pem));
+        }
+        if let (Some(cert_path), Some(key_path)) = (&tls.client_cert_path, &tls.client_key_path) {
+            let cert = read_pem(cert_path)?;
+            let key = read_pem(key_path)?;
+            tls_options = tls_options.identity(Identity::from_pem(cert, key));
+        }
+        if let Some(domain) = &tls.domain_name {
+            tls_options = tls_options.domain_name(domain.clone());
+        }
+        options = options.with_tls(tls_options);
+    }
+    Ok(options)
+}
+
+fn read_pem(path: &std::path::Path) -> StateStoreResult<Vec<u8>> {
+    std::fs::read(path).map_err(|error| StateStoreError::Unavailable {
+        backend: REVISION_BACKEND,
+        // Path only; never surfaces certificate/key material.
+        detail: format!("failed to read TLS material at {}: {error}", path.display()),
+    })
+}
+
+fn map_connect_error(error: etcd_client::Error) -> StateStoreError {
+    match map_etcd_error(error) {
+        // A failed connection is always an availability problem regardless of
+        // the underlying transport detail.
+        StateStoreError::Unavailable { detail, .. } => StateStoreError::Unavailable {
+            backend: REVISION_BACKEND,
+            detail,
+        },
+        other => other,
+    }
+}
+
+fn map_etcd_error(error: etcd_client::Error) -> StateStoreError {
+    use etcd_client::Error as E;
+    match error {
+        E::GRpcStatus(status) => match status.code() {
+            tonic::Code::Unauthenticated => StateStoreError::Authentication {
+                backend: REVISION_BACKEND,
+            },
+            tonic::Code::PermissionDenied => StateStoreError::PermissionDenied {
+                backend: REVISION_BACKEND,
+            },
+            tonic::Code::DeadlineExceeded => StateStoreError::Timeout {
+                backend: REVISION_BACKEND,
+            },
+            code => StateStoreError::Unavailable {
+                backend: REVISION_BACKEND,
+                detail: format!("etcd rpc failed: {code}"),
+            },
+        },
+        other => StateStoreError::Unavailable {
+            backend: REVISION_BACKEND,
+            detail: sanitize_transport_error(&other),
+        },
+    }
+}
+
+/// Produce a stable, credential-free description of a transport-level failure.
+fn sanitize_transport_error(error: &etcd_client::Error) -> String {
+    use etcd_client::Error as E;
+    match error {
+        E::InvalidArgs(_) => "invalid etcd request arguments".into(),
+        E::InvalidUri(_) => "invalid etcd endpoint uri".into(),
+        E::TransportError(_) => "etcd transport error".into(),
+        E::WatchError(_) => "etcd watch error".into(),
+        E::LeaseKeepAliveError(_) => "etcd lease keep-alive error".into(),
+        E::ElectError(_) => "etcd election error".into(),
+        _ => "etcd backend error".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lease_ttl_rounds_up_to_whole_seconds() {
+        assert_eq!(lease_ttl_to_seconds(Duration::from_millis(100)).unwrap(), 1);
+        assert_eq!(
+            lease_ttl_to_seconds(Duration::from_millis(1_000)).unwrap(),
+            1
+        );
+        assert_eq!(
+            lease_ttl_to_seconds(Duration::from_millis(1_001)).unwrap(),
+            2
+        );
+        assert_eq!(lease_ttl_to_seconds(Duration::from_secs(30)).unwrap(), 30);
+        assert!(matches!(
+            lease_ttl_to_seconds(Duration::ZERO),
+            Err(StateStoreError::InvalidLeaseTtl(_))
+        ));
+    }
+
+    #[test]
+    fn revision_round_trips_through_opaque_token() {
+        let token = revision(42).unwrap();
+        assert_eq!(token.as_str(), "etcd:42");
+        assert_eq!(parse_revision(&token).unwrap(), 42);
+        assert!(matches!(
+            parse_revision(&StoreRevision::new("memory:7").unwrap()),
+            Err(StateStoreError::InvalidRevision { .. })
+        ));
+    }
+
+    #[test]
+    fn disposition_enforces_incarnation_and_sequence_rule() {
+        let base = crate::state_store::testkit::worker_status("w1", "inc-1", 5);
+        let duplicate = crate::state_store::testkit::worker_status("w1", "inc-1", 5);
+        assert_eq!(
+            disposition_for(&base, &duplicate),
+            Some(WriteDisposition::Duplicate)
+        );
+        let older = crate::state_store::testkit::worker_status("w1", "inc-1", 4);
+        assert_eq!(
+            disposition_for(&base, &older),
+            Some(WriteDisposition::Stale)
+        );
+        let newer = crate::state_store::testkit::worker_status("w1", "inc-1", 6);
+        assert_eq!(disposition_for(&base, &newer), None);
+
+        let restart = crate::state_store::testkit::worker_status("w1", "inc-2", 0);
+        assert_eq!(disposition_for(&base, &restart), None);
+        let stale_restart = crate::state_store::testkit::worker_status("w1", "inc-1", 99);
+        assert_eq!(
+            disposition_for(&restart, &stale_restart),
+            Some(WriteDisposition::Stale)
+        );
+    }
+
+    #[test]
+    fn config_validation_catches_missing_and_mismatched_fields() {
+        assert_eq!(
+            EtcdConfig::default().validate(),
+            Err(EtcdConfigError::NoEndpoints)
+        );
+        let mut config = EtcdConfig {
+            endpoints: vec!["localhost:2379".into()],
+            ..Default::default()
+        };
+        config.validate().unwrap();
+
+        config.username = Some("root".into());
+        assert_eq!(
+            config.validate(),
+            Err(EtcdConfigError::IncompleteCredentials)
+        );
+        config.password = Some("secret".into());
+        config.validate().unwrap();
+
+        config.tls = Some(EtcdTlsConfig {
+            client_cert_path: Some("cert.pem".into()),
+            ..Default::default()
+        });
+        assert_eq!(
+            config.validate(),
+            Err(EtcdConfigError::IncompleteClientIdentity)
+        );
+    }
+
+    #[test]
+    fn debug_redacts_password_and_key_paths() {
+        let config = EtcdConfig {
+            endpoints: vec!["localhost:2379".into()],
+            username: Some("root".into()),
+            password: Some("super-secret".into()),
+            tls: Some(EtcdTlsConfig {
+                client_key_path: Some("/etc/talon/client.key".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let rendered = format!("{config:?}");
+        assert!(!rendered.contains("super-secret"));
+        assert!(rendered.contains("<redacted>"));
+        assert!(!rendered.contains("client.key"));
+    }
+}

--- a/crates/talon-coordinator/src/state_store/mod.rs
+++ b/crates/talon-coordinator/src/state_store/mod.rs
@@ -6,6 +6,8 @@
 //! ordered by clients.
 
 mod config;
+#[cfg(feature = "etcd")]
+mod etcd;
 #[cfg(feature = "kubernetes")]
 mod kubernetes;
 mod memory;
@@ -21,6 +23,8 @@ use async_trait::async_trait;
 use talon_core::{NodeId, NodeStatus, NodeStatusError};
 
 pub use config::{ClusterStateConfig, ConfigError, StateBackend};
+#[cfg(feature = "etcd")]
+pub use etcd::{EtcdConfig, EtcdConfigError, EtcdStateStore, EtcdTlsConfig, DEFAULT_ETCD_PREFIX};
 #[cfg(feature = "kubernetes")]
 pub use kubernetes::{
     KubernetesConfig, KubernetesConfigError, KubernetesStateStore, DEFAULT_LEASE_LABEL_PREFIX,

--- a/crates/talon-coordinator/tests/etcd_contract.rs
+++ b/crates/talon-coordinator/tests/etcd_contract.rs
@@ -1,0 +1,77 @@
+//! Behavioral contract suite for the etcd [`ClusterStateStore`] backend, run
+//! against a real ephemeral etcd instance.
+//!
+//! The test is skipped unless `TALON_ETCD_TEST_ENDPOINT` points at a reachable
+//! etcd (for example `127.0.0.1:2379`). CI starts an ephemeral etcd and sets the
+//! variable; local runs without etcd skip cleanly.
+
+#![cfg(feature = "etcd")]
+
+use std::process;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use etcd_client::Client;
+use talon_coordinator::state_store::testkit::{assert_store_contract, StoreContractHarness};
+use talon_coordinator::{ClusterStateStore, EtcdStateStore};
+
+/// Lease TTL used for the contract run. Kept comfortably longer than the whole
+/// suite's operation stream so records only disappear when we intend them to.
+const LEASE_TTL: Duration = Duration::from_secs(4);
+
+/// Extra slack added on top of the requested elapse so etcd has time to
+/// actually revoke an expired lease before the harness inspects the snapshot.
+const EXPIRY_SLACK: Duration = Duration::from_secs(3);
+
+struct EtcdHarness {
+    store: Arc<EtcdStateStore>,
+}
+
+#[async_trait]
+impl StoreContractHarness for EtcdHarness {
+    fn store(&self) -> Arc<dyn ClusterStateStore> {
+        self.store.clone()
+    }
+
+    fn lease_ttl(&self) -> Duration {
+        LEASE_TTL
+    }
+
+    async fn elapse(&self, duration: Duration) {
+        // Real time only: etcd owns lease expiry, so wait long enough that a
+        // lease whose TTL has passed is guaranteed to be revoked server-side.
+        tokio::time::sleep(duration + EXPIRY_SLACK).await;
+    }
+}
+
+fn unique_prefix() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("/talon-test/{}-{nanos}-{seq}", process::id())
+}
+
+#[tokio::test]
+async fn etcd_backend_passes_store_contract() {
+    let Ok(endpoint) = std::env::var("TALON_ETCD_TEST_ENDPOINT") else {
+        eprintln!("skipping etcd contract test: TALON_ETCD_TEST_ENDPOINT is not set");
+        return;
+    };
+
+    let client = Client::connect([endpoint], None)
+        .await
+        .expect("connect to ephemeral etcd");
+    let prefix = unique_prefix();
+    let store = EtcdStateStore::from_client(client, prefix, Duration::from_secs(5))
+        .expect("construct etcd store");
+
+    let harness = EtcdHarness {
+        store: Arc::new(store),
+    };
+    assert_store_contract(&harness).await;
+}


### PR DESCRIPTION
## Summary

Implements the production etcd v3 `ClusterStateStore` backend (#78, parent #72), behind an `etcd` cargo feature so non-etcd builds stay lean.

- **Lease-backed records**: each node record lives under `/<prefix>/clusters/<cluster>/nodes/<role>/<node-id>` attached to an etcd lease; a crashed coordinator's record expires automatically when heartbeats stop.
- **Ordering rule**: upserts enforce the incarnation / heartbeat-sequence contract via a linearizable read + `mod_revision`-guarded transaction with bounded optimistic retry under contention.
- **Linearizable snapshots & resumable watches**: snapshots return the etcd response revision as an opaque `etcd:<rev>` token; watches resume from it and surface `Compacted` for relist recovery.
- **Config**: multiple endpoints, password auth, TLS (CA + mutual TLS via ring/native-roots), namespace prefix, request timeout, lease TTL. Secrets are redacted from `Debug` and never returned in errors.
- **Error mapping**: gRPC status -> `Authentication` / `PermissionDenied` / `Timeout` / `Unavailable`; transport errors sanitized.

## Test plan

- [x] `cargo test -p talon-coordinator --features etcd,state-store-testkit` unit tests (lease rounding, revision round-trip, disposition rule, config validation, secret redaction).
- [x] Reusable #75 store contract suite runs against a **real ephemeral etcd** (`tests/etcd_contract.rs`, gated on `TALON_ETCD_TEST_ENDPOINT`) - passed locally against etcd 3.5.16, covering insert/update/duplicate/stale, restart incarnation, concurrent writers, lease expiry, explicit removal, watch resume.
- [x] New `etcd backend contract` CI job spins up an ephemeral etcd service and runs the suite.
- [x] `cargo fmt`, `cargo clippy --all-features` (`-D warnings`), full `cargo test --workspace --all-features --locked`, and `cargo doc` all clean.
- [x] Verified `etcd-client` is absent from the default dependency tree.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)