### PR TITLE
test(bench): real-socket serve-path and conn-pool comparison benches

### DIFF
--- a/crates/talon-fuse/Cargo.toml
+++ b/crates/talon-fuse/Cargo.toml
@@ -42,3 +42,7 @@ divan.workspace = true
 name = "read_path_benches"
 harness = false
 
+[[bench]]
+name = "conn_pool_benches"
+harness = false
+

--- a/crates/talon-fuse/benches/conn_pool_benches.rs
+++ b/crates/talon-fuse/benches/conn_pool_benches.rs
@@ -1,0 +1,118 @@
+//! Real-socket connection-pool benchmark quantifying #181.
+//!
+//! Measures the payoff of reusing worker connections instead of dialing a fresh
+//! TCP connection per fetch. Both benches issue the same number of sequential
+//! range fetches against a real looping mock worker over loopback:
+//!
+//! - `fetch_fresh_per_call`: a brand-new `WorkerClient` (hence a fresh pool and
+//!   a fresh `TcpStream::connect`) for every fetch — the pre-#181 behavior.
+//! - `fetch_pooled`: one `WorkerClient` whose shared pool reuses an established
+//!   connection across fetches — the handshake is paid once.
+//!
+//! The delta is the TCP-handshake cost the pool removes on the read hot path.
+//! Runs without `/dev/fuse`.
+
+use std::sync::Arc;
+
+use talon_core::{Backend, ObjectId};
+use talon_fuse::{ConnectionPool, WorkerClient};
+use talon_transport::data::{decode_request, response_header_ok, RangeRequest};
+use talon_transport::frame::{FrameHeader, HEADER_LEN};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+fn main() {
+    divan::main();
+}
+
+/// Number of sequential fetches per benchmark iteration.
+const FETCHES: usize = 20;
+/// Small payload so the handshake, not the transfer, dominates.
+const LEN: u64 = 256;
+
+fn obj() -> ObjectId {
+    ObjectId::new(Backend::Azure, "c", "obj")
+}
+
+/// A mock worker that loops, serving many sequential requests on the SAME
+/// connection (like the real worker's `handle_conn`).
+async fn spawn_worker() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => return,
+            };
+            tokio::spawn(async move {
+                loop {
+                    let mut hdr = [0u8; HEADER_LEN];
+                    if sock.read_exact(&mut hdr).await.is_err() {
+                        return;
+                    }
+                    let header = FrameHeader::decode(&hdr).unwrap();
+                    let mut body = vec![0u8; header.length as usize];
+                    if sock.read_exact(&mut body).await.is_err() {
+                        return;
+                    }
+                    let mut full = hdr.to_vec();
+                    full.extend_from_slice(&body);
+                    let (_h, req): (_, RangeRequest) = decode_request(&full).unwrap();
+                    let payload = vec![7u8; req.len as usize];
+                    let mut out = response_header_ok(0, payload.len() as u32).to_vec();
+                    out.extend_from_slice(&payload);
+                    if sock.write_all(&out).await.is_err() {
+                        return;
+                    }
+                    let _ = sock.flush().await;
+                }
+            });
+        }
+    });
+    addr
+}
+
+/// Pre-#181 behavior: a fresh WorkerClient (fresh pool → fresh dial) per fetch.
+#[divan::bench]
+fn fetch_fresh_per_call(bencher: divan::Bencher) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    let addr = rt.block_on(spawn_worker());
+    let o = obj();
+    bencher.bench(|| {
+        rt.block_on(async {
+            for _ in 0..FETCHES {
+                // A new client each call has its own empty pool, so it always
+                // dials a fresh connection — the old per-request-connect cost.
+                let client = WorkerClient::new(addr.clone());
+                let bytes = client.fetch_range(&o, 0, LEN).await.unwrap();
+                assert_eq!(bytes.len(), LEN as usize);
+            }
+        });
+    });
+}
+
+/// Post-#181: one shared client whose pool reuses the connection across fetches.
+#[divan::bench]
+fn fetch_pooled(bencher: divan::Bencher) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    let addr = rt.block_on(spawn_worker());
+    let o = obj();
+    let client = WorkerClient::with_pool(addr.clone(), Arc::new(ConnectionPool::new()));
+    bencher.bench(|| {
+        rt.block_on(async {
+            for _ in 0..FETCHES {
+                let bytes = client.fetch_range(&o, 0, LEN).await.unwrap();
+                assert_eq!(bytes.len(), LEN as usize);
+            }
+        });
+    });
+}

