### PR TITLE
fix(worker): dedup concurrent misses and use unique staging temp files

### DIFF
--- a/crates/talon-worker/src/block_store.rs
+++ b/crates/talon-worker/src/block_store.rs
@@ -23,7 +23,12 @@ use std::hash::{Hash, Hasher};
 use std::io::{Read, Write};
 use std::os::fd::OwnedFd;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use talon_core::{BlockHandle, BlockId, Error, ObjectStore, PageIndex, Result};
+
+/// Process-wide monotonic counter making staging temp filenames unique, so two
+/// concurrent writers of the same block never share a `.tmp` path (issue #113).
+static STAGING_SEQ: AtomicU64 = AtomicU64::new(0);
 
 /// A local, file-backed store for whole blocks.
 pub struct WholeBlockStore {
@@ -110,15 +115,27 @@ impl ObjectStore for WholeBlockStore {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        // Write to a temp file then rename so a present `.blk` is always
-        // complete (crash-atomic commit).
-        let tmp = path.with_extension("blk.tmp");
+        // Write to a per-writer-unique temp file then rename, so a present
+        // `.blk` is always complete (crash-atomic commit) AND two concurrent
+        // writers of the same block never truncate each other's staging file
+        // (issue #113). Both writers stage identical content; whichever renames
+        // last wins with a complete file, and the loser's rename is a harmless
+        // overwrite of the same bytes.
+        let seq = STAGING_SEQ.fetch_add(1, Ordering::Relaxed);
+        let tmp = path.with_extension(format!("blk.tmp.{}.{seq}", std::process::id()));
         {
             let mut f = std::fs::File::create(&tmp)?;
             f.write_all(&value)?;
             f.sync_all()?;
         }
-        std::fs::rename(&tmp, &path)?;
+        // Rename our own unique temp into place. If a concurrent writer already
+        // renamed theirs, this atomically replaces it with identical bytes.
+        if let Err(e) = std::fs::rename(&tmp, &path) {
+            // Best-effort cleanup of our staging file on failure so a failed
+            // commit never leaks a `.tmp`.
+            let _ = std::fs::remove_file(&tmp);
+            return Err(e.into());
+        }
         Ok(())
     }
 
@@ -140,6 +157,7 @@ impl ObjectStore for WholeBlockStore {
 mod tests {
     use super::*;
     use std::os::fd::AsRawFd;
+    use std::sync::Arc;
     use talon_core::{Backend, ObjectId, Version};
 
     fn block(n: u64) -> BlockId {
@@ -189,6 +207,43 @@ mod tests {
         assert!(!store.contains(&id).await.unwrap());
         // Deleting again is a no-op.
         store.delete(&id).await.unwrap();
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[tokio::test]
+    async fn concurrent_puts_of_same_block_commit_complete_bytes() {
+        // Two writers staging the same block must not share a temp file and
+        // truncate each other; the committed `.blk` is always the full content
+        // and no `.tmp` is leaked (issue #113).
+        let root = tmp_root();
+        let store = Arc::new(WholeBlockStore::open(&root).unwrap());
+        let id = block(7);
+        let data = Bytes::from(vec![0xABu8; 4096]);
+
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let store = Arc::clone(&store);
+            let id = id.clone();
+            let data = data.clone();
+            tasks.push(tokio::spawn(
+                async move { store.put(&id, data).await.unwrap() },
+            ));
+        }
+        for t in tasks {
+            t.await.unwrap();
+        }
+
+        // The committed block is complete.
+        assert_eq!(store.get_bytes(&id).await.unwrap(), data);
+        // No staging temp files leaked.
+        let shard = store.path_for(&id).parent().unwrap().to_path_buf();
+        let leaked: Vec<_> = std::fs::read_dir(&shard)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp"))
+            .collect();
+        assert!(leaked.is_empty(), "leaked staging temp files: {leaked:?}");
 
         std::fs::remove_dir_all(&root).ok();
     }

--- a/crates/talon-worker/src/miss.rs
+++ b/crates/talon-worker/src/miss.rs
@@ -11,13 +11,16 @@
 //!   only the touched pages, never the whole 256MB block.
 //!
 //! [`InFlightLoads::admit`] returns an [`Admission`]: `Started` for the first
-//! caller (which submits a [`LoadTask`](crate::LoadTask) to the loader pool) or
-//! `AlreadyLoading` for the rest (which just return `LOADING`). When a load
-//! completes, [`InFlightLoads::complete`] clears the key so a later refetch can
-//! proceed if needed.
+//! caller (which performs the backend load) or `AlreadyLoading` for the rest.
+//! An `AlreadyLoading` caller can [`InFlightLoads::wait`] for the leader's load
+//! to finish and then serve from the now-warm cache, so N concurrent misses for
+//! the same block trigger exactly **one** backend fetch. When a load completes,
+//! [`InFlightLoads::complete`] clears the key and wakes all waiters.
 
-use std::collections::HashSet;
-use std::sync::Mutex;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::Notify;
 
 use talon_core::{BlockId, PageIndex};
 
@@ -33,16 +36,21 @@ pub enum LoadKey {
 /// Outcome of trying to admit a demand load.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Admission {
-    /// This caller is the first; it owns submitting the load.
+    /// This caller is the first; it owns performing the load.
     Started,
-    /// A load for this key is already in flight; caller returns `LOADING`.
+    /// A load for this key is already in flight; the caller can [`wait`] for it.
+    ///
+    /// [`wait`]: InFlightLoads::wait
     AlreadyLoading,
 }
 
 /// Tracks demand loads currently in flight to deduplicate concurrent misses.
+///
+/// Each in-flight key carries a [`Notify`] the leader signals on completion, so
+/// followers can await the leader instead of each issuing a redundant fetch.
 #[derive(Default)]
 pub struct InFlightLoads {
-    inner: Mutex<HashSet<LoadKey>>,
+    inner: Mutex<HashMap<LoadKey, Arc<Notify>>>,
 }
 
 impl InFlightLoads {
@@ -57,25 +65,66 @@ impl InFlightLoads {
     /// [`complete`](Self::complete); all overlapping callers get
     /// [`Admission::AlreadyLoading`].
     pub fn admit(&self, key: LoadKey) -> Admission {
+        use std::collections::hash_map::Entry;
         let mut g = self.inner.lock().unwrap();
-        if g.insert(key) {
-            Admission::Started
-        } else {
-            Admission::AlreadyLoading
+        match g.entry(key) {
+            Entry::Occupied(_) => Admission::AlreadyLoading,
+            Entry::Vacant(slot) => {
+                slot.insert(Arc::new(Notify::new()));
+                Admission::Started
+            }
         }
     }
 
-    /// Mark a load complete (success or failure), clearing its key.
+    /// Wait until the in-flight load for `key` completes.
+    ///
+    /// Returns immediately if no load is in flight (it already finished). Uses
+    /// the register-then-recheck pattern so a `complete` racing between the
+    /// lookup and the await cannot cause a missed wakeup.
+    pub async fn wait(&self, key: &LoadKey) {
+        loop {
+            let notify = {
+                let g = self.inner.lock().unwrap();
+                match g.get(key) {
+                    Some(n) => Arc::clone(n),
+                    None => return, // load already completed
+                }
+            };
+            let notified = notify.notified();
+            tokio::pin!(notified);
+            // Register interest before re-checking, so a completion after this
+            // point is guaranteed to wake us.
+            notified.as_mut().enable();
+            // Re-check: if the leader completed between the lookup and enable(),
+            // the key is gone and we must not wait for a signal that won't come.
+            if !self.is_in_flight(key) {
+                return;
+            }
+            notified.await;
+            // Woken; loop to confirm the key is actually gone (guards spurious
+            // wakeups and re-admitted keys).
+        }
+    }
+
+    /// Mark a load complete (success or failure), clearing its key and waking
+    /// any waiters.
     ///
     /// Returns `true` if the key was in flight. After this a subsequent miss for
     /// the same key can start a fresh load.
     pub fn complete(&self, key: &LoadKey) -> bool {
-        self.inner.lock().unwrap().remove(key)
+        let notify = self.inner.lock().unwrap().remove(key);
+        match notify {
+            Some(n) => {
+                n.notify_waiters();
+                true
+            }
+            None => false,
+        }
     }
 
     /// Whether a load for `key` is currently in flight.
     pub fn is_in_flight(&self, key: &LoadKey) -> bool {
-        self.inner.lock().unwrap().contains(key)
+        self.inner.lock().unwrap().contains_key(key)
     }
 
     /// Number of loads currently in flight.
@@ -163,6 +212,40 @@ mod tests {
             Admission::AlreadyLoading
         );
         assert_eq!(f.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn wait_returns_immediately_when_not_in_flight() {
+        let f = InFlightLoads::new();
+        // No load in flight -> wait returns at once.
+        f.wait(&LoadKey::Whole(block(10))).await;
+    }
+
+    #[tokio::test]
+    async fn waiters_wake_on_completion() {
+        use std::sync::Arc;
+        let f = Arc::new(InFlightLoads::new());
+        let key = LoadKey::Whole(block(11));
+        assert_eq!(f.admit(key.clone()), Admission::Started);
+
+        // Spawn several followers that wait for the leader.
+        let mut waiters = Vec::new();
+        for _ in 0..4 {
+            let f = Arc::clone(&f);
+            let key = key.clone();
+            waiters.push(tokio::spawn(async move {
+                f.wait(&key).await;
+                // After waking, the key must be gone.
+                assert!(!f.is_in_flight(&key));
+            }));
+        }
+
+        // Give the waiters a moment to register interest, then complete.
+        tokio::task::yield_now().await;
+        assert!(f.complete(&key));
+        for w in waiters {
+            w.await.unwrap();
+        }
     }
 
     #[test]

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -8,7 +8,9 @@ use talon_core::{
 };
 use talon_transport::data::RangeRequest;
 
-use crate::{BlockIndex, InFlightLoads, LoadKey, Presence, WholeBlockStore, WorkerMetrics};
+use crate::{
+    Admission, BlockIndex, InFlightLoads, LoadKey, Presence, WholeBlockStore, WorkerMetrics,
+};
 
 /// Placeholder source version used until coordinator metadata includes etags.
 const PLACEHOLDER_VERSION: &str = "e2e-v1";
@@ -106,35 +108,85 @@ impl WorkerRuntime {
 
     /// Return the full committed/fetched bytes of a single block, using the
     /// cache-hit path when resident and the backend-miss path otherwise.
+    ///
+    /// Concurrent misses for the same block are deduplicated: the first caller
+    /// (`Admission::Started`) performs the backend fetch; the rest wait for it
+    /// and then serve from the now-warm cache, so N concurrent misses trigger a
+    /// single backend fetch instead of N (issue #113).
     async fn block_bytes(
         &self,
         request: &RangeRequest,
         block: &BlockId,
     ) -> anyhow::Result<bytes::Bytes> {
+        if let Some(bytes) = self.cached_block(block).await? {
+            return Ok(bytes);
+        }
+
+        self.metrics.record_cache_miss();
+        let key = LoadKey::Whole(block.clone());
+        match self.inflight.admit(key.clone()) {
+            Admission::AlreadyLoading => {
+                // A peer is already fetching this block; wait for it and serve
+                // from cache rather than issuing a duplicate backend fetch.
+                self.inflight.wait(&key).await;
+                if let Some(bytes) = self.cached_block(block).await? {
+                    return Ok(bytes);
+                }
+                // The leader's load failed (key cleared, block still absent).
+                // Fall through and fetch ourselves, admitting a fresh load.
+                if self.inflight.admit(key.clone()) == Admission::AlreadyLoading {
+                    // Another peer already restarted; wait once more, then, if
+                    // still absent, fetch without holding admission to avoid an
+                    // unbounded wait loop.
+                    self.inflight.wait(&key).await;
+                    if let Some(bytes) = self.cached_block(block).await? {
+                        return Ok(bytes);
+                    }
+                    return self.fetch_and_commit(request, block).await;
+                }
+                let result = self.fetch_and_commit(request, block).await;
+                self.inflight.complete(&key);
+                result
+            }
+            Admission::Started => {
+                let result = self.fetch_and_commit(request, block).await;
+                self.inflight.complete(&key);
+                result
+            }
+        }
+    }
+
+    /// Return a block's bytes from the local cache if resident, else `None`.
+    async fn cached_block(&self, block: &BlockId) -> anyhow::Result<Option<bytes::Bytes>> {
         if matches!(
             self.index.presence(block, PageIndex(0), PageIndex(1)),
             Presence::Whole
         ) {
             self.metrics.record_cache_hit();
             tracing::info!(block = %block, "HIT");
-            return self
+            let bytes = self
                 .store
                 .get_bytes(block)
                 .await
-                .map_err(|error| anyhow::anyhow!("read committed block: {error}"));
+                .map_err(|error| anyhow::anyhow!("read committed block: {error}"))?;
+            Ok(Some(bytes))
+        } else {
+            Ok(None)
         }
+    }
 
-        self.metrics.record_cache_miss();
+    /// Fetch a block from the backend and commit it to the local cache.
+    async fn fetch_and_commit(
+        &self,
+        request: &RangeRequest,
+        block: &BlockId,
+    ) -> anyhow::Result<bytes::Bytes> {
         tracing::info!(block = %block, "MISS -> backend fetch");
-        let key = LoadKey::Whole(block.clone());
-        let _ = self.inflight.admit(key.clone());
-
         let started = Instant::now();
         let fetched = self
             .backend
             .fetch_range(&request.object, block.offset, self.block_size as u64)
             .await;
-        self.inflight.complete(&key);
         let bytes = match fetched {
             Ok(bytes) => {
                 self.metrics
@@ -372,6 +424,58 @@ mod tests {
         };
         let got = runtime.serve_range(&req).await.unwrap();
         assert_eq!(got, expected(2, 4));
+        assert_eq!(runtime.block_count(), 1);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    /// A backend that counts calls and is slow enough that concurrent misses
+    /// overlap, so the dedup path is actually exercised.
+    struct SlowCountingBackend {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl BackendStore for SlowCountingBackend {
+        async fn fetch_range(&self, _object: &ObjectId, _offset: u64, _len: u64) -> Result<Bytes> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            Ok(Bytes::from_static(b"abcdefgh"))
+        }
+
+        async fn head(&self, _object: &ObjectId) -> Result<ObjectStat> {
+            Ok(ObjectStat {
+                len: 8,
+                version: Version::new("v1"),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_misses_trigger_a_single_backend_fetch() {
+        // Many simultaneous misses for the same block must dedup to one backend
+        // fetch; the followers wait for the leader and serve from cache (#113).
+        let root = tmp_root();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let backend = Arc::new(SlowCountingBackend {
+            calls: Arc::clone(&calls),
+        });
+        let runtime = Arc::new(runtime_with(backend, WorkerMetrics::new(1024), &root, 8));
+
+        let mut tasks = Vec::new();
+        for _ in 0..16 {
+            let runtime = Arc::clone(&runtime);
+            tasks.push(tokio::spawn(async move {
+                runtime.serve_range(&request("ok")).await.unwrap()
+            }));
+        }
+        for t in tasks {
+            assert_eq!(t.await.unwrap(), Bytes::from_static(b"abcd"));
+        }
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "concurrent misses must dedup to one backend fetch"
+        );
         assert_eq!(runtime.block_count(), 1);
         std::fs::remove_dir_all(root).ok();
     }


### PR DESCRIPTION
## Summary
Concurrent misses for the same block each ran a **full backend download** (the `admit()` result was discarded), then **raced on a fixed `<digest>.blk.tmp`** filename, truncating each other into a failed/torn commit.

- **Dedup**: `InFlightLoads` now maps each in-flight key to a `Notify`. The first caller (`Started`) fetches; concurrent callers (`AlreadyLoading`) `wait()` for the leader and serve from the now-warm cache — N misses → **one** backend fetch. `wait()` uses register-then-recheck to avoid a missed wakeup, and falls back to fetching if the leader failed.
- **Staging**: commits write to a per-writer-unique temp (`<digest>.blk.tmp.<pid>.<seq>` via a process-wide atomic), so concurrent writers never share a temp; each renames its own complete file (identical bytes → last rename wins harmlessly), and a failed commit cleans up its temp.

## Testing
16 concurrent misses dedup to one backend fetch; `InFlightLoads` waiters wake on completion / return immediately when idle; 8 concurrent puts of the same block commit full bytes with no leaked `.tmp`. `fmt`/`clippy -D warnings`/`test --all-features` clean.

Closes #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)