### PR TITLE
fix(worker): cache resolved version and send If-Match on miss GET

### DIFF
--- a/crates/talon-backend/src/azure.rs
+++ b/crates/talon-backend/src/azure.rs
@@ -88,8 +88,26 @@ impl AzureBackend {
 
     /// Build the ranged GET request (exposed for testing).
     pub fn build_get(&self, obj: &ObjectId, offset: u64, len: u64) -> HttpRequest {
+        self.build_get_if_match(obj, offset, len, None)
+    }
+
+    /// Build the ranged GET request with an optional `If-Match` precondition.
+    ///
+    /// When set, Azure returns `412 Precondition Failed` if the blob's ETag no
+    /// longer matches, i.e. it was overwritten since the version was resolved
+    /// (issue #163).
+    pub fn build_get_if_match(
+        &self,
+        obj: &ObjectId,
+        offset: u64,
+        len: u64,
+        if_match: Option<&Version>,
+    ) -> HttpRequest {
         let mut headers = self.common_headers();
         headers.push(("x-ms-range".to_string(), Self::range_header(offset, len)));
+        if let Some(version) = if_match {
+            headers.push(("If-Match".to_string(), format!("\"{}\"", version.as_str())));
+        }
         HttpRequest {
             method: Method::Get,
             url: self.blob_url(obj),
@@ -110,12 +128,22 @@ impl AzureBackend {
 #[async_trait]
 impl BackendStore for AzureBackend {
     async fn fetch_range(&self, obj: &ObjectId, offset: u64, len: u64) -> Result<bytes::Bytes> {
+        self.fetch_range_if_match(obj, offset, len, None).await
+    }
+
+    async fn fetch_range_if_match(
+        &self,
+        obj: &ObjectId,
+        offset: u64,
+        len: u64,
+        if_match: Option<&Version>,
+    ) -> Result<bytes::Bytes> {
         if len == 0 {
             return Ok(bytes::Bytes::new());
         }
         let resp = self
             .http
-            .execute(self.build_get(obj, offset, len))
+            .execute(self.build_get_if_match(obj, offset, len, if_match))
             .await
             .map_err(Error::Backend)?;
         match resp.status {
@@ -131,6 +159,15 @@ impl BackendStore for AzureBackend {
                 .map_err(Error::Backend)
             }
             404 => Err(Error::NotFound(obj.to_path())),
+            // Precondition failed: the blob changed since the version was
+            // resolved (issue #163). Report the new ETag if present.
+            412 => Err(Error::VersionMismatch {
+                expected: if_match.map(|v| v.0.clone()).unwrap_or_default(),
+                found: resp
+                    .header("etag")
+                    .map(|e| e.trim_matches('"').to_string())
+                    .unwrap_or_default(),
+            }),
             s => Err(Error::Backend(format!(
                 "Azure GET {} -> HTTP {s}",
                 obj.to_path()
@@ -242,6 +279,42 @@ mod tests {
         let req = http.last.lock().unwrap().clone().unwrap();
         assert_eq!(req.header("x-ms-range"), Some("bytes=8-15"));
         assert_eq!(req.header("x-ms-version"), Some("2021-12-02"));
+    }
+
+    #[tokio::test]
+    async fn fetch_range_if_match_sends_quoted_precondition() {
+        let http = MockHttp::new(HttpResponse {
+            status: 206,
+            headers: vec![],
+            body: bytes::Bytes::from_static(b"az-bytes"),
+        });
+        let a = AzureBackend::new(AzureConfig::new("acct"), None, http.clone());
+        let _ = a
+            .fetch_range_if_match(&obj(), 8, 8, Some(&Version::new("0x8DABCDEF")))
+            .await
+            .unwrap();
+        let req = http.last.lock().unwrap().clone().unwrap();
+        assert_eq!(req.header("If-Match"), Some("\"0x8DABCDEF\""));
+    }
+
+    #[tokio::test]
+    async fn fetch_range_maps_412_to_version_mismatch() {
+        let http = MockHttp::new(HttpResponse {
+            status: 412,
+            headers: vec![("ETag".into(), "\"0xNEW\"".into())],
+            body: bytes::Bytes::new(),
+        });
+        let a = AzureBackend::new(AzureConfig::new("acct"), None, http);
+        match a
+            .fetch_range_if_match(&obj(), 0, 8, Some(&Version::new("0xOLD")))
+            .await
+        {
+            Err(Error::VersionMismatch { expected, found }) => {
+                assert_eq!(expected, "0xOLD");
+                assert_eq!(found, "0xNEW");
+            }
+            other => panic!("expected VersionMismatch, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/talon-backend/src/gcs.rs
+++ b/crates/talon-backend/src/gcs.rs
@@ -74,8 +74,32 @@ impl GcsBackend {
 
     /// Build the ranged GET request (exposed for testing).
     pub fn build_get(&self, obj: &ObjectId, offset: u64, len: u64) -> HttpRequest {
+        self.build_get_if_match(obj, offset, len, None)
+    }
+
+    /// Build the ranged GET request with an optional generation/ETag precondition.
+    ///
+    /// A numeric version is treated as an object generation and sent as
+    /// `x-goog-if-generation-match`; a non-numeric version (ETag fallback) is
+    /// sent as `If-Match`. Either makes GCS return `412` if the object changed
+    /// since the version was resolved (issue #163).
+    pub fn build_get_if_match(
+        &self,
+        obj: &ObjectId,
+        offset: u64,
+        len: u64,
+        if_match: Option<&Version>,
+    ) -> HttpRequest {
         let mut headers = self.auth_headers();
         headers.push(("Range".to_string(), Self::range_header(offset, len)));
+        if let Some(version) = if_match {
+            let v = version.as_str();
+            if !v.is_empty() && v.bytes().all(|b| b.is_ascii_digit()) {
+                headers.push(("x-goog-if-generation-match".to_string(), v.to_string()));
+            } else {
+                headers.push(("If-Match".to_string(), format!("\"{v}\"")));
+            }
+        }
         HttpRequest {
             method: Method::Get,
             url: self.object_url(obj),
@@ -96,12 +120,22 @@ impl GcsBackend {
 #[async_trait]
 impl BackendStore for GcsBackend {
     async fn fetch_range(&self, obj: &ObjectId, offset: u64, len: u64) -> Result<bytes::Bytes> {
+        self.fetch_range_if_match(obj, offset, len, None).await
+    }
+
+    async fn fetch_range_if_match(
+        &self,
+        obj: &ObjectId,
+        offset: u64,
+        len: u64,
+        if_match: Option<&Version>,
+    ) -> Result<bytes::Bytes> {
         if len == 0 {
             return Ok(bytes::Bytes::new());
         }
         let resp = self
             .http
-            .execute(self.build_get(obj, offset, len))
+            .execute(self.build_get_if_match(obj, offset, len, if_match))
             .await
             .map_err(Error::Backend)?;
         match resp.status {
@@ -117,6 +151,16 @@ impl BackendStore for GcsBackend {
                 .map_err(Error::Backend)
             }
             404 => Err(Error::NotFound(obj.to_path())),
+            // Precondition failed: the object changed since the version was
+            // resolved (issue #163). Report the new generation/ETag if present.
+            412 => Err(Error::VersionMismatch {
+                expected: if_match.map(|v| v.0.clone()).unwrap_or_default(),
+                found: resp
+                    .header("x-goog-generation")
+                    .or_else(|| resp.header("etag"))
+                    .map(|e| e.trim_matches('"').to_string())
+                    .unwrap_or_default(),
+            }),
             s => Err(Error::Backend(format!(
                 "GCS GET {} -> HTTP {s}",
                 obj.to_path()
@@ -221,6 +265,61 @@ mod tests {
         let req = http.last.lock().unwrap().clone().unwrap();
         assert_eq!(req.header("Authorization"), Some("Bearer tok"));
         assert_eq!(req.header("Range"), Some("bytes=4-8"));
+    }
+
+    #[tokio::test]
+    async fn fetch_range_if_match_numeric_uses_generation_precondition() {
+        let http = MockHttp::new(HttpResponse {
+            status: 206,
+            headers: vec![],
+            body: bytes::Bytes::from_static(b"gcsby"),
+        });
+        let g = GcsBackend::new(GcsConfig::default(), Some("tok".into()), http.clone());
+        let _ = g
+            .fetch_range_if_match(&obj(), 4, 5, Some(&Version::new("1699999999")))
+            .await
+            .unwrap();
+        let req = http.last.lock().unwrap().clone().unwrap();
+        // A numeric version is an object generation.
+        assert_eq!(req.header("x-goog-if-generation-match"), Some("1699999999"));
+        assert_eq!(req.header("If-Match"), None);
+    }
+
+    #[tokio::test]
+    async fn fetch_range_if_match_nonnumeric_uses_if_match() {
+        let http = MockHttp::new(HttpResponse {
+            status: 206,
+            headers: vec![],
+            body: bytes::Bytes::from_static(b"gcsby"),
+        });
+        let g = GcsBackend::new(GcsConfig::default(), None, http.clone());
+        let _ = g
+            .fetch_range_if_match(&obj(), 4, 5, Some(&Version::new("etagxyz")))
+            .await
+            .unwrap();
+        let req = http.last.lock().unwrap().clone().unwrap();
+        assert_eq!(req.header("If-Match"), Some("\"etagxyz\""));
+        assert_eq!(req.header("x-goog-if-generation-match"), None);
+    }
+
+    #[tokio::test]
+    async fn fetch_range_maps_412_to_version_mismatch() {
+        let http = MockHttp::new(HttpResponse {
+            status: 412,
+            headers: vec![("x-goog-generation".into(), "1700000001".into())],
+            body: bytes::Bytes::new(),
+        });
+        let g = GcsBackend::new(GcsConfig::default(), None, http);
+        match g
+            .fetch_range_if_match(&obj(), 0, 8, Some(&Version::new("1699999999")))
+            .await
+        {
+            Err(Error::VersionMismatch { expected, found }) => {
+                assert_eq!(expected, "1699999999");
+                assert_eq!(found, "1700000001");
+            }
+            other => panic!("expected VersionMismatch, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/talon-backend/src/s3.rs
+++ b/crates/talon-backend/src/s3.rs
@@ -97,10 +97,29 @@ impl S3Backend {
     }
 
     /// Build the ranged GET request for a fetch (exposed for testing).
+    ///
+    /// When `if_match` is set, adds an `If-Match` header so the origin returns
+    /// `412 Precondition Failed` if the object was overwritten since the version
+    /// was resolved (issue #163).
     pub fn build_get(&self, obj: &ObjectId, offset: u64, len: u64) -> HttpRequest {
+        self.build_get_if_match(obj, offset, len, None)
+    }
+
+    /// Build the ranged GET request with an optional `If-Match` precondition.
+    pub fn build_get_if_match(
+        &self,
+        obj: &ObjectId,
+        offset: u64,
+        len: u64,
+        if_match: Option<&Version>,
+    ) -> HttpRequest {
         let mut headers = vec![("Range".to_string(), Self::range_header(offset, len))];
         if let Some(tok) = &self.creds.session_token {
             headers.push(("x-amz-security-token".to_string(), tok.clone()));
+        }
+        if let Some(version) = if_match {
+            // S3 echoes the ETag with surrounding quotes; send it quoted.
+            headers.push(("If-Match".to_string(), format!("\"{}\"", version.as_str())));
         }
         HttpRequest {
             method: Method::Get,
@@ -131,10 +150,20 @@ fn etag_to_version(etag: &str) -> Version {
 #[async_trait]
 impl BackendStore for S3Backend {
     async fn fetch_range(&self, obj: &ObjectId, offset: u64, len: u64) -> Result<bytes::Bytes> {
+        self.fetch_range_if_match(obj, offset, len, None).await
+    }
+
+    async fn fetch_range_if_match(
+        &self,
+        obj: &ObjectId,
+        offset: u64,
+        len: u64,
+        if_match: Option<&Version>,
+    ) -> Result<bytes::Bytes> {
         if len == 0 {
             return Ok(bytes::Bytes::new());
         }
-        let req = self.build_get(obj, offset, len);
+        let req = self.build_get_if_match(obj, offset, len, if_match);
         let resp = self.http.execute(req).await.map_err(Error::Backend)?;
         // 206 (range honored) or 200 (server ignored Range, returned the whole
         // object). `range_body` yields exactly the requested window in both
@@ -152,6 +181,17 @@ impl BackendStore for S3Backend {
             .map_err(Error::Backend)
         } else if resp.status == 404 {
             Err(Error::NotFound(obj.to_path()))
+        } else if resp.status == 412 {
+            // The If-Match precondition failed: the object was overwritten since
+            // the version was resolved (issue #163). The ETag now on the object
+            // (if returned) is the new version.
+            Err(Error::VersionMismatch {
+                expected: if_match.map(|v| v.0.clone()).unwrap_or_default(),
+                found: resp
+                    .header("etag")
+                    .map(|e| e.trim_matches('"').to_string())
+                    .unwrap_or_default(),
+            })
         } else {
             Err(Error::Backend(format!(
                 "S3 GET {} -> HTTP {}",
@@ -308,6 +348,45 @@ mod tests {
             s3.fetch_range(&obj(), 0, 8).await,
             Err(Error::NotFound(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn fetch_range_if_match_sends_quoted_precondition() {
+        let http = MockHttp::new(HttpResponse {
+            status: 206,
+            headers: vec![],
+            body: bytes::Bytes::from_static(b"partial-bytes"),
+        });
+        let s3 = S3Backend::new(S3Config::aws("us-east-1"), creds(), http.clone());
+        let _ = s3
+            .fetch_range_if_match(&obj(), 10, 13, Some(&Version::new("abc123")))
+            .await
+            .unwrap();
+        let req = http.last.lock().unwrap().clone().unwrap();
+        // S3 expects the ETag quoted in If-Match.
+        assert_eq!(req.header("If-Match"), Some("\"abc123\""));
+    }
+
+    #[tokio::test]
+    async fn fetch_range_maps_412_to_version_mismatch() {
+        // The If-Match precondition failed: the object was overwritten since the
+        // version was resolved (issue #163). The new ETag rides on the response.
+        let http = MockHttp::new(HttpResponse {
+            status: 412,
+            headers: vec![("ETag".into(), "\"v2\"".into())],
+            body: bytes::Bytes::new(),
+        });
+        let s3 = S3Backend::new(S3Config::aws("us-east-1"), creds(), http);
+        match s3
+            .fetch_range_if_match(&obj(), 0, 8, Some(&Version::new("v1")))
+            .await
+        {
+            Err(Error::VersionMismatch { expected, found }) => {
+                assert_eq!(expected, "v1");
+                assert_eq!(found, "v2");
+            }
+            other => panic!("expected VersionMismatch, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/talon-core/src/backend.rs
+++ b/crates/talon-core/src/backend.rs
@@ -29,6 +29,32 @@ pub trait BackendStore: Send + Sync {
     /// checksum can be computed here.
     async fn fetch_range(&self, obj: &ObjectId, offset: u64, len: u64) -> Result<Bytes>;
 
+    /// Fetch a byte range, optionally guarded by an `If-Match` precondition.
+    ///
+    /// When `if_match` is `Some`, the fetch is conditioned on the object still
+    /// being at that version (S3/Azure `If-Match`, GCS `x-goog-if-generation-match`),
+    /// so a source overwrite between the version resolution and the GET is
+    /// rejected with [`Error::VersionMismatch`](crate::Error::VersionMismatch)
+    /// instead of silently committing
+    /// the newer bytes under the older version's key (the HEAD→GET TOCTOU,
+    /// issue #163). The worker keys cache blocks by the resolved version, so a
+    /// precondition failure means the caller must re-resolve and refetch.
+    ///
+    /// The default implementation ignores the precondition and delegates to
+    /// [`fetch_range`](Self::fetch_range); real backends override it to carry the
+    /// precondition into the request. This keeps in-memory/test backends that
+    /// have no notion of preconditions working unchanged.
+    async fn fetch_range_if_match(
+        &self,
+        obj: &ObjectId,
+        offset: u64,
+        len: u64,
+        if_match: Option<&Version>,
+    ) -> Result<Bytes> {
+        let _ = if_match;
+        self.fetch_range(obj, offset, len).await
+    }
+
     /// Fetch object metadata (size + version) without transferring data.
     async fn head(&self, obj: &ObjectId) -> Result<ObjectStat>;
 }

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -1,14 +1,29 @@
 //! Instrumented worker cache request runtime.
 
-use std::sync::Arc;
-use std::time::Instant;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use talon_core::{
-    BackendStore, BlockForm, BlockId, BlockMeta, ObjectId, ObjectStore, PageIndex, Version,
+    BackendStore, BlockForm, BlockId, BlockMeta, Error, ObjectId, ObjectStore, PageIndex, Version,
 };
 use talon_transport::data::RangeRequest;
 
 use crate::{BlockIndex, InFlightLoads, LoadKey, Presence, WholeBlockStore, WorkerMetrics};
+
+/// Default lifetime of a cached resolved object version.
+///
+/// A short TTL keeps warm cache hits from paying a backend `HEAD` per read
+/// while still bounding how long a source overwrite can go unnoticed on the
+/// read path; the conditional GET (`If-Match`) is the hard correctness guard
+/// that catches an overwrite inside the window (issue #163).
+const DEFAULT_VERSION_TTL: Duration = Duration::from_secs(3);
+
+/// A per-object resolved version with the instant it was resolved.
+struct CachedVersion {
+    version: Version,
+    resolved_at: Instant,
+}
 
 /// Shared state required to serve instrumented data-plane range requests.
 pub struct WorkerRuntime {
@@ -18,6 +33,10 @@ pub struct WorkerRuntime {
     backend: Arc<dyn BackendStore>,
     block_size: u32,
     metrics: WorkerMetrics,
+    /// Short-TTL cache of resolved object versions, so a warm read does not pay
+    /// a backend `HEAD` per request (issue #163).
+    version_cache: Mutex<HashMap<ObjectId, CachedVersion>>,
+    version_ttl: Duration,
 }
 
 impl WorkerRuntime {
@@ -37,7 +56,16 @@ impl WorkerRuntime {
             backend,
             block_size,
             metrics,
+            version_cache: Mutex::new(HashMap::new()),
+            version_ttl: DEFAULT_VERSION_TTL,
         }
+    }
+
+    /// Override the resolved-version cache TTL (test hook).
+    #[cfg(test)]
+    fn with_version_ttl(mut self, ttl: Duration) -> Self {
+        self.version_ttl = ttl;
+        self
     }
 
     /// The block-aligned [`BlockId`] containing `offset` of `object` at a given
@@ -61,30 +89,62 @@ impl WorkerRuntime {
     /// the *start* offset was read and the result clamped to that block's end,
     /// silently truncating cross-block reads (issue #112).
     ///
-    /// The object's real version (ETag/generation) is resolved once per request
-    /// via a backend `head()` and folded into every `BlockId`, so an overwrite
-    /// at the source produces distinct keys and the stale cached block is no
-    /// longer served (issue #119). A missing/empty version is refused rather than
-    /// cached under a placeholder.
+    /// The object's real version (ETag/generation) is resolved via a backend
+    /// `head()` and folded into every `BlockId`, so an overwrite at the source
+    /// produces distinct keys and the stale cached block is no longer served
+    /// (issue #119). A missing/empty version is refused rather than cached under
+    /// a placeholder.
+    ///
+    /// The resolved version is cached per object with a short TTL so a warm read
+    /// does not pay a `HEAD` per request, and it is carried as an `If-Match`
+    /// precondition into the miss GET so an overwrite inside the TTL window is
+    /// caught (`412` → [`Error::VersionMismatch`]) rather than silently commits
+    /// newer bytes under the older version's key. On a mismatch the cache is
+    /// invalidated and the request is retried once against the freshly-resolved
+    /// version (issue #163).
     pub async fn serve_range(&self, request: &RangeRequest) -> anyhow::Result<bytes::Bytes> {
         if request.len == 0 {
             return Ok(bytes::Bytes::new());
         }
+
+        // Resolve using the cache first; on a precondition failure (the object
+        // was overwritten within the version-cache window) drop the stale entry
+        // and retry once against a force-resolved version.
+        let version = self.resolve_version(&request.object, false).await?;
+        match self.serve_range_at(request, &version).await {
+            Ok(bytes) => Ok(bytes),
+            Err(error) if is_version_mismatch(&error) => {
+                self.invalidate_version(&request.object);
+                let version = self.resolve_version(&request.object, true).await?;
+                self.serve_range_at(request, &version).await
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Serve `[offset, offset + len)` against an already-resolved `version`.
+    ///
+    /// A request whose range crosses one or more block boundaries is split into
+    /// per-block reads (each a cache hit or a backend miss) and the pieces are
+    /// stitched into one contiguous buffer. Previously only the block containing
+    /// the *start* offset was read and the result clamped to that block's end,
+    /// silently truncating cross-block reads (issue #112).
+    async fn serve_range_at(
+        &self,
+        request: &RangeRequest,
+        version: &Version,
+    ) -> anyhow::Result<bytes::Bytes> {
         let block_size = self.block_size as u64;
         let end = request
             .offset
             .checked_add(request.len)
             .ok_or_else(|| anyhow::anyhow!("range offset+len overflows u64"))?;
 
-        // Resolve the object's real version once for this request. Blocks are
-        // keyed by it, so a later overwrite (new ETag) misses the stale cache.
-        let version = self.resolve_version(&request.object).await?;
-
         // Fast path: the whole range lies within a single block. Keeps the
         // common case allocation-free (returns the per-block slice directly).
         let start_block = (request.offset / block_size) * block_size;
         if end <= start_block + block_size {
-            let block = self.block_for(&request.object, request.offset, &version);
+            let block = self.block_for(&request.object, request.offset, version);
             let offset_in_block = request.offset - block.offset;
             let bytes = self.block_bytes(request, &block).await?;
             return slice(&bytes, offset_in_block, request.len);
@@ -94,7 +154,7 @@ impl WorkerRuntime {
         let mut out = bytes::BytesMut::with_capacity(request.len as usize);
         let mut cursor = request.offset;
         while cursor < end {
-            let block = self.block_for(&request.object, cursor, &version);
+            let block = self.block_for(&request.object, cursor, version);
             let offset_in_block = cursor - block.offset;
             let block_end = block.offset + block_size;
             let take = block_end.min(end) - cursor;
@@ -112,9 +172,19 @@ impl WorkerRuntime {
         Ok(out.freeze())
     }
 
-    /// Resolve the object's current version via a backend `head()`, refusing an
-    /// empty/missing version rather than caching under a placeholder (#119).
-    async fn resolve_version(&self, object: &ObjectId) -> anyhow::Result<Version> {
+    /// Resolve the object's current version, refusing an empty/missing version
+    /// rather than caching under a placeholder (#119).
+    ///
+    /// Returns a fresh cached value when one is within the TTL and `force` is
+    /// false; otherwise issues a backend `head()`, caches the result, and
+    /// returns it. `force` bypasses the cache (used after a precondition
+    /// failure) so the retry always sees the newest version (#163).
+    async fn resolve_version(&self, object: &ObjectId, force: bool) -> anyhow::Result<Version> {
+        if !force {
+            if let Some(version) = self.cached_version(object) {
+                return Ok(version);
+            }
+        }
         let stat = self
             .backend
             .head(object)
@@ -125,7 +195,35 @@ impl WorkerRuntime {
                 "backend returned no version/etag for {object}; refusing to cache without a version"
             );
         }
+        self.store_version(object, &stat.version);
         Ok(stat.version)
+    }
+
+    /// Return a cached version for `object` if one is within the TTL.
+    fn cached_version(&self, object: &ObjectId) -> Option<Version> {
+        let cache = self.version_cache.lock().unwrap();
+        let entry = cache.get(object)?;
+        if entry.resolved_at.elapsed() < self.version_ttl {
+            Some(entry.version.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Record a freshly-resolved version for `object`.
+    fn store_version(&self, object: &ObjectId, version: &Version) {
+        self.version_cache.lock().unwrap().insert(
+            object.clone(),
+            CachedVersion {
+                version: version.clone(),
+                resolved_at: Instant::now(),
+            },
+        );
+    }
+
+    /// Drop any cached version for `object` (after a precondition failure).
+    fn invalidate_version(&self, object: &ObjectId) {
+        self.version_cache.lock().unwrap().remove(object);
     }
 
     /// Return the full committed/fetched bytes of a single block, using the
@@ -213,9 +311,17 @@ impl WorkerRuntime {
     ) -> anyhow::Result<bytes::Bytes> {
         tracing::info!(block = %block, "MISS -> backend fetch");
         let started = Instant::now();
+        // Carry the resolved version as an If-Match precondition so an overwrite
+        // between version resolution and this GET is rejected (412) rather than
+        // committing newer bytes under the older version's key (issue #163).
         let fetched = self
             .backend
-            .fetch_range(&request.object, block.offset, self.block_size as u64)
+            .fetch_range_if_match(
+                &request.object,
+                block.offset,
+                self.block_size as u64,
+                Some(&block.version),
+            )
             .await;
         let bytes = match fetched {
             Ok(bytes) => {
@@ -261,6 +367,18 @@ fn slice(buffer: &[u8], offset: u64, len: u64) -> anyhow::Result<bytes::Bytes> {
     let requested = usize::try_from(len).unwrap_or(usize::MAX);
     let end = start.saturating_add(requested).min(buffer.len());
     Ok(bytes::Bytes::copy_from_slice(&buffer[start..end]))
+}
+
+/// Whether an error chain carries a backend [`Error::VersionMismatch`], i.e. an
+/// `If-Match` precondition failed because the object was overwritten (issue
+/// #163). Used to trigger a single re-resolve-and-retry.
+fn is_version_mismatch(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<Error>(),
+            Some(Error::VersionMismatch { .. })
+        )
+    })
 }
 
 #[cfg(test)]
@@ -317,6 +435,9 @@ mod tests {
             8,
             metrics,
         )
+        // Most tests assert version-sensitivity per read; a zero TTL keeps the
+        // resolved-version cache from masking a source overwrite between reads.
+        .with_version_ttl(Duration::ZERO)
     }
 
     #[tokio::test]
@@ -392,6 +513,9 @@ mod tests {
             block_size,
             metrics,
         )
+        // Default to always-resolve so version-sensitivity assertions are not
+        // masked by the version cache; caching is exercised explicitly below.
+        .with_version_ttl(Duration::ZERO)
     }
 
     #[tokio::test]
@@ -613,6 +737,136 @@ mod tests {
         // Nothing was fetched or cached without a version.
         assert_eq!(backend.fetches.load(Ordering::SeqCst), 0);
         assert_eq!(runtime.block_count(), 0);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    /// A backend that counts HEADs and, when `enforce_precondition` is set, fails
+    /// a fetch carrying a stale `If-Match` with [`Error::VersionMismatch`] — the
+    /// 412 the real backends map — so the retry-on-mismatch path is exercised.
+    struct CondBackend {
+        version: std::sync::Mutex<String>,
+        body: std::sync::Mutex<Bytes>,
+        heads: AtomicUsize,
+        fetches: AtomicUsize,
+        enforce_precondition: bool,
+    }
+
+    #[async_trait]
+    impl BackendStore for CondBackend {
+        async fn fetch_range(&self, _object: &ObjectId, _offset: u64, _len: u64) -> Result<Bytes> {
+            self.fetches.fetch_add(1, Ordering::SeqCst);
+            Ok(self.body.lock().unwrap().clone())
+        }
+
+        async fn fetch_range_if_match(
+            &self,
+            object: &ObjectId,
+            offset: u64,
+            len: u64,
+            if_match: Option<&Version>,
+        ) -> Result<Bytes> {
+            if self.enforce_precondition {
+                if let Some(expected) = if_match {
+                    let current = self.version.lock().unwrap().clone();
+                    if expected.as_str() != current {
+                        return Err(Error::VersionMismatch {
+                            expected: expected.0.clone(),
+                            found: current,
+                        });
+                    }
+                }
+            }
+            self.fetch_range(object, offset, len).await
+        }
+
+        async fn head(&self, _object: &ObjectId) -> Result<ObjectStat> {
+            self.heads.fetch_add(1, Ordering::SeqCst);
+            Ok(ObjectStat {
+                len: self.body.lock().unwrap().len() as u64,
+                version: Version::new(self.version.lock().unwrap().clone()),
+            })
+        }
+    }
+
+    fn cond_runtime(backend: Arc<CondBackend>, root: &PathBuf, ttl: Duration) -> WorkerRuntime {
+        WorkerRuntime::new(
+            WholeBlockStore::open(root).unwrap(),
+            Arc::new(BlockIndex::new()),
+            Arc::new(InFlightLoads::new()),
+            backend as Arc<dyn BackendStore>,
+            8,
+            WorkerMetrics::new(1024),
+        )
+        .with_version_ttl(ttl)
+    }
+
+    #[tokio::test]
+    async fn warm_read_within_ttl_skips_the_head() {
+        // With a live version-cache TTL, a warm cache hit must not pay a backend
+        // HEAD per read — only the first read resolves the version (issue #163).
+        let root = tmp_root();
+        let backend = Arc::new(CondBackend {
+            version: std::sync::Mutex::new("v1".into()),
+            body: std::sync::Mutex::new(Bytes::from_static(b"abcdefgh")),
+            heads: AtomicUsize::new(0),
+            fetches: AtomicUsize::new(0),
+            enforce_precondition: false,
+        });
+        let runtime = cond_runtime(Arc::clone(&backend), &root, Duration::from_secs(60));
+
+        for _ in 0..3 {
+            let _ = runtime.serve_range(&request("obj")).await.unwrap();
+        }
+        assert_eq!(
+            backend.heads.load(Ordering::SeqCst),
+            1,
+            "warm reads within the TTL must reuse the cached version, not re-HEAD"
+        );
+        assert_eq!(backend.fetches.load(Ordering::SeqCst), 1);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn precondition_failure_reresolves_and_retries_once() {
+        // Read block0 first: resolves+caches version v1 and caches block0. The
+        // source is then overwritten to v2 while the version cache still holds
+        // v1. A read of block1 (not yet cached) is a miss that issues an
+        // If-Match(v1) GET, which fails the precondition (412 -> VersionMismatch)
+        // because the object is now v2. The runtime must invalidate the cached
+        // version, re-resolve v2, and retry so it commits the fresh bytes under
+        // the v2 key rather than surfacing the error (issue #163 TOCTOU).
+        let root = tmp_root();
+        let backend = Arc::new(CondBackend {
+            version: std::sync::Mutex::new("v1".into()),
+            body: std::sync::Mutex::new(Bytes::from_static(b"old-data-old-data")),
+            heads: AtomicUsize::new(0),
+            fetches: AtomicUsize::new(0),
+            enforce_precondition: true,
+        });
+        let runtime = cond_runtime(Arc::clone(&backend), &root, Duration::from_secs(60));
+
+        // block0 (offset 0): resolves v1, caches block0 under v1.
+        let obj = ObjectId::new(Backend::Azure, "container", "obj");
+        let read = |offset| RangeRequest {
+            object: obj.clone(),
+            offset,
+            len: 4,
+        };
+        let first = runtime.serve_range(&read(0)).await.unwrap();
+        assert_eq!(first, Bytes::from_static(b"old-"));
+
+        // Overwrite the source; the version cache still holds v1.
+        *backend.version.lock().unwrap() = "v2".into();
+        *backend.body.lock().unwrap() = Bytes::from_static(b"new-data-new-data");
+
+        // block1 (offset 8): a miss under the stale cached v1 -> If-Match(v1)
+        // 412 -> re-resolve v2 -> refetch. Must serve the fresh v2 bytes.
+        let after = runtime.serve_range(&read(8)).await.unwrap();
+        assert_eq!(
+            after,
+            Bytes::from_static(b"new-"),
+            "must re-resolve and serve fresh bytes after a precondition failure"
+        );
         std::fs::remove_dir_all(root).ok();
     }
 }


### PR DESCRIPTION
## Summary
`serve_range` resolved the object version with a backend `HEAD` on **every** read — even a warm cache hit paid a full HEAD round-trip, doubling origin request volume. The resolved version was also not carried into the miss GET, so an overwrite between the HEAD and the GET committed newer bytes under the older version's `BlockId` (a silent key/content mismatch — TOCTOU).

- **Version cache:** `WorkerRuntime` keeps a short-TTL (3s) per-object cache of the resolved version; warm reads reuse it instead of issuing a HEAD. `serve_range` split into a resolve step + inner `serve_range_at`.
- **Conditional GET:** `BackendStore::fetch_range_if_match` carries the version as a precondition (S3/Azure `If-Match`, GCS `x-goog-if-generation-match` for a numeric generation else `If-Match`); a `412` maps to the previously-unconstructed `Error::VersionMismatch`. Default trait method delegates to `fetch_range` so test/in-memory backends compile unchanged. On mismatch, `serve_range` invalidates the cached version, re-resolves, and retries once.

## Testing
- Worker: `warm_read_within_ttl_skips_the_head`, `precondition_failure_reresolves_and_retries_once`.
- Backends: per-backend `If-Match`/precondition header assertions + `412 -> VersionMismatch` for S3, GCS (numeric + etag), Azure.
- `fmt` / `clippy -D warnings` / `test --all-features` / `doc -D warnings` all clean.

Closes #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)