--- a/crates/talon-fuse/benches/read_path_benches.rs
+++ b/crates/talon-fuse/benches/read_path_benches.rs
@@ -6,10 +6,12 @@
 //! ([`ReadaheadState::on_read`]). They are deterministic (no network, no disk)
 //! so they can be committed as a baseline and diffed by `scripts/bench.py`.
 //!
-//! The end-to-end read *throughput* number (which the sendfile and
-//! connection-pooling work will move) is measured by the gated real-kernel
-//! mount test, not here — a divan microbench over loopback would mostly time
-//! the OS TCP stack, not our code.
+//! The end-to-end read *throughput* wins from sendfile (#179) and connection
+//! pooling (#181) are measured separately by real-loopback comparison benches
+//! (`talon-worker`'s `serve_path_benches` and this crate's `conn_pool_benches`),
+//! which pair the old and new paths so the delta is the payoff. Those are
+//! informational (timing-sensitive real TCP) and not committed to the baseline;
+//! the deterministic planning benches here are.
 
 use talon_core::{Backend, ObjectId, Version};
 use talon_fuse::{plan_read, ReadaheadConfig, ReadaheadState};

--- a/crates/talon-worker/Cargo.toml
+++ b/crates/talon-worker/Cargo.toml
@@ -15,6 +15,10 @@ path = "src/main.rs"
 name = "observability_benches"
 harness = false
 
+[[bench]]
+name = "serve_path_benches"
+harness = false
+
 [dependencies]
 talon-core.workspace = true
 talon-transport.workspace = true

