### PR TITLE
fix(worker): release in-flight dedup marker via RAII guard

### DIFF
--- a/crates/talon-worker/src/lib.rs
+++ b/crates/talon-worker/src/lib.rs
@@ -24,7 +24,7 @@ pub use eviction::{CacheUnit, Lru};
 pub use index::{BlockIndex, Presence};
 pub use loader::{LoadOutcome, LoadTask, LoaderPool};
 pub use memory_store::MemoryStore;
-pub use miss::{touched_pages, Admission, InFlightLoads, LoadKey};
+pub use miss::{touched_pages, Admission, InFlightGuard, InFlightLoads, LoadKey};
 pub use observability::{serve_admin, WorkerMetrics, WorkerObservability, WorkerReadiness};
 pub use paged_store::PagedBlockStore;
 pub use runtime::WorkerRuntime;

--- a/crates/talon-worker/src/miss.rs
+++ b/crates/talon-worker/src/miss.rs
@@ -16,6 +16,10 @@
 //! to finish and then serve from the now-warm cache, so N concurrent misses for
 //! the same block trigger exactly **one** backend fetch. When a load completes,
 //! [`InFlightLoads::complete`] clears the key and wakes all waiters.
+//!
+//! Prefer [`InFlightLoads::admit_owned`], which hands the leader an
+//! [`InFlightGuard`] that clears the marker on drop — so a cancelled or
+//! panicking leader can never orphan the key and hang the waiters (#162).
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -72,6 +76,30 @@ impl InFlightLoads {
             Entry::Vacant(slot) => {
                 slot.insert(Arc::new(Notify::new()));
                 Admission::Started
+            }
+        }
+    }
+
+    /// Like [`admit`](Self::admit) but, when this caller becomes the leader,
+    /// returns an RAII [`InFlightGuard`] that calls [`complete`](Self::complete)
+    /// on drop.
+    ///
+    /// This is cancellation- and panic-safe: if the leader's fetch task is
+    /// dropped (client disconnect) or panics, the guard's `Drop` still clears
+    /// the in-flight marker and wakes waiters, so a followers' [`wait`] can never
+    /// hang forever on an orphaned key (issue #162). `None` means a load is
+    /// already in flight (the caller should [`wait`](Self::wait)).
+    pub fn admit_owned(self: &Arc<Self>, key: LoadKey) -> Option<InFlightGuard> {
+        use std::collections::hash_map::Entry;
+        let mut g = self.inner.lock().unwrap();
+        match g.entry(key.clone()) {
+            Entry::Occupied(_) => None,
+            Entry::Vacant(slot) => {
+                slot.insert(Arc::new(Notify::new()));
+                Some(InFlightGuard {
+                    inflight: Arc::clone(self),
+                    key: Some(key),
+                })
             }
         }
     }
@@ -135,6 +163,24 @@ impl InFlightLoads {
     /// Whether no loads are in flight.
     pub fn is_empty(&self) -> bool {
         self.inner.lock().unwrap().is_empty()
+    }
+}
+
+/// RAII marker for an in-flight load owned by the leader caller.
+///
+/// Dropping the guard calls [`InFlightLoads::complete`], clearing the key and
+/// waking any waiters — even if the owning task is cancelled or panics — so an
+/// interrupted fetch can never orphan the key and hang future readers (#162).
+pub struct InFlightGuard {
+    inflight: Arc<InFlightLoads>,
+    key: Option<LoadKey>,
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        if let Some(key) = self.key.take() {
+            self.inflight.complete(&key);
+        }
     }
 }
 
@@ -246,6 +292,42 @@ mod tests {
         for w in waiters {
             w.await.unwrap();
         }
+    }
+
+    #[tokio::test]
+    async fn guard_drop_clears_marker_and_wakes_waiters() {
+        // The RAII guard must clear the in-flight key and wake waiters when it is
+        // dropped WITHOUT an explicit complete() -- e.g. the leader task was
+        // cancelled or panicked mid-fetch (issue #162). Otherwise waiters hang
+        // forever on an orphaned key.
+        use std::sync::Arc;
+        let f = Arc::new(InFlightLoads::new());
+        let key = LoadKey::Whole(block(12));
+        let guard = f
+            .admit_owned(key.clone())
+            .expect("first caller is the leader");
+        // A second caller is not the leader.
+        assert!(f.admit_owned(key.clone()).is_none());
+        assert!(f.is_in_flight(&key));
+
+        let waiter = {
+            let f = Arc::clone(&f);
+            let key = key.clone();
+            tokio::spawn(async move {
+                f.wait(&key).await;
+                assert!(!f.is_in_flight(&key));
+            })
+        };
+        tokio::task::yield_now().await;
+
+        // Simulate the leader being dropped (cancellation/panic) with no explicit
+        // complete(): the guard's Drop must release the marker and wake waiters.
+        drop(guard);
+        assert!(!f.is_in_flight(&key));
+        waiter.await.unwrap();
+
+        // After release a fresh caller can become the leader again.
+        assert!(f.admit_owned(key).is_some());
     }
 
     #[test]

