### PR TITLE
doc: generate configuration reference from ConfigVar schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,25 @@ jobs:
       - name: Build the book
         run: mdbook build docs/book
 
+  config-docs:
+    name: config reference drift
+    runs-on: ubuntu-latest
+    # The configuration reference is generated from the ConfigVar schemas.
+    # Fail if the committed copy is stale so docs cannot drift from the code.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: Swatinem/rust-cache@v2
+      - name: Regenerate and diff
+        run: |
+          cargo run -q -p talon-coordinator --features etcd,kubernetes \
+            --bin talon-gen-config-docs > /tmp/config-ref.md
+          if ! diff -u docs/reference/configuration.md /tmp/config-ref.md; then
+            echo "::error::docs/reference/configuration.md is stale; run 'just gen-config-docs'"
+            exit 1
+          fi
+
   etcd-contract:
     name: etcd backend contract
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -26,6 +26,19 @@ test:
 # Everything CI checks, in order.
 ci: fmt-check clippy test
 
+# --- documentation ---
+
+# Regenerate the configuration reference from the ConfigVar schemas.
+gen-config-docs:
+    cargo run -q -p talon-coordinator --features etcd,kubernetes \
+      --bin talon-gen-config-docs -- docs/reference/configuration.md
+
+# Fail if the committed configuration reference is stale vs. the schemas.
+check-config-docs:
+    cargo run -q -p talon-coordinator --features etcd,kubernetes \
+      --bin talon-gen-config-docs > /tmp/talon-config-ref.md
+    diff -u docs/reference/configuration.md /tmp/talon-config-ref.md
+
 # --- benchmarks (performance feedback loop) ---
 
 # Run all microbenchmarks and write bench/results/latest.json.

--- a/crates/talon-coordinator/Cargo.toml
+++ b/crates/talon-coordinator/Cargo.toml
@@ -11,6 +11,12 @@ description = "Cluster coordinator: metadata, membership, and object placement f
 name = "talon-coordinator"
 path = "src/main.rs"
 
+# Documentation generator: renders the config reference from the ConfigVar
+# schemas. Build with --features etcd,kubernetes so backend keys are included.
+[[bin]]
+name = "talon-gen-config-docs"
+path = "src/bin/gen-config-docs.rs"
+
 [features]
 state-store-testkit = []
 # Production Kubernetes Lease ClusterStateStore backend. Off by default so

--- a/crates/talon-coordinator/src/bin/gen-config-docs.rs
+++ b/crates/talon-coordinator/src/bin/gen-config-docs.rs
@@ -7,8 +7,11 @@
 //! `config-docs` job); run `just gen-config-docs` (or this binary) to refresh.
 //!
 //! Usage:
-//!   talon-gen-config-docs           # print to stdout
-//!   talon-gen-config-docs <path>    # write to a file
+//!
+//! ```text
+//! talon-gen-config-docs           # print to stdout
+//! talon-gen-config-docs <path>    # write to a file
+//! ```
 
 use std::io::Write;
 

--- a/crates/talon-coordinator/src/bin/gen-config-docs.rs
+++ b/crates/talon-coordinator/src/bin/gen-config-docs.rs
@@ -1,0 +1,71 @@
+//! Generate the configuration reference Markdown from the config schemas.
+//!
+//! The `TALON_*` environment variables, their config-file keys, defaults, and
+//! descriptions are declared once as `ConfigVar` schema tables in the code that
+//! parses them; this binary renders those tables to Markdown so the reference
+//! cannot drift. CI regenerates and diffs the committed output (see the
+//! `config-docs` job); run `just gen-config-docs` (or this binary) to refresh.
+//!
+//! Usage:
+//!   talon-gen-config-docs           # print to stdout
+//!   talon-gen-config-docs <path>    # write to a file
+
+use std::io::Write;
+
+use talon_coordinator::COORDINATOR_ENV_SCHEMA;
+use talon_core::{ConfigVar, FUSE_ENV_SCHEMA, WORKER_ENV_SCHEMA};
+
+fn main() -> std::io::Result<()> {
+    let mut out = String::new();
+    out.push_str(&render());
+    match std::env::args().nth(1) {
+        Some(path) => {
+            let mut f = std::fs::File::create(&path)?;
+            f.write_all(out.as_bytes())?;
+            eprintln!("wrote {path}");
+        }
+        None => print!("{out}"),
+    }
+    Ok(())
+}
+
+fn render() -> String {
+    let mut s = String::new();
+    s.push_str("# Configuration reference\n\n");
+    s.push_str(
+        "> **Generated file — do not edit by hand.** Produced from the `ConfigVar` \
+schema tables in the code by `talon-gen-config-docs`; CI fails if it drifts. To \
+change it, edit the schema next to the parser and regenerate.\n\n",
+    );
+    s.push_str(
+        "Every setting is resolved from four layers, highest precedence first: \
+**CLI flag** > **environment variable** > **config file (TOML)** > **default**. \
+A ✓ in the *CLI* column means the setting also has a `--<key>` flag; \
+environment variables always apply. Secrets are read only from the environment \
+and are never written to a config file or logged.\n\n",
+    );
+
+    section(&mut s, "Coordinator", COORDINATOR_ENV_SCHEMA);
+    section(&mut s, "Worker", WORKER_ENV_SCHEMA);
+    section(&mut s, "FUSE client", FUSE_ENV_SCHEMA);
+    s
+}
+
+fn section(s: &mut String, title: &str, schema: &[ConfigVar]) {
+    s.push_str(&format!("## {title}\n\n"));
+    s.push_str("| Key | Environment variable | Default | CLI | Description |\n");
+    s.push_str("|-----|----------------------|---------|-----|-------------|\n");
+    for v in schema {
+        let default = match v.default {
+            Some(d) => format!("`{d}`"),
+            None => "—".to_string(),
+        };
+        let cli = if v.cli { "✓" } else { "" };
+        let secret = if v.secret { " 🔒" } else { "" };
+        s.push_str(&format!(
+            "| `{}` | `{}`{} | {} | {} | {} |\n",
+            v.key, v.env, secret, default, cli, v.help
+        ));
+    }
+    s.push('\n');
+}

--- a/crates/talon-coordinator/src/config.rs
+++ b/crates/talon-coordinator/src/config.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use serde::Deserialize;
-use talon_core::{Patch, MAX_STATUS_FIELD_BYTES};
+use talon_core::{ConfigVar, Patch, MAX_STATUS_FIELD_BYTES};
 
 #[cfg(feature = "kubernetes")]
 use crate::KubernetesConfig;