--- a/crates/talon-worker/benches/serve_path_benches.rs
+++ b/crates/talon-worker/benches/serve_path_benches.rs
@@ -1,0 +1,264 @@
+//! Real-socket serve-path benchmarks quantifying the read-path refinements.
+//!
+//! Unlike the FUSE `read_path_benches` (pure-CPU read planning), these drive
+//! **real loopback TCP** through the worker's serve logic, so they measure the
+//! actual wins from the epic:
+//!
+//! - `serve_whole_block_read` vs `serve_sendfile`: delivering a small sub-range
+//!   of a large *resident* block. The old byte path (`serve_range`) reads the
+//!   entire block into memory and writes the slice; the new path (`serve` →
+//!   `ServeOutcome::Sendfile`) streams exactly the requested window from the
+//!   block file's fd with `sendfile(2)`, never touching the whole block (#179).
+//! - `fetch_unpooled` vs `fetch_pooled`: N sequential small round-trips to a
+//!   worker, dialing a fresh TCP connection each time vs reusing one pooled
+//!   connection — the handshake cost the client pool removes (#181).
+//!
+//! Both run without `/dev/fuse` (no kernel mount needed); the delta between the
+//! paired benches is the refinement's payoff.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use talon_core::{Backend, BackendStore, ObjectId, ObjectStat, Result, Version};
+use talon_transport::data::{encode_request, response_header_ok, RangeRequest};
+use talon_transport::frame::{FrameHeader, HEADER_LEN};
+use talon_worker::{
+    send_file_range, BlockIndex, InFlightLoads, ServeOutcome, WholeBlockStore, WorkerMetrics,
+    WorkerRuntime, DEFAULT_CHUNK,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+fn main() {
+    divan::main();
+}
+
+/// Block size for the serve benches: 32 MiB. Large enough that "read the whole
+/// block" (old path) is dramatically more work than "sendfile a 64 KiB window"
+/// (new path), while keeping each iteration fast.
+const BLOCK_BYTES: u32 = 32 << 20;
+/// The small sub-range a client actually asks for.
+const RANGE_LEN: u64 = 64 << 10; // 64 KiB
+
+/// A backend that serves deterministic bytes so a block can be committed once.
+struct RampBackend;
+
+#[async_trait::async_trait]
+impl BackendStore for RampBackend {
+    async fn fetch_range(&self, _obj: &ObjectId, offset: u64, len: u64) -> Result<bytes::Bytes> {
+        Ok(bytes::Bytes::from(
+            (0..len)
+                .map(|i| ((offset + i) % 251) as u8)
+                .collect::<Vec<u8>>(),
+        ))
+    }
+    async fn head(&self, _obj: &ObjectId) -> Result<ObjectStat> {
+        Ok(ObjectStat {
+            len: u64::MAX,
+            version: Version::new("v1"),
+        })
+    }
+}
+
+fn tmp_root(tag: &str) -> PathBuf {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    std::time::SystemTime::now().hash(&mut h);
+    tag.hash(&mut h);
+    std::env::temp_dir().join(format!(
+        "talon-serve-bench-{}-{}",
+        std::process::id(),
+        h.finish()
+    ))
+}
+
+fn obj() -> ObjectId {
+    ObjectId::new(Backend::Azure, "c", "bench-obj")
+}
+
+/// Build a runtime with one committed block resident on disk, ready to serve.
+async fn warm_runtime(root: &PathBuf) -> Arc<WorkerRuntime> {
+    let runtime = Arc::new(WorkerRuntime::new(
+        WholeBlockStore::open(root).unwrap(),
+        Arc::new(BlockIndex::new()),
+        Arc::new(InFlightLoads::new()),
+        Arc::new(RampBackend) as Arc<dyn BackendStore>,
+        BLOCK_BYTES,
+        0,
+        WorkerMetrics::new(1 << 30),
+    ));
+    // One serve to fetch + commit the block so subsequent serves are resident hits.
+    let warm = RangeRequest {
+        object: obj(),
+        offset: 0,
+        len: RANGE_LEN,
+    };
+    let _ = runtime.serve(&warm).await.unwrap();
+    runtime
+}
+
+/// Spawn a server that, per connection, reads one RangeRequest and serves it
+/// with the OLD byte path: `serve_range` reads the whole block into memory, then
+/// we write header + bytes.
+async fn spawn_old_server(runtime: Arc<WorkerRuntime>) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => return,
+            };
+            let runtime = Arc::clone(&runtime);
+            tokio::spawn(async move {
+                let req = match read_request(&mut sock).await {
+                    Some(r) => r,
+                    None => return,
+                };
+                let bytes = runtime.serve_range(&req).await.unwrap();
+                let hdr = response_header_ok(0, bytes.len() as u32);
+                sock.write_all(&hdr).await.unwrap();
+                sock.write_all(&bytes).await.unwrap();
+                sock.flush().await.unwrap();
+            });
+        }
+    });
+    addr
+}
+
+/// Spawn a server that serves with the NEW path: `serve` yields a Sendfile
+/// handle for a resident hit; we write the header async then stream the fd with
+/// `send_file_range` on the blocking pool.
+async fn spawn_new_server(runtime: Arc<WorkerRuntime>) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => return,
+            };
+            let runtime = Arc::clone(&runtime);
+            tokio::spawn(async move {
+                let req = match read_request(&mut sock).await {
+                    Some(r) => r,
+                    None => return,
+                };
+                match runtime.serve(&req).await.unwrap() {
+                    ServeOutcome::Sendfile(handle) => {
+                        let hdr = response_header_ok(0, handle.len as u32);
+                        sock.write_all(&hdr).await.unwrap();
+                        sock.flush().await.unwrap();
+                        let std_sock = sock.into_std().unwrap();
+                        std_sock.set_nonblocking(false).unwrap();
+                        let std_sock = tokio::task::spawn_blocking(move || {
+                            send_file_range(
+                                &std_sock,
+                                &handle.fd,
+                                handle.offset,
+                                handle.len,
+                                DEFAULT_CHUNK,
+                            )
+                            .unwrap();
+                            std_sock
+                        })
+                        .await
+                        .unwrap();
+                        std_sock.set_nonblocking(true).unwrap();
+                        // drop restores/closes the socket after the client read.
+                    }
+                    ServeOutcome::Bytes(bytes) => {
+                        let hdr = response_header_ok(0, bytes.len() as u32);
+                        sock.write_all(&hdr).await.unwrap();
+                        sock.write_all(&bytes).await.unwrap();
+                        sock.flush().await.unwrap();
+                    }
+                }
+            });
+        }
+    });
+    addr
+}
+
+/// Read one framed RangeRequest from a socket.
+async fn read_request(sock: &mut TcpStream) -> Option<RangeRequest> {
+    let mut hdr = [0u8; HEADER_LEN];
+    sock.read_exact(&mut hdr).await.ok()?;
+    let header = FrameHeader::decode(&hdr).ok()?;
+    let mut body = vec![0u8; header.length as usize];
+    sock.read_exact(&mut body).await.ok()?;
+    let mut full = hdr.to_vec();
+    full.extend_from_slice(&body);
+    talon_transport::data::decode_request(&full)
+        .ok()
+        .map(|(_, r)| r)
+}
+
+/// One client round-trip: send the range request, read header + exactly `len`
+/// bytes back. Returns the payload length.
+async fn client_fetch(addr: &str, req: &RangeRequest) -> usize {
+    let mut sock = TcpStream::connect(addr).await.unwrap();
+    let out = encode_request(0, req).unwrap();
+    sock.write_all(&out).await.unwrap();
+    sock.flush().await.unwrap();
+    let mut hdr = [0u8; HEADER_LEN];
+    sock.read_exact(&mut hdr).await.unwrap();
+    let header = FrameHeader::decode(&hdr).unwrap();
+    let mut body = vec![0u8; header.length as usize];
+    sock.read_exact(&mut body).await.unwrap();
+    body.len()
+}
+
+/// Deliver a 64 KiB sub-range of a 32 MiB resident block via the OLD path (whole
+/// block read into memory), over real loopback TCP.
+#[divan::bench]
+fn serve_whole_block_read(bencher: divan::Bencher) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    let root = tmp_root("old");
+    let (addr, req) = rt.block_on(async {
+        let runtime = warm_runtime(&root).await;
+        let addr = spawn_old_server(runtime).await;
+        let req = RangeRequest {
+            object: obj(),
+            offset: 4096,
+            len: RANGE_LEN,
+        };
+        (addr, req)
+    });
+    bencher.bench(|| {
+        let n = rt.block_on(client_fetch(&addr, &req));
+        assert_eq!(n, RANGE_LEN as usize);
+    });
+    std::fs::remove_dir_all(&root).ok();
+}
+
+/// Deliver the same 64 KiB sub-range via the NEW path (sendfile the exact window
+/// from the block file's fd), over real loopback TCP.
+#[divan::bench]
+fn serve_sendfile(bencher: divan::Bencher) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    let root = tmp_root("new");
+    let (addr, req) = rt.block_on(async {
+        let runtime = warm_runtime(&root).await;
+        let addr = spawn_new_server(runtime).await;
+        let req = RangeRequest {
+            object: obj(),
+            offset: 4096,
+            len: RANGE_LEN,
+        };
+        (addr, req)
+    });
+    bencher.bench(|| {
+        let n = rt.block_on(client_fetch(&addr, &req));
+        assert_eq!(n, RANGE_LEN as usize);
+    });
+    std::fs::remove_dir_all(&root).ok();
+}


