### PR TITLE
fix(fuse): address mount blocks under a canonical version token

### DIFF
--- a/crates/talon-fuse/src/lib.rs
+++ b/crates/talon-fuse/src/lib.rs
@@ -29,7 +29,7 @@ pub use fs::TalonFs;
 pub use mapping::{object_to_path, path_to_object, resolve_read, ReadTarget};
 pub use metrics::{ReadStats, ReadStatsSnapshot};
 #[cfg(feature = "mount")]
-pub use mount::TalonFuse;
+pub use mount::{TalonFuse, CANONICAL_MOUNT_VERSION};
 pub use ops::{Attr, DirEntry, FileKind, FsError, ReadOnlyFs, ROOT_INO};
 pub use placement_cache::{Cached, PlacementCache, RefreshReason};
 pub use pool::ConnectionPool;

--- a/crates/talon-fuse/src/main.rs
+++ b/crates/talon-fuse/src/main.rs
@@ -102,9 +102,12 @@ async fn run_mount(
     reader: BlockReader,
 ) -> anyhow::Result<()> {
     use fuser::MountOption;
-    use talon_fuse::mount::TalonFuse;
+    use talon_fuse::mount::{TalonFuse, CANONICAL_MOUNT_VERSION};
 
-    let version = talon_core::Version::new("v1");
+    // The mount path is version-independent by design: the worker is the sole
+    // authority on freshness (#119/#163) and the client never sends a version to
+    // it, so every block is addressed under one canonical token (#182).
+    let version = talon_core::Version::new(CANONICAL_MOUNT_VERSION);
     let handle = tokio::runtime::Handle::current();
     let stats = reader.stats().clone();
     let adapter = TalonFuse::new(fs, reader, handle, cfg.block_size, version);

--- a/crates/talon-fuse/src/mapping.rs
+++ b/crates/talon-fuse/src/mapping.rs
@@ -12,7 +12,10 @@
 //! [`path_to_object`] parses such a path into an [`ObjectId`]; [`object_to_path`]
 //! is its inverse. For an open file, [`resolve_read`] maps a byte `offset` to
 //! the [`BlockId`] that contains it plus the offset *within* that block, given
-//! the file's block size and version (supplied by a coordinator `HEAD`).
+//! the file's block size and version. On the mount path the version is a
+//! canonical placeholder, not a per-object ETag: placement is version-
+//! independent and the worker owns freshness (see `mount::CANONICAL_MOUNT_VERSION`,
+//! issue #182).
 //!
 //! Parsing rejects ambiguous paths (empty components, `.`/`..`, absolute object
 //! keys) so odd object names cannot escape their namespace.

--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -78,6 +78,26 @@ pub(crate) fn to_file_attr(attr: Attr, uid: u32, gid: u32) -> fuser::FileAttr {
     }
 }
 
+/// The canonical placeholder version the mount path uses to address blocks.
+///
+/// **Placement is version-independent on the mount path in v1, by design.** The
+/// coordinator locates a block by hashing the [`BlockId`](talon_core::BlockId) the client sends
+/// (rendezvous/HRW), and the worker is the sole authority on *freshness*: it
+/// resolves each object's real ETag itself and refuses to serve stale bytes
+/// (issues #119, #163). The client never transmits a version to the worker —
+/// [`RangeRequest`](talon_transport::RangeRequest) carries only `object` +
+/// `[offset, len)` — so the version in a client-side [`BlockId`](talon_core::BlockId) affects only the
+/// client's own placement-cache key, never the bytes returned.
+///
+/// Rather than fabricate a per-object `"v1"` that looks meaningful but isn't,
+/// every mount-path block is addressed under this single canonical token. This
+/// keeps client and coordinator trivially consistent (both hash the same value)
+/// and makes the "no per-object version negotiation here" contract explicit. A
+/// future revision that wants version-aware placement would resolve the real
+/// version on both sides and revisit the mount's page-cache retention
+/// (`FOPEN_KEEP_CACHE`), which currently relies on session immutability.
+pub const CANONICAL_MOUNT_VERSION: &str = "talon-mount-v1";
+
 /// A mountable Talon filesystem: the `fuser` adapter over the read path.
 ///
 /// Holds the namespace tree ([`ReadOnlyFs`]) that answers metadata ops and the
