### PR TITLE
fix(backend): accept an object-end short 206 and validate Content-Range

### DIFF
--- a/crates/talon-backend/src/azure.rs
+++ b/crates/talon-backend/src/azure.rs
@@ -120,7 +120,15 @@ impl BackendStore for AzureBackend {
             .map_err(Error::Backend)?;
         match resp.status {
             200 | 206 => {
-                crate::http::range_body(resp.status, resp.body, offset, len).map_err(Error::Backend)
+                let content_range = resp.header("content-range").map(str::to_owned);
+                crate::http::range_body(
+                    resp.status,
+                    resp.body,
+                    offset,
+                    len,
+                    content_range.as_deref(),
+                )
+                .map_err(Error::Backend)
             }
             404 => Err(Error::NotFound(obj.to_path())),
             s => Err(Error::Backend(format!(

--- a/crates/talon-backend/src/gcs.rs
+++ b/crates/talon-backend/src/gcs.rs
@@ -106,7 +106,15 @@ impl BackendStore for GcsBackend {
             .map_err(Error::Backend)?;
         match resp.status {
             200 | 206 => {
-                crate::http::range_body(resp.status, resp.body, offset, len).map_err(Error::Backend)
+                let content_range = resp.header("content-range").map(str::to_owned);
+                crate::http::range_body(
+                    resp.status,
+                    resp.body,
+                    offset,
+                    len,
+                    content_range.as_deref(),
+                )
+                .map_err(Error::Backend)
             }
             404 => Err(Error::NotFound(obj.to_path())),
             s => Err(Error::Backend(format!(
@@ -205,11 +213,11 @@ mod tests {
         let http = MockHttp::new(HttpResponse {
             status: 206,
             headers: vec![],
-            body: bytes::Bytes::from_static(b"gcs-bytes"),
+            body: bytes::Bytes::from_static(b"gcsby"),
         });
         let g = GcsBackend::new(GcsConfig::default(), Some("tok".into()), http.clone());
         let got = g.fetch_range(&obj(), 4, 5).await.unwrap();
-        assert_eq!(got, bytes::Bytes::from_static(b"gcs-bytes"));
+        assert_eq!(got, bytes::Bytes::from_static(b"gcsby"));
         let req = http.last.lock().unwrap().clone().unwrap();
         assert_eq!(req.header("Authorization"), Some("Bearer tok"));
         assert_eq!(req.header("Range"), Some("bytes=4-8"));

--- a/crates/talon-backend/src/http.rs
+++ b/crates/talon-backend/src/http.rs
@@ -66,19 +66,21 @@ impl HttpResponse {
 }
 
 /// Extract the bytes for a ranged GET of `[offset, offset+len)` from a response,
-/// correcting for servers that ignore the `Range` header (issue #117).
+/// correcting for servers that ignore the `Range` header (issues #117, #161).
 ///
-/// - **206 Partial Content**: the body already *is* the requested range. We
-///   accept it but still verify its length matches `len` (a 206 with a short
-///   body would otherwise be cached as correct); a mismatch is an error.
+/// - **206 Partial Content**: the body is the requested range. `content_range`
+///   (the `Content-Range` header, if any) is validated to start at `offset`, so
+///   a server that returns 206 but ignores the offset is rejected. A body whose
+///   length equals `len` is accepted; a *longer* body is rejected. A *shorter*
+///   body is accepted only when `Content-Range` shows it is the tail of the
+///   object (`end == total-1` and `offset+got == total`) — i.e. the requested
+///   range legitimately ran past EOF (the last block of an object whose size is
+///   not a multiple of the block size). Without that evidence a short 206 is a
+///   truncated read and is rejected.
 /// - **200 OK**: the server ignored `Range` and returned the **whole object**.
-///   A proxy or non-compliant S3 store does this. Naively caching that body
-///   under the block's `BlockId` (then slicing at `offset_in_block`) serves the
-///   *head* of the object for every non-zero-offset block. Instead we slice the
-///   full-object body at `[offset, offset+len)` so the caller always receives
-///   exactly the requested range. If the body is shorter than `offset` the
-///   requested range lies past EOF and yields empty; the final block is clamped
-///   to whatever remains.
+///   We slice the full body at `[offset, offset+len)` (clamped at EOF) so the
+///   caller always receives exactly the requested window rather than the object
+///   head.
 ///
 /// Any other status is the caller's responsibility (404/errors handled there);
 /// this is only invoked for 200/206.
@@ -87,18 +89,54 @@ pub fn range_body(
     body: bytes::Bytes,
     offset: u64,
     len: u64,
+    content_range: Option<&str>,
 ) -> Result<bytes::Bytes, String> {
     match status {
         206 => {
-            // Trust the server's partial content, but reject a short partial:
-            // caching fewer bytes than requested as a "hit" is silent corruption.
-            if (body.len() as u64) < len {
+            // If the server sent Content-Range, verify it starts at the offset
+            // we asked for. A server that returns 206 but ignores the offset
+            // (bytes [0,len) instead of [offset,offset+len)) would otherwise be
+            // cached as the requested window — silent corruption.
+            let parsed = content_range.map(parse_content_range).transpose()?;
+            if let Some(ContentRange { start, .. }) = parsed {
+                if start != offset {
+                    return Err(format!(
+                        "ranged GET returned 206 Content-Range starting at {start}, expected {offset}"
+                    ));
+                }
+            }
+            let got = body.len() as u64;
+            if got == len {
+                return Ok(body);
+            }
+            if got > len {
+                // More bytes than requested — the server misbehaved; trimming
+                // could hide a range mismatch, so reject rather than guess.
                 return Err(format!(
-                    "ranged GET returned 206 with {} bytes, expected {len}",
-                    body.len()
+                    "ranged GET returned 206 with {got} bytes, more than the requested {len}"
                 ));
             }
-            Ok(body)
+            // Short body: acceptable only if it is the tail of the object (the
+            // requested range legitimately extends past EOF, e.g. the last block
+            // of an object whose size is not a multiple of the block size). We
+            // trust that when Content-Range reports the response reaches the last
+            // byte of the object (end == total-1). Without Content-Range we
+            // cannot distinguish EOF from a truncated read, so reject.
+            match parsed {
+                Some(ContentRange {
+                    end,
+                    total: Some(total),
+                    ..
+                }) if end.checked_add(1) == Some(total)
+                    && offset.checked_add(got) == Some(total) =>
+                {
+                    Ok(body)
+                }
+                _ => Err(format!(
+                    "ranged GET returned 206 with {got} bytes, expected {len} \
+                     (not an object-end short read)"
+                )),
+            }
         }
         200 => {
             // Whole object returned; slice out the requested window.
@@ -114,6 +152,33 @@ pub fn range_body(
         }
         other => Err(format!("range_body called with unexpected status {other}")),
     }
+}
+
+/// A parsed `Content-Range: bytes <start>-<end>/<total>` header (RFC 7233).
+struct ContentRange {
+    start: u64,
+    end: u64,
+    /// The object's total length, or `None` if the server sent `*`.
+    total: Option<u64>,
+}
+
+/// Parse a `Content-Range` response header value. Accepts `bytes 0-99/1234` and
+/// `bytes 0-99/*`; rejects anything else.
+fn parse_content_range(value: &str) -> Result<ContentRange, String> {
+    let malformed = || format!("malformed Content-Range: {value:?}");
+    let rest = value.trim().strip_prefix("bytes ").ok_or_else(malformed)?;
+    let (range, total) = rest.split_once('/').ok_or_else(malformed)?;
+    let (start, end) = range.split_once('-').ok_or_else(malformed)?;
+    let start = start.trim().parse::<u64>().map_err(|_| malformed())?;
+    let end = end.trim().parse::<u64>().map_err(|_| malformed())?;
+    if end < start {
+        return Err(malformed());
+    }
+    let total = match total.trim() {
+        "*" => None,
+        t => Some(t.parse::<u64>().map_err(|_| malformed())?),
+    };
+    Ok(ContentRange { start, end, total })
 }
 
 /// An async HTTP transport a backend uses to talk to its origin store.
@@ -132,16 +197,69 @@ mod tests {
     #[test]
     fn partial_206_is_trusted_when_full_length() {
         let body = Bytes::from(vec![7u8; 100]);
-        let out = range_body(206, body.clone(), 256, 100).unwrap();
+        let out = range_body(206, body.clone(), 256, 100, None).unwrap();
         assert_eq!(out, body);
     }
 
     #[test]
-    fn short_206_is_rejected() {
-        // A 206 that returned fewer bytes than requested must not be cached as a
-        // correct block.
+    fn short_206_without_content_range_is_rejected() {
+        // A 206 shorter than requested, with no Content-Range to prove it's the
+        // object tail, is a truncated read and must be rejected.
         let body = Bytes::from(vec![7u8; 50]);
-        assert!(range_body(206, body, 0, 100).is_err());
+        assert!(range_body(206, body, 0, 100, None).is_err());
+    }
+
+    #[test]
+    fn short_206_at_object_end_is_accepted() {
+        // Last block of a 300-byte object: request [256, 512) (len 256) but only
+        // 44 bytes remain. A compliant server answers 206 with Content-Range
+        // bytes 256-299/300 and 44 bytes — this must be accepted, not rejected
+        // (issue #161: previously the last block of every non-aligned object
+        // failed on range-honoring stores).
+        let body = Bytes::from(vec![9u8; 44]);
+        let out = range_body(206, body.clone(), 256, 256, Some("bytes 256-299/300")).unwrap();
+        assert_eq!(out, body);
+    }
+
+    #[test]
+    fn short_206_not_at_object_end_is_rejected() {
+        // A short 206 whose Content-Range does NOT reach the object end is a
+        // genuine truncated read.
+        let body = Bytes::from(vec![9u8; 50]);
+        assert!(range_body(206, body, 0, 100, Some("bytes 0-49/1000")).is_err());
+    }
+
+    #[test]
+    fn over_long_206_is_rejected() {
+        let body = Bytes::from(vec![9u8; 150]);
+        assert!(range_body(206, body, 0, 100, Some("bytes 0-149/1000")).is_err());
+    }
+
+    #[test]
+    fn offset_ignoring_206_is_rejected() {
+        // Server returned 206 but the range starts at 0, not the requested 256.
+        let body = Bytes::from(vec![9u8; 100]);
+        assert!(range_body(206, body, 256, 100, Some("bytes 0-99/1000")).is_err());
+    }
+
+    #[test]
+    fn honored_206_with_matching_content_range_is_accepted() {
+        let body = Bytes::from(vec![9u8; 100]);
+        let out = range_body(206, body.clone(), 256, 100, Some("bytes 256-355/1000")).unwrap();
+        assert_eq!(out, body);
+    }
+
+    #[test]
+    fn malformed_content_range_is_rejected() {
+        let body = Bytes::from(vec![9u8; 100]);
+        assert!(range_body(206, body, 256, 100, Some("garbage")).is_err());
+    }
+
+    #[test]
+    fn content_range_with_unknown_total_short_read_is_rejected() {
+        // total == "*" means we can't prove EOF, so a short body is rejected.
+        let body = Bytes::from(vec![9u8; 50]);
+        assert!(range_body(206, body, 0, 100, Some("bytes 0-49/*")).is_err());
     }
 
     #[test]
@@ -150,7 +268,7 @@ mod tests {
         // for [100, 200) must yield bytes 100..200, not the object head.
         let object: Vec<u8> = (0..255u8).cycle().take(300).collect();
         let body = Bytes::from(object.clone());
-        let out = range_body(200, body, 100, 100).unwrap();
+        let out = range_body(200, body, 100, 100, None).unwrap();
         assert_eq!(out.len(), 100);
         assert_eq!(&out[..], &object[100..200]);
     }
@@ -160,14 +278,14 @@ mod tests {
         // Requested window runs past the object end; return what remains.
         let object: Vec<u8> = (0..255u8).cycle().take(300).collect();
         let body = Bytes::from(object.clone());
-        let out = range_body(200, body, 256, 256).unwrap();
+        let out = range_body(200, body, 256, 256, None).unwrap();
         assert_eq!(&out[..], &object[256..300]);
     }
 
     #[test]
     fn whole_object_200_offset_past_eof_is_empty() {
         let body = Bytes::from(vec![1u8; 100]);
-        let out = range_body(200, body, 500, 100).unwrap();
+        let out = range_body(200, body, 500, 100, None).unwrap();
         assert!(out.is_empty());
     }
 }

--- a/crates/talon-backend/src/s3.rs
+++ b/crates/talon-backend/src/s3.rs
@@ -138,9 +138,18 @@ impl BackendStore for S3Backend {
         let resp = self.http.execute(req).await.map_err(Error::Backend)?;
         // 206 (range honored) or 200 (server ignored Range, returned the whole
         // object). `range_body` yields exactly the requested window in both
-        // cases and rejects a short 206 (issue #117).
+        // cases, validates the 206 Content-Range, and accepts an object-end
+        // short 206 (issues #117, #161).
         if resp.status == 206 || resp.status == 200 {
-            crate::http::range_body(resp.status, resp.body, offset, len).map_err(Error::Backend)
+            let content_range = resp.header("content-range").map(str::to_owned);
+            crate::http::range_body(
+                resp.status,
+                resp.body,
+                offset,
+                len,
+                content_range.as_deref(),
+            )
+            .map_err(Error::Backend)
         } else if resp.status == 404 {
             Err(Error::NotFound(obj.to_path()))
         } else {


### PR DESCRIPTION
## Summary
`range_body`'s 206 branch rejected any body shorter than `len` as corruption — the inverse of the 200 branch which clamps past-EOF reads. The worker requests block-aligned ranges, so the **last block of every non-block-aligned object** has a `len` past EOF; a compliant 206 store returns just the tail, which `range_body` then rejected. Result: correct (206) stores failed every object's last block, while broken range-ignoring (200) proxies succeeded.

`range_body` now takes the `Content-Range` header:
- 206 `== len` → accept; `> len` → reject; `< len` → accept **only** if `Content-Range` proves the object tail (`end==total-1 && offset+got==total`), else reject as truncated (no/unknown Content-Range → reject).
- 206 whose `Content-Range` start ≠ requested offset → reject (closes an offset-ignoring-proxy corruption gap).
- 200 slicing unchanged. Parsing is overflow-safe.

## Testing
9 `range_body` cases (EOF-short accepted; not-at-EOF / over-long / offset-ignoring / malformed / unknown-total rejected; honored accepted; 200 slicing preserved). `fmt`/`clippy -D warnings`/`test --all-features`/`doc` clean.

Closes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)