### PR TITLE
doc: generate REST API reference from openapi.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,21 +85,28 @@ jobs:
         run: mdbook build docs/book
 
   config-docs:
-    name: config reference drift
+    name: reference docs drift
     runs-on: ubuntu-latest
-    # The configuration reference is generated from the ConfigVar schemas.
-    # Fail if the committed copy is stale so docs cannot drift from the code.
+    # The configuration and REST API references are generated from the code /
+    # OpenAPI spec. Fail if a committed copy is stale so docs cannot drift.
     steps:
       - uses: actions/checkout@v4
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: Swatinem/rust-cache@v2
-      - name: Regenerate and diff
+      - name: Configuration reference drift
         run: |
           cargo run -q -p talon-coordinator --features etcd,kubernetes \
             --bin talon-gen-config-docs > /tmp/config-ref.md
           if ! diff -u docs/reference/configuration.md /tmp/config-ref.md; then
             echo "::error::docs/reference/configuration.md is stale; run 'just gen-config-docs'"
+            exit 1
+          fi
+      - name: REST API reference drift
+        run: |
+          cargo run -q -p talon-coordinator --bin talon-gen-api-docs > /tmp/api-ref.md
+          if ! diff -u docs/reference/rest-api.md /tmp/api-ref.md; then
+            echo "::error::docs/reference/rest-api.md is stale; run 'just gen-api-docs'"
             exit 1
           fi
 

--- a/Justfile
+++ b/Justfile
@@ -39,6 +39,15 @@ check-config-docs:
       --bin talon-gen-config-docs > /tmp/talon-config-ref.md
     diff -u docs/reference/configuration.md /tmp/talon-config-ref.md
 
+# Regenerate the REST API reference from openapi.json.
+gen-api-docs:
+    cargo run -q -p talon-coordinator --bin talon-gen-api-docs -- docs/reference/rest-api.md
+
+# Fail if the committed REST API reference is stale vs. openapi.json.
+check-api-docs:
+    cargo run -q -p talon-coordinator --bin talon-gen-api-docs > /tmp/talon-api-ref.md
+    diff -u docs/reference/rest-api.md /tmp/talon-api-ref.md
+
 # --- benchmarks (performance feedback loop) ---
 
 # Run all microbenchmarks and write bench/results/latest.json.

--- a/crates/talon-coordinator/Cargo.toml
+++ b/crates/talon-coordinator/Cargo.toml
@@ -17,6 +17,11 @@ path = "src/main.rs"
 name = "talon-gen-config-docs"
 path = "src/bin/gen-config-docs.rs"
 
+# Documentation generator: renders the REST API reference from openapi.json.
+[[bin]]
+name = "talon-gen-api-docs"
+path = "src/bin/gen-api-docs.rs"
+
 [features]
 state-store-testkit = []
 # Production Kubernetes Lease ClusterStateStore backend. Off by default so