@@ -93,11 +113,12 @@ pub struct TalonFuse {
     runtime: tokio::runtime::Handle,
     /// Logical block size used to split reads into per-block fetches.
     block_size: u32,
-    /// Source version/etag used to address blocks.
+    /// Canonical placeholder version used to address blocks.
     ///
-    /// v1 has no per-object version negotiation on the mount path, so a single
-    /// placeholder version is used cluster-wide (client and worker agree by
-    /// construction); a future revision resolves it from a coordinator `HEAD`.
+    /// The mount path is version-independent by design (see
+    /// [`CANONICAL_MOUNT_VERSION`]): this value only keys the client's placement
+    /// cache and feeds the HRW hash, never the bytes the worker returns. It is
+    /// normally [`CANONICAL_MOUNT_VERSION`].
     version: talon_core::Version,
 }
 
@@ -354,11 +375,21 @@ mod tests {
             reader,
             tokio::runtime::Handle::current(),
             256 << 20,
-            talon_core::Version::new("v1"),
+            talon_core::Version::new(CANONICAL_MOUNT_VERSION),
         );
         // The adapter exposes its components for the callbacks to use.
         assert_eq!(mounted.namespace().getattr(1).unwrap().ino, 1);
         assert_eq!(mounted.reader().coordinator_addr(), "127.0.0.1:7000");
+    }
+
+    #[test]
+    fn canonical_mount_version_is_a_stable_nonempty_token() {
+        // The mount path is version-independent (issue #182): placement hashes
+        // this token on both client and coordinator, and the worker owns
+        // freshness. It must be non-empty (an empty version is refused by the
+        // worker) and stable, so this guards against an accidental change.
+        assert!(!CANONICAL_MOUNT_VERSION.is_empty());
+        assert_eq!(CANONICAL_MOUNT_VERSION, "talon-mount-v1");
     }
 
     #[test]

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -144,7 +144,7 @@ async fn mount_read_is_byte_exact_through_the_kernel() {
         reader,
         tokio::runtime::Handle::current(),
         block_size,
-        talon_core::Version::new("v1"),
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
     );
 
     // Mount at a temp dir. Skip (don't fail) if /dev/fuse is unavailable.


### PR DESCRIPTION
Part of #178. Closes #182.

## Summary
The mount hardcoded `Version::new("v1")` and the docs claimed a future coordinator-`HEAD`-resolved per-object version. Investigation showed the mount path is **version-independent by construction**:
- `RangeRequest` (client→worker) carries only `object` + `[offset, len)` — the client never sends a version to the worker.
- The worker resolves each object's real ETag itself and refuses stale bytes (#119/#163) — it is the sole authority on freshness.
- The coordinator hashes the `BlockId` the client sends **verbatim** (deterministic HRW, no worker-side ownership registration), so client/coordinator are consistent for any version.

So the client's version only keys its own placement cache; it never affects returned bytes. Per the chosen design (keep the mount version-agnostic since the worker is authoritative), the fake `"v1"` is replaced with a single documented `CANONICAL_MOUNT_VERSION`, and the misleading docs are rewritten to state the real contract.

**Tension with #180 (documented on the constant):** `FOPEN_KEEP_CACHE` relies on session immutability; a future version-aware mount would resolve real versions on both sides and revisit page-cache retention.

## Testing
`canonical_mount_version_is_a_stable_nonempty_token`; mount e2e + construction tests use the constant. `fmt`/`clippy -D warnings` (default + `--features mount`)/`test --all-features`/`doc -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)