### PR TITLE
fix(coordinator): deterministic placement version across coordinators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,6 +1314,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/crates/talon-coordinator/Cargo.toml
+++ b/crates/talon-coordinator/Cargo.toml
@@ -28,6 +28,7 @@ thiserror.workspace = true
 serde_json.workspace = true
 toml.workspace = true
 axum.workspace = true
+xxhash-rust.workspace = true
 
 [dev-dependencies]
 divan.workspace = true

--- a/crates/talon-coordinator/src/membership.rs
+++ b/crates/talon-coordinator/src/membership.rs
@@ -4,8 +4,14 @@
 //! placement. Its contents are driven by a [`MembershipSource`] — in production
 //! a Kubernetes watch/poll ([`KubernetesMembership`]), in tests a mock. On each
 //! poll the source produces the desired node set and [`Membership::reconcile`]
-//! applies the diff, bumping the [`Epoch`] whenever the set
-//! actually changes so clients/workers can detect stale placement.
+//! applies the diff.
+//!
+//! The placement version ([`Epoch`]) is **not** a stored counter: it is derived
+//! on demand from the current node set via [`Epoch::for_nodes`], so it is
+//! identical on every coordinator observing the same membership and changes iff
+//! the placement-relevant node set changes. This is what lets coordinators run
+//! active-active without a client seeing the version flip as it is load-balanced
+//! between processes (issue #80).
 //!
 //! Liveness and block inventory come separately from worker heartbeats
 //! (see the heartbeat issue); the K8s source only answers "which pods exist".
@@ -16,9 +22,12 @@ use talon_core::{NodeId, NodeInfo};
 
 use crate::Epoch;
 
-/// An in-memory registry of known cluster nodes, versioned by an epoch.
+/// An in-memory registry of known cluster nodes.
+///
+/// The placement version is a pure function of the node set, so the registry
+/// stores only the nodes; [`Membership::epoch`] computes the version on demand.
 pub struct Membership {
-    inner: RwLock<Inner>,
+    inner: RwLock<HashMap<NodeId, NodeInfo>>,
 }
 
 impl Default for Membership {
@@ -27,76 +36,51 @@ impl Default for Membership {
     }
 }
 