--- a/crates/talon-coordinator/src/bin/gen-api-docs.rs
+++ b/crates/talon-coordinator/src/bin/gen-api-docs.rs
@@ -1,0 +1,203 @@
+//! Generate the REST API reference Markdown from the OpenAPI spec.
+//!
+//! The coordinator management API is described by
+//! `crates/talon-coordinator/src/openapi.json` (served at
+//! `/api/v1/openapi.json`). This binary renders that spec to Markdown so the
+//! API reference tracks the spec and cannot drift. CI regenerates and diffs the
+//! committed output (see the `api-docs` job); run `just gen-api-docs` to refresh.
+//!
+//! Usage:
+//!
+//! ```text
+//! talon-gen-api-docs           # print to stdout
+//! talon-gen-api-docs <path>    # write to a file
+//! ```
+
+use std::fmt::Write as _;
+use std::io::Write as _;
+
+use serde_json::Value;
+use talon_coordinator::api::OPENAPI_JSON;
+
+fn main() -> std::io::Result<()> {
+    let spec: Value = serde_json::from_str(OPENAPI_JSON).expect("openapi.json is valid JSON");
+    let out = render(&spec);
+    match std::env::args().nth(1) {
+        Some(path) => {
+            let mut f = std::fs::File::create(&path)?;
+            f.write_all(out.as_bytes())?;
+            eprintln!("wrote {path}");
+        }
+        None => print!("{out}"),
+    }
+    Ok(())
+}
+
+/// Short type label for a schema node, resolving `$ref` names.
+fn type_label(schema: &Value) -> String {
+    if let Some(r) = schema.get("$ref").and_then(Value::as_str) {
+        let name = r.rsplit('/').next().unwrap_or(r);
+        return format!("[`{name}`](#{})", anchor(name));
+    }
+    match schema.get("type").and_then(Value::as_str) {
+        Some("array") => {
+            let inner = schema
+                .get("items")
+                .map(type_label)
+                .unwrap_or_else(|| "array".into());
+            format!("array of {inner}")
+        }
+        Some(t) => match schema.get("format").and_then(Value::as_str) {
+            Some(f) => format!("{t} ({f})"),
+            None => t.to_string(),
+        },
+        None => "object".to_string(),
+    }
+}
+
+fn anchor(name: &str) -> String {
+    name.to_lowercase()
+}
+
+fn render(spec: &Value) -> String {
+    let mut s = String::new();
+    s.push_str("# REST API reference\n\n");
+    s.push_str(
+        "> **Generated file — do not edit by hand.** Rendered from \
+`crates/talon-coordinator/src/openapi.json` by `talon-gen-api-docs`; CI fails \
+if it drifts. To change it, edit the OpenAPI spec and regenerate.\n\n",
+    );
+    if let Some(info) = spec.get("info") {
+        if let Some(desc) = info.get("description").and_then(Value::as_str) {
+            s.push_str(desc);
+            s.push_str("\n\n");
+        }
+        let version = info.get("version").and_then(Value::as_str).unwrap_or("v1");
+        writeln!(s, "**API version:** `{version}`\n").ok();
+    }
+
+    // --- endpoints ---
+    s.push_str("## Endpoints\n\n");
+    let paths = spec.get("paths").and_then(Value::as_object);
+    if let Some(paths) = paths {
+        let mut keys: Vec<&String> = paths.keys().collect();
+        keys.sort();
+        for path in keys {
+            let ops = paths[path].as_object();
+            if let Some(ops) = ops {
+                for (method, op) in ops {
+                    render_op(&mut s, path, method, op);
+                }
+            }
+        }
+    }
+
+    // --- schemas ---
+    if let Some(schemas) = spec
+        .get("components")
+        .and_then(|c| c.get("schemas"))
+        .and_then(Value::as_object)
+    {
+        s.push_str("## Schemas\n\n");
+        let mut names: Vec<&String> = schemas.keys().collect();
+        names.sort();
+        for name in names {
+            render_schema(&mut s, name, &schemas[name]);
+        }
+    }
+    s
+}
+
+fn render_op(s: &mut String, path: &str, method: &str, op: &Value) {
+    let summary = op.get("summary").and_then(Value::as_str).unwrap_or("");
+    writeln!(s, "### `{} {path}`\n", method.to_uppercase()).ok();
+    if !summary.is_empty() {
+        writeln!(s, "{summary}\n").ok();
+    }
+    // Parameters.
+    if let Some(params) = op.get("parameters").and_then(Value::as_array) {
+        if !params.is_empty() {
+            s.push_str("**Parameters:**\n\n");
+            s.push_str("| Name | In | Required | Type | Description |\n");
+            s.push_str("|------|----|----------|------|-------------|\n");
+            for p in params {
+                let name = p.get("name").and_then(Value::as_str).unwrap_or("");
+                let loc = p.get("in").and_then(Value::as_str).unwrap_or("");
+                let req = p.get("required").and_then(Value::as_bool).unwrap_or(false);
+                let ty = p.get("schema").map(type_label).unwrap_or_default();
+                let desc = p.get("description").and_then(Value::as_str).unwrap_or("");
+                writeln!(
+                    s,
+                    "| `{name}` | {loc} | {} | {ty} | {desc} |",
+                    if req { "yes" } else { "no" }
+                )
+                .ok();
+            }
+            s.push('\n');
+        }
+    }
+    // Responses.
+    if let Some(resps) = op.get("responses").and_then(Value::as_object) {
+        s.push_str("**Responses:**\n\n");
+        s.push_str("| Status | Body | Description |\n");
+        s.push_str("|--------|------|-------------|\n");
+        let mut codes: Vec<&String> = resps.keys().collect();
+        codes.sort();
+        for code in codes {
+            let r = &resps[code];
+            // A response may be a $ref to components/responses.
+            let (desc, body) = if let Some(rref) = r.get("$ref").and_then(Value::as_str) {
+                (
+                    format!("(see {})", rref.rsplit('/').next().unwrap_or(rref)),
+                    String::new(),
+                )
+            } else {
+                let desc = r
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                let body = r
+                    .get("content")
+                    .and_then(|c| c.get("application/json"))
+                    .and_then(|j| j.get("schema"))
+                    .map(type_label)
+                    .unwrap_or_default();
+                (desc, body)
+            };
+            let body = if body.is_empty() {
+                "—".to_string()
+            } else {
+                body
+            };
+            writeln!(s, "| `{code}` | {body} | {desc} |").ok();
+        }
+        s.push('\n');
+    }
+}
+
+fn render_schema(s: &mut String, name: &str, schema: &Value) {
+    writeln!(s, "### {name}\n").ok();
+    let required: Vec<&str> = schema
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    if let Some(props) = schema.get("properties").and_then(Value::as_object) {
+        s.push_str("| Field | Type | Required |\n");
+        s.push_str("|-------|------|----------|\n");
+        for (field, ty) in props {
+            let req = required.contains(&field.as_str());
+            writeln!(
+                s,
+                "| `{field}` | {} | {} |",
+                type_label(ty),
+                if req { "yes" } else { "no" }
+            )
+            .ok();
+        }
+        s.push('\n');
+    } else {
+        writeln!(s, "_{}_\n", type_label(schema)).ok();
+    }
+}

