### PR TITLE
ci: run the real-kernel FUSE mount test on a Linux runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,36 @@ jobs:
       - name: Test
         run: cargo test --workspace --all-features --locked
 
+  fuse-mount:
+    name: fuse mount e2e
+    runs-on: ubuntu-latest
+    # The read-path unit/integration tests never touch the kernel (they use mock
+    # TCP servers). This job mounts a real TalonFuse on /dev/fuse and reads a
+    # file back through the kernel, asserting byte-exactness end to end — the one
+    # layer only a real mount can cover. GitHub's Linux runners provide an
+    # accessible /dev/fuse; macOS and restricted sandboxes do not, which is why
+    # the test is #[ignore]d and gated behind the `mount` feature by default.
+    env:
+      # Turn a missing/unusable /dev/fuse into a hard failure here, so this job
+      # can never pass without actually exercising the kernel mount path.
+      TALON_REQUIRE_FUSE: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify /dev/fuse is available
+        run: |
+          if [ ! -e /dev/fuse ]; then
+            echo "::error::/dev/fuse is missing on this runner; the FUSE mount test cannot run"
+            exit 1
+          fi
+          ls -l /dev/fuse
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: Swatinem/rust-cache@v2
+      - name: Run the real-kernel mount test
+        run: >-
+          cargo test -p talon-fuse --features mount --test mount_e2e --locked
+          -- --ignored --nocapture
+
   docs:
     name: doc
     runs-on: ubuntu-latest

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -13,9 +13,13 @@
 //! - marked `#[ignore]`, so even with the feature it runs only when explicitly
 //!   requested: `cargo test -p talon-fuse --features mount --test mount_e2e -- --ignored`.
 //!
-//! Running it requires a working `/dev/fuse` (present in most Linux dev boxes
-//! and CI runners with `--privileged`, absent in restricted sandboxes), which
-//! is why it is not part of the default suite.
+//! Running it requires a working `/dev/fuse` (present on GitHub's Linux runners
+//! and most Linux dev boxes, absent on macOS and in restricted sandboxes), which
+//! is why it is not part of the default suite. By default a missing `/dev/fuse`
+//! makes the test skip (pass as a no-op). Set `TALON_REQUIRE_FUSE=1` — as the CI
+//! `fuse-mount` job does — to turn a mount failure into a hard error instead, so
+//! a runner that unexpectedly lacks FUSE fails the job rather than passing
+//! without exercising the kernel path.
 #![cfg(feature = "mount")]
 
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -147,7 +151,12 @@ async fn mount_read_is_byte_exact_through_the_kernel() {
         talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
     );
 
-    // Mount at a temp dir. Skip (don't fail) if /dev/fuse is unavailable.
+    // Mount at a temp dir. If /dev/fuse is unavailable this normally skips, so
+    // the test is a no-op on machines without FUSE. In CI, set
+    // TALON_REQUIRE_FUSE=1 so a mount failure is a hard error instead — that way
+    // a runner that silently lacks /dev/fuse turns the job red rather than
+    // passing without exercising the kernel path (a false green).
+    let require_fuse = std::env::var_os("TALON_REQUIRE_FUSE").is_some();
     let mountpoint = std::env::temp_dir().join(format!("talon-mount-e2e-{}", std::process::id()));
     std::fs::create_dir_all(&mountpoint).unwrap();
     let options = vec![MountOption::RO, MountOption::FSName("talon".into())];
@@ -155,6 +164,12 @@ async fn mount_read_is_byte_exact_through_the_kernel() {
         Ok(s) => s,
         Err(e) => {
             std::fs::remove_dir_all(&mountpoint).ok();
+            if require_fuse {
+                panic!(
+                    "TALON_REQUIRE_FUSE is set but the FUSE mount failed: {e}. \
+                     The runner must provide an accessible /dev/fuse."
+                );
+            }
             eprintln!("skipping: /dev/fuse unavailable: {e}");
             return;
         }


### PR DESCRIPTION
## Summary
The read-path unit/integration tests never touch the kernel — they use mock TCP servers. The one layer only a real mount can cover (a genuine `/dev/fuse` mount + `read(2)` through the kernel) exists as `mount_e2e` but is `#[ignore]`d, so **nothing ran it**: it needs an accessible `/dev/fuse`, absent on macOS and in restricted sandboxes.

Adds a `fuse-mount` CI job on `ubuntu-latest` (GitHub's Linux runners expose `/dev/fuse` without `--privileged`) that verifies the device exists, then runs `cargo test -p talon-fuse --features mount --test mount_e2e -- --ignored`.

## No false green
The test now honors `TALON_REQUIRE_FUSE`: by default a missing `/dev/fuse` still **skips** (so `cargo test` on a Mac or sandbox is a no-op), but with `TALON_REQUIRE_FUSE=1` — which the CI job sets — a mount failure is a **hard panic**. So the job can never pass without actually mounting and reading through the kernel (which also exercises the #180 read-size tuning by observing the read length the kernel issues).

## Verified locally
- Without the env var → test skips and passes (Mac/sandbox behavior).
- With `TALON_REQUIRE_FUSE=1` and no `/dev/fuse` → fails with an explicit message.
- `fmt`/`clippy -D warnings --features mount` clean.

This PR is also the first time the mount test actually runs — the new job on GitHub's runner is the real validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)