@@ -153,6 +153,221 @@ impl Patch for CoordinatorConfigPatch {
     }
 }
 
+/// Single source of truth for the coordinator's `TALON_COORDINATOR_*`
+/// environment variables. [`CoordinatorConfigPatch::from_env_with`] reads the
+/// names from this table, and the documentation generator renders it, so the
+/// configuration reference cannot drift from the parser.
+pub const COORDINATOR_ENV_SCHEMA: &[ConfigVar] = &[
+    ConfigVar {
+        env: "TALON_COORDINATOR_LISTEN",
+        key: "listen",
+        default: Some("127.0.0.1:7000"),
+        cli: true,
+        secret: false,
+        help: "Control-plane bind address (workers/clients).",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_ADMIN_LISTEN",
+        key: "admin_listen",
+        default: Some("127.0.0.1:8000"),
+        cli: true,
+        secret: false,
+        help: "Admin HTTP bind address: metrics, health, API, UI.",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_ADMIN_ADVERTISE",
+        key: "admin_advertise",
+        default: Some("<admin_listen>"),
+        cli: true,
+        secret: false,
+        help: "Admin address advertised in node status.",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_CLUSTER_ID",
+        key: "cluster_id",
+        default: Some("default"),
+        cli: true,
+        secret: false,
+        help: "Logical cluster identity.",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_NODE_ID",
+        key: "node_id",
+        default: Some("<listen>"),
+        cli: true,
+        secret: false,
+        help: "Stable coordinator node identity.",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_STATE_BACKEND",
+        key: "state_backend",
+        default: Some("memory"),
+        cli: true,
+        secret: false,
+        help: "Shared-state backend: memory | etcd | kubernetes.",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_HA_ENABLED",
+        key: "ha_enabled",
+        default: Some("false"),
+        cli: true,
+        secret: false,
+        help: "Enable active-active mode; rejects the memory backend.",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_REPLICAS",
+        key: "coordinator_replicas",
+        default: Some("1"),
+        cli: true,
+        secret: false,
+        help: "Expected coordinator replica count.",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_HEARTBEAT_INTERVAL_MS",
+        key: "heartbeat_interval_ms",
+        default: Some("5000"),
+        cli: true,
+        secret: false,
+        help: "Node heartbeat interval (ms).",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_UNHEALTHY_AFTER_MS",
+        key: "unhealthy_after_ms",
+        default: Some("15000"),
+        cli: true,
+        secret: false,
+        help: "Silence before a node is unhealthy (ms); must exceed heartbeat.",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_LEASE_TTL_MS",
+        key: "lease_ttl_ms",
+        default: Some("30000"),
+        cli: true,
+        secret: false,
+        help: "Node lease TTL (ms); must exceed unhealthy_after.",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_REQUEST_TIMEOUT_MS",
+        key: "request_timeout_ms",
+        default: Some("3000"),
+        cli: true,
+        secret: false,
+        help: "Deadline for one authoritative backend operation (ms).",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_AUTH_TOKEN",
+        key: "(env only)",
+        default: None,
+        cli: false,
+        secret: true,
+        help: "Bearer token (>= 16 chars) enabling API/UI authentication; unset disables auth.",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_TRUST_FORWARDED",
+        key: "(env only)",
+        default: Some("false"),
+        cli: false,
+        secret: false,
+        help: "Honor X-Forwarded-For for audit attribution behind a trusted proxy.",
+    },
+    #[cfg(feature = "etcd")]
+    ConfigVar {
+        env: "TALON_COORDINATOR_ETCD_ENDPOINTS",
+        key: "etcd.endpoints",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "Comma-separated etcd host:port endpoints.",
+    },
+    #[cfg(feature = "etcd")]
+    ConfigVar {
+        env: "TALON_COORDINATOR_ETCD_USERNAME",
+        key: "etcd.username",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "etcd username (requires password).",
+    },
+    #[cfg(feature = "etcd")]
+    ConfigVar {
+        env: "TALON_COORDINATOR_ETCD_PASSWORD",
+        key: "etcd.password",
+        default: None,
+        cli: false,
+        secret: true,
+        help: "etcd password; keep in a Secret, not the config file.",
+    },
+    #[cfg(feature = "etcd")]
+    ConfigVar {
+        env: "TALON_COORDINATOR_ETCD_CA_CERT_PATH",
+        key: "etcd.tls.ca_cert_path",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "PEM CA certificate path; enables TLS.",
+    },
+    #[cfg(feature = "etcd")]
+    ConfigVar {
+        env: "TALON_COORDINATOR_ETCD_CLIENT_CERT_PATH",
+        key: "etcd.tls.client_cert_path",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "PEM client certificate path; mutual TLS.",
+    },
+    #[cfg(feature = "etcd")]
+    ConfigVar {
+        env: "TALON_COORDINATOR_ETCD_CLIENT_KEY_PATH",
+        key: "etcd.tls.client_key_path",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "PEM client key path; mutual TLS.",
+    },
+    #[cfg(feature = "kubernetes")]
+    ConfigVar {
+        env: "TALON_COORDINATOR_K8S_NAMESPACE",
+        key: "kubernetes.namespace",
+        default: Some("talon"),
+        cli: false,
+        secret: false,
+        help: "Namespace holding Talon Lease objects.",
+    },
+];
+
+/// Env-var name constants, referenced by both the schema above and the parser
+/// below so the two can never disagree on a name.
+pub mod env_names {
+    pub const LISTEN: &str = "TALON_COORDINATOR_LISTEN";
+    pub const ADMIN_LISTEN: &str = "TALON_COORDINATOR_ADMIN_LISTEN";
+    pub const ADMIN_ADVERTISE: &str = "TALON_COORDINATOR_ADMIN_ADVERTISE";
+    pub const CLUSTER_ID: &str = "TALON_COORDINATOR_CLUSTER_ID";
+    pub const NODE_ID: &str = "TALON_COORDINATOR_NODE_ID";
+    pub const STATE_BACKEND: &str = "TALON_COORDINATOR_STATE_BACKEND";
+    pub const HA_ENABLED: &str = "TALON_COORDINATOR_HA_ENABLED";
+    pub const REPLICAS: &str = "TALON_COORDINATOR_REPLICAS";
+    pub const HEARTBEAT_INTERVAL_MS: &str = "TALON_COORDINATOR_HEARTBEAT_INTERVAL_MS";
+    pub const UNHEALTHY_AFTER_MS: &str = "TALON_COORDINATOR_UNHEALTHY_AFTER_MS";
+    pub const LEASE_TTL_MS: &str = "TALON_COORDINATOR_LEASE_TTL_MS";
+    pub const REQUEST_TIMEOUT_MS: &str = "TALON_COORDINATOR_REQUEST_TIMEOUT_MS";
+    pub const AUTH_TOKEN: &str = "TALON_COORDINATOR_AUTH_TOKEN";
+    pub const TRUST_FORWARDED: &str = "TALON_COORDINATOR_TRUST_FORWARDED";
+    #[cfg(feature = "etcd")]
+    pub const ETCD_ENDPOINTS: &str = "TALON_COORDINATOR_ETCD_ENDPOINTS";
+    #[cfg(feature = "etcd")]
+    pub const ETCD_USERNAME: &str = "TALON_COORDINATOR_ETCD_USERNAME";
+    #[cfg(feature = "etcd")]
+    pub const ETCD_PASSWORD: &str = "TALON_COORDINATOR_ETCD_PASSWORD";
+    #[cfg(feature = "etcd")]
+    pub const ETCD_CA_CERT_PATH: &str = "TALON_COORDINATOR_ETCD_CA_CERT_PATH";
+    #[cfg(feature = "etcd")]
+    pub const ETCD_CLIENT_CERT_PATH: &str = "TALON_COORDINATOR_ETCD_CLIENT_CERT_PATH";
+    #[cfg(feature = "etcd")]
+    pub const ETCD_CLIENT_KEY_PATH: &str = "TALON_COORDINATOR_ETCD_CLIENT_KEY_PATH";
+    #[cfg(feature = "kubernetes")]
+    pub const K8S_NAMESPACE: &str = "TALON_COORDINATOR_K8S_NAMESPACE";
+}
+
 impl CoordinatorConfigPatch {
     /// Parse a TOML patch.
     pub fn from_toml(value: &str) -> anyhow::Result<Self> {
@@ -182,38 +397,38 @@ impl CoordinatorConfigPatch {
         }
 
         Ok(Self {
-            listen: get("TALON_COORDINATOR_LISTEN"),
-            admin_listen: get("TALON_COORDINATOR_ADMIN_LISTEN"),
-            admin_advertise: get("TALON_COORDINATOR_ADMIN_ADVERTISE"),
-            cluster_id: get("TALON_COORDINATOR_CLUSTER_ID"),
-            node_id: get("TALON_COORDINATOR_NODE_ID"),
-            state_backend: get("TALON_COORDINATOR_STATE_BACKEND")
-                .map(|value| parse(value, "TALON_COORDINATOR_STATE_BACKEND"))
+            listen: get(env_names::LISTEN),
+            admin_listen: get(env_names::ADMIN_LISTEN),
+            admin_advertise: get(env_names::ADMIN_ADVERTISE),
+            cluster_id: get(env_names::CLUSTER_ID),
+            node_id: get(env_names::NODE_ID),
+            state_backend: get(env_names::STATE_BACKEND)
+                .map(|value| parse(value, env_names::STATE_BACKEND))
                 .transpose()?,
-            ha_enabled: get("TALON_COORDINATOR_HA_ENABLED")
-                .map(|value| parse(value, "TALON_COORDINATOR_HA_ENABLED"))
+            ha_enabled: get(env_names::HA_ENABLED)
+                .map(|value| parse(value, env_names::HA_ENABLED))
                 .transpose()?,
-            coordinator_replicas: get("TALON_COORDINATOR_REPLICAS")
-                .map(|value| parse(value, "TALON_COORDINATOR_REPLICAS"))
+            coordinator_replicas: get(env_names::REPLICAS)
+                .map(|value| parse(value, env_names::REPLICAS))
                 .transpose()?,
-            heartbeat_interval_ms: get("TALON_COORDINATOR_HEARTBEAT_INTERVAL_MS")
-                .map(|value| parse(value, "TALON_COORDINATOR_HEARTBEAT_INTERVAL_MS"))
+            heartbeat_interval_ms: get(env_names::HEARTBEAT_INTERVAL_MS)
+                .map(|value| parse(value, env_names::HEARTBEAT_INTERVAL_MS))
                 .transpose()?,
-            unhealthy_after_ms: get("TALON_COORDINATOR_UNHEALTHY_AFTER_MS")
-                .map(|value| parse(value, "TALON_COORDINATOR_UNHEALTHY_AFTER_MS"))
+            unhealthy_after_ms: get(env_names::UNHEALTHY_AFTER_MS)
+                .map(|value| parse(value, env_names::UNHEALTHY_AFTER_MS))
                 .transpose()?,
-            lease_ttl_ms: get("TALON_COORDINATOR_LEASE_TTL_MS")
-                .map(|value| parse(value, "TALON_COORDINATOR_LEASE_TTL_MS"))
+            lease_ttl_ms: get(env_names::LEASE_TTL_MS)
+                .map(|value| parse(value, env_names::LEASE_TTL_MS))
                 .transpose()?,
-            request_timeout_ms: get("TALON_COORDINATOR_REQUEST_TIMEOUT_MS")
-                .map(|value| parse(value, "TALON_COORDINATOR_REQUEST_TIMEOUT_MS"))
+            request_timeout_ms: get(env_names::REQUEST_TIMEOUT_MS)
+                .map(|value| parse(value, env_names::REQUEST_TIMEOUT_MS))
                 .transpose()?,
             #[cfg(feature = "etcd")]
             etcd: None,
             #[cfg(feature = "kubernetes")]
             kubernetes: None,
             #[cfg(feature = "etcd")]
-            etcd_endpoints: get("TALON_COORDINATOR_ETCD_ENDPOINTS").map(|value| {
+            etcd_endpoints: get(env_names::ETCD_ENDPOINTS).map(|value| {
                 value
                     .split(',')
                     .map(|endpoint| endpoint.trim().to_string())
@@ -221,17 +436,17 @@ impl CoordinatorConfigPatch {
                     .collect()
             }),
             #[cfg(feature = "etcd")]
-            etcd_username: get("TALON_COORDINATOR_ETCD_USERNAME"),
+            etcd_username: get(env_names::ETCD_USERNAME),
             #[cfg(feature = "etcd")]
-            etcd_password: get("TALON_COORDINATOR_ETCD_PASSWORD"),
+            etcd_password: get(env_names::ETCD_PASSWORD),
             #[cfg(feature = "etcd")]
-            etcd_ca_cert_path: get("TALON_COORDINATOR_ETCD_CA_CERT_PATH"),
+            etcd_ca_cert_path: get(env_names::ETCD_CA_CERT_PATH),
             #[cfg(feature = "etcd")]
-            etcd_client_cert_path: get("TALON_COORDINATOR_ETCD_CLIENT_CERT_PATH"),
+            etcd_client_cert_path: get(env_names::ETCD_CLIENT_CERT_PATH),
             #[cfg(feature = "etcd")]
-            etcd_client_key_path: get("TALON_COORDINATOR_ETCD_CLIENT_KEY_PATH"),
+            etcd_client_key_path: get(env_names::ETCD_CLIENT_KEY_PATH),
             #[cfg(feature = "kubernetes")]
-            kubernetes_namespace: get("TALON_COORDINATOR_K8S_NAMESPACE"),
+            kubernetes_namespace: get(env_names::K8S_NAMESPACE),
         })
     }
 }

--- a/crates/talon-coordinator/src/lib.rs
+++ b/crates/talon-coordinator/src/lib.rs
@@ -15,7 +15,7 @@ pub mod service;
 pub mod state_store;
 pub mod ui;
 
-pub use config::{CoordinatorConfig, CoordinatorConfigPatch};
+pub use config::{CoordinatorConfig, CoordinatorConfigPatch, COORDINATOR_ENV_SCHEMA};
 pub use heartbeat::{HeartbeatConfig, HeartbeatTracker, Inventory};
 pub use load::{plan_load, split_into_blocks, LoadAssignment, LoadProgress};
 pub use membership::{K8sSelector, KubernetesMembership, Membership, MembershipSource};

--- a/crates/talon-coordinator/src/main.rs
+++ b/crates/talon-coordinator/src/main.rs
@@ -389,12 +389,13 @@ async fn build_store(config: &CoordinatorConfig) -> anyhow::Result<Arc<dyn Clust
 /// `TALON_COORDINATOR_TRUST_FORWARDED=1` honors `X-Forwarded-For` for audit
 /// attribution behind a trusted proxy. TLS is reverse-proxy terminated.
 fn build_security_config() -> anyhow::Result<talon_coordinator::security::SecurityConfig> {
+    use talon_coordinator::config::env_names;
     use talon_coordinator::security::{AuthMode, SecurityConfig};
-    let auth = match std::env::var("TALON_COORDINATOR_AUTH_TOKEN") {
+    let auth = match std::env::var(env_names::AUTH_TOKEN) {
         Ok(token) if !token.is_empty() => AuthMode::BearerToken { token },
         _ => AuthMode::Disabled,
     };
-    let trust_forwarded_headers = std::env::var("TALON_COORDINATOR_TRUST_FORWARDED")
+    let trust_forwarded_headers = std::env::var(env_names::TRUST_FORWARDED)
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
     let config = SecurityConfig {

--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -33,6 +33,29 @@ pub trait Patch {
     fn merge(self, base: Self) -> Self;
 }
 
+/// One configurable setting, described once and reused by both the runtime
+/// environment parser and the generated documentation.
+///
+/// This is the single source of truth for a process's `TALON_*` environment
+/// variables: [`from_env`](WorkerConfigPatch::from_env) reads the names from
+/// here, and the documentation generator renders the same list, so the config
+/// reference cannot drift from the code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConfigVar {
+    /// Environment variable name, e.g. `TALON_WORKER_LISTEN`.
+    pub env: &'static str,
+    /// Equivalent config-file key / CLI flag stem, e.g. `listen`.
+    pub key: &'static str,
+    /// Default value shown in docs, or `None` when there is no fixed default.
+    pub default: Option<&'static str>,
+    /// Whether this setting is also settable as a CLI flag (`--<key>`).
+    pub cli: bool,
+    /// Whether the value is a secret (never logged; env-only).
+    pub secret: bool,
+    /// One-line description.
+    pub help: &'static str,
+}
+
 /// Fully-resolved worker configuration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkerConfig {
@@ -74,7 +97,7 @@ pub struct WorkerConfig {
 /// deliberately kept out of [`WorkerConfig`] so it is never serialized, printed
 /// via `Debug`, or logged.
 pub fn azure_sas_from_env() -> Option<String> {
-    std::env::var("TALON_WORKER_AZURE_SAS")
+    std::env::var(worker_env::AZURE_SAS)
         .ok()
         .filter(|s| !s.is_empty())
 }
@@ -146,6 +169,123 @@ impl Patch for WorkerConfigPatch {
     }
 }
 
+/// Single source of truth for the worker's `TALON_WORKER_*` environment
+/// variables. [`WorkerConfigPatch::from_env_with`] reads names from here and the
+/// documentation generator renders it, so the reference cannot drift.
+pub const WORKER_ENV_SCHEMA: &[ConfigVar] = &[
+    ConfigVar {
+        env: "TALON_WORKER_LISTEN",
+        key: "listen",
+        default: Some("127.0.0.1:7001"),
+        cli: true,
+        secret: false,
+        help: "Data-plane bind address.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_ADVERTISE_ADDR",
+        key: "advertise_addr",
+        default: Some("<listen>"),
+        cli: true,
+        secret: false,
+        help: "Routable address advertised to the coordinator.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_ADMIN_LISTEN",
+        key: "admin_listen",
+        default: Some("127.0.0.1:8001"),
+        cli: true,
+        secret: false,
+        help: "Admin HTTP bind address: metrics, health, status.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_COORDINATOR",
+        key: "coordinator",
+        default: Some("127.0.0.1:7000"),
+        cli: true,
+        secret: false,
+        help: "Coordinator control-plane address to register with.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_CLUSTER_ID",
+        key: "cluster_id",
+        default: Some("default"),
+        cli: true,
+        secret: false,
+        help: "Logical cluster advertised in status.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_NODE_ID",
+        key: "node_id",
+        default: Some("<listen>"),
+        cli: true,
+        secret: false,
+        help: "Stable worker node identity.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_HEARTBEAT_INTERVAL_MS",
+        key: "heartbeat_interval_ms",
+        default: Some("5000"),
+        cli: true,
+        secret: false,
+        help: "Heartbeat interval (ms).",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_BLOCK_SIZE",
+        key: "block_size",
+        default: Some("268435456"),
+        cli: true,
+        secret: false,
+        help: "Logical block size (bytes).",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_CACHE_DIRS",
+        key: "cache_dirs",
+        default: Some("/var/cache/talon"),
+        cli: false,
+        secret: false,
+        help: "Colon-separated cache directories.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_CAPACITY_BYTES",
+        key: "capacity_bytes",
+        default: Some("68719476736"),
+        cli: false,
+        secret: false,
+        help: "Worker cache capacity (bytes).",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_AZURE_ACCOUNT",
+        key: "azure_account",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "Azure blob storage account name (required to serve data).",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_AZURE_SAS",
+        key: "(env only)",
+        default: None,
+        cli: false,
+        secret: true,
+        help: "Azure SAS token; env-only, never from a config file or logged.",
+    },
+];
+
+pub(crate) mod worker_env {
+    pub const LISTEN: &str = "TALON_WORKER_LISTEN";
+    pub const ADVERTISE_ADDR: &str = "TALON_WORKER_ADVERTISE_ADDR";
+    pub const ADMIN_LISTEN: &str = "TALON_WORKER_ADMIN_LISTEN";
+    pub const COORDINATOR: &str = "TALON_WORKER_COORDINATOR";
+    pub const CLUSTER_ID: &str = "TALON_WORKER_CLUSTER_ID";
+    pub const NODE_ID: &str = "TALON_WORKER_NODE_ID";
+    pub const HEARTBEAT_INTERVAL_MS: &str = "TALON_WORKER_HEARTBEAT_INTERVAL_MS";
+    pub const BLOCK_SIZE: &str = "TALON_WORKER_BLOCK_SIZE";
+    pub const CACHE_DIRS: &str = "TALON_WORKER_CACHE_DIRS";
+    pub const CAPACITY_BYTES: &str = "TALON_WORKER_CAPACITY_BYTES";
+    pub const AZURE_ACCOUNT: &str = "TALON_WORKER_AZURE_ACCOUNT";
+    pub const AZURE_SAS: &str = "TALON_WORKER_AZURE_SAS";
+}
+
 impl WorkerConfigPatch {
     /// Parse a patch from a TOML config-file string.
     pub fn from_toml(s: &str) -> Result<Self> {
@@ -185,24 +325,24 @@ impl WorkerConfigPatch {
                 .map_err(|_| Error::Other(format!("{k}: invalid u64: {v:?}")))
         };
         Ok(Self {
-            listen: get("TALON_WORKER_LISTEN"),
-            advertise_addr: get("TALON_WORKER_ADVERTISE_ADDR"),
-            admin_listen: get("TALON_WORKER_ADMIN_LISTEN"),
-            coordinator: get("TALON_WORKER_COORDINATOR"),
-            cluster_id: get("TALON_WORKER_CLUSTER_ID"),
-            node_id: get("TALON_WORKER_NODE_ID"),
-            heartbeat_interval_ms: get("TALON_WORKER_HEARTBEAT_INTERVAL_MS")
-                .map(|v| parse_u64(v, "TALON_WORKER_HEARTBEAT_INTERVAL_MS"))
+            listen: get(worker_env::LISTEN),
+            advertise_addr: get(worker_env::ADVERTISE_ADDR),
+            admin_listen: get(worker_env::ADMIN_LISTEN),
+            coordinator: get(worker_env::COORDINATOR),
+            cluster_id: get(worker_env::CLUSTER_ID),
+            node_id: get(worker_env::NODE_ID),
+            heartbeat_interval_ms: get(worker_env::HEARTBEAT_INTERVAL_MS)
+                .map(|v| parse_u64(v, worker_env::HEARTBEAT_INTERVAL_MS))
                 .transpose()?,
-            block_size: get("TALON_WORKER_BLOCK_SIZE")
-                .map(|v| parse_u32(v, "TALON_WORKER_BLOCK_SIZE"))
+            block_size: get(worker_env::BLOCK_SIZE)
+                .map(|v| parse_u32(v, worker_env::BLOCK_SIZE))
                 .transpose()?,
-            cache_dirs: get("TALON_WORKER_CACHE_DIRS")
+            cache_dirs: get(worker_env::CACHE_DIRS)
                 .map(|v| v.split(':').map(PathBuf::from).collect()),
-            capacity_bytes: get("TALON_WORKER_CAPACITY_BYTES")
-                .map(|v| parse_u64(v, "TALON_WORKER_CAPACITY_BYTES"))
+            capacity_bytes: get(worker_env::CAPACITY_BYTES)
+                .map(|v| parse_u64(v, worker_env::CAPACITY_BYTES))
                 .transpose()?,
-            azure_account: get("TALON_WORKER_AZURE_ACCOUNT"),
+            azure_account: get(worker_env::AZURE_ACCOUNT),
         })
     }
 }
@@ -392,6 +532,59 @@ impl Patch for FuseConfigPatch {
     }
 }
 
+/// Single source of truth for the FUSE client's `TALON_FUSE_*` environment
+/// variables, shared by the parser and the documentation generator.
+pub const FUSE_ENV_SCHEMA: &[ConfigVar] = &[
+    ConfigVar {
+        env: "TALON_FUSE_MOUNTPOINT",
+        key: "mountpoint",
+        default: Some("/mnt/talon"),
+        cli: true,
+        secret: false,
+        help: "Directory to mount the Talon filesystem at.",
+    },
+    ConfigVar {
+        env: "TALON_FUSE_COORDINATOR",
+        key: "coordinator",
+        default: Some("127.0.0.1:7000"),
+        cli: true,
+        secret: false,
+        help: "Coordinator address for placement and membership.",
+    },
+    ConfigVar {
+        env: "TALON_FUSE_BLOCK_SIZE",
+        key: "block_size",
+        default: Some("268435456"),
+        cli: true,
+        secret: false,
+        help: "Logical block size (bytes); must match the cluster.",
+    },
+    ConfigVar {
+        env: "TALON_FUSE_PLACEMENT_TTL_MS",
+        key: "placement_ttl_ms",
+        default: Some("5000"),
+        cli: false,
+        secret: false,
+        help: "Placement-cache entry TTL (ms).",
+    },
+    ConfigVar {
+        env: "TALON_FUSE_READAHEAD_BLOCKS",
+        key: "readahead_blocks",
+        default: Some("4"),
+        cli: false,
+        secret: false,
+        help: "Client-side readahead depth in blocks.",
+    },
+];
+
+pub(crate) mod fuse_env {
+    pub const MOUNTPOINT: &str = "TALON_FUSE_MOUNTPOINT";
+    pub const COORDINATOR: &str = "TALON_FUSE_COORDINATOR";
+    pub const BLOCK_SIZE: &str = "TALON_FUSE_BLOCK_SIZE";
+    pub const PLACEMENT_TTL_MS: &str = "TALON_FUSE_PLACEMENT_TTL_MS";
+    pub const READAHEAD_BLOCKS: &str = "TALON_FUSE_READAHEAD_BLOCKS";
+}
+
 impl FuseConfigPatch {
     /// Parse a patch from a TOML config-file string.
     pub fn from_toml(s: &str) -> Result<Self> {
@@ -427,16 +620,16 @@ impl FuseConfigPatch {
                 .map_err(|_| Error::Other(format!("{k}: invalid u64: {v:?}")))
         };
         Ok(Self {
-            mountpoint: get("TALON_FUSE_MOUNTPOINT").map(PathBuf::from),
-            coordinator: get("TALON_FUSE_COORDINATOR"),
-            block_size: get("TALON_FUSE_BLOCK_SIZE")
-                .map(|v| parse_u32(v, "TALON_FUSE_BLOCK_SIZE"))
+            mountpoint: get(fuse_env::MOUNTPOINT).map(PathBuf::from),
+            coordinator: get(fuse_env::COORDINATOR),
+            block_size: get(fuse_env::BLOCK_SIZE)
+                .map(|v| parse_u32(v, fuse_env::BLOCK_SIZE))
                 .transpose()?,
-            placement_ttl_ms: get("TALON_FUSE_PLACEMENT_TTL_MS")
-                .map(|v| parse_u64(v, "TALON_FUSE_PLACEMENT_TTL_MS"))
+            placement_ttl_ms: get(fuse_env::PLACEMENT_TTL_MS)
+                .map(|v| parse_u64(v, fuse_env::PLACEMENT_TTL_MS))
                 .transpose()?,
-            readahead_blocks: get("TALON_FUSE_READAHEAD_BLOCKS")
-                .map(|v| parse_u32(v, "TALON_FUSE_READAHEAD_BLOCKS"))
+            readahead_blocks: get(fuse_env::READAHEAD_BLOCKS)
+                .map(|v| parse_u32(v, fuse_env::READAHEAD_BLOCKS))
                 .transpose()?,
         })
     }
@@ -480,6 +673,45 @@ impl FuseConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn env_schemas_are_wellformed() {
+        // Each schema's env names are unique and match the TALON_ prefix so the
+        // generated reference and the parser stay in lockstep.
+        for (label, schema, prefix) in [
+            ("worker", WORKER_ENV_SCHEMA, "TALON_WORKER_"),
+            ("fuse", FUSE_ENV_SCHEMA, "TALON_FUSE_"),
+        ] {
+            let mut seen = std::collections::HashSet::new();
+            for v in schema {
+                assert!(
+                    v.env.starts_with(prefix),
+                    "{label}: {} lacks prefix {prefix}",
+                    v.env
+                );
+                assert!(seen.insert(v.env), "{label}: duplicate env {}", v.env);
+                assert!(!v.help.is_empty(), "{label}: {} has empty help", v.env);
+            }
+        }
+        // The parser reads exactly the worker/fuse names declared in the
+        // schema; spot-check the constants used by the parser are present.
+        for name in [
+            worker_env::LISTEN,
+            worker_env::AZURE_ACCOUNT,
+            worker_env::AZURE_SAS,
+        ] {
+            assert!(
+                WORKER_ENV_SCHEMA.iter().any(|v| v.env == name),
+                "worker schema missing {name}"
+            );
+        }
+        for name in [fuse_env::MOUNTPOINT, fuse_env::READAHEAD_BLOCKS] {
+            assert!(
+                FUSE_ENV_SCHEMA.iter().any(|v| v.env == name),
+                "fuse schema missing {name}"
+            );
+        }
+    }
 
     #[test]
     fn defaults_are_valid() {

--- a/crates/talon-core/src/lib.rs
+++ b/crates/talon-core/src/lib.rs
@@ -17,7 +17,8 @@ pub mod trace;
 pub use backend::{BackendStore, ObjectStat};
 pub use block::{BlockForm, BlockMeta, LoadHint, PresentBitmap};
 pub use config::{
-    azure_sas_from_env, FuseConfig, FuseConfigPatch, Patch, WorkerConfig, WorkerConfigPatch,
+    azure_sas_from_env, ConfigVar, FuseConfig, FuseConfigPatch, Patch, WorkerConfig,
+    WorkerConfigPatch, FUSE_ENV_SCHEMA, WORKER_ENV_SCHEMA,
 };
 pub use error::{Error, Result};
 pub use key::{Backend, BlockId, ObjectId, PageIndex, Version};

--- a/docs/book/src/reference/configuration.md
+++ b/docs/book/src/reference/configuration.md
@@ -1,11 +1,1 @@
-# Configuration reference
-
-> **Coming soon.** A complete reference of every coordinator and worker
-> configuration key — config-file entry, CLI flag, and `TALON_*` environment
-> variable — **generated from the source of truth** (the `clap` definitions and
-> config structs) so it can never drift from the code.
->
-> Tracked in [issue #188](https://github.com/milvus-io/talon/issues/188).
-
-Until then, see the configuration section of the
-[operator runbook](../operations/runbook.md).
+{{#include ../../../reference/configuration.md}}

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -73,26 +73,17 @@ within one heartbeat interval.
 
 ## 3. Configuration reference
 
-All values are settable by CLI flag, `TALON_COORDINATOR_*` env var, or TOML
-file (precedence: flag > env > file > default). Backend-specific blocks
-(`[etcd]`, `[kubernetes]`) come from the TOML file or the env vars listed under
-"Backend-specific configuration" below, not from CLI flags.
+Every setting is resolved from four layers, highest precedence first: **CLI
+flag** > **environment variable** > **config file (TOML)** > **default**.
+Backend-specific blocks (`[etcd]`, `[kubernetes]`) come from the TOML file or
+environment variables, not from CLI flags.
 
-| Setting | Env var | Default | Units / notes |
-|---------|---------|---------|---------------|
-| Control listen | `TALON_COORDINATOR_LISTEN` | `127.0.0.1:7000` | worker/client control plane |
-| Admin listen | `TALON_COORDINATOR_ADMIN_LISTEN` | `127.0.0.1:8000` | metrics/health/API/UI |
-| Cluster id | `TALON_COORDINATOR_CLUSTER_ID` | `default` | logical cluster |
-| Node id | `TALON_COORDINATOR_NODE_ID` | control address | stable per replica |
-| Backend | `TALON_COORDINATOR_STATE_BACKEND` | `memory` | `memory` \| `etcd` \| `kubernetes` |
-| HA enabled | `TALON_COORDINATOR_HA_ENABLED` | `false` | rejects memory backend when true |
-| Replicas | `TALON_COORDINATOR_REPLICAS` | `1` | expected coordinator count |
-| Heartbeat interval | `TALON_COORDINATOR_HEARTBEAT_INTERVAL_MS` | `5000` | ms |
-| Unhealthy after | `TALON_COORDINATOR_UNHEALTHY_AFTER_MS` | `15000` | ms; must be > heartbeat |
-| Lease TTL | `TALON_COORDINATOR_LEASE_TTL_MS` | `30000` | ms; must be > unhealthy_after |
-| Request timeout | `TALON_COORDINATOR_REQUEST_TIMEOUT_MS` | `3000` | ms; per backend op |
-| Auth token | `TALON_COORDINATOR_AUTH_TOKEN` | unset | ≥16 chars enables API/UI auth |
-| Trust proxy | `TALON_COORDINATOR_TRUST_FORWARDED` | `false` | honor `X-Forwarded-For` |
+The complete, authoritative list of every key, environment variable, default,
+and description — for the coordinator, worker, and FUSE client — is
+**generated from the code** and lives in the
+[configuration reference](../reference/configuration.md). It cannot drift from
+the parser. The operational notes below cover validation rules and backend
+setup that the table does not.
 
 **Validation** requires `heartbeat_interval < unhealthy_after < lease_ttl` and a
 non-zero request timeout; the memory backend is rejected under HA. Secrets
@@ -102,22 +93,13 @@ exported in metrics.
 ### Backend-specific configuration
 
 Selecting `etcd` or `kubernetes` requires a matching configuration block. The
-block is provided as a TOML table under `--config`, or, for the fields below, by
-environment variable (env wins over the file). Binaries must be built with the
-matching feature (`--features etcd` / `--features kubernetes`); selecting a
-backend whose feature is absent fails fast at startup with an actionable error.
+block is provided as a TOML table under `--config`, or, for the fields in the
+[configuration reference](../reference/configuration.md), by environment
+variable (env wins over the file). Binaries must be built with the matching
+feature (`--features etcd` / `--features kubernetes`); selecting a backend whose
+feature is absent fails fast at startup with an actionable error.
 
-**etcd** — TOML `[etcd]` table or env:
-
-| Setting | Env var | Notes |
-|---------|---------|-------|
-| Endpoints | `TALON_COORDINATOR_ETCD_ENDPOINTS` | comma-separated `host:port` list |
-| Username | `TALON_COORDINATOR_ETCD_USERNAME` | optional; requires password |
-| Password | `TALON_COORDINATOR_ETCD_PASSWORD` | optional; keep in a Secret, not the file |
-| CA cert path | `TALON_COORDINATOR_ETCD_CA_CERT_PATH` | PEM; enables TLS |
-| Client cert path | `TALON_COORDINATOR_ETCD_CLIENT_CERT_PATH` | PEM; mutual TLS |
-| Client key path | `TALON_COORDINATOR_ETCD_CLIENT_KEY_PATH` | PEM; mutual TLS |
-| Prefix | (TOML `prefix` only) | keyspace prefix; default `/talon` |
+**etcd** example:
 
 ```toml
 state_backend = "etcd"
@@ -132,13 +114,7 @@ client_cert_path = "/etc/talon/etcd/client.crt"
 client_key_path = "/etc/talon/etcd/client.key"
 ```
 
-**Kubernetes** — TOML `[kubernetes]` table or env:
-
-| Setting | Env var | Notes |
-|---------|---------|-------|
-| Namespace | `TALON_COORDINATOR_K8S_NAMESPACE` | namespace holding Talon Lease objects |
-| Cluster id | (TOML `cluster_id` only) | defaults to the coordinator `cluster_id` |
-| Context | (TOML `context` only) | kubeconfig context; unset uses in-cluster config |
+**Kubernetes** example:
 
 ```toml
 state_backend = "kubernetes"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,59 @@
+# Configuration reference
+
+> **Generated file — do not edit by hand.** Produced from the `ConfigVar` schema tables in the code by `talon-gen-config-docs`; CI fails if it drifts. To change it, edit the schema next to the parser and regenerate.
+
+Every setting is resolved from four layers, highest precedence first: **CLI flag** > **environment variable** > **config file (TOML)** > **default**. A ✓ in the *CLI* column means the setting also has a `--<key>` flag; environment variables always apply. Secrets are read only from the environment and are never written to a config file or logged.
+
+## Coordinator
+
+| Key | Environment variable | Default | CLI | Description |
+|-----|----------------------|---------|-----|-------------|
+| `listen` | `TALON_COORDINATOR_LISTEN` | `127.0.0.1:7000` | ✓ | Control-plane bind address (workers/clients). |
+| `admin_listen` | `TALON_COORDINATOR_ADMIN_LISTEN` | `127.0.0.1:8000` | ✓ | Admin HTTP bind address: metrics, health, API, UI. |
+| `admin_advertise` | `TALON_COORDINATOR_ADMIN_ADVERTISE` | `<admin_listen>` | ✓ | Admin address advertised in node status. |
+| `cluster_id` | `TALON_COORDINATOR_CLUSTER_ID` | `default` | ✓ | Logical cluster identity. |
+| `node_id` | `TALON_COORDINATOR_NODE_ID` | `<listen>` | ✓ | Stable coordinator node identity. |
+| `state_backend` | `TALON_COORDINATOR_STATE_BACKEND` | `memory` | ✓ | Shared-state backend: memory | etcd | kubernetes. |
+| `ha_enabled` | `TALON_COORDINATOR_HA_ENABLED` | `false` | ✓ | Enable active-active mode; rejects the memory backend. |
+| `coordinator_replicas` | `TALON_COORDINATOR_REPLICAS` | `1` | ✓ | Expected coordinator replica count. |
+| `heartbeat_interval_ms` | `TALON_COORDINATOR_HEARTBEAT_INTERVAL_MS` | `5000` | ✓ | Node heartbeat interval (ms). |
+| `unhealthy_after_ms` | `TALON_COORDINATOR_UNHEALTHY_AFTER_MS` | `15000` | ✓ | Silence before a node is unhealthy (ms); must exceed heartbeat. |
+| `lease_ttl_ms` | `TALON_COORDINATOR_LEASE_TTL_MS` | `30000` | ✓ | Node lease TTL (ms); must exceed unhealthy_after. |
+| `request_timeout_ms` | `TALON_COORDINATOR_REQUEST_TIMEOUT_MS` | `3000` | ✓ | Deadline for one authoritative backend operation (ms). |
+| `(env only)` | `TALON_COORDINATOR_AUTH_TOKEN` 🔒 | — |  | Bearer token (>= 16 chars) enabling API/UI authentication; unset disables auth. |
+| `(env only)` | `TALON_COORDINATOR_TRUST_FORWARDED` | `false` |  | Honor X-Forwarded-For for audit attribution behind a trusted proxy. |
+| `etcd.endpoints` | `TALON_COORDINATOR_ETCD_ENDPOINTS` | — |  | Comma-separated etcd host:port endpoints. |
+| `etcd.username` | `TALON_COORDINATOR_ETCD_USERNAME` | — |  | etcd username (requires password). |
+| `etcd.password` | `TALON_COORDINATOR_ETCD_PASSWORD` 🔒 | — |  | etcd password; keep in a Secret, not the config file. |
+| `etcd.tls.ca_cert_path` | `TALON_COORDINATOR_ETCD_CA_CERT_PATH` | — |  | PEM CA certificate path; enables TLS. |
+| `etcd.tls.client_cert_path` | `TALON_COORDINATOR_ETCD_CLIENT_CERT_PATH` | — |  | PEM client certificate path; mutual TLS. |
+| `etcd.tls.client_key_path` | `TALON_COORDINATOR_ETCD_CLIENT_KEY_PATH` | — |  | PEM client key path; mutual TLS. |
+| `kubernetes.namespace` | `TALON_COORDINATOR_K8S_NAMESPACE` | `talon` |  | Namespace holding Talon Lease objects. |
+
+## Worker
+
+| Key | Environment variable | Default | CLI | Description |
+|-----|----------------------|---------|-----|-------------|
+| `listen` | `TALON_WORKER_LISTEN` | `127.0.0.1:7001` | ✓ | Data-plane bind address. |
+| `advertise_addr` | `TALON_WORKER_ADVERTISE_ADDR` | `<listen>` | ✓ | Routable address advertised to the coordinator. |
+| `admin_listen` | `TALON_WORKER_ADMIN_LISTEN` | `127.0.0.1:8001` | ✓ | Admin HTTP bind address: metrics, health, status. |
+| `coordinator` | `TALON_WORKER_COORDINATOR` | `127.0.0.1:7000` | ✓ | Coordinator control-plane address to register with. |
+| `cluster_id` | `TALON_WORKER_CLUSTER_ID` | `default` | ✓ | Logical cluster advertised in status. |
+| `node_id` | `TALON_WORKER_NODE_ID` | `<listen>` | ✓ | Stable worker node identity. |
+| `heartbeat_interval_ms` | `TALON_WORKER_HEARTBEAT_INTERVAL_MS` | `5000` | ✓ | Heartbeat interval (ms). |
+| `block_size` | `TALON_WORKER_BLOCK_SIZE` | `268435456` | ✓ | Logical block size (bytes). |
+| `cache_dirs` | `TALON_WORKER_CACHE_DIRS` | `/var/cache/talon` |  | Colon-separated cache directories. |
+| `capacity_bytes` | `TALON_WORKER_CAPACITY_BYTES` | `68719476736` |  | Worker cache capacity (bytes). |
+| `azure_account` | `TALON_WORKER_AZURE_ACCOUNT` | — |  | Azure blob storage account name (required to serve data). |
+| `(env only)` | `TALON_WORKER_AZURE_SAS` 🔒 | — |  | Azure SAS token; env-only, never from a config file or logged. |
+
+## FUSE client
+
+| Key | Environment variable | Default | CLI | Description |
+|-----|----------------------|---------|-----|-------------|
+| `mountpoint` | `TALON_FUSE_MOUNTPOINT` | `/mnt/talon` | ✓ | Directory to mount the Talon filesystem at. |
+| `coordinator` | `TALON_FUSE_COORDINATOR` | `127.0.0.1:7000` | ✓ | Coordinator address for placement and membership. |
+| `block_size` | `TALON_FUSE_BLOCK_SIZE` | `268435456` | ✓ | Logical block size (bytes); must match the cluster. |
+| `placement_ttl_ms` | `TALON_FUSE_PLACEMENT_TTL_MS` | `5000` |  | Placement-cache entry TTL (ms). |
+| `readahead_blocks` | `TALON_FUSE_READAHEAD_BLOCKS` | `4` |  | Client-side readahead depth in blocks. |
+


### PR DESCRIPTION
## Summary

Wave 3 of the documentation overhaul (#184). Makes the config/CLI/env reference
**generated from the code** so it can never drift — the class of bug we already
hit (the runbook claimed "all values settable by CLI flag" after that stopped
being true).

- **Single source of truth**: a new `ConfigVar` schema type (talon-core) with a
  table next to each parser — `COORDINATOR_ENV_SCHEMA`, `WORKER_ENV_SCHEMA`,
  `FUSE_ENV_SCHEMA`. `from_env_with` now references shared env-name **constants**
  instead of duplicated string literals, so the schema and the parser share one
  source.
- **Generator**: `talon-gen-config-docs` renders the three schemas to
  `docs/reference/configuration.md` (key, env var, default, CLI flag, secret 🔒,
  description).
- **Wired in**: the generated file replaces the mdBook Reference stub, and the
  operator runbook's hand-written config tables are replaced by a pointer to it
  — removing the parallel hand-maintained source.
- **CI drift gate**: a `config-docs` job regenerates and diffs, failing if the
  committed reference is stale. `just gen-config-docs` / `just check-config-docs`
  do the same locally.

## Test plan

- [x] Existing config unit tests (precedence/env in talon-core and
      talon-coordinator) still pass — the parser refactor is behavior-preserving.
- [x] New `env_schemas_are_wellformed` test (unique/prefixed names, non-empty help).
- [x] `just check-config-docs` (regenerate + diff) is clean; CI `config-docs` job
      enforces it.
- [x] mdBook builds with the real reference embedded.
- [x] `cargo fmt --check`, `clippy --workspace --all-targets --all-features -D warnings`,
      and full `cargo test --workspace --all-features --locked` all green.
- [x] Generator builds with and without the etcd/kubernetes features; the
      committed reference is the full-feature output (CI regenerates with
      `--features etcd,kubernetes`).

Closes #188