### PR TITLE
fix(backend): strip URL from reqwest errors to prevent SAS token leak

### DIFF
--- a/crates/talon-backend/src/reqwest_client.rs
+++ b/crates/talon-backend/src/reqwest_client.rs
@@ -51,18 +51,60 @@ impl HttpClient for ReqwestClient {
         for (k, v) in &req.headers {
             builder = builder.header(k.as_str(), v.as_str());
         }
-        let resp = builder.send().await.map_err(|e| e.to_string())?;
+        let resp = builder.send().await.map_err(sanitize_error)?;
         let status = resp.status().as_u16();
         let headers = resp
             .headers()
             .iter()
             .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
             .collect();
-        let body = resp.bytes().await.map_err(|e| e.to_string())?;
+        let body = resp.bytes().await.map_err(sanitize_error)?;
         Ok(HttpResponse {
             status,
             headers,
             body,
         })
+    }
+}
+
+/// Stringify a `reqwest::Error` **without its URL**.
+///
+/// `reqwest::Error`'s `Display` embeds the request URL, and the backend URL can
+/// carry an Azure SAS token (or other query-string credential). This error is
+/// returned verbatim to a credential-less client over the data plane, so a
+/// transport-layer failure (DNS/TLS/connect/timeout) must never leak the
+/// SAS-bearing URL. `without_url()` strips it before stringifying (issue #116).
+fn sanitize_error(error: reqwest::Error) -> String {
+    error.without_url().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::HttpRequest;
+
+    #[tokio::test]
+    async fn transport_error_does_not_leak_sas_url() {
+        // A connect failure to a URL carrying a SAS-like query string must not
+        // surface that URL (and thus the token) in the returned error string.
+        let secret = "sig=SUPERSECRETsignature123&se=2030-01-01";
+        let url = format!("https://nonexistent-host.invalid.example/container/blob.bin?{secret}");
+        let client = ReqwestClient::new();
+        let err = client
+            .execute(HttpRequest {
+                method: Method::Get,
+                url,
+                headers: Vec::new(),
+            })
+            .await
+            .expect_err("request to an unresolvable host must fail");
+        assert!(
+            !err.contains("SUPERSECRETsignature123"),
+            "error leaked the SAS token: {err}"
+        );
+        assert!(
+            !err.contains("nonexistent-host.invalid.example"),
+            "error leaked the URL: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
`reqwest::Error`'s `Display` embeds the request URL, and the Azure backend URL carries the SAS token as a query string. That error string was returned verbatim to a credential-less client over the data plane, so a transport-layer failure (DNS/TLS/connect/timeout) could **leak the full SAS-bearing URL** to the client.

Both call sites in `ReqwestClient::execute` (`send()` and `bytes()`) now stringify through `error.without_url()`, stripping the URL before formatting. HTTP-status errors were already URL-free, so this closes the transport-error path.

## Testing
Added a test: a GET to an unresolvable host with a SAS-like query string fails with an error containing neither the signature nor the host. `fmt`/`clippy -D warnings`/`test` clean.

Closes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)