### PR TITLE
doc: add mdBook site, four-quadrant structure, and Pages deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,21 @@ jobs:
       - name: Build docs
         run: cargo doc --workspace --no-deps --all-features
 
+  docs-book:
+    name: mdbook build
+    runs-on: ubuntu-latest
+    # Ensures the mdBook documentation site always builds. Deployment to GitHub
+    # Pages happens separately (docs.yml) only on merge to main.
+    env:
+      MDBOOK_VERSION: "0.4.52"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - name: Install mdBook
+        run: cargo install mdbook --version ${MDBOOK_VERSION} --locked
+      - name: Build the book
+        run: mdbook build docs/book
+
   etcd-contract:
     name: etcd backend contract
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,63 @@
+name: Docs
+
+# Build and publish the mdBook documentation site to GitHub Pages on merge to
+# main. Pull requests only build the book (see the docs-book job in ci.yml);
+# this workflow is the deploy path.
+#
+# NOTE: deployment requires GitHub Pages to be enabled with "GitHub Actions" as
+# the source (repository Settings -> Pages). Until then this workflow's deploy
+# step will fail, but that does not affect PR merges — PRs never run it.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/book/**"
+      - "docs/**/*.md"
+      - "*.md"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+# Least-privilege: only the Pages deploy needs write + id-token.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Serialize deployments; never cancel an in-progress publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  MDBOOK_VERSION: "0.4.52"
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - name: Install mdBook
+        run: cargo install mdbook --version ${MDBOOK_VERSION} --locked
+      - name: Build the book
+        run: mdbook build docs/book
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book/book
+
+  deploy:
+    name: deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Build artifacts
 /target
 
+# mdBook rendered output (source lives in docs/book/src)
+/docs/book/book/
+
 # Benchmark run output (baselines are committed; per-run results are not)
 /bench/results/
 

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -1,0 +1,19 @@
+[book]
+title = "Talon"
+authors = ["The Talon authors"]
+description = "A distributed object-store cache written in Rust."
+src = "src"
+language = "en"
+
+[output.html]
+git-repository-url = "https://github.com/milvus-io/talon"
+edit-url-template = "https://github.com/milvus-io/talon/edit/main/docs/book/{path}"
+default-theme = "navy"
+preferred-dark-theme = "navy"
+
+[output.html.search]
+enable = true
+
+[output.html.fold]
+enable = true
+level = 1

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -1,0 +1,27 @@
+# Summary
+
+[Introduction](./introduction.md)
+
+# Tutorials
+
+- [Getting started](./tutorials/getting-started.md)
+
+# How-to guides
+
+- [Operator runbook](./operations/runbook.md)
+- [Security hardening](./operations/security.md)
+
+# Reference
+
+- [Configuration reference](./reference/configuration.md)
+- [REST API reference](./reference/rest-api.md)
+
+# Explanation
+
+- [Design (v1)](./explanation/design.md)
+- [ADR 0001: Management-plane HA](./explanation/adr-0001-management-plane-ha.md)
+
+# Contributing
+
+- [Contributing guide](./contributing/contributing.md)
+- [Benchmarks](./contributing/benchmarks.md)