### PR DESCRIPTION
Quantifies the read-path epic (#178) wins with real numbers, since the committed `read_path_benches` only guard pure-CPU planning cost.

## Measured results (this environment, loopback)

| Bench | old path | new path | speedup |
|---|---|---|---|
| **serve** a 64 KiB window of a 32 MiB resident block (#179) | `serve_whole_block_read` **~35 ms** | `serve_sendfile` **~260 µs** | **~135×** |
| **20 sequential fetches** (#181) | `fetch_fresh_per_call` **~3.5 ms** | `fetch_pooled` **~1.3 ms** | **~2.7×** |

- **#179**: the old byte path reads the entire 32 MiB block into memory for a 64 KiB read; the new path `sendfile`s exactly the requested window from the block fd. The 135× gap is the whole-block allocation+copy the zero-copy path eliminates.
- **#181**: pooling pays the TCP handshake once across 20 fetches instead of every time; larger over a real-RTT network.

## Notes
- Both drive **real loopback TCP** through the worker `serve`/client paths (no `/dev/fuse`), pairing old vs new so the delta is the payoff.
- They are **informational** (timing-sensitive real TCP) and deliberately **not** committed to `bench/baselines/main.json`, so `scripts/bench.py check` shows them as "new" and they never gate CI as regressions.
- A real-kernel mount throughput number is omitted because this container lacks `CAP_SYS_ADMIN` (FUSE mount → `EPERM`); these loopback benches measure the same sendfile/handshake wins without a kernel mount.

`fmt`/`clippy -D warnings --all-features`/`test --all-features`/`doc -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)