### PR TITLE
fix(backend): fail on missing ETag in HEAD instead of an empty version

### DIFF
--- a/crates/talon-backend/src/azure.rs
+++ b/crates/talon-backend/src/azure.rs
@@ -153,7 +153,13 @@ impl BackendStore for AzureBackend {
         let version = resp
             .header("etag")
             .map(|v| Version::new(v.trim_matches('"').to_string()))
-            .unwrap_or_else(|| Version::new(""));
+            .filter(|v| !v.0.trim().is_empty())
+            .ok_or_else(|| {
+                Error::Backend(format!(
+                    "Azure HEAD {} returned no ETag; refusing to cache without a version",
+                    obj.to_path()
+                ))
+            })?;
         Ok(ObjectStat { len, version })
     }
 }

--- a/crates/talon-backend/src/gcs.rs
+++ b/crates/talon-backend/src/gcs.rs
@@ -141,7 +141,13 @@ impl BackendStore for GcsBackend {
             .header("x-goog-generation")
             .or_else(|| resp.header("etag"))
             .map(|v| Version::new(v.trim_matches('"').to_string()))
-            .unwrap_or_else(|| Version::new(""));
+            .filter(|v| !v.0.trim().is_empty())
+            .ok_or_else(|| {
+                Error::Backend(format!(
+                    "GCS HEAD {} returned no generation/ETag; refusing to cache without a version",
+                    obj.to_path()
+                ))
+            })?;
         Ok(ObjectStat { len, version })
     }
 }

--- a/crates/talon-backend/src/s3.rs
+++ b/crates/talon-backend/src/s3.rs
@@ -172,7 +172,13 @@ impl BackendStore for S3Backend {
         let version = resp
             .header("etag")
             .map(etag_to_version)
-            .unwrap_or_else(|| Version::new(""));
+            .filter(|v| !v.0.trim().is_empty())
+            .ok_or_else(|| {
+                Error::Backend(format!(
+                    "S3 HEAD {} returned no usable ETag; refusing to cache without a version",
+                    obj.to_path()
+                ))
+            })?;
         Ok(ObjectStat { len, version })
     }
 }
@@ -317,6 +323,31 @@ mod tests {
         let http = MockHttp::new(HttpResponse {
             status: 200,
             headers: vec![("ETag".into(), "\"x\"".into())],
+            body: bytes::Bytes::new(),
+        });
+        let s3 = S3Backend::new(S3Config::aws("us-east-1"), creds(), http);
+        assert!(matches!(s3.head(&obj()).await, Err(Error::Backend(_))));
+    }
+
+    #[tokio::test]
+    async fn head_missing_or_empty_etag_errors_not_empty_version() {
+        // No ETag at all -> error (an empty version would collapse all object
+        // generations onto one cache key and serve stale data, issue #160).
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![("Content-Length".into(), "4096".into())],
+            body: bytes::Bytes::new(),
+        });
+        let s3 = S3Backend::new(S3Config::aws("us-east-1"), creds(), http.clone());
+        assert!(matches!(s3.head(&obj()).await, Err(Error::Backend(_))));
+
+        // A present-but-empty ETag is likewise refused.
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![
+                ("Content-Length".into(), "4096".into()),
+                ("ETag".into(), "\"\"".into()),
+            ],
             body: bytes::Bytes::new(),
         });
         let s3 = S3Backend::new(S3Config::aws("us-east-1"), creds(), http);


### PR DESCRIPTION
## Summary
When a HEAD omitted the version header (ETag / `x-goog-generation`), S3/GCS/Azure fell back to `Version::new("")`. Since `version` is part of `BlockId` identity, an empty version collapsed **all generations of an object onto one cache key** → overwrite served stale forever, defeating #119.

All three `head()` now return `Error::Backend` when the version header is missing **or present-but-empty** (e.g. `ETag: ""`), instead of manufacturing an empty version that becomes a live cache key.

## Testing
S3 HEAD with no ETag and with an empty ETag both error. `fmt`/`clippy -D warnings`/`test` clean.

Closes #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)