### PR TITLE
fix(backend): correct ranged GET when the store returns HTTP 200

### DIFF
--- a/crates/talon-backend/src/azure.rs
+++ b/crates/talon-backend/src/azure.rs
@@ -119,7 +119,9 @@ impl BackendStore for AzureBackend {
             .await
             .map_err(Error::Backend)?;
         match resp.status {
-            200 | 206 => Ok(resp.body),
+            200 | 206 => {
+                crate::http::range_body(resp.status, resp.body, offset, len).map_err(Error::Backend)
+            }
             404 => Err(Error::NotFound(obj.to_path())),
             s => Err(Error::Backend(format!(
                 "Azure GET {} -> HTTP {s}",

--- a/crates/talon-backend/src/gcs.rs
+++ b/crates/talon-backend/src/gcs.rs
@@ -105,7 +105,9 @@ impl BackendStore for GcsBackend {
             .await
             .map_err(Error::Backend)?;
         match resp.status {
-            200 | 206 => Ok(resp.body),
+            200 | 206 => {
+                crate::http::range_body(resp.status, resp.body, offset, len).map_err(Error::Backend)
+            }
             404 => Err(Error::NotFound(obj.to_path())),
             s => Err(Error::Backend(format!(
                 "GCS GET {} -> HTTP {s}",

--- a/crates/talon-backend/src/http.rs
+++ b/crates/talon-backend/src/http.rs
@@ -65,10 +65,109 @@ impl HttpResponse {
     }
 }
 
+/// Extract the bytes for a ranged GET of `[offset, offset+len)` from a response,
+/// correcting for servers that ignore the `Range` header (issue #117).
+///
+/// - **206 Partial Content**: the body already *is* the requested range. We
+///   accept it but still verify its length matches `len` (a 206 with a short
+///   body would otherwise be cached as correct); a mismatch is an error.
+/// - **200 OK**: the server ignored `Range` and returned the **whole object**.
+///   A proxy or non-compliant S3 store does this. Naively caching that body
+///   under the block's `BlockId` (then slicing at `offset_in_block`) serves the
+///   *head* of the object for every non-zero-offset block. Instead we slice the
+///   full-object body at `[offset, offset+len)` so the caller always receives
+///   exactly the requested range. If the body is shorter than `offset` the
+///   requested range lies past EOF and yields empty; the final block is clamped
+///   to whatever remains.
+///
+/// Any other status is the caller's responsibility (404/errors handled there);
+/// this is only invoked for 200/206.
+pub fn range_body(
+    status: u16,
+    body: bytes::Bytes,
+    offset: u64,
+    len: u64,
+) -> Result<bytes::Bytes, String> {
+    match status {
+        206 => {
+            // Trust the server's partial content, but reject a short partial:
+            // caching fewer bytes than requested as a "hit" is silent corruption.
+            if (body.len() as u64) < len {
+                return Err(format!(
+                    "ranged GET returned 206 with {} bytes, expected {len}",
+                    body.len()
+                ));
+            }
+            Ok(body)
+        }
+        200 => {
+            // Whole object returned; slice out the requested window.
+            let start = usize::try_from(offset)
+                .unwrap_or(usize::MAX)
+                .min(body.len());
+            let end = offset
+                .checked_add(len)
+                .and_then(|e| usize::try_from(e).ok())
+                .unwrap_or(usize::MAX)
+                .min(body.len());
+            Ok(body.slice(start..end))
+        }
+        other => Err(format!("range_body called with unexpected status {other}")),
+    }
+}
+
 /// An async HTTP transport a backend uses to talk to its origin store.
 #[async_trait]
 pub trait HttpClient: Send + Sync {
     /// Execute `req` and return the response, or an error string on transport
     /// failure (DNS/connect/timeout).
     async fn execute(&self, req: HttpRequest) -> Result<HttpResponse, String>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::range_body;
+    use bytes::Bytes;
+
+    #[test]
+    fn partial_206_is_trusted_when_full_length() {
+        let body = Bytes::from(vec![7u8; 100]);
+        let out = range_body(206, body.clone(), 256, 100).unwrap();
+        assert_eq!(out, body);
+    }
+
+    #[test]
+    fn short_206_is_rejected() {
+        // A 206 that returned fewer bytes than requested must not be cached as a
+        // correct block.
+        let body = Bytes::from(vec![7u8; 50]);
+        assert!(range_body(206, body, 0, 100).is_err());
+    }
+
+    #[test]
+    fn whole_object_200_is_sliced_to_the_requested_window() {
+        // Server ignored Range and returned a 300-byte whole object; a request
+        // for [100, 200) must yield bytes 100..200, not the object head.
+        let object: Vec<u8> = (0..255u8).cycle().take(300).collect();
+        let body = Bytes::from(object.clone());
+        let out = range_body(200, body, 100, 100).unwrap();
+        assert_eq!(out.len(), 100);
+        assert_eq!(&out[..], &object[100..200]);
+    }
+
+    #[test]
+    fn whole_object_200_final_block_clamps_at_eof() {
+        // Requested window runs past the object end; return what remains.
+        let object: Vec<u8> = (0..255u8).cycle().take(300).collect();
+        let body = Bytes::from(object.clone());
+        let out = range_body(200, body, 256, 256).unwrap();
+        assert_eq!(&out[..], &object[256..300]);
+    }
+
+    #[test]
+    fn whole_object_200_offset_past_eof_is_empty() {
+        let body = Bytes::from(vec![1u8; 100]);
+        let out = range_body(200, body, 500, 100).unwrap();
+        assert!(out.is_empty());
+    }
 }

--- a/crates/talon-backend/src/s3.rs
+++ b/crates/talon-backend/src/s3.rs
@@ -136,9 +136,11 @@ impl BackendStore for S3Backend {
         }
         let req = self.build_get(obj, offset, len);
         let resp = self.http.execute(req).await.map_err(Error::Backend)?;
-        // 206 Partial Content (range) or 200 (whole) are both acceptable.
+        // 206 (range honored) or 200 (server ignored Range, returned the whole
+        // object). `range_body` yields exactly the requested window in both
+        // cases and rejects a short 206 (issue #117).
         if resp.status == 206 || resp.status == 200 {
-            Ok(resp.body)
+            crate::http::range_body(resp.status, resp.body, offset, len).map_err(Error::Backend)
         } else if resp.status == 404 {
             Err(Error::NotFound(obj.to_path()))
         } else {
@@ -264,6 +266,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fetch_range_slices_whole_object_on_200() {
+        // A range-ignoring store/proxy returns HTTP 200 + the whole object; the
+        // backend must slice out the requested window rather than caching the
+        // object head under a non-zero-offset block (issue #117).
+        let object: Vec<u8> = (0..255u8).cycle().take(600).collect();
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![],
+            body: bytes::Bytes::from(object.clone()),
+        });
+        let s3 = S3Backend::new(S3Config::aws("us-east-1"), creds(), http);
+        let got = s3.fetch_range(&obj(), 256, 256).await.unwrap();
+        assert_eq!(&got[..], &object[256..512]);
+    }
+
+    #[tokio::test]
     async fn fetch_range_maps_404_to_notfound() {
         let http = MockHttp::new(HttpResponse {
             status: 404,
@@ -310,7 +328,7 @@ mod tests {
         let http = MockHttp::new(HttpResponse {
             status: 206,
             headers: vec![],
-            body: bytes::Bytes::new(),
+            body: bytes::Bytes::from_static(b"12345678"),
         });
         let mut c = creds();
         c.session_token = Some("token123".into());


### PR DESCRIPTION
## Summary
All three backends accepted an HTTP **200** to a ranged GET and returned the body unchecked. A proxy or non-compliant S3 store that ignores `Range` returns the **whole object** with 200; caching that under the block's `BlockId` (then slicing at `offset_in_block`) serves the object *head* for every non-zero-offset block — silent, persistent wrong-bytes corruption. A short **206** was likewise cached as a correct block.

New shared `http::range_body(status, body, offset, len)`, wired into S3/GCS/Azure GET paths:
- **206**: trust the partial, but reject a body shorter than requested.
- **200**: slice out `[offset, offset+len)` from the whole object (checked_add; clamps at EOF; offset past EOF → empty).

## Testing
`range_body` unit tests (full/short 206, whole-object 200 slice, EOF clamp, past-EOF) + an S3 backend test that a 200 whole-object yields the correct non-zero-offset window. `fmt`/`clippy -D warnings`/`test --all-features` clean.

Closes #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)