--- a/docs/book/src/contributing/benchmarks.md
+++ b/docs/book/src/contributing/benchmarks.md
@@ -1,0 +1,1 @@
+{{#include ../../../../BENCHMARKS.md}}

--- a/docs/book/src/contributing/contributing.md
+++ b/docs/book/src/contributing/contributing.md
@@ -1,0 +1,1 @@
+{{#include ../../../../CONTRIBUTING.md}}

--- a/docs/book/src/explanation/adr-0001-management-plane-ha.md
+++ b/docs/book/src/explanation/adr-0001-management-plane-ha.md
@@ -1,0 +1,1 @@
+{{#include ../../../adr/0001-management-plane-ha.md}}

--- a/docs/book/src/explanation/design.md
+++ b/docs/book/src/explanation/design.md
@@ -1,0 +1,1 @@
+{{#include ../../../../DESIGN.md}}

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -1,0 +1,1 @@
+{{#include ../../../README.md}}

--- a/docs/book/src/operations/runbook.md
+++ b/docs/book/src/operations/runbook.md
@@ -1,0 +1,1 @@
+{{#include ../../../operations/runbook.md}}

--- a/docs/book/src/operations/security.md
+++ b/docs/book/src/operations/security.md
@@ -1,0 +1,1 @@
+{{#include ../../../operations/security.md}}

--- a/docs/book/src/reference/configuration.md
+++ b/docs/book/src/reference/configuration.md
@@ -1,0 +1,11 @@
+# Configuration reference
+
+> **Coming soon.** A complete reference of every coordinator and worker
+> configuration key — config-file entry, CLI flag, and `TALON_*` environment
+> variable — **generated from the source of truth** (the `clap` definitions and
+> config structs) so it can never drift from the code.
+>
+> Tracked in [issue #188](https://github.com/milvus-io/talon/issues/188).
+
+Until then, see the configuration section of the
+[operator runbook](../operations/runbook.md).

--- a/docs/book/src/reference/rest-api.md
+++ b/docs/book/src/reference/rest-api.md
@@ -1,0 +1,11 @@
+# REST API reference
+
+> **Coming soon.** A complete reference for the coordinator management API,
+> **generated from `openapi.json`** so it tracks the spec rather than being
+> hand-written.
+>
+> Tracked in [issue #189](https://github.com/milvus-io/talon/issues/189).
+
+Until then, the machine-readable spec lives at
+`crates/talon-coordinator/src/openapi.json`, and a running coordinator serves it
+at `/api/v1/openapi.json`.

--- a/docs/book/src/tutorials/getting-started.md
+++ b/docs/book/src/tutorials/getting-started.md
@@ -1,0 +1,1 @@
+{{#include ../../../tutorials/getting-started.md}}


### PR DESCRIPTION
## Summary

Wave 2 of the documentation overhaul (#184). Stands up a searchable **mdBook**
site organized on the [Divio four-quadrant model](https://documentation.divio.com/)
(Tutorials / How-to / Reference / Explanation / Contributing) and wires it into CI.

**Zero file movement, zero duplication, no broken links.** Existing docs stay
exactly where they are — each book page is a one-line `{{#include}}` of the real
file (README, DESIGN, CONTRIBUTING, BENCHMARKS, runbook, security, ADR 0001, the
getting-started tutorial). Verified that mdBook's `{{#include ../../../…}}`
resolves files outside `src/`, so this works cleanly.

- `docs/book/` — `book.toml` + `SUMMARY.md` + 11 include-shell pages.
- Two **Reference** stubs point at the generated config (#188) and REST API
  (#189) references that land next.
- **CI:** a `docs-book` job builds the book on every PR (gate); a separate
  `docs.yml` deploys to GitHub Pages on merge to main. Rendered output
  (`docs/book/book/`) is gitignored.

## ⚠️ Action required to enable the live site

Deployment needs a maintainer to set **repository Settings → Pages → Source =
"GitHub Actions"** once. Until then the `docs.yml` deploy step will fail on main,
but **this does not affect PR merges** — PRs only run the build gate. After
enabling, the next push to main publishes to `https://milvus-io.github.io/talon/`.

## Test plan

- [x] `mdbook build docs/book` succeeds from the repo root (as CI runs it);
      `index.html` produced.
- [x] Every `{{#include}}` resolves — no missing-include errors; spot-checked
      that each rendered page contains the real source content.
- [x] Sidebar shows all five parts (Tutorials / How-to / Reference / Explanation
      / Contributing) + Introduction + 9 pages.
- [x] Both workflow YAMLs validate; build artifacts are gitignored (only source
      committed).

Closes #187