--- a/docs/book/src/reference/rest-api.md
+++ b/docs/book/src/reference/rest-api.md
@@ -1,11 +1,1 @@
-# REST API reference
-
-> **Coming soon.** A complete reference for the coordinator management API,
-> **generated from `openapi.json`** so it tracks the spec rather than being
-> hand-written.
->
-> Tracked in [issue #189](https://github.com/milvus-io/talon/issues/189).
-
-Until then, the machine-readable spec lives at
-`crates/talon-coordinator/src/openapi.json`, and a running coordinator serves it
-at `/api/v1/openapi.json`.
+{{#include ../../../reference/rest-api.md}}

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -1,0 +1,156 @@
+# REST API reference
+
+> **Generated file — do not edit by hand.** Rendered from `crates/talon-coordinator/src/openapi.json` by `talon-gen-api-docs`; CI fails if it drifts. To change it, edit the OpenAPI spec and regenerate.
+
+Read-only, versioned view of the live Talon cluster served by every coordinator from shared cluster state. Responses are equivalent across coordinators for the same backend revision.
+
+**API version:** `v1`
+
+## Endpoints
+
+### `GET /api/v1/backend`
+
+Backend status
+
+**Responses:**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`BackendStatus`](#backendstatus) | Backend status. |
+| `503` | — | (see BackendUnavailable) |
+
+### `GET /api/v1/cluster`
+
+Cluster summary
+
+**Responses:**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`ClusterSummary`](#clustersummary) | Cluster summary. |
+| `503` | — | (see BackendUnavailable) |
+
+### `GET /api/v1/nodes`
+
+List nodes
+
+**Parameters:**
+
+| Name | In | Required | Type | Description |
+|------|----|----------|------|-------------|
+| `role` | query | no | string |  |
+| `health` | query | no | string |  |
+| `offset` | query | no | integer |  |
+| `limit` | query | no | integer |  |
+
+**Responses:**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`NodeList`](#nodelist) | A page of nodes. |
+| `503` | — | (see BackendUnavailable) |
+
+### `GET /api/v1/nodes/{node_id}`
+
+Node detail
+
+**Parameters:**
+
+| Name | In | Required | Type | Description |
+|------|----|----------|------|-------------|
+| `node_id` | path | yes | string |  |
+
+**Responses:**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`NodeView`](#nodeview) | One node's detail. |
+| `404` | [`ApiError`](#apierror) | No such node in the current snapshot. |
+| `503` | — | (see BackendUnavailable) |
+
+### `GET /api/v1/openapi.json`
+
+This OpenAPI document
+
+**Responses:**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | — | The OpenAPI 3.0 contract. |
+
+## Schemas
+
+### ApiError
+
+| Field | Type | Required |
+|-------|------|----------|
+| `error` | string | yes |
+| `message` | string | yes |
+
+### BackendStatus
+
+| Field | Type | Required |
+|-------|------|----------|
+| `backend` | string | yes |
+| `meta` | [`ResponseMeta`](#responsemeta) | yes |
+| `ready` | boolean | yes |
+| `revision` | string | yes |
+| `snapshot_age_ms` | integer (int64) | yes |
+
+### ClusterSummary
+
+| Field | Type | Required |
+|-------|------|----------|
+| `cluster_id` | string | yes |
+| `coordinator_count` | integer | yes |
+| `healthy_worker_count` | integer | yes |
+| `meta` | [`ResponseMeta`](#responsemeta) | yes |
+| `node_count` | integer | yes |
+| `total_block_count` | integer (int64) | yes |
+| `total_capacity_bytes` | integer (int64) | yes |
+| `total_resident_bytes` | integer (int64) | yes |
+| `worker_count` | integer | yes |
+
+### NodeList
+
+| Field | Type | Required |
+|-------|------|----------|
+| `limit` | integer | yes |
+| `meta` | [`ResponseMeta`](#responsemeta) | yes |
+| `nodes` | array of [`NodeView`](#nodeview) | yes |
+| `offset` | integer | yes |
+| `total` | integer | yes |
+
+### NodeView
+
+| Field | Type | Required |
+|-------|------|----------|
+| `address` | string | yes |
+| `admin_address` | string | no |
+| `block_count` | integer (int64) | yes |
+| `build_version` | string | yes |
+| `bytes_served_total` | integer (int64) | yes |
+| `cache_hits_total` | integer (int64) | yes |
+| `cache_misses_total` | integer (int64) | yes |
+| `capacity_bytes` | integer (int64) | yes |
+| `errors_total` | integer (int64) | yes |
+| `health` | string | yes |
+| `labels` | object | yes |
+| `node_id` | string | yes |
+| `ready` | boolean | yes |
+| `reported_at_unix_ms` | integer (int64) | yes |
+| `requests_total` | integer (int64) | yes |
+| `resident_bytes` | integer (int64) | yes |
+| `role` | string | yes |
+| `started_at_unix_ms` | integer (int64) | yes |
+
+### ResponseMeta
+
+| Field | Type | Required |
+|-------|------|----------|
+| `api_version` | string | yes |
+| `backend` | string | yes |
+| `generated_at_unix_ms` | integer (int64) | yes |
+| `snapshot_age_ms` | integer (int64) | yes |
+| `snapshot_revision` | string | yes |
+


### PR DESCRIPTION
## Summary

Wave 3 of the documentation overhaul (#184), companion to #188. Renders the
coordinator management API reference **from `openapi.json`** so the API docs
track the spec instead of being hand-written.

- **Generator**: `talon-gen-api-docs` parses `OPENAPI_JSON` (already embedded and
  served at `/api/v1/openapi.json`) and renders Markdown — every `/api/v1/*`
  endpoint with its parameters and responses, plus the component schemas with
  cross-links.
- **Wired in**: the generated `docs/reference/rest-api.md` replaces the mdBook
  Reference stub.
- **CI drift gate**: the `reference docs drift` job now regenerates and diffs
  both the config and API references. `just gen-api-docs` / `just check-api-docs`
  do the same locally.

## Test plan

- [x] `just check-api-docs` (regenerate + diff) is clean; CI enforces it.
- [x] All 5 `/api/v1/*` endpoints and all 6 component schemas render.
- [x] mdBook builds with the API reference embedded (page shows real content).
- [x] `cargo fmt --check`, `clippy --all-targets -D warnings`, rustdoc
      `-D warnings`, and the coordinator test suite (83 tests) all pass.

Closes #189