-struct Inner {
-    nodes: HashMap<NodeId, NodeInfo>,
-    epoch: Epoch,
-}
-
 impl Membership {
-    /// Create an empty membership registry seeded from the process start time.
-    ///
-    /// The epoch base comes from [`Epoch::seeded_now`] rather than `0` so that
-    /// this coordinator's epochs outrank any earlier process's, keeping client
-    /// placement caches correct across a coordinator restart (issue #69).
+    /// Create an empty membership registry.
     pub fn new() -> Self {
-        Self::with_epoch_base(Epoch::seeded_now())
-    }
-
-    /// Create an empty registry starting at a specific epoch base.
-    ///
-    /// Production uses [`Membership::new`] (wall-clock seed); this constructor
-    /// lets tests pin a deterministic base (e.g. `Epoch(0)`) or simulate a
-    /// restart by seeding a second instance at a strictly larger base.
-    pub fn with_epoch_base(base: Epoch) -> Self {
         Self {
-            inner: RwLock::new(Inner {
-                nodes: HashMap::new(),
-                epoch: base,
-            }),
+            inner: RwLock::new(HashMap::new()),
         }
     }
 
-    /// Register or update a node. Bumps the epoch if this changed the set.
+    /// Register or update a node.
     pub fn register(&self, info: NodeInfo) {
-        let mut g = self.inner.write().unwrap();
-        let changed = g.nodes.insert(info.id.clone(), info.clone()) != Some(info);
-        if changed {
-            g.epoch = g.epoch.next();
-        }
+        self.inner.write().unwrap().insert(info.id.clone(), info);
     }
 
-    /// Remove a node. Bumps the epoch if a node was actually removed.
+    /// Remove a node.
     pub fn remove(&self, id: &NodeId) {
-        let mut g = self.inner.write().unwrap();
-        if g.nodes.remove(id).is_some() {
-            g.epoch = g.epoch.next();
-        }
+        self.inner.write().unwrap().remove(id);
     }
 
     /// Return a snapshot of all currently known nodes.
     pub fn snapshot(&self) -> Vec<NodeInfo> {
-        self.inner.read().unwrap().nodes.values().cloned().collect()
+        self.inner.read().unwrap().values().cloned().collect()
     }
 
-    /// The current placement epoch.
+    /// The current placement version, derived from the node set.
+    ///
+    /// Deterministic across coordinators: any process holding the same
+    /// membership computes the same value (see [`Epoch::for_nodes`]).
     pub fn epoch(&self) -> Epoch {
-        self.inner.read().unwrap().epoch
+        let nodes: Vec<NodeInfo> = self.inner.read().unwrap().values().cloned().collect();
+        Epoch::for_nodes(&nodes)
     }
 
-    /// Replace the node set with `desired`, bumping the epoch iff it changed.
+    /// Replace the node set with `desired`.
     ///
     /// This is the reconcile step a [`MembershipSource`] poll feeds into:
     /// additions, removals, and address/role changes are all applied
-    /// atomically. Returns `true` if the set changed (epoch bumped).
+    /// atomically. Returns `true` if the set changed.
     pub fn reconcile(&self, desired: Vec<NodeInfo>) -> bool {
         let desired: HashMap<NodeId, NodeInfo> =
             desired.into_iter().map(|n| (n.id.clone(), n)).collect();
         let mut g = self.inner.write().unwrap();
-        if g.nodes == desired {
+        if *g == desired {
             return false;
         }
-        g.nodes = desired;
-        g.epoch = g.epoch.next();
+        *g = desired;
         true
     }
 }
@@ -179,79 +163,86 @@ mod tests {
     }
 
     #[test]
-    fn reconcile_bumps_epoch_only_on_change() {
-        // Pin a deterministic base so we can assert exact epoch values; the
-        // +1-on-change semantics are what matter here, not the base.
-        let m = Membership::with_epoch_base(Epoch(0));
-        assert_eq!(m.epoch(), Epoch(0));
+    fn reconcile_changes_version_only_on_change() {
+        let m = Membership::new();
+        let empty = m.epoch();
+        assert_eq!(empty, Epoch::EMPTY);
 
         assert!(m.reconcile(vec![worker("a", "1"), worker("b", "2")]));
-        assert_eq!(m.epoch(), Epoch(1));
+        let two = m.epoch();
+        assert_ne!(two, empty);
         assert_eq!(m.snapshot().len(), 2);
 
-        // Same set (order-independent) -> no bump.
+        // Same set (order-independent) -> no change, identical version.
         assert!(!m.reconcile(vec![worker("b", "2"), worker("a", "1")]));
-        assert_eq!(m.epoch(), Epoch(1));
+        assert_eq!(m.epoch(), two);
 
-        // Address change -> bump.
+        // Address change -> version changes.
         assert!(m.reconcile(vec![worker("a", "9"), worker("b", "2")]));
-        assert_eq!(m.epoch(), Epoch(2));
+        let moved = m.epoch();
+        assert_ne!(moved, two);
 
-        // Removal -> bump.
+        // Removal -> version changes.
         assert!(m.reconcile(vec![worker("a", "9")]));
-        assert_eq!(m.epoch(), Epoch(3));
+        assert_ne!(m.epoch(), moved);
         assert_eq!(m.snapshot().len(), 1);
     }
 
     #[test]
-    fn register_and_remove_track_epoch() {
-        let m = Membership::with_epoch_base(Epoch(0));
-        m.register(worker("a", "1"));
-        assert_eq!(m.epoch(), Epoch(1));
-        // Re-register identical -> no change.
-        m.register(worker("a", "1"));
-        assert_eq!(m.epoch(), Epoch(1));
-        m.remove(&NodeId::new("a"));
-        assert_eq!(m.epoch(), Epoch(2));
-        m.remove(&NodeId::new("a")); // absent -> no bump
-        assert_eq!(m.epoch(), Epoch(2));
-    }
-
-    #[test]
-    fn new_seeds_nonzero_epoch_base() {
-        // A production Membership seeds from the wall clock, so its base is far
-        // above 0 and — critically — above the low-counter range a prior
-        // process would have reached (issue #69).
+    fn register_and_remove_track_version() {
         let m = Membership::new();
-        assert!(m.epoch().0 > 0, "epoch base must be seeded, not 0");
-        // The seed lives in the high 32 bits; the low counter starts at 0.
-        assert_eq!(m.epoch().0 & 0xFFFF_FFFF, 0);
+        assert_eq!(m.epoch(), Epoch::EMPTY);
+        m.register(worker("a", "1"));
+        let one = m.epoch();
+        assert_ne!(one, Epoch::EMPTY);
+        // Re-register identical -> version unchanged.
+        m.register(worker("a", "1"));
+        assert_eq!(m.epoch(), one);
+        m.remove(&NodeId::new("a"));
+        assert_eq!(m.epoch(), Epoch::EMPTY);
+        m.remove(&NodeId::new("a")); // absent -> still empty
+        assert_eq!(m.epoch(), Epoch::EMPTY);
     }
 
     #[test]
-    fn restarted_coordinator_outranks_prior_process() {
-        // Simulate: an earlier process seeded at second T1 that then churned
-        // through many membership changes, vs. a later process seeded at a
-        // strictly greater second T2. The later process's *initial* epoch must
-        // already exceed the earlier one's *final* epoch, so clients refresh.
-        let t1 = 1_000u64;
-        let t2 = 1_001u64; // one second later
-        let old = Membership::with_epoch_base(Epoch(t1 << 32));
-        for i in 0..10_000 {
-            old.register(worker(&format!("w{i}"), "a"));
-        }
-        let new = Membership::with_epoch_base(Epoch(t2 << 32));
-        assert!(
-            new.epoch() > old.epoch(),
-            "restarted coordinator epoch {:?} must outrank prior {:?}",
-            new.epoch(),
-            old.epoch()
-        );
+    fn identical_membership_yields_identical_version_across_instances() {
+        // Two independent coordinator processes (simulated by two registries)
+        // that observe the same healthy worker set must advertise the *same*
+        // placement version, so a load-balanced client never thrashes its
+        // cache (issue #80). Order of registration must not matter.
+        let a = Membership::new();
+        a.register(worker("w1", "10.0.0.1"));
+        a.register(worker("w2", "10.0.0.2"));
+        a.register(worker("w3", "10.0.0.3"));
+
+        let b = Membership::new();
+        b.register(worker("w3", "10.0.0.3"));
+        b.register(worker("w1", "10.0.0.1"));
+        b.register(worker("w2", "10.0.0.2"));
+
+        assert_eq!(a.epoch(), b.epoch());
+    }
+
+    #[test]
+    fn restarted_coordinator_reproduces_prior_version() {
+        // A coordinator restart that rebuilds the same membership must land on
+        // the *same* version it had before, not a larger one: the placement is
+        // unchanged, so a client's cache is still valid and need not refresh.
+        let before = Membership::new();
+        before.register(worker("w1", "a"));
+        before.register(worker("w2", "b"));
+        let v = before.epoch();
+
+        let after_restart = Membership::new();
+        after_restart.register(worker("w2", "b"));
+        after_restart.register(worker("w1", "a"));
+        assert_eq!(after_restart.epoch(), v);
     }
 
     #[test]
     fn k8s_source_reflects_cluster_changes() {
-        // A mock lister scripted to add then remove a node across polls.
+        // A mock lister scripted to add then remove a node across polls; each
+        // real change must move the placement version.
         let step = Cell::new(0u32);
         let selector = K8sSelector {
             namespace: "talon".into(),
@@ -266,22 +257,23 @@ mod tests {
             })
         });
 
-        let m = Membership::with_epoch_base(Epoch(0));
+        let m = Membership::new();
 
         assert!(m.reconcile(source.poll().unwrap()));
         assert_eq!(m.snapshot().len(), 1);
-        assert_eq!(m.epoch(), Epoch(1));
+        let v0 = m.epoch();
 
         step.set(1);
         assert!(m.reconcile(source.poll().unwrap()));
         assert_eq!(m.snapshot().len(), 2);
-        assert_eq!(m.epoch(), Epoch(2));
+        let v1 = m.epoch();
+        assert_ne!(v1, v0);
 
         step.set(2);
         assert!(m.reconcile(source.poll().unwrap()));
         let ids: Vec<String> = m.snapshot().into_iter().map(|n| n.id.0).collect();
         assert_eq!(ids, vec!["w2".to_string()]);
-        assert_eq!(m.epoch(), Epoch(3));
+        assert_ne!(m.epoch(), v1);
     }
 
     #[test]

--- a/crates/talon-coordinator/src/placement.rs
+++ b/crates/talon-coordinator/src/placement.rs
@@ -9,53 +9,90 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use talon_core::{BlockId, NodeId, NodeInfo};
+use xxhash_rust::xxh3::xxh3_64;
 
-/// A monotonically increasing version of the placement/node set.
+/// A content-derived version of the placement/node set.
 ///
-/// The coordinator bumps the epoch whenever membership changes so that clients
-/// and workers can detect stale placement decisions and refresh.
+/// The coordinator publishes this version alongside every placement answer so
+/// clients and workers can detect when their cached placement predates a
+/// membership change and refresh.
 ///
-/// # Monotonicity across restarts
+/// # Deterministic across coordinators
 ///
-/// Clients only refresh cached placement when they observe an epoch **strictly
-/// greater** than the one they hold, so the epoch must never move backwards —
-/// including across a coordinator process restart. A plain in-memory counter
-/// from `0` breaks this: a restarted coordinator would re-advertise low epochs
-/// that clients (holding a higher pre-restart epoch) silently ignore, pinning
-/// them to a stale replica list forever (see issue #69).
+/// Talon runs coordinators **active-active**: several stateless processes serve
+/// placement for the same cluster behind a load balancer. A client's successive
+/// lookups can land on different coordinators, so the version a client caches
+/// must depend only on the *observable membership*, never on which process
+/// answered or when it started.
 ///
-/// To stay monotonic without external state, the epoch is seeded from the
-/// process **start time**: the wall-clock second occupies the high 32 bits and
-/// an in-process counter the low 32 bits. A later process always starts from a
-/// larger seed than any earlier one produced, so its epochs outrank them.
+/// Earlier revisions seeded the version from the process start time plus a
+/// process-local counter (issue #69/#71). That is fine for a single coordinator
+/// but breaks under active-active: two processes holding the **same** healthy
+/// worker set would advertise **different** counters, so a load-balanced client
+/// would see the version flip on every other request and refresh its cache
+/// continuously — or, worse, treat a peer's legitimately different value as
+/// "older" and ignore it.
 ///
-/// This keeps the coordinator free of unrebuildable persistent state (a v1
-/// design invariant). The residual edge — two restarts within the *same* second
-/// where the later process observes fewer membership changes — is negligible in
-/// practice (pod restarts take seconds). A future revision may instead derive
-/// the epoch from the Kubernetes `resourceVersion` of the worker endpoints,
-/// which is monotonic by construction (tracked for v1.5).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+/// Instead the version is a stable 64-bit hash of the placement-relevant fields
+/// of the healthy node set (each node's id, address, and role), computed over a
+/// canonical, id-sorted encoding. Two coordinators with identical membership
+/// therefore compute the **identical** version, and any placement-relevant
+/// change (a node joining, leaving, or changing address) changes it. The value
+/// carries no ordering meaning: clients compare versions for **equality**, not
+/// magnitude (see the FUSE placement cache).
+///
+/// The hash keeps coordinators free of unrebuildable persistent state (a v1
+/// design invariant) while remaining backend-neutral: a future revision can map
+/// an opaque Kubernetes `resourceVersion` or etcd revision onto the same token
+/// type without changing clients.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Epoch(pub u64);
 
 impl Epoch {
-    /// Return the next epoch (this + 1).
-    pub fn next(self) -> Self {
-        Epoch(self.0 + 1)
-    }
+    /// The version of an empty node set.
+    ///
+    /// Distinct from any non-empty membership's version so a client caching a
+    /// placement against a populated cluster still refreshes if the cluster
+    /// drains to zero nodes.
+    pub const EMPTY: Epoch = Epoch(0);
 
-    /// A fresh epoch seeded from the current wall-clock second in the high 32
-    /// bits, with a zero low counter. Used as the base for a newly started
-    /// coordinator so its epochs outrank any earlier process's (see the type
-    /// docs for the monotonicity rationale).
-    pub fn seeded_now() -> Self {
-        let secs = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-        // Clamp to 32 bits (good past year 2106) and shift into the high half.
-        Epoch((secs & 0xFFFF_FFFF) << 32)
+    /// Compute the deterministic placement version for a node set.
+    ///
+    /// The result depends only on the placement-relevant fields (id, address,
+    /// role) of the nodes, is independent of their input order, and is identical
+    /// on any coordinator observing the same membership. An empty set maps to
+    /// [`Epoch::EMPTY`].
+    pub fn for_nodes(nodes: &[NodeInfo]) -> Self {
+        if nodes.is_empty() {
+            return Epoch::EMPTY;
+        }
+        // Canonicalize: sort by node id so input order never affects the hash,
+        // and encode each placement-relevant field with an unambiguous length
+        // delimiter so distinct field boundaries can never collide (e.g.
+        // id="ab",addr="c" must not hash like id="a",addr="bc").
+        let mut ids: Vec<&NodeInfo> = nodes.iter().collect();
+        ids.sort_unstable_by(|a, b| a.id.0.cmp(&b.id.0));
+        let mut buf: Vec<u8> = Vec::with_capacity(nodes.len() * 48);
+        for node in ids {
+            let role = match node.role {
+                talon_core::NodeRole::Coordinator => 0u8,
+                talon_core::NodeRole::Worker => 1u8,
+            };
+            push_field(&mut buf, node.id.0.as_bytes());
+            push_field(&mut buf, node.address.as_bytes());
+            buf.push(role);
+        }
+        // A non-empty set must never hash to the reserved empty sentinel, so a
+        // populated cluster is always distinguishable from a drained one.
+        let raw = xxh3_64(&buf);
+        Epoch(if raw == Epoch::EMPTY.0 { 1 } else { raw })
     }
+}
+
+/// Append a length-prefixed field to the canonical membership encoding.
+fn push_field(buf: &mut Vec<u8>, bytes: &[u8]) {
+    buf.extend_from_slice(&(bytes.len() as u64).to_le_bytes());
+    buf.extend_from_slice(bytes);
 }
 
 /// Decides which node(s) should hold a given block.
@@ -189,21 +226,45 @@ mod tests {
     }
 
     #[test]
-    fn epoch_increments() {
-        let e = Epoch::default();
-        assert_eq!(e.0, 0);
-        assert_eq!(e.next().0, 1);
-        assert!(e < e.next());
+    fn version_is_deterministic_and_order_independent() {
+        let a = nodes(&["a", "b", "c"]);
+        let mut shuffled = a.clone();
+        shuffled.reverse();
+        // Same membership, different input order -> identical version.
+        assert_eq!(Epoch::for_nodes(&a), Epoch::for_nodes(&shuffled));
+        // Recomputing on a fresh process (simulated by a fresh call) is stable.
+        assert_eq!(Epoch::for_nodes(&a), Epoch::for_nodes(&a));
     }
 
     #[test]
-    fn seeded_now_puts_time_in_high_bits() {
-        let e = Epoch::seeded_now();
-        // High 32 bits carry a nonzero wall-clock second; low 32 start clear.
-        assert!(e.0 >> 32 > 0, "seed must occupy the high bits");
-        assert_eq!(e.0 & 0xFFFF_FFFF, 0, "low counter starts at 0");
-        // A seed leaves ample low-bit headroom before it could collide with the
-        // next second's seed (2^32 counter increments per second).
-        assert!(e.next().0 > e.0);
+    fn version_changes_on_placement_relevant_change() {
+        let base = Epoch::for_nodes(&nodes(&["a", "b"]));
+        // Adding a node changes the version.
+        assert_ne!(base, Epoch::for_nodes(&nodes(&["a", "b", "c"])));
+        // Removing a node changes the version.
+        assert_ne!(base, Epoch::for_nodes(&nodes(&["a"])));
+        // An address change on the same id changes the version.
+        let mut moved = nodes(&["a", "b"]);
+        moved[0].address = "moved:9999".into();
+        assert_ne!(base, Epoch::for_nodes(&moved));
+    }
+
+    #[test]
+    fn empty_set_is_reserved_sentinel() {
+        assert_eq!(Epoch::for_nodes(&[]), Epoch::EMPTY);
+        assert_eq!(Epoch::EMPTY.0, 0);
+        // A populated cluster is always distinguishable from a drained one.
+        assert_ne!(Epoch::for_nodes(&nodes(&["a"])), Epoch::EMPTY);
+    }
+
+    #[test]
+    fn field_boundaries_do_not_collide() {
+        // Length-delimited encoding: shifting a byte across the id/address
+        // boundary must produce a different version.
+        let mut left = nodes(&["ab"]);
+        left[0].address = "c".into();
+        let mut right = nodes(&["a"]);
+        right[0].address = "bc".into();
+        assert_ne!(Epoch::for_nodes(&left), Epoch::for_nodes(&right));
     }
 }

--- a/crates/talon-coordinator/src/service.rs
+++ b/crates/talon-coordinator/src/service.rs
@@ -103,9 +103,7 @@ mod tests {
     }
 
     fn svc(ids: &[&str]) -> PlacementService<RendezvousPlacement> {
-        // Pin a deterministic epoch base so exact-value assertions below hold;
-        // production seeds from the wall clock (see Epoch::seeded_now).
-        let m = Membership::with_epoch_base(Epoch(0));
+        let m = Membership::new();
         for id in ids {
             m.register(NodeInfo {
                 id: NodeId::new(*id),
@@ -117,11 +115,12 @@ mod tests {
     }
 
     #[test]
-    fn lookup_returns_owners_and_epoch() {
+    fn lookup_returns_owners_and_version() {
         let s = svc(&["a", "b", "c"]);
         let res = s.lookup(&block(1), 2);
         assert_eq!(res.owners.len(), 2);
-        assert_eq!(res.epoch, Epoch(3)); // three registrations
+        // The version is the deterministic hash of the node set.
+        assert_eq!(res.epoch, Epoch::for_nodes(&s.membership().snapshot()));
 
         // Matches the raw placement's top-K ordering.
         let nodes = s.membership().snapshot();
@@ -134,7 +133,7 @@ mod tests {
     }
 
     #[test]
-    fn epoch_advances_and_is_visible_to_clients() {
+    fn version_changes_on_membership_change() {
         let s = svc(&["a", "b"]);
         let e0 = s.lookup(&block(9), 1).epoch;
         s.membership().register(NodeInfo {
@@ -143,12 +142,13 @@ mod tests {
             role: NodeRole::Worker,
         });
         let e1 = s.lookup(&block(9), 1).epoch;
-        assert!(e1 > e0, "epoch must advance on membership change");
+        assert_ne!(e1, e0, "version must change on membership change");
     }
 
     #[test]
     fn handle_placement_lookup_message() {
         let s = svc(&["a", "b", "c"]);
+        let expected = s.lookup(&block(2), 1).epoch.0;
         let req = ControlMessage::PlacementLookup {
             block: block(2),
             k: 1,
@@ -156,7 +156,7 @@ mod tests {
         match s.handle(req) {
             ControlMessage::PlacementResponse { owners, epoch } => {
                 assert_eq!(owners.len(), 1);
-                assert_eq!(epoch, 3);
+                assert_eq!(epoch, expected);
             }
             other => panic!("expected PlacementResponse, got {other:?}"),
         }
@@ -174,6 +174,6 @@ mod tests {
         let s = svc(&[]);
         let res = s.lookup(&block(1), 3);
         assert!(res.owners.is_empty());
-        assert_eq!(res.epoch, Epoch(0));
+        assert_eq!(res.epoch, Epoch::EMPTY);
     }
 }

--- a/crates/talon-fuse/src/block_reader.rs
+++ b/crates/talon-fuse/src/block_reader.rs
@@ -17,7 +17,7 @@
 //! On a fetch failure the reader walks the cached replicas in order; if all are
 //! exhausted it invalidates the entry and performs one coordinator refresh
 //! before giving up. [`BlockReader::observe_epoch`] reconciles the cache when a
-//! newer placement epoch is seen. Multi-block splitting is handled by
+//! different placement version is seen. Multi-block splitting is handled by
 //! [`crate::read_plan`] and readahead by [`crate::prefetch`].
 
 use std::sync::Arc;
@@ -218,12 +218,15 @@ impl BlockReader {
         Err(last)
     }
 
-    /// Reconcile the cache against an observed epoch.
+    /// Reconcile the cache against an observed placement version.
     ///
-    /// When a response (placement or otherwise) carries a newer epoch than a
-    /// cached entry, that entry is dropped so the next read re-looks-up. This is
-    /// the client half of the coordinator's epoch bump: a membership change
-    /// advances the epoch, and any client holding an older placement refreshes.
+    /// When a response (placement or otherwise) carries a version token that
+    /// differs from a cached entry's, that entry is dropped so the next read
+    /// re-looks-up. This is the client half of the coordinator's placement
+    /// versioning: a membership change changes the deterministic version token,
+    /// and any client holding a placement computed against a different set
+    /// refreshes. The token is a content hash, not an ordered counter, so any
+    /// difference triggers a refresh (see [`crate::PlacementCache::observe_epoch`]).
     /// Returns `true` if the entry was invalidated.
     pub fn observe_epoch(&self, block: &BlockId, observed_epoch: u64) -> bool {
         self.cache.observe_epoch(block, observed_epoch)
@@ -619,10 +622,10 @@ mod tests {
         // Warm the cache (mock_coordinator answers epoch=3).
         let _ = reader.read_block(&block(), 0, 8, 0).await.unwrap();
         assert_eq!(cache.len(), 1);
-        // An older/equal epoch does not invalidate.
+        // The identical version token does not invalidate.
         assert!(!reader.observe_epoch(&block(), 3));
         assert_eq!(cache.len(), 1);
-        // A newer epoch drops the entry so the next read re-looks-up.
+        // A different token drops the entry so the next read re-looks-up.
         assert!(reader.observe_epoch(&block(), 4));
         assert_eq!(cache.len(), 0);
     }

--- a/crates/talon-fuse/src/placement_cache.rs
+++ b/crates/talon-fuse/src/placement_cache.rs
@@ -5,7 +5,7 @@
 //! (evicted, forcing a re-lookup) on any staleness trigger:
 //!
 //! - **TTL expiry** — the cached entry aged out.
-//! - **Epoch mismatch** — a response carried a newer placement epoch.
+//! - **Version mismatch** — a response carried a different placement version.
 //! - **Wrong owner / NOT_FOUND** — the contacted worker doesn't have the block.
 //! - **Connect failure** — the contacted worker is unreachable.
 //!
@@ -23,7 +23,7 @@ use talon_core::BlockId;
 pub enum RefreshReason {
     /// The entry's TTL elapsed.
     Expired,
-    /// A newer epoch was observed than the cached entry's.
+    /// A placement version token different from the cached entry's was observed.
     EpochMismatch,
     /// The contacted worker did not own / have the block.
     WrongOwner,
@@ -31,12 +31,16 @@ pub enum RefreshReason {
     ConnectFailure,
 }
 
-/// A cached placement: ordered replicas + the epoch they were computed at.
+/// A cached placement: ordered replicas + the version they were computed at.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Cached {
     /// Ordered replica node ids (primary first).
     pub replicas: Vec<String>,
-    /// Placement epoch these replicas were computed against.
+    /// Placement version token these replicas were computed against.
+    ///
+    /// This is an opaque coordinator-issued token (a content hash of the node
+    /// set), **not** a monotonically increasing counter. Clients compare it for
+    /// equality only — see [`PlacementCache::observe_epoch`].
     pub epoch: u64,
 }
 
@@ -113,14 +117,23 @@ impl PlacementCache {
         self.entries.write().unwrap().remove(block).is_some()
     }
 
-    /// Reconcile against an observed epoch: if the cached entry predates
-    /// `observed_epoch`, drop it so the next access re-looks-up.
+    /// Reconcile against an observed placement version: if the cached entry's
+    /// version differs from `observed_epoch`, drop it so the next access
+    /// re-looks-up.
     ///
-    /// Returns `true` if the entry was invalidated by the epoch check.
+    /// The version is an opaque token (a content hash of the coordinator's node
+    /// set), not an ordered counter, so this compares for **inequality** rather
+    /// than `<`. Any difference — a membership change on one coordinator, or a
+    /// response served by a peer that observed a different set — invalidates the
+    /// entry. Because identical membership always hashes to the identical token
+    /// (issue #80), a client load-balanced across active-active coordinators
+    /// with a stable cluster sees no spurious invalidations.
+    ///
+    /// Returns `true` if the entry was invalidated by the version check.
     pub fn observe_epoch(&self, block: &BlockId, observed_epoch: u64) -> bool {
         let mut g = self.entries.write().unwrap();
         if let Some(e) = g.get(block) {
-            if e.cached.epoch < observed_epoch {
+            if e.cached.epoch != observed_epoch {
                 g.remove(block);
                 return true;
             }
@@ -198,44 +211,44 @@ mod tests {
     }
 
     #[test]
-    fn epoch_mismatch_self_heals() {
+    fn version_mismatch_self_heals() {
         let c = PlacementCache::new(10_000);
         c.insert(block(3), cached(5, &["a"]), 0);
-        // Older/equal epoch does not invalidate.
+        // Identical version token does not invalidate.
         assert!(!c.observe_epoch(&block(3), 5));
         assert!(c.get(&block(3), 0).is_some());
-        // Newer epoch drops the stale entry.
+        // Any different token drops the stale entry — the token is a content
+        // hash, not an ordered counter, so "different" (not "greater") is the
+        // trigger.
         assert!(c.observe_epoch(&block(3), 6));
         assert!(c.get(&block(3), 0).is_none());
     }
 
     #[test]
-    fn coordinator_restart_invalidates_stale_cache() {
-        // Regression for issue #69: a client caches placement at a high epoch
-        // produced by one coordinator process; that coordinator restarts and,
-        // because epochs are now seeded from the process start time (wall-clock
-        // second in the high 32 bits), the restarted process advertises a
-        // *larger* epoch — so the client's pre-restart cache is invalidated.
-        //
-        // Before the fix, the restarted coordinator restarted its counter at 0,
-        // `cached_epoch < 0` was false, and the stale entry lived forever.
-        let seed = |secs: u64, counter: u64| (secs << 32) | counter;
-
-        // Pre-restart: coordinator seeded at second T1, churned to counter 37.
-        let pre_restart = seed(1_000, 37);
+    fn membership_change_invalidates_regardless_of_token_order() {
+        // Regression for issue #80: the version is a content hash, so a newer
+        // membership can hash to a *numerically smaller* token. Invalidation
+        // must still fire on any difference, not only on an increase.
         let c = PlacementCache::new(10_000);
-        c.insert(block(7), cached(pre_restart, &["w3"]), 0);
-
-        // Post-restart: a fresh process seeded at a later second T2. Its very
-        // first advertised epoch already exceeds the pre-restart one.
-        let post_restart = seed(1_001, 0);
-        assert!(
-            post_restart > pre_restart,
-            "restart epoch must outrank pre-restart"
-        );
-
-        // The stale entry pinning the client to the now-dead w3 is dropped.
-        assert!(c.observe_epoch(&block(7), post_restart));
+        c.insert(block(7), cached(9_000, &["w3"]), 0);
+        // A different membership hashes to a smaller value here.
+        let different_but_smaller = 42u64;
+        assert!(different_but_smaller < 9_000);
+        assert!(c.observe_epoch(&block(7), different_but_smaller));
         assert!(c.get(&block(7), 0).is_none());
+    }
+
+    #[test]
+    fn stable_membership_across_coordinators_does_not_thrash() {
+        // A client load-balanced between two active-active coordinators that
+        // observe the *same* membership sees the *same* token, so its cache is
+        // never spuriously invalidated (issue #80).
+        let c = PlacementCache::new(10_000);
+        let token = 0xABCD_1234u64; // both coordinators compute this same hash.
+        c.insert(block(4), cached(token, &["a", "b"]), 0);
+        // Repeated observations from either coordinator, same token -> no drop.
+        assert!(!c.observe_epoch(&block(4), token));
+        assert!(!c.observe_epoch(&block(4), token));
+        assert!(c.get(&block(4), 0).is_some());
     }
 }

--- a/docs/adr/0001-management-plane-ha.md
+++ b/docs/adr/0001-management-plane-ha.md
@@ -223,8 +223,23 @@ Clients must not assume a version is numerically greater or lower. Connect
 failure, wrong owner, not found, and TTL expiry remain independent refresh
 triggers.
 
-The exact wire representation and rolling-upgrade transition are delivered by
-#80.
+**Wire representation (delivered by #80).** The version stays the existing
+`u64` field on `PlacementResponse`/`EpochBump`, so the transition is
+wire-compatible — no new message or schema bump is required. What changes is how
+the value is *produced* and *interpreted*: the coordinator now fills it with a
+64-bit xxh3 hash of the canonical, id-sorted worker set (each node's id,
+address, and role, length-delimited), and clients compare it for equality rather
+than magnitude. An all-zero value is reserved for the empty node set.
+
+**Rolling upgrade.** During a mixed-version window some coordinators emit the
+old wall-clock-seeded epoch and some emit the new hash. A client that caches a
+placement from one and then observes a different value from the other simply
+invalidates and refreshes — the worst case is an extra lookup, never a stale
+pin, because the new equality rule treats *any* difference as a refresh trigger
+(the old "strictly greater" rule was the only thing that could ignore a peer's
+value). Once all coordinators run the new code, two of them observing the same
+membership emit the identical token and the spurious refreshes stop. No operator
+action or flag day is required.
 
 ### 8. Backend failure is fail-closed for new authoritative reads
 


### PR DESCRIPTION
## Summary
- Replaces the wall-clock-seeded, process-local placement epoch with a **content-derived version** (`Epoch::for_nodes`): a 64-bit xxh3 hash of the canonical, id-sorted worker set (id, address, role; length-delimited). Two active-active coordinators observing the same membership now emit the **identical** token, so a load-balanced client no longer thrashes its placement cache.
- `Membership` no longer carries an epoch counter — the version is derived on demand from the node set, so a coordinator restart that rebuilds the same membership reproduces the same version (obsoleting the #69/#71 wall-clock workaround).
- The FUSE placement cache (`observe_epoch`) now invalidates on token **inequality** rather than numeric `<`, since a content hash has no ordering. Any difference triggers a refresh; identical membership never does.

## Design
Implements ADR 0001 §7 ("Placement uses an opaque membership version"). The wire representation is unchanged (existing `u64` field), so it's a **wire-compatible rolling upgrade**: during a mixed-version window a client sees at worst one extra lookup, never a stale pin. ADR §7 updated with the wire/rolling-upgrade details.

## Acceptance criteria (#80)
- [x] Identical membership snapshots produce identical versions on different processes.
- [x] Any placement-relevant membership/address change changes the version.
- [x] Version semantics are equality-only (works with opaque K8s/etcd revisions later).
- [x] FUSE/client cache invalidates on token inequality, not numeric ordering.
- [x] Rolling upgrade / old-schema behavior documented (ADR 0001 §7).
- [x] Regression tests: coordinator restart, cross-coordinator equality, membership churn, stale-cache recovery under a numerically-smaller token.

## Testing
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo test --workspace --all-features`, `cargo doc` — all clean.

Closes #80. Part of #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)