--- a/crates/talon-worker/src/miss.rs
+++ b/crates/talon-worker/src/miss.rs
@@ -86,9 +86,10 @@ impl InFlightLoads {
     ///
     /// This is cancellation- and panic-safe: if the leader's fetch task is
     /// dropped (client disconnect) or panics, the guard's `Drop` still clears
-    /// the in-flight marker and wakes waiters, so a followers' [`wait`] can never
-    /// hang forever on an orphaned key (issue #162). `None` means a load is
-    /// already in flight (the caller should [`wait`](Self::wait)).
+    /// the in-flight marker and wakes waiters, so a follower's
+    /// [`wait`](Self::wait) can never hang forever on an orphaned key (issue
+    /// #162). `None` means a load is already in flight (the caller should
+    /// [`wait`](Self::wait)).
     pub fn admit_owned(self: &Arc<Self>, key: LoadKey) -> Option<InFlightGuard> {
         use std::collections::hash_map::Entry;
         let mut g = self.inner.lock().unwrap();

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -8,9 +8,7 @@ use talon_core::{
 };
 use talon_transport::data::RangeRequest;
 
-use crate::{
-    Admission, BlockIndex, InFlightLoads, LoadKey, Presence, WholeBlockStore, WorkerMetrics,
-};
+use crate::{BlockIndex, InFlightLoads, LoadKey, Presence, WholeBlockStore, WorkerMetrics};
 
 /// Shared state required to serve instrumented data-plane range requests.
 pub struct WorkerRuntime {
@@ -134,9 +132,11 @@ impl WorkerRuntime {
     /// cache-hit path when resident and the backend-miss path otherwise.
     ///
     /// Concurrent misses for the same block are deduplicated: the first caller
-    /// (`Admission::Started`) performs the backend fetch; the rest wait for it
-    /// and then serve from the now-warm cache, so N concurrent misses trigger a
-    /// single backend fetch instead of N (issue #113).
+    /// (the leader, holding an `InFlightGuard`) performs the backend fetch; the
+    /// rest wait for it and then serve from the now-warm cache, so N concurrent
+    /// misses trigger a single backend fetch instead of N (issue #113). The
+    /// guard clears the in-flight marker on drop, so a cancelled or panicking
+    /// leader can never orphan the key and hang the waiters (issue #162).
     async fn block_bytes(
         &self,
         request: &RangeRequest,
@@ -148,34 +148,40 @@ impl WorkerRuntime {
 
         self.metrics.record_cache_miss();
         let key = LoadKey::Whole(block.clone());
-        match self.inflight.admit(key.clone()) {
-            Admission::AlreadyLoading => {
+        match self.inflight.admit_owned(key.clone()) {
+            Some(guard) => {
+                // Leader: fetch and commit; the guard wakes waiters on drop
+                // (including on cancellation/panic).
+                let result = self.fetch_and_commit(request, block).await;
+                drop(guard);
+                result
+            }
+            None => {
                 // A peer is already fetching this block; wait for it and serve
                 // from cache rather than issuing a duplicate backend fetch.
                 self.inflight.wait(&key).await;
                 if let Some(bytes) = self.cached_block(block).await? {
                     return Ok(bytes);
                 }
-                // The leader's load failed (key cleared, block still absent).
-                // Fall through and fetch ourselves, admitting a fresh load.
-                if self.inflight.admit(key.clone()) == Admission::AlreadyLoading {
-                    // Another peer already restarted; wait once more, then, if
-                    // still absent, fetch without holding admission to avoid an
-                    // unbounded wait loop.
-                    self.inflight.wait(&key).await;
-                    if let Some(bytes) = self.cached_block(block).await? {
-                        return Ok(bytes);
+                // The leader's load failed (marker cleared, block still absent).
+                // Try to become the leader ourselves.
+                match self.inflight.admit_owned(key.clone()) {
+                    Some(guard) => {
+                        let result = self.fetch_and_commit(request, block).await;
+                        drop(guard);
+                        result
                     }
-                    return self.fetch_and_commit(request, block).await;
+                    None => {
+                        // Another peer already restarted the load; wait once
+                        // more, then, if still absent, fetch without holding
+                        // admission to avoid an unbounded wait loop.
+                        self.inflight.wait(&key).await;
+                        if let Some(bytes) = self.cached_block(block).await? {
+                            return Ok(bytes);
+                        }
+                        self.fetch_and_commit(request, block).await
+                    }
                 }
-                let result = self.fetch_and_commit(request, block).await;
-                self.inflight.complete(&key);
-                result
-            }
-            Admission::Started => {
-                let result = self.fetch_and_commit(request, block).await;
-                self.inflight.complete(&key);
-                result
             }
         }
     }


### PR DESCRIPTION
## Summary
The concurrent-miss dedup cleared its marker with a bare `complete(&key)` **after** the fetch await. If the leader task was cancelled (client disconnect mid-fetch) or panicked, `complete()` never ran → the key stayed in `InFlightLoads` forever and every subsequent reader of that block waited on a `Notify` that never fired: a permanent hang plus a leaked entry.

New `InFlightLoads::admit_owned` returns an RAII `InFlightGuard` when this caller is the leader; the guard's `Drop` calls `complete()`, clearing the key and waking waiters even on cancellation/panic. `block_bytes` now uses it instead of `admit` + trailing `complete()`. Dedup behavior (N misses → one fetch) unchanged.

## Testing
A leader guard dropped without an explicit `complete()` (simulating cancellation/panic) releases the marker and wakes a waiting follower; a fresh caller can then become leader. Existing dedup/wait tests still pass. `fmt`/`clippy -D warnings`/`test --all-features`/`doc` clean.

Closes #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)