### PR TITLE
enhance(worker): serve cached-block hits via zero-copy sendfile

### DIFF
--- a/crates/talon-worker/src/lib.rs
+++ b/crates/talon-worker/src/lib.rs
@@ -27,7 +27,7 @@ pub use memory_store::MemoryStore;
 pub use miss::{touched_pages, Admission, InFlightGuard, InFlightLoads, LoadKey};
 pub use observability::{serve_admin, WorkerMetrics, WorkerObservability, WorkerReadiness};
 pub use paged_store::PagedBlockStore;
-pub use runtime::WorkerRuntime;
+pub use runtime::{ServeOutcome, WorkerRuntime};
 pub use sendfile::{send_file_range, DEFAULT_CHUNK};
 pub use splice::{ingest_put, splice_to_file};
 pub use staging::{Checksum, Stager};

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -14,9 +14,12 @@
 //! - Backend fetch is the real [`AzureBackend`] over [`ReqwestClient`]; the SAS
 //!   token is read from the environment and **never logged**.
 //!
-//! The response returns bytes inline for simplicity; the production hot path
-//! serves them zero-copy via `sendfile` from the committed block file
-//! ([`send_file_range`](talon_worker::send_file_range)).
+//! The hot path serves cached blocks **zero-copy** via `sendfile(2)`
+//! ([`send_file_range`](talon_worker::send_file_range)) straight from the
+//! committed block file's descriptor into the client socket — the bytes never
+//! enter user space and no per-request block buffer is allocated (issue #179). A
+//! cache miss (bytes just fetched into memory) or a boundary-spanning read falls
+//! back to writing the in-memory bytes inline.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -31,7 +34,8 @@ use talon_transport::data;
 use talon_transport::frame::{MsgType, HEADER_LEN};
 use talon_transport::{codec, ControlMessage, FrameHeader};
 use talon_worker::{
-    serve_admin, BlockIndex, InFlightLoads, WholeBlockStore, WorkerObservability, WorkerRuntime,
+    send_file_range, serve_admin, BlockIndex, InFlightLoads, ServeOutcome, WholeBlockStore,
+    WorkerObservability, WorkerRuntime, DEFAULT_CHUNK,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -404,8 +408,34 @@ async fn handle_conn(
             continue;
         }
 
-        match worker.serve_range(&req).await {
-            Ok(bytes) => {
+        match worker.serve(&req).await {
+            Ok(ServeOutcome::Sendfile(handle)) => {
+                // Zero-copy hit: write the frame header async, then stream the
+                // block file's fd straight into the socket with sendfile(2) on
+                // the blocking pool. The header's advertised length equals the
+                // handle length, so a short read can never desync the client.
+                let len = handle.len;
+                let hdr = data::response_header_ok(h.request_id, len as u32);
+                stream.write_all(&hdr).await?;
+                stream.flush().await?;
+                match sendfile_payload(stream, handle).await {
+                    Ok(returned) => {
+                        stream = returned;
+                        observability
+                            .metrics()
+                            .record_request_success(len, request_started.elapsed());
+                    }
+                    Err(error) => {
+                        // The header is already on the wire, so we cannot send an
+                        // error frame; the connection is desynced. Drop it.
+                        observability
+                            .metrics()
+                            .record_request_error(request_started.elapsed());
+                        return Err(error);
+                    }
+                }
+            }
+            Ok(ServeOutcome::Bytes(bytes)) => {
                 let hdr = data::response_header_ok(h.request_id, bytes.len() as u32);
                 stream.write_all(&hdr).await?;
                 stream.write_all(&bytes).await?;
@@ -424,6 +454,48 @@ async fn handle_conn(
             }
         }
     }
+}
+
+/// Stream a resident block's bytes to the client with `sendfile(2)`.
+///
+/// `sendfile` is blocking and Linux-specific, and the tokio [`TcpStream`] is
+/// non-blocking (a blocking `sendfile` on it would spuriously `EAGAIN`). So we
+/// take the stream out of tokio ([`into_std`]), put the socket in blocking mode,
+/// run the chunked [`send_file_range`] loop on the blocking helper pool
+/// ([`spawn_blocking`]) — never on the async reactor, per DESIGN.md — then
+/// restore non-blocking mode and hand the stream back for the next request.
+///
+/// [`into_std`]: tokio::net::TcpStream::into_std
+/// [`spawn_blocking`]: tokio::task::spawn_blocking
+async fn sendfile_payload(
+    stream: TcpStream,
+    handle: talon_core::BlockHandle,
+) -> anyhow::Result<TcpStream> {
+    let std_stream = stream.into_std()?;
+    std_stream.set_nonblocking(false)?;
+    let (std_stream, result) = tokio::task::spawn_blocking(move || {
+        let res = send_file_range(
+            &std_stream,
+            &handle.fd,
+            handle.offset,
+            handle.len,
+            DEFAULT_CHUNK,
+        );
+        (std_stream, res)
+    })
+    .await?;
+    let sent = result?;
+    if sent != handle.len {
+        // sendfile hit EOF before the advertised length: the block file is
+        // shorter than the index claimed. The header already promised `len`
+        // bytes, so the connection is desynced — surface an error to drop it.
+        anyhow::bail!(
+            "sendfile short read: sent {sent} of {} bytes; block file truncated",
+            handle.len
+        );
+    }
+    std_stream.set_nonblocking(true)?;
+    Ok(TcpStream::from_std(std_stream)?)
 }
 
 /// Read one framed control message (header + payload). `Ok(None)` on clean EOF.
@@ -585,6 +657,117 @@ mod tests {
         assert!(!observability.is_ready());
 
         control.abort();
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    /// A backend that serves deterministic bytes so a block can be committed and
+    /// then re-served on a hit — used to exercise the end-to-end sendfile path.
+    struct RampBackend;
+
+    #[async_trait]
+    impl BackendStore for RampBackend {
+        async fn fetch_range(&self, _object: &ObjectId, offset: u64, len: u64) -> Result<Bytes> {
+            Ok(Bytes::from(
+                (0..len)
+                    .map(|i| ((offset + i) % 251) as u8)
+                    .collect::<Vec<u8>>(),
+            ))
+        }
+
+        async fn head(&self, _object: &ObjectId) -> Result<ObjectStat> {
+            Ok(ObjectStat {
+                len: u64::MAX,
+                version: Version::new("v1"),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_conn_serves_a_hit_via_sendfile_byte_exact() {
+        use talon_transport::data::{encode_request, RangeRequest};
+
+        // Build a worker over a ramp backend so the first request commits a block
+        // and the second is a resident hit served with sendfile.
+        let root = tmp_root();
+        let index = Arc::new(BlockIndex::new());
+        let inflight = Arc::new(InFlightLoads::new());
+        let node = NodeInfo {
+            id: NodeId::new("w"),
+            address: "127.0.0.1:7001".into(),
+            role: NodeRole::Worker,
+        };
+        let observability = Arc::new(
+            WorkerObservability::new(
+                "c".into(),
+                node,
+                "127.0.0.1:8001".into(),
+                1024,
+                Arc::clone(&index),
+                Arc::clone(&inflight),
+            )
+            .unwrap(),
+        );
+        observability.readiness().set_backend_ready(true);
+        observability.readiness().set_store_ready(true);
+        observability.readiness().set_control_registered(true);
+        let backend: Arc<dyn BackendStore> = Arc::new(RampBackend);
+        let worker = Arc::new(WorkerRuntime::new(
+            WholeBlockStore::open(&root).unwrap(),
+            index,
+            inflight,
+            backend,
+            16, // block_size
+            0,
+            observability.metrics().clone(),
+        ));
+
+        // Serve the connection loop in the background.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let srv_worker = Arc::clone(&worker);
+        let srv_obs = Arc::clone(&observability);
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let _ = handle_conn(stream, srv_worker, srv_obs).await;
+        });
+
+        // A client that issues two identical range requests on one connection:
+        // the first is a miss (Bytes path), the second a hit (sendfile path).
+        let obj = ObjectId::new(talon_core::Backend::Azure, "c", "obj");
+        let req = RangeRequest {
+            object: obj,
+            offset: 3,
+            len: 8,
+        };
+        let mut client = TcpStream::connect(addr).await.unwrap();
+        let expected: Vec<u8> = (0..8u64).map(|i| ((3 + i) % 251) as u8).collect();
+
+        for _ in 0..2 {
+            let out = encode_request(0, &req).unwrap();
+            client.write_all(&out).await.unwrap();
+            client.flush().await.unwrap();
+
+            let mut hdr = [0u8; HEADER_LEN];
+            client.read_exact(&mut hdr).await.unwrap();
+            let header = FrameHeader::decode(&hdr).unwrap();
+            assert!(
+                !header.flags.contains(talon_transport::Flags::ERROR),
+                "worker returned an error frame"
+            );
+            // The response body is the raw range bytes (no envelope), so a worker
+            // can sendfile them straight from the block file.
+            let mut body = vec![0u8; header.length as usize];
+            client.read_exact(&mut body).await.unwrap();
+            assert_eq!(body, expected, "range bytes must match on miss and hit");
+        }
+
+        drop(client);
+        server.await.unwrap();
+        // A hit was recorded (the sendfile path bumps the cache-hit counter).
+        assert!(observability
+            .metrics()
+            .render()
+            .contains("talon_worker_cache_hits_total{form=\"whole\"} 1"));
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -5,7 +5,8 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use talon_core::{
-    BackendStore, BlockForm, BlockId, BlockMeta, Error, ObjectId, ObjectStore, PageIndex, Version,
+    BackendStore, BlockForm, BlockHandle, BlockId, BlockMeta, Error, ObjectId, ObjectStore,
+    PageIndex, Version,
 };
 use talon_transport::data::RangeRequest;
 
@@ -25,6 +26,22 @@ const DEFAULT_VERSION_TTL: Duration = Duration::from_secs(3);
 struct CachedVersion {
     version: Version,
     resolved_at: Instant,
+}
+
+/// How the serve loop should transmit a range's bytes to the client.
+///
+/// The whole point is to avoid pulling a resident block through user space: when
+/// the request lies entirely within a single already-cached block, the runtime
+/// hands back an open file descriptor over the exact sub-range so the caller can
+/// stream it with `sendfile(2)` (zero-copy, no per-request allocation). Every
+/// other shape — a cache miss, or a request spanning block boundaries — falls
+/// back to the in-memory byte path.
+pub enum ServeOutcome {
+    /// Serve these bytes with `sendfile` straight from the block file's fd.
+    Sendfile(BlockHandle),
+    /// Serve these already-in-memory bytes (miss just fetched, or a stitched
+    /// multi-block read).
+    Bytes(bytes::Bytes),
 }
 
 /// Shared state required to serve instrumented data-plane range requests.
@@ -140,6 +157,92 @@ impl WorkerRuntime {
             }
             Err(error) => Err(error),
         }
+    }
+
+    /// Serve `[offset, offset + len)`, choosing a zero-copy `sendfile` path when
+    /// the whole range lies within a single already-resident block.
+    ///
+    /// This is the preferred entry point for the data plane: for the common case
+    /// (a sub-range read of a cached block) it returns a [`ServeOutcome::Sendfile`]
+    /// carrying an open fd over the exact bytes, so the caller streams them with
+    /// `sendfile(2)` without ever reading the block into user space or allocating
+    /// (issue #179). A cache miss, a boundary-spanning read, or a lost open race
+    /// falls back to [`ServeOutcome::Bytes`] via the existing in-memory path.
+    ///
+    /// Version resolution and the precondition retry mirror [`serve_range`](Self::serve_range):
+    /// blocks are keyed by the resolved ETag, and a `412`/`VersionMismatch` inside
+    /// the version-cache window re-resolves once (issues #119, #163).
+    pub async fn serve(&self, request: &RangeRequest) -> anyhow::Result<ServeOutcome> {
+        if request.len == 0 {
+            return Ok(ServeOutcome::Bytes(bytes::Bytes::new()));
+        }
+        let version = self.resolve_version(&request.object, false).await?;
+        match self.serve_at(request, &version).await {
+            Ok(outcome) => Ok(outcome),
+            Err(error) if is_version_mismatch(&error) => {
+                self.invalidate_version(&request.object);
+                let version = self.resolve_version(&request.object, true).await?;
+                self.serve_at(request, &version).await
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    /// The single-resolved-version body of [`serve`](Self::serve).
+    ///
+    /// Tries the zero-copy fast path: if the request lies within one block and
+    /// that block is already resident, open an fd over the exact sub-range and
+    /// return [`ServeOutcome::Sendfile`]. Anything else (miss, boundary span)
+    /// falls through to [`serve_range_at`](Self::serve_range_at) and returns [`ServeOutcome::Bytes`].
+    async fn serve_at(
+        &self,
+        request: &RangeRequest,
+        version: &Version,
+    ) -> anyhow::Result<ServeOutcome> {
+        let block_size = self.block_size as u64;
+        let end = request
+            .offset
+            .checked_add(request.len)
+            .ok_or_else(|| anyhow::anyhow!("range offset+len overflows u64"))?;
+        let start_block = (request.offset / block_size) * block_size;
+
+        // Zero-copy fast path: whole range within one block that is resident.
+        if end <= start_block + block_size {
+            let block = self.block_for(&request.object, request.offset, version);
+            if matches!(
+                self.index.presence(&block, PageIndex(0), PageIndex(1)),
+                Presence::Whole
+            ) {
+                let offset_in_block = request.offset - block.offset;
+                // Open an fd over exactly the requested window. This can fail if
+                // the block was evicted between the presence check and the open
+                // (a benign race); fall through to the byte path in that case.
+                match self
+                    .store
+                    .get_range(&block, offset_in_block, request.len)
+                    .await
+                {
+                    // The whole-block store returns exactly one handle spanning
+                    // the requested window.
+                    Ok(mut handles) if handles.len() == 1 => {
+                        let handle = handles.pop().expect("one handle");
+                        self.metrics.record_cache_hit();
+                        self.lru.touch(&CacheUnit::Whole(block.clone()));
+                        tracing::info!(block = %block, "HIT (sendfile)");
+                        return Ok(ServeOutcome::Sendfile(handle));
+                    }
+                    Ok(_) | Err(_) => {
+                        // Lost the race with eviction, or an unexpected multi-handle
+                        // result; serve via the byte path (which re-fetches if
+                        // still absent).
+                    }
+                }
+            }
+        }
+
+        // Fallback: miss or boundary-spanning read → in-memory bytes.
+        let bytes = self.serve_range_at(request, version).await?;
+        Ok(ServeOutcome::Bytes(bytes))
     }
 
     /// Serve `[offset, offset + len)` against an already-resolved `version`.
@@ -538,12 +641,98 @@ mod tests {
         std::fs::remove_dir_all(root).ok();
     }
 
+    /// Read the bytes a `Sendfile` outcome would transmit, straight from its fd.
+    fn read_handle(outcome: ServeOutcome) -> Vec<u8> {
+        use std::io::{Read, Seek, SeekFrom};
+        match outcome {
+            ServeOutcome::Sendfile(handle) => {
+                let mut f = std::fs::File::from(handle.fd);
+                f.seek(SeekFrom::Start(handle.offset)).unwrap();
+                let mut buf = vec![0u8; handle.len as usize];
+                f.read_exact(&mut buf).unwrap();
+                buf
+            }
+            ServeOutcome::Bytes(_) => panic!("expected Sendfile, got Bytes"),
+        }
+    }
+
+    #[tokio::test]
+    async fn serve_uses_sendfile_on_a_resident_hit() {
+        // First serve is a miss → in-memory Bytes (block just fetched). The
+        // second serve of the same resident block returns a Sendfile handle over
+        // exactly the requested sub-range, byte-for-byte (issue #179).
+        let root = tmp_root();
+        let backend = Arc::new(MockBackend {
+            calls: AtomicUsize::new(0),
+        });
+        let runtime = runtime(Arc::clone(&backend), WorkerMetrics::new(1024), &root);
+
+        // Miss: bytes path.
+        match runtime.serve(&request("ok")).await.unwrap() {
+            ServeOutcome::Bytes(b) => assert_eq!(b, Bytes::from_static(b"abcd")),
+            ServeOutcome::Sendfile(_) => panic!("first serve (miss) must be Bytes"),
+        }
+
+        // Hit: sendfile path, exact sub-range.
+        let outcome = runtime.serve(&request("ok")).await.unwrap();
+        assert_eq!(read_handle(outcome), b"abcd");
+        // No second backend fetch.
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn serve_sendfile_serves_a_mid_block_subrange() {
+        // A sub-range that does not start at 0 must open an fd at the right
+        // offset, so the handle covers exactly [offset, offset+len).
+        let root = tmp_root();
+        let backend = Arc::new(MockBackend {
+            calls: AtomicUsize::new(0),
+        });
+        let runtime = runtime(Arc::clone(&backend), WorkerMetrics::new(1024), &root);
+
+        // Warm the block (returns b"abcdefgh").
+        let _ = runtime.serve(&request("ok")).await.unwrap();
+        // Request bytes [3, 7) of the same block: "defg".
+        let req = RangeRequest {
+            object: ObjectId::new(Backend::Azure, "container", "ok"),
+            offset: 3,
+            len: 4,
+        };
+        let outcome = runtime.serve(&req).await.unwrap();
+        assert_eq!(read_handle(outcome), b"defg");
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn serve_falls_back_to_bytes_across_block_boundary() {
+        // A read spanning two blocks cannot be a single-fd sendfile; it must
+        // stitch in memory and return Bytes even when both blocks are resident.
+        let root = tmp_root();
+        let runtime = runtime_with(
+            Arc::new(RampBackend { block_size: 8 }),
+            WorkerMetrics::new(1024),
+            &root,
+            8,
+        );
+        // [6, 14) spans block0 [0,8) and block1 [8,16).
+        let req = RangeRequest {
+            object: ObjectId::new(Backend::Azure, "container", "ramp"),
+            offset: 6,
+            len: 8,
+        };
+        match runtime.serve(&req).await.unwrap() {
+            ServeOutcome::Bytes(b) => assert_eq!(b, expected(6, 8)),
+            ServeOutcome::Sendfile(_) => panic!("boundary-spanning read must be Bytes"),
+        }
+        std::fs::remove_dir_all(root).ok();
+    }
+
     /// A backend whose block content is deterministic per absolute offset, so a
     /// stitched multi-block read can be verified byte-for-byte.
     struct RampBackend {
         block_size: u64,
     }
-
     #[async_trait]
     impl BackendStore for RampBackend {
         async fn fetch_range(&self, _object: &ObjectId, offset: u64, len: u64) -> Result<Bytes> {


### PR DESCRIPTION
Part of #178. Closes #179.

## Summary
The `GetRange` serve path read the **entire** cached block into a `Vec` and `write_all`'d it, even for a small sub-range read (`serve_range` → `get_bytes` → `read_to_end` of the whole 256 MiB block, then a second user-space → socket copy). The zero-copy `send_file_range` helper existed and was documented as the hot path but was **never called** — the same designed-but-unwired pattern as eviction (#159).

- New `WorkerRuntime::serve` returns a `ServeOutcome`: `Sendfile(BlockHandle)` when the request lies within one already-resident block, else `Bytes` for a miss or a boundary-spanning stitched read. It mirrors `serve_range`'s version resolution + precondition retry (#119/#163); a lost race with eviction falls back to the byte path.
- The serve loop writes the frame header async, then streams the block fd into the socket with `send_file_range` on the **blocking pool** (`sendfile(2)` is blocking, the tokio socket is non-blocking → `into_std` + set-blocking + `spawn_blocking` + restore). The header length equals the handle length; a short read is a desync error (drop the connection).

Eliminates both the whole-block allocation and the user-space copy on every hit — a 4 KiB read of a 256 MiB block no longer buffers 256 MiB.

## Testing
Runtime unit tests (sendfile on resident hit, mid-block sub-range fd offset, boundary-span fallback to Bytes) + an **end-to-end `handle_conn` test** driving the real serve loop over a socket, asserting byte-exactness on both the miss and the sendfile hit. `fmt`/`clippy -D warnings --all-features`/`test --all-features`/`doc -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)