### PR TITLE
doc: add CI documentation quality gate (spelling + links)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,25 @@ jobs:
             exit 1
           fi
 
+  docs-quality:
+    name: docs quality
+    runs-on: ubuntu-latest
+    # Documentation hygiene: spelling (typos) and links (lychee). Config lives
+    # in typos.toml and lychee.toml; run the same checks locally via
+    # `just spell` and `just linkcheck`.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Spell check
+        uses: crate-ci/typos@master
+      - name: Link check
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            README.md DESIGN.md CONTRIBUTING.md BENCHMARKS.md
+            'docs/**/*.md' '.github/**/*.md'
+          fail: true
+
   etcd-contract:
     name: etcd backend contract
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,25 @@ cargo doc --workspace --no-deps             # doc build (RUSTDOCFLAGS=-D warning
 CI denies all warnings (`RUSTFLAGS=-D warnings`), so a clean local `just ci` is
 required for a green PR. Run `just fmt` to auto-format.
 
+### Documentation checks
+
+Docs are gated too. If you touch documentation, mirror the CI docs checks
+locally:
+
+```sh
+just spell        # spelling (typos); config in typos.toml
+just linkcheck    # links (lychee); config in lychee.toml
+```
+
+Install the tools once with `cargo install typos-cli lychee`. When you change a
+config knob or the management API, also regenerate the references so the drift
+gate stays green:
+
+```sh
+just gen-config-docs   # from the ConfigVar schemas
+just gen-api-docs      # from openapi.json
+```
+
 ## Performance feedback loop
 
 Talon has a microbenchmark harness for fast, machine-readable perf signal. If

--- a/Justfile
+++ b/Justfile
@@ -48,6 +48,14 @@ check-api-docs:
     cargo run -q -p talon-coordinator --bin talon-gen-api-docs > /tmp/talon-api-ref.md
     diff -u docs/reference/rest-api.md /tmp/talon-api-ref.md
 
+# Spell-check the repo (install: cargo install typos-cli). Config: typos.toml.
+spell:
+    typos
+
+# Link-check the docs (install: cargo install lychee). Config: lychee.toml.
+linkcheck:
+    lychee --no-progress README.md DESIGN.md CONTRIBUTING.md BENCHMARKS.md 'docs/**/*.md' '.github/**/*.md'
+
 # --- benchmarks (performance feedback loop) ---
 
 # Run all microbenchmarks and write bench/results/latest.json.

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,26 @@
+# Link-check configuration for the `lychee` CI gate.
+# See https://github.com/lycheeverse/lychee
+
+# Example URLs in docs are illustrative, not real endpoints: local dev
+# addresses, example etcd hosts, and placeholder hostnames. Exclude them so the
+# gate flags only genuinely broken links.
+exclude = [
+    # Local development endpoints shown in the quick start / tutorial.
+    "^https?://127\\.0\\.0\\.1",
+    "^https?://localhost",
+    "^https?://0\\.0\\.0\\.0",
+    # Example etcd/host placeholders in the operator runbook.
+    "^https?://etcd-[0-9]",
+]
+
+# Do not check generated book output or vendored trees.
+exclude_path = [
+    "docs/book/book",
+    "target",
+]
+
+# Treat these as success even if a server rate-limits HEAD requests.
+accept = [200, 206, 429]
+
+# GitHub can rate-limit anonymous requests; retry politely.
+max_retries = 2

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,19 @@
+# Spell-check configuration for the `typos` CI gate.
+# See https://github.com/crate-ci/typos
+#
+# `extend-words` entries below are legitimate terms `typos` would otherwise
+# flag: hyphenated prefixes and accepted spellings that appear in comments and
+# prose. Add real project vocabulary here rather than disabling the check.
+
+[default.extend-words]
+# "mis-configured", "mis-bucket" — a valid hyphenated prefix, not "miss".
+mis = "mis"
+# Accepted English spelling used in doc comments.
+clonable = "clonable"
+
+[files]
+# Generated and vendored content should not be spell-checked.
+extend-exclude = [
+    "docs/book/book/",
+    "target/",
+]


### PR DESCRIPTION
## Summary

Final sub-issue of the documentation overhaul (#184). Adds a CI gate that keeps
docs healthy over time — spelling and links — treating docs as code.

- **`docs-quality` CI job**: `crate-ci/typos` (spelling) + `lycheeverse/lychee-action`
  (links) over the README and `docs/` tree.
- **`typos.toml`**: a small project dictionary so legitimate terms
  (`mis-configured`, `clonable`) pass while real typos fail — the check that
  would have caught the original `tylon` misspelling.
- **`lychee.toml`**: excludes illustrative example URLs (local dev endpoints,
  placeholder etcd hosts) and generated book output, so only genuinely broken
  links fail.
- **Local parity**: `just spell` / `just linkcheck`; CONTRIBUTING documents them
  next to the reference-regeneration recipes.

## Test plan

- [x] `typos` passes repo-wide (exit 0) with the project dictionary.
- [x] `lychee` validates all **64** doc links **online** with **0 errors** using
      the exact CI glob (`README.md … 'docs/**/*.md' '.github/**/*.md'`).
- [x] Example URLs (127.0.0.1, etcd-N) are correctly excluded, not silently
      passed — verified they were the only online failures before the config.
- [x] `ci.yml` YAML validates.

Closes #190

---

This completes the six-part documentation overhaul (#184): #185 README hub,
#186 getting-started tutorial, #187 mdBook site, #188 generated config
reference, #189 generated API reference, and this quality gate.