### PR TITLE
fix: assorted low-severity hardening from code review

### DIFF
--- a/crates/talon-backend/src/azure.rs
+++ b/crates/talon-backend/src/azure.rs
@@ -75,8 +75,14 @@ impl AzureBackend {
     }
 
     /// Format the Azure `x-ms-range` header value for `[offset, offset+len)`.
+    ///
+    /// `len` is expected `> 0` (guarded in `fetch_range`); a zero/overflowing
+    /// `len` is clamped with checked arithmetic so this public helper never
+    /// under/overflows into a bogus range (#167).
     pub fn range_header(offset: u64, len: u64) -> String {
-        format!("bytes={offset}-{}", offset + len - 1)
+        let span = len.saturating_sub(1);
+        let end = offset.saturating_add(span);
+        format!("bytes={offset}-{end}")
     }
 
     /// The API version header Azure requires on every request.

--- a/crates/talon-backend/src/gcs.rs
+++ b/crates/talon-backend/src/gcs.rs
@@ -61,8 +61,14 @@ impl GcsBackend {
     }
 
     /// Format an inclusive HTTP `Range` header for `[offset, offset+len)`.
+    ///
+    /// `len` is expected `> 0` (guarded in `fetch_range`); a zero/overflowing
+    /// `len` is clamped with checked arithmetic so this public helper never
+    /// under/overflows into a bogus range (#167).
     pub fn range_header(offset: u64, len: u64) -> String {
-        format!("bytes={offset}-{}", offset + len - 1)
+        let span = len.saturating_sub(1);
+        let end = offset.saturating_add(span);
+        format!("bytes={offset}-{end}")
     }
 
     fn auth_headers(&self) -> Vec<(String, String)> {

--- a/crates/talon-backend/src/s3.rs
+++ b/crates/talon-backend/src/s3.rs
@@ -90,9 +90,18 @@ impl S3Backend {
     }
 
     /// Format an HTTP `Range` header value for `[offset, offset+len)`.
+    ///
+    /// `len` must be `> 0` (callers guard this in `fetch_range`). A zero or
+    /// overflowing `len` is clamped with checked arithmetic so this public
+    /// helper can never underflow/overflow into a bogus `bytes=` range (#167):
+    /// a zero `len` yields the single byte at `offset`, and an overflowing end
+    /// saturates at `u64::MAX`.
     pub fn range_header(offset: u64, len: u64) -> String {
-        // HTTP ranges are inclusive on both ends.
-        let end = offset + len - 1;
+        // Inclusive end = offset + len - 1, guarded against under/overflow: a
+        // zero len yields the single byte at `offset`, and an overflowing end
+        // saturates at u64::MAX.
+        let span = len.saturating_sub(1);
+        let end = offset.saturating_add(span);
         format!("bytes={offset}-{end}")
     }
 
@@ -278,6 +287,18 @@ mod tests {
     fn range_header_is_inclusive() {
         assert_eq!(S3Backend::range_header(0, 100), "bytes=0-99");
         assert_eq!(S3Backend::range_header(256, 256), "bytes=256-511");
+    }
+
+    #[test]
+    fn range_header_clamps_zero_and_overflow() {
+        // len == 0 must not underflow (would panic in debug / wrap in release).
+        assert_eq!(S3Backend::range_header(10, 0), "bytes=10-10");
+        // offset + len overflowing u64 saturates the inclusive end at u64::MAX
+        // instead of wrapping to a bogus small range (#167).
+        assert_eq!(
+            S3Backend::range_header(u64::MAX - 1, u64::MAX),
+            format!("bytes={}-{}", u64::MAX - 1, u64::MAX)
+        );
     }
 
     #[test]

--- a/crates/talon-client/tests/control_path.rs
+++ b/crates/talon-client/tests/control_path.rs
@@ -1,15 +1,20 @@
 //! Integration test: the coordinator serve loop over real TCP.
 //!
 //! Launches the built `talon-coordinator` binary, registers a mock worker via
-//! the real control protocol, then exercises the two client-side lookups
-//! (`PlacementLookup` + `MembershipQuery`) and asserts the owner id resolves
-//! back to the worker's address. This covers the whole control path end-to-end
-//! without needing Azure credentials or a running worker/data plane.
+//! the real control protocol (`NodeStatusHeartbeat`, the store-authoritative
+//! path), then exercises the two client-side lookups (`PlacementLookup` +
+//! `MembershipQuery`) and asserts the owner id resolves back to the worker's
+//! address. This covers the whole control path end-to-end without needing Azure
+//! credentials or a running worker/data plane.
 
+use std::collections::BTreeMap;
 use std::process::{Child, Command};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use talon_core::{Backend, BlockId, NodeId, NodeInfo, NodeRole, ObjectId, Version};
+use talon_core::{
+    Backend, BlockId, NodeHealth, NodeId, NodeInfo, NodeMetricsSnapshot, NodeRole, NodeStatus,
+    ObjectId, Version, NODE_STATUS_SCHEMA_VERSION,
+};
 use talon_transport::frame::HEADER_LEN;
 use talon_transport::{codec, ControlMessage, FrameHeader};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -75,13 +80,40 @@ async fn control_path_register_lookup_resolve() {
     }
     assert!(connected, "coordinator did not start listening");
 
-    // A mock worker registers itself.
+    // A mock worker registers itself via the store-authoritative heartbeat
+    // (the legacy Register path is now a membership no-op, #167).
     let node = NodeInfo {
         id: NodeId::new("127.0.0.1:9999"),
         address: "127.0.0.1:9999".into(),
         role: NodeRole::Worker,
     };
-    let ack = round_trip(addr, &ControlMessage::Register { node: node.clone() }).await;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    let status = NodeStatus {
+        schema_version: NODE_STATUS_SCHEMA_VERSION,
+        // The coordinator binary defaults to cluster_id "default".
+        cluster_id: "default".into(),
+        node: node.clone(),
+        incarnation_id: "e2e-incarnation".into(),
+        admin_address: Some("127.0.0.1:8999".into()),
+        build_version: "test".into(),
+        started_at_unix_ms: now,
+        reported_at_unix_ms: now,
+        heartbeat_seq: 0,
+        health: NodeHealth::Healthy,
+        ready: true,
+        metrics: NodeMetricsSnapshot::default(),
+        labels: BTreeMap::new(),
+    };
+    let ack = round_trip(
+        addr,
+        &ControlMessage::NodeStatusHeartbeat {
+            status: Box::new(status),
+        },
+    )
+    .await;
     assert!(matches!(ack, ControlMessage::Ack { ok: true, .. }));
 
     // Placement lookup should now name our worker as the owner.

--- a/crates/talon-coordinator/src/main.rs
+++ b/crates/talon-coordinator/src/main.rs
@@ -104,8 +104,21 @@ impl Coordinator {
     async fn dispatch(&self, message: ControlMessage) -> ControlMessage {
         match message {
             ControlMessage::Register { node } => {
-                tracing::info!(id = %node.id, address = %node.address, "worker registered");
-                self.service.membership().register(node);
+                // Legacy control-plane path. It used to call
+                // `membership().register(node)` directly, which writes only this
+                // coordinator's in-memory set — no ClusterStateStore write, no
+                // is_ready()/health gate. In active-active that makes the node
+                // visible on just the receiving coordinator, and the very next
+                // reconcile_membership tick (which replaces the whole set from the
+                // store snapshot) deletes it. That local-only, self-erasing insert
+                // is misleading, so make Register a no-op for membership: workers
+                // use NodeStatusHeartbeat, which persists through the store (#167).
+                tracing::info!(
+                    id = %node.id,
+                    address = %node.address,
+                    "legacy Register received; membership is store-authoritative, \
+                     use NodeStatusHeartbeat"
+                );
                 self.observability.metrics().record_registration(true);
                 ControlMessage::Ack {
                     ok: true,
@@ -287,10 +300,15 @@ async fn main() -> anyhow::Result<()> {
         tokio::select! {
             accepted = listener.accept() => {
                 let (stream, peer) = accepted?;
-                let permit = conn_limit.acquire().await;
+                let conn_limit = conn_limit.clone();
                 let state = Arc::clone(&state);
+                // Acquire the connection permit *inside* the spawned task, not in
+                // the select! arm: at MAX_CONTROL_CONNECTIONS a blocking
+                // acquire().await here would stall the accept loop and starve the
+                // ctrl_c shutdown branch until a permit frees (#167). The task
+                // waits for a slot instead, keeping the select! responsive.
                 tokio::spawn(async move {
-                    let _permit = permit;
+                    let _permit = conn_limit.acquire().await;
                     if let Err(error) = handle_conn(stream, state).await {
                         tracing::debug!(%peer, %error, "coordinator connection ended");
                     }

--- a/crates/talon-coordinator/src/placement.rs
+++ b/crates/talon-coordinator/src/placement.rs
@@ -45,7 +45,13 @@ use xxhash_rust::xxh3::xxh3_64;
 /// design invariant) while remaining backend-neutral: a future revision can map
 /// an opaque Kubernetes `resourceVersion` or etcd revision onto the same token
 /// type without changing clients.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+/// `Ord`/`PartialOrd` are intentionally NOT derived: the epoch is an
+/// equality-only content hash, so magnitude comparison is meaningless (there is
+/// no "newer > older" since the #80 monotonic→hash change). Omitting the derives
+/// makes a stray `>`/`<` on an epoch fail to compile rather than silently do the
+/// wrong thing; clients compare with `==`/`!=` only. `StoreRevision` models the
+/// same constraint by not deriving `Ord` (#167).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct Epoch(pub u64);
 
 impl Epoch {

--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -267,12 +267,21 @@ impl WorkerConfig {
         if self.advertise_addr.is_empty() {
             return Err(Error::Other("advertise_addr must not be empty".into()));
         }
-        if self.advertise_addr.starts_with("0.0.0.0:") || self.advertise_addr.starts_with("[::]:") {
-            return Err(Error::Other(format!(
-                "advertise_addr {:?} is a wildcard bind and is unreachable by clients; \
-                 set advertise_addr (or TALON_WORKER_ADVERTISE_ADDR) to a routable address",
-                self.advertise_addr
-            )));
+        // The advertised address is handed to clients to dial, so a wildcard
+        // bind is unreachable. When it parses as an IP socket address, reject an
+        // unspecified IP so every spelling of the wildcard is caught (`0.0.0.0`,
+        // `::`, `[::]`, `[::0]`, `0:0:0:0:0:0:0:0`, ...), not just two string
+        // prefixes (issue #118, hardened per #167). A non-IP form (hostname:port)
+        // does not parse as SocketAddr and is left to DNS — it is never a
+        // wildcard, so it is permitted as before.
+        if let Ok(addr) = self.advertise_addr.parse::<std::net::SocketAddr>() {
+            if addr.ip().is_unspecified() {
+                return Err(Error::Other(format!(
+                    "advertise_addr {:?} is a wildcard bind and is unreachable by clients; \
+                     set advertise_addr (or TALON_WORKER_ADVERTISE_ADDR) to a routable address",
+                    self.advertise_addr
+                )));
+            }
         }
         if self.heartbeat_interval_ms == 0 {
             return Err(Error::Other(
@@ -595,6 +604,36 @@ mod tests {
         };
         let err = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
         assert!(err.to_string().contains("advertise_addr"));
+
+        // Every spelling of the unspecified address is rejected, not just the
+        // two string prefixes the old check matched (issue #167).
+        for wildcard in [
+            "[::]:7001",
+            "[::0]:7001",
+            "[0:0:0:0:0:0:0:0]:7001",
+            "[0000:0000:0000:0000:0000:0000:0000:0000]:7001",
+        ] {
+            let cli = WorkerConfigPatch {
+                advertise_addr: Some(wildcard.into()),
+                ..Default::default()
+            };
+            let err =
+                WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
+            assert!(
+                err.to_string().contains("advertise_addr"),
+                "{wildcard} must be rejected as a wildcard"
+            );
+        }
+
+        // A routable IPv6 address and a hostname:port form are both accepted.
+        for ok in ["[2001:db8::1]:7001", "worker-0.svc:7001"] {
+            let cli = WorkerConfigPatch {
+                advertise_addr: Some(ok.into()),
+                ..Default::default()
+            };
+            let cfg = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap();
+            assert_eq!(cfg.advertise_addr, ok);
+        }
     }
 
     #[test]

--- a/crates/talon-core/src/metrics.rs
+++ b/crates/talon-core/src/metrics.rs
@@ -107,7 +107,16 @@ pub struct Histogram {
 }
 
 impl Histogram {
-    fn new(bounds: Vec<f64>) -> Self {
+    fn new(mut bounds: Vec<f64>) -> Self {
+        // Prometheus requires strictly ascending, finite bucket bounds so the
+        // cumulative `_bucket` output is monotonic. `histogram_with` accepts
+        // caller-supplied bounds, so normalize defensively: drop non-finite
+        // values, sort ascending, and dedup. Without this, unsorted bounds
+        // render non-monotonic buckets that violate the exposition contract
+        // (#167).
+        bounds.retain(|b| b.is_finite());
+        bounds.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        bounds.dedup();
         let n = bounds.len() + 1; // +Inf bucket
         Self {
             bounds: Arc::new(bounds),
@@ -119,6 +128,12 @@ impl Histogram {
 
     /// Record an observation `v`.
     pub fn observe(&self, v: f64) {
+        // A non-finite observation (NaN/±Inf) would poison `_sum` and, for NaN,
+        // never satisfy `v <= bound`, silently landing in the +Inf bucket. Drop
+        // it rather than corrupt the series (#167).
+        if !v.is_finite() {
+            return;
+        }
         let idx = self
             .bounds
             .iter()
@@ -314,8 +329,12 @@ impl Metrics {
 }
 
 fn fmt_f64(v: f64) -> String {
-    if v == f64::INFINITY {
+    if v.is_nan() {
+        "NaN".to_string()
+    } else if v == f64::INFINITY {
         "+Inf".to_string()
+    } else if v == f64::NEG_INFINITY {
+        "-Inf".to_string()
     } else {
         format!("{v}")
     }
@@ -413,5 +432,46 @@ mod tests {
         let m = Metrics::new();
         m.counter("x", "h", labels(&[("k", "a\"b")])).inc();
         assert!(m.render().contains("k=\"a\\\"b\""));
+    }
+
+    #[test]
+    fn histogram_normalizes_unsorted_and_nonfinite_bounds() {
+        // Unsorted + non-finite bounds must be normalized so `_bucket` output is
+        // still cumulative/monotonic (#167).
+        let m = Metrics::new();
+        let h = m.histogram_with(
+            "lat",
+            "latency",
+            Labels::new(),
+            vec![1.0, f64::NAN, 0.1, f64::INFINITY, 0.1],
+        );
+        h.observe(0.05);
+        h.observe(0.5);
+        let out = m.render();
+        // Bounds became [0.1, 1.0] (sorted, deduped, finite-only).
+        assert!(out.contains("lat_bucket{le=\"0.1\"} 1"), "{out}");
+        assert!(out.contains("lat_bucket{le=\"1\"} 2"), "{out}");
+        assert!(out.contains("lat_bucket{le=\"+Inf\"} 2"), "{out}");
+    }
+
+    #[test]
+    fn histogram_drops_nonfinite_observations() {
+        // NaN/±Inf observations would poison _sum and mis-bucket; they are
+        // dropped (#167).
+        let m = Metrics::new();
+        let h = m.histogram_with("lat", "latency", Labels::new(), vec![1.0]);
+        h.observe(f64::NAN);
+        h.observe(f64::INFINITY);
+        h.observe(0.5);
+        assert_eq!(h.count(), 1);
+        assert!((h.sum() - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn fmt_f64_renders_nonfinite() {
+        assert_eq!(fmt_f64(f64::NAN), "NaN");
+        assert_eq!(fmt_f64(f64::INFINITY), "+Inf");
+        assert_eq!(fmt_f64(f64::NEG_INFINITY), "-Inf");
+        assert_eq!(fmt_f64(1.5), "1.5");
     }
 }

--- a/crates/talon-transport/src/runtime.rs
+++ b/crates/talon-transport/src/runtime.rs
@@ -87,6 +87,10 @@ impl Shutdown {
 /// The single-ring server: accept + frame-dispatch loop.
 pub struct Server<H: Handler> {
     handler: Arc<H>,
+    /// Optional cap on concurrent connections. When set, each accepted
+    /// connection acquires a permit (held for its lifetime) before it is
+    /// handled, so a flood of peers cannot spawn unbounded tasks/FDs (#167).
+    conn_limit: Option<crate::limits::ConnectionLimit>,
 }
 
 impl<H: Handler> Server<H> {
@@ -94,7 +98,16 @@ impl<H: Handler> Server<H> {
     pub fn new(handler: H) -> Self {
         Self {
             handler: Arc::new(handler),
+            conn_limit: None,
         }
+    }
+
+    /// Bound concurrent connections to `max`, mirroring the live worker/
+    /// coordinator accept loops. Without this a service built on the shared
+    /// `Server` would accept unboundedly (#167).
+    pub fn with_connection_limit(mut self, max: usize) -> Self {
+        self.conn_limit = Some(crate::limits::ConnectionLimit::new(max));
+        self
     }
 
     /// Bind `addr` and run the accept loop until `shutdown` is triggered.
@@ -105,6 +118,11 @@ impl<H: Handler> Server<H> {
     /// header decoder's `MAX_PAYLOAD_LEN` guard.
     pub async fn serve(&self, addr: &str, shutdown: Shutdown) -> std::io::Result<()> {
         let listener = TcpListener::bind(addr).await?;
+        self.serve_on(listener, shutdown).await
+    }
+
+    /// Run the accept loop over an already-bound listener (used with [`bind`]).
+    pub async fn serve_on(&self, listener: TcpListener, shutdown: Shutdown) -> std::io::Result<()> {
         loop {
             tokio::select! {
                 _ = shutdown.wait() => {
@@ -114,26 +132,17 @@ impl<H: Handler> Server<H> {
                 accepted = listener.accept() => {
                     let (stream, _peer) = accepted?;
                     let handler = Arc::clone(&self.handler);
+                    let conn_limit = self.conn_limit.clone();
                     tokio::spawn(async move {
+                        // Acquire the permit inside the task so the accept loop
+                        // stays responsive to shutdown even at the limit (#167).
+                        let _permit = match conn_limit {
+                            Some(limit) => Some(limit.acquire().await),
+                            None => None,
+                        };
                         if let Err(e) = handle_conn(stream, handler).await {
                             tracing::debug!(error = %e, "runtime: connection ended");
                         }
-                    });
-                }
-            }
-        }
-    }
-
-    /// Run the accept loop over an already-bound listener (used with [`bind`]).
-    pub async fn serve_on(&self, listener: TcpListener, shutdown: Shutdown) -> std::io::Result<()> {
-        loop {
-            tokio::select! {
-                _ = shutdown.wait() => return Ok(()),
-                accepted = listener.accept() => {
-                    let (stream, _peer) = accepted?;
-                    let handler = Arc::clone(&self.handler);
-                    tokio::spawn(async move {
-                        let _ = handle_conn(stream, handler).await;
                     });
                 }
             }
@@ -229,6 +238,40 @@ mod tests {
 
         shutdown.trigger();
         // Accept loop returns cleanly after shutdown.
+        let _ = handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn connection_limit_still_serves_within_capacity() {
+        // A Server built with a connection limit acquires+releases a permit per
+        // connection and still serves normally within capacity (#167).
+        let server = Server::new(|header: FrameHeader, payload: Vec<u8>| {
+            let mut out = header.encode().to_vec();
+            out.extend_from_slice(&payload);
+            Some(out)
+        })
+        .with_connection_limit(2);
+        let (listener, addr) = bind("127.0.0.1:0").await.unwrap();
+        let shutdown = Shutdown::new();
+        let sd = shutdown.clone();
+        let handle = tokio::spawn(async move { server.serve_on(listener, sd).await });
+
+        // Two sequential connections both succeed (the first's permit is released
+        // on drop before the second acquires).
+        for _ in 0..2 {
+            let mut client = TcpStream::connect(addr).await.unwrap();
+            let body = b"hi";
+            let hdr = FrameHeader::new(MsgType::Control, 1, body.len() as u32);
+            client.write_all(&hdr.encode()).await.unwrap();
+            client.write_all(body).await.unwrap();
+            let mut echoed_hdr = [0u8; HEADER_LEN];
+            client.read_exact(&mut echoed_hdr).await.unwrap();
+            let mut echoed_body = vec![0u8; body.len()];
+            client.read_exact(&mut echoed_body).await.unwrap();
+            assert_eq!(echoed_body, body);
+        }
+
+        shutdown.trigger();
         let _ = handle.await.unwrap();
     }
 


### PR DESCRIPTION
## Summary
Seven small, verified, independent findings from the HEAD d9e7ae0 review, grouped into one change:

1. **Legacy `Register` is now a membership no-op** — it wrote only local, self-erasing membership; workers use `NodeStatusHeartbeat`.
2. **`range_header` checked arithmetic** (s3/gcs/azure) — `offset + len - 1` underflowed on `len == 0` and could overflow; now `offset.saturating_add(len.saturating_sub(1))`.
3. **`advertise_addr` wildcard rejection via `SocketAddr`** — rejects `ip().is_unspecified()`, catching every spelling of the unspecified address (not just `0.0.0.0:`/`[::]:`). Hostname forms are left as-is.
4. **Histogram robustness** — sort/dedup/finite-filter bounds so `_bucket` stays monotonic; drop non-finite observations; render `NaN`/`-Inf` in `fmt_f64`.
5. **`Epoch` drops `Ord`/`PartialOrd`** — it's an equality-only content hash; magnitude comparison now fails to compile.
6. **Coordinator accept loop acquires the permit inside the spawned task** — `ctrl_c` shutdown stays responsive at the connection cap.
7. **Transport `Server` gains `with_connection_limit`** — the shared server is no longer a latent unbounded-connection hazard.

## Testing
New tests for items 2, 3, 4, 7; `control_path` integration test migrated to `NodeStatusHeartbeat` (item 1). `fmt` / `clippy -D warnings` / `test --all-features` / `doc -D warnings` all clean.

Closes #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)