### PR TITLE
feat(ui): embedded management UI foundation and asset serving

### DIFF
--- a/crates/talon-coordinator/src/lib.rs
+++ b/crates/talon-coordinator/src/lib.rs
@@ -12,6 +12,7 @@ pub mod observability;
 pub mod placement;
 pub mod service;
 pub mod state_store;
+pub mod ui;
 
 pub use config::{CoordinatorConfig, CoordinatorConfigPatch};
 pub use heartbeat::{HeartbeatConfig, HeartbeatTracker, Inventory};

--- a/crates/talon-coordinator/src/observability.rs
+++ b/crates/talon-coordinator/src/observability.rs
@@ -675,17 +675,22 @@ pub async fn serve_admin(
     listener: TcpListener,
     state: Arc<CoordinatorObservability>,
 ) -> std::io::Result<()> {
-    axum::serve(
-        listener,
-        Router::new()
-            .route("/metrics", get(metrics_handler))
-            .route("/healthz", get(health_handler))
-            .route("/readyz", get(readiness_handler))
-            .with_state(Arc::clone(&state))
-            // Read-only versioned management API under /api/v1 (issue #82).
-            .merge(crate::api::router(state)),
-    )
-    .await
+    axum::serve(listener, admin_router(state)).await
+}
+
+/// Build the coordinator administration router: metrics/health/readiness, the
+/// versioned management API (#82), and the embedded UI (#83). Split out from
+/// [`serve_admin`] so route coexistence is unit-testable without binding a port.
+pub fn admin_router(state: Arc<CoordinatorObservability>) -> Router {
+    Router::new()
+        .route("/metrics", get(metrics_handler))
+        .route("/healthz", get(health_handler))
+        .route("/readyz", get(readiness_handler))
+        .with_state(Arc::clone(&state))
+        // Read-only versioned management API under /api/v1 (issue #82).
+        .merge(crate::api::router(state))
+        // Embedded management UI under / and /ui (issue #83).
+        .merge(crate::ui::router())
 }
 
 async fn metrics_handler(State(state): State<Arc<CoordinatorObservability>>) -> impl IntoResponse {
@@ -904,6 +909,40 @@ mod tests {
         let ready = request(address, "/readyz").await;
         assert!(ready.starts_with("HTTP/1.1 503 Service Unavailable"));
         assert!(ready.contains("\"reason\":\"unavailable\""));
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn ui_and_api_coexist_without_shadowing_admin_routes() {
+        // The embedded UI (#83) and the management API (#82) share the admin
+        // server with /metrics, /healthz, /readyz. None must shadow another.
+        let (observability, _store) = observability();
+        observability.check_ready().await.unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(serve_admin(listener, Arc::clone(&observability)));
+
+        // UI shell at / and /ui, with the strict CSP.
+        let root = request(address, "/").await;
+        assert!(root.starts_with("HTTP/1.1 200 OK"));
+        assert!(root.contains("content-security-policy"));
+        assert!(root.contains("id=\"app\""));
+        let asset = request(address, "/ui/assets/app.js").await;
+        assert!(asset.contains("text/javascript"));
+
+        // API still answers under /api/v1.
+        let cluster = request(address, "/api/v1/cluster").await;
+        assert!(cluster.starts_with("HTTP/1.1 200 OK"));
+        assert!(cluster.contains("\"cluster_id\""));
+
+        // Operational routes are unaffected.
+        assert!(request(address, "/healthz")
+            .await
+            .starts_with("HTTP/1.1 200 OK"));
+        assert!(request(address, "/metrics")
+            .await
+            .contains("talon_coordinator_build_info"));
 
         server.abort();
     }

--- a/crates/talon-coordinator/src/ui.rs
+++ b/crates/talon-coordinator/src/ui.rs
@@ -1,0 +1,184 @@
+//! Embedded management UI and static asset serving.
+//!
+//! Every coordinator serves the same self-contained single-page console under
+//! `/ui`. The production assets (`index.html`, `app.css`, `app.js`) are
+//! [`include_str!`]d into the binary at build time, so there is **no external
+//! CDN or runtime dependency** — the console works in air-gapped deployments and
+//! ships reproducibly with the coordinator image (issue #83).
+//!
+//! Routing model:
+//! - `GET /` and `GET /ui` → the app shell (`index.html`).
+//! - `GET /ui/assets/{file}` → a known static asset with a long-lived immutable
+//!   cache header (assets are content-stable per build).
+//! - `GET /ui/*` (any other sub-path) → SPA fallback to the shell, so client-side
+//!   hash routes deep-link correctly without a server round trip per view.
+//!
+//! Security headers on every UI response: a strict `Content-Security-Policy`
+//! that forbids inline/`eval` script and any remote origin (`default-src
+//! 'self'`), plus `X-Content-Type-Options: nosniff`. The API, metrics, and
+//! health routes are registered separately and are never shadowed by the UI —
+//! the fallback only applies under `/ui` and `/`.
+
+use axum::body::Body;
+use axum::extract::Path;
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+
+const INDEX_HTML: &str = include_str!("../ui/index.html");
+const APP_CSS: &str = include_str!("../ui/assets/app.css");
+const APP_JS: &str = include_str!("../ui/assets/app.js");
+
+/// Strict CSP: only same-origin resources, no inline/eval script. The app is
+/// written to need neither, so this holds without `unsafe-inline`.
+const CSP: &str = "default-src 'self'; script-src 'self'; style-src 'self'; \
+img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; \
+frame-ancestors 'none'";
+
+/// Build the UI router (shell + assets + SPA fallback).
+pub fn router() -> Router {
+    Router::new()
+        .route("/", get(index))
+        .route("/ui", get(index))
+        .route("/ui/", get(index))
+        .route("/ui/assets/{file}", get(asset))
+        .route("/ui/{*rest}", get(index)) // SPA fallback for deep links.
+}
+
+fn security_headers(mut resp: Response) -> Response {
+    let h = resp.headers_mut();
+    h.insert(
+        header::CONTENT_SECURITY_POLICY,
+        HeaderValue::from_static(CSP),
+    );
+    h.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    resp
+}
+
+async fn index() -> Response {
+    // The shell is regenerated per deploy but references immutable asset URLs;
+    // keep it uncached so a new deploy is picked up immediately.
+    let resp = (
+        [
+            (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        INDEX_HTML,
+    )
+        .into_response();
+    security_headers(resp)
+}
+
+async fn asset(Path(file): Path<String>) -> Response {
+    let (body, content_type) = match file.as_str() {
+        "app.css" => (APP_CSS, "text/css; charset=utf-8"),
+        "app.js" => (APP_JS, "text/javascript; charset=utf-8"),
+        _ => {
+            return security_headers(
+                (StatusCode::NOT_FOUND, Body::from("asset not found")).into_response(),
+            );
+        }
+    };
+    // Assets are content-stable for a given build; allow long-lived caching.
+    let resp = (
+        [
+            (header::CONTENT_TYPE, content_type),
+            (header::CACHE_CONTROL, "public, max-age=3600"),
+        ],
+        body,
+    )
+        .into_response();
+    security_headers(resp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    async fn get(uri: &str) -> Response {
+        router()
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn root_serves_app_shell_with_security_headers() {
+        let resp = get("/").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_SECURITY_POLICY).unwrap(),
+            CSP
+        );
+        assert_eq!(
+            resp.headers().get(header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        let body = to_bytes(resp.into_body(), 1 << 20).await.unwrap();
+        let html = std::str::from_utf8(&body).unwrap();
+        // The real app shell, not a placeholder/marketing page.
+        assert!(html.contains("id=\"app\""));
+        assert!(html.contains("/ui/assets/app.js"));
+    }
+
+    #[tokio::test]
+    async fn assets_are_served_with_correct_types_and_caching() {
+        let css = get("/ui/assets/app.css").await;
+        assert_eq!(css.status(), StatusCode::OK);
+        assert_eq!(
+            css.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/css; charset=utf-8"
+        );
+        assert!(css
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .contains("max-age=3600"));
+        let js = get("/ui/assets/app.js").await;
+        assert_eq!(
+            js.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/javascript; charset=utf-8"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_asset_is_404() {
+        let resp = get("/ui/assets/nope.png").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn spa_deep_link_falls_back_to_shell() {
+        // A client-side route under /ui must return the shell, not 404, so a
+        // refresh on a deep link works.
+        let resp = get("/ui/nodes/worker-1").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), 1 << 20).await.unwrap();
+        assert!(std::str::from_utf8(&body).unwrap().contains("id=\"app\""));
+    }
+
+    #[test]
+    fn embedded_assets_are_non_empty_and_within_budget() {
+        // Guard the asset size budget: the whole console must stay small enough
+        // to embed and ship comfortably. 256 KiB total is generous headroom for
+        // a dependency-free vanilla app.
+        let total = INDEX_HTML.len() + APP_CSS.len() + APP_JS.len();
+        assert!(total > 0);
+        assert!(
+            total < 256 * 1024,
+            "UI asset budget exceeded: {total} bytes"
+        );
+        // The app must be framework-free: no bundler runtime markers.
+        assert!(!APP_JS.contains("webpackJsonp"));
+        assert!(!APP_JS.contains("__vite"));
+    }
+}

--- a/crates/talon-coordinator/ui/README.md
+++ b/crates/talon-coordinator/ui/README.md
@@ -1,0 +1,58 @@
+# Talon management console
+
+The self-contained web console every coordinator serves under `/ui`.
+
+## Design
+
+- **No build step, no framework, no runtime dependency.** The console is
+  hand-authored HTML/CSS/vanilla ES2020. The three files in this directory are
+  `include_str!`d into the coordinator binary (`src/ui.rs`), so the console
+  ships reproducibly with the binary/image and works in air-gapped deployments.
+- **Strict CSP.** Every UI response sets `default-src 'self'; script-src 'self'`
+  (no inline/`eval`), so the app is written to need no inline scripts or styles
+  and no remote origins.
+- **SPA routing.** The client uses hash routes (`#/overview`, `#/nodes`,
+  `#/backend`). Deep links under `/ui/...` fall back to the shell server-side so
+  a refresh works.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `index.html` | App shell: top bar, nav, main region, no-JS fallback. |
+| `assets/app.css` | Design tokens (dark/light) and shell/table/stat styles. |
+| `assets/app.js` | Hash router, `/api/v1` data client, loading/error/empty boundaries, 5s poll. |
+
+## Serving
+
+`src/ui.rs` mounts these routes into the coordinator admin server:
+
+- `GET /`, `GET /ui` → `index.html` (`Cache-Control: no-cache`).
+- `GET /ui/assets/{file}` → the asset (`Cache-Control: public, max-age=3600`).
+- `GET /ui/{*rest}` → SPA fallback to the shell.
+
+The API (`/api/v1`), metrics (`/metrics`), and health routes are registered
+separately and are never shadowed by the UI (covered by a coexistence test).
+
+## Development workflow
+
+Because there is no bundler, iterate by editing the files directly and running a
+coordinator:
+
+```sh
+cargo run -p talon-coordinator -- --admin-listen 127.0.0.1:8080
+# open http://127.0.0.1:8080/ui
+```
+
+The console talks to the same-origin `/api/v1`, so no proxy or CORS config is
+needed. To iterate against a remote cluster's API, serve these files with any
+static server and point `fetch` at the remote origin (temporarily relaxing the
+`connect-src` CSP in `src/ui.rs`).
+
+## Budget & checks
+
+`cargo test -p talon-coordinator` validates, in CI: the shell and assets are
+served with the right content types and caching, the CSP and `nosniff` headers
+are present, the SPA fallback works, unknown assets 404, and the **total asset
+size stays under a 256 KiB budget** with no bundler-runtime markers (the app
+must remain framework-free).

--- a/crates/talon-coordinator/ui/assets/app.css
+++ b/crates/talon-coordinator/ui/assets/app.css
@@ -1,0 +1,101 @@
+/* Talon management console — design tokens + application shell.
+ * No external fonts or assets: everything ships with the coordinator binary,
+ * so the console works in air-gapped deployments with a strict CSP. */
+:root {
+  --bg: #0f1419;
+  --bg-panel: #171d26;
+  --bg-elev: #1e2530;
+  --border: #2a3441;
+  --text: #e6edf3;
+  --text-muted: #8b98a9;
+  --accent: #4c9aff;
+  --ok: #3fb950;
+  --warn: #d29922;
+  --err: #f85149;
+  --radius: 8px;
+  --space: 8px;
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f6f8fa; --bg-panel: #ffffff; --bg-elev: #f0f3f6;
+    --border: #d0d7de; --text: #1f2328; --text-muted: #656d76;
+  }
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  background: var(--bg); color: var(--text);
+  font-family: var(--font); font-size: 14px; line-height: 1.5;
+}
+.skip-link {
+  position: absolute; left: -9999px; top: 0;
+  background: var(--accent); color: #fff; padding: var(--space);
+  z-index: 100; border-radius: 0 0 var(--radius) 0;
+}
+.skip-link:focus { left: 0; }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.topbar {
+  display: flex; align-items: center; gap: calc(var(--space) * 3);
+  padding: 0 calc(var(--space) * 2); height: 56px;
+  background: var(--bg-panel); border-bottom: 1px solid var(--border);
+  position: sticky; top: 0; z-index: 10;
+}
+.brand { display: flex; align-items: center; gap: var(--space); font-weight: 600; }
+.brand-mark { color: var(--accent); }
+.nav { display: flex; gap: var(--space); flex: 1; }
+.nav-link {
+  color: var(--text-muted); text-decoration: none;
+  padding: var(--space) calc(var(--space) * 1.5); border-radius: var(--radius);
+}
+.nav-link:hover { background: var(--bg-elev); color: var(--text); }
+.nav-link[aria-current="page"] { color: var(--text); background: var(--bg-elev); }
+.conn { font-size: 12px; color: var(--text-muted); }
+.conn[data-state="ok"]::before { content: "● "; color: var(--ok); }
+.conn[data-state="stale"]::before { content: "● "; color: var(--warn); }
+.conn[data-state="down"]::before { content: "● "; color: var(--err); }
+
+.main { padding: calc(var(--space) * 3); max-width: 1200px; margin: 0 auto; }
+.view { display: grid; gap: calc(var(--space) * 2); }
+.panel {
+  background: var(--bg-panel); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: calc(var(--space) * 2);
+}
+h1 { font-size: 20px; margin: 0 0 var(--space); }
+h2 { font-size: 16px; margin: 0 0 var(--space); }
+.muted { color: var(--text-muted); }
+.error { color: var(--err); }
+code { font-family: var(--mono); background: var(--bg-elev); padding: 1px 5px; border-radius: 4px; }
+
+.stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: calc(var(--space) * 2); }
+.stat { background: var(--bg-elev); border-radius: var(--radius); padding: calc(var(--space) * 2); }
+.stat .value { font-size: 28px; font-weight: 600; }
+.stat .label { color: var(--text-muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }
+
+table { width: 100%; border-collapse: collapse; }
+th, td { text-align: left; padding: var(--space) calc(var(--space) * 1.5); border-bottom: 1px solid var(--border); }
+th { color: var(--text-muted); font-weight: 500; font-size: 12px; text-transform: uppercase; }
+tbody tr:hover { background: var(--bg-elev); }
+.badge { display: inline-block; padding: 1px 8px; border-radius: 12px; font-size: 12px; }
+.badge.healthy { background: rgba(63,185,80,0.15); color: var(--ok); }
+.badge.degraded, .badge.unknown { background: rgba(210,153,34,0.15); color: var(--warn); }
+.badge.unhealthy { background: rgba(248,81,73,0.15); color: var(--err); }
+
+.boundary { text-align: center; padding: calc(var(--space) * 6) var(--space); color: var(--text-muted); }
+.spinner {
+  width: 24px; height: 24px; margin: 0 auto var(--space);
+  border: 3px solid var(--border); border-top-color: var(--accent);
+  border-radius: 50%; animation: spin 0.8s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) { .spinner { animation: none; } }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.footer { padding: calc(var(--space) * 2); text-align: center; border-top: 1px solid var(--border); font-size: 12px; }
+
+@media (max-width: 640px) {
+  .topbar { gap: var(--space); }
+  .nav-link { padding: var(--space); }
+  .main { padding: var(--space); }
+}

--- a/crates/talon-coordinator/ui/assets/app.js
+++ b/crates/talon-coordinator/ui/assets/app.js
@@ -1,0 +1,213 @@
+// Talon management console — application shell + data client.
+//
+// Vanilla ES2020, no framework, no build step, no external runtime dependency:
+// the file ships verbatim inside the coordinator binary and runs under a strict
+// CSP (no inline handlers, no eval). It provides the shell foundation (#83):
+// a hash router, a resilient API client with loading/error/empty boundaries,
+// an accessible navigation model, and a short polling loop. Rich per-view
+// dashboards are layered on in #84.
+"use strict";
+
+(function () {
+  const API = "/api/v1";
+  const POLL_MS = 5000;
+
+  /** Minimal fetch wrapper that normalizes errors to {ok,data,error}. */
+  async function apiGet(path) {
+    try {
+      const res = await fetch(API + path, { headers: { accept: "application/json" } });
+      if (!res.ok) {
+        let body = null;
+        try { body = await res.json(); } catch (_) { /* non-JSON error */ }
+        return { ok: false, status: res.status, error: (body && body.error) || "http_" + res.status };
+      }
+      return { ok: true, data: await res.json() };
+    } catch (e) {
+      return { ok: false, status: 0, error: "network_error" };
+    }
+  }
+
+  // --- tiny DOM helpers (no innerHTML with untrusted data) ------------------
+  function el(tag, attrs, children) {
+    const node = document.createElement(tag);
+    if (attrs) for (const k in attrs) {
+      if (k === "class") node.className = attrs[k];
+      else if (k === "text") node.textContent = attrs[k];
+      else node.setAttribute(k, attrs[k]);
+    }
+    if (children) for (const c of children) node.appendChild(c);
+    return node;
+  }
+  function boundary(kind, msg) {
+    const box = el("div", { class: "boundary" });
+    if (kind === "loading") box.appendChild(el("div", { class: "spinner", "aria-hidden": "true" }));
+    box.appendChild(el("p", { text: msg }));
+    if (kind === "error") box.firstChild || box.classList.add("error");
+    return box;
+  }
+  function fmtBytes(n) {
+    if (!n) return "0 B";
+    const u = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+    let i = 0, v = n;
+    while (v >= 1024 && i < u.length - 1) { v /= 1024; i++; }
+    return v.toFixed(v < 10 && i > 0 ? 1 : 0) + " " + u[i];
+  }
+
+  // --- connection indicator -------------------------------------------------
+  function setConn(state, text) {
+    const c = document.getElementById("conn-status");
+    if (!c) return;
+    c.setAttribute("data-state", state);
+    c.textContent = text;
+  }
+  function setMeta(meta) {
+    const m = document.getElementById("app-meta");
+    if (m && meta) {
+      m.textContent =
+        "backend: " + meta.backend + " · revision: " + meta.snapshot_revision +
+        " · age: " + meta.snapshot_age_ms + " ms";
+    }
+  }
+
+  // --- views ----------------------------------------------------------------
+  const views = {
+    async overview(root) {
+      root.appendChild(boundary("loading", "Loading cluster overview…"));
+      const r = await apiGet("/cluster");
+      root.textContent = "";
+      if (!r.ok) return renderError(root, r);
+      const d = r.data;
+      setMeta(d.meta);
+      const panel = el("section", { class: "panel" });
+      panel.appendChild(el("h1", { text: "Cluster: " + d.cluster_id }));
+      const grid = el("div", { class: "stat-grid" });
+      const stat = (label, value) =>
+        el("div", { class: "stat" }, [
+          el("div", { class: "value", text: String(value) }),
+          el("div", { class: "label", text: label }),
+        ]);
+      grid.appendChild(stat("Coordinators", d.coordinator_count));
+      grid.appendChild(stat("Workers", d.worker_count));
+      grid.appendChild(stat("Healthy workers", d.healthy_worker_count));
+      grid.appendChild(stat("Capacity", fmtBytes(d.total_capacity_bytes)));
+      grid.appendChild(stat("Resident", fmtBytes(d.total_resident_bytes)));
+      grid.appendChild(stat("Blocks", d.total_block_count));
+      panel.appendChild(grid);
+      root.appendChild(panel);
+    },
+
+    async nodes(root) {
+      root.appendChild(boundary("loading", "Loading fleet…"));
+      const r = await apiGet("/nodes?limit=500");
+      root.textContent = "";
+      if (!r.ok) return renderError(root, r);
+      const d = r.data;
+      setMeta(d.meta);
+      const panel = el("section", { class: "panel" });
+      panel.appendChild(el("h1", { text: "Fleet (" + d.total + " nodes)" }));
+      if (!d.nodes.length) {
+        panel.appendChild(el("p", { class: "muted", text: "No nodes reporting yet." }));
+        root.appendChild(panel);
+        return;
+      }
+      const table = el("table");
+      const head = el("tr", null, ["Node", "Role", "Health", "Ready", "Blocks", "Resident", "Address"]
+        .map((h) => el("th", { text: h })));
+      table.appendChild(el("thead", null, [head]));
+      const body = el("tbody");
+      for (const n of d.nodes) {
+        const badge = el("span", { class: "badge " + n.health, text: n.health });
+        body.appendChild(el("tr", null, [
+          el("td", null, [el("code", { text: n.node_id })]),
+          el("td", { text: n.role }),
+          el("td", null, [badge]),
+          el("td", { text: n.ready ? "yes" : "no" }),
+          el("td", { text: String(n.block_count) }),
+          el("td", { text: fmtBytes(n.resident_bytes) }),
+          el("td", null, [el("code", { text: n.address })]),
+        ]));
+      }
+      table.appendChild(body);
+      panel.appendChild(table);
+      root.appendChild(panel);
+    },
+
+    async backend(root) {
+      root.appendChild(boundary("loading", "Loading backend status…"));
+      const r = await apiGet("/backend");
+      root.textContent = "";
+      if (!r.ok) return renderError(root, r);
+      const d = r.data;
+      setMeta(d.meta);
+      const panel = el("section", { class: "panel" });
+      panel.appendChild(el("h1", { text: "State backend" }));
+      const grid = el("div", { class: "stat-grid" });
+      grid.appendChild(el("div", { class: "stat" }, [
+        el("div", { class: "value", text: d.backend }),
+        el("div", { class: "label", text: "Backend" }),
+      ]));
+      grid.appendChild(el("div", { class: "stat" }, [
+        el("div", { class: "value", text: d.ready ? "ready" : "not ready" }),
+        el("div", { class: "label", text: "Readiness" }),
+      ]));
+      grid.appendChild(el("div", { class: "stat" }, [
+        el("div", { class: "value", text: d.snapshot_age_ms + " ms" }),
+        el("div", { class: "label", text: "Snapshot age" }),
+      ]));
+      panel.appendChild(grid);
+      panel.appendChild(el("p", { class: "muted", text: "Revision: " + d.revision }));
+      root.appendChild(panel);
+    },
+  };
+
+  function renderError(root, r) {
+    const box = el("div", { class: "boundary" });
+    if (r.status === 503) {
+      box.appendChild(el("p", { class: "error", text: "The cluster state backend is unavailable." }));
+      box.appendChild(el("p", { class: "muted", text: "The coordinator is failing closed rather than serving stale data. Retrying…" }));
+      setConn("down", "backend unavailable");
+    } else {
+      box.appendChild(el("p", { class: "error", text: "Could not load data (" + r.error + ")." }));
+      setConn("down", "error");
+    }
+    root.appendChild(box);
+  }
+
+  // --- router ---------------------------------------------------------------
+  const ROUTES = ["overview", "nodes", "backend"];
+  function currentRoute() {
+    const h = (location.hash || "#/overview").replace(/^#\//, "");
+    return ROUTES.indexOf(h) >= 0 ? h : "overview";
+  }
+  function highlightNav(route) {
+    document.querySelectorAll(".nav-link").forEach((a) => {
+      if (a.getAttribute("data-route") === route) a.setAttribute("aria-current", "page");
+      else a.removeAttribute("aria-current");
+    });
+  }
+  let pollTimer = null;
+  async function render() {
+    const route = currentRoute();
+    highlightNav(route);
+    const view = document.getElementById("view");
+    document.getElementById("app").removeAttribute("data-loading");
+    await views[route](view);
+    if (document.querySelector(".conn").getAttribute("data-state") !== "down") {
+      setConn("ok", "connected");
+    }
+  }
+  function schedulePoll() {
+    if (pollTimer) clearTimeout(pollTimer);
+    pollTimer = setTimeout(async function tick() {
+      await render();
+      pollTimer = setTimeout(tick, POLL_MS);
+    }, POLL_MS);
+  }
+
+  window.addEventListener("hashchange", function () { render(); schedulePoll(); });
+  window.addEventListener("DOMContentLoaded", function () {
+    if (!location.hash) location.hash = "#/overview";
+    render();
+    schedulePoll();
+  });
+})();

--- a/crates/talon-coordinator/ui/index.html
+++ b/crates/talon-coordinator/ui/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Talon — Cluster Management</title>
+    <link rel="stylesheet" href="/ui/assets/app.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to main content</a>
+    <div id="app" data-loading="true">
+      <header class="topbar" role="banner">
+        <div class="brand">
+          <span class="brand-mark" aria-hidden="true">◆</span>
+          <span class="brand-name">Talon</span>
+        </div>
+        <nav class="nav" aria-label="Primary">
+          <a href="#/overview" data-route="overview" class="nav-link">Overview</a>
+          <a href="#/nodes" data-route="nodes" class="nav-link">Fleet</a>
+          <a href="#/backend" data-route="backend" class="nav-link">Backend</a>
+        </nav>
+        <div class="conn" id="conn-status" role="status" aria-live="polite"></div>
+      </header>
+      <main id="main" class="main" tabindex="-1">
+        <div id="view" class="view">
+          <!-- Populated by app.js. Static fallback content below is replaced
+               once the app boots, so no-JS users still see a real shell. -->
+          <section class="panel">
+            <h1>Talon Cluster Management</h1>
+            <p class="muted">Loading the management console…</p>
+            <noscript>
+              <p class="error">
+                This console requires JavaScript. The read-only management API is
+                available at <code>/api/v1/</code>.
+              </p>
+            </noscript>
+          </section>
+        </div>
+      </main>
+      <footer class="footer" role="contentinfo">
+        <span id="app-meta" class="muted"></span>
+      </footer>
+    </div>
+    <script src="/ui/assets/app.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
Establish the management console foundation and serve it from every coordinator under `/ui` — the admin address loads a real app shell, not a placeholder.

**Frontend** (`crates/talon-coordinator/ui/`): dependency-free HTML/CSS/vanilla ES2020 — no bundler, no framework, no external CDN. `index.html` shell + no-JS fallback; `app.css` dark/light tokens, responsive, accessible focus; `app.js` hash router (overview/fleet/backend), resilient `/api/v1` client with loading/error/empty boundaries + 503 fail-closed message + 5s poll (no `innerHTML` on untrusted data).

**Serving** (`src/ui.rs`): assets `include_str!`'d into the binary (reproducible, air-gap-friendly). `/` and `/ui` → shell (`no-cache`); `/ui/assets/{file}` → asset (`max-age=3600`); `/ui/{*rest}` → SPA fallback. Strict CSP (`default-src 'self'; script-src 'self'`, no inline/eval) + `nosniff` on every UI response. `serve_admin` refactored to a testable `admin_router()`.

## Acceptance criteria (#83)
- [x] Coordinator address loads the actual app shell (test asserts `id="app"`, not marketing).
- [x] Production assets embedded/packaged with the binary (`include_str!`), reproducible.
- [x] Dev workflow against the API documented (same-origin `/api/v1`, README).
- [x] CSP, cache headers, SPA fallback defined (base path `/ui`; compression left to a proxy).
- [x] Responsive nav, accessible focus, keyboard operation, empty/loading/error boundaries.
- [x] Asset size budget check in CI (256 KiB) + framework-free guard.
- [x] Rust tests: index/assets served without shadowing API/metrics/health (live-server coexistence test).

## Testing
`cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo test --workspace --all-features`, `cargo doc` — all clean.

Closes #83. Part of #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)