### PR TITLE
chore(fuse): prune test-only public exports

### DIFF
--- a/crates/talon-fuse/src/coordinator_client.rs
+++ b/crates/talon-fuse/src/coordinator_client.rs
@@ -128,6 +128,13 @@ impl CoordinatorClient {
     }
 
     /// Fetch an object's size + version for `getattr` / block addressing.
+    ///
+    /// Forward-surface: the mount currently sizes files from the coordinator
+    /// listing (`list_objects`) and addresses blocks under a canonical version
+    /// (the worker owns freshness, #182), so this per-object `StatObject` RPC is
+    /// not yet on the hot path. It is the natural entry point for real per-object
+    /// version resolution if the mount ever becomes version-aware; kept for that
+    /// and covered by its own test.
     pub async fn stat_object(&self, object: &ObjectId) -> Result<ObjectStat, CoordinatorError> {
         let req = ControlMessage::StatObject {
             object: object.clone(),

--- a/crates/talon-fuse/src/lib.rs
+++ b/crates/talon-fuse/src/lib.rs
@@ -22,7 +22,7 @@ pub use block_reader::{BlockReadError, BlockReader, FileView};
 pub use coordinator_client::{
     CoordinatorClient, CoordinatorError, ObjectStat, Placement, ResolvedPlacement,
 };
-pub use mapping::{object_to_path, path_to_object, resolve_read, ReadTarget};
+pub use mapping::{path_to_object, resolve_read, ReadTarget};
 pub use metrics::{ReadStats, ReadStatsSnapshot};
 #[cfg(feature = "mount")]
 pub use mount::{TalonFuse, CANONICAL_MOUNT_VERSION};

--- a/crates/talon-fuse/src/mapping.rs
+++ b/crates/talon-fuse/src/mapping.rs
@@ -9,8 +9,9 @@
 //! /az/<account-or-container>/<object key...>
 //! ```
 //!
-//! [`path_to_object`] parses such a path into an [`ObjectId`]; [`object_to_path`]
-//! is its inverse. For an open file, [`resolve_read`] maps a byte `offset` to
+//! [`path_to_object`] parses such a path into an [`ObjectId`] (the reverse,
+//! [`ObjectId::to_path`], renders it back). For an open file, [`resolve_read`]
+//! maps a byte `offset` to
 //! the [`BlockId`] that contains it plus the offset *within* that block, given
 //! the file's block size and version. On the mount path the version is a
 //! canonical placeholder, not a per-object ETag: placement is version-
@@ -62,12 +63,6 @@ pub fn path_to_object(path: &str) -> Result<ObjectId> {
     Ok(ObjectId::new(backend, bucket, object_path))
 }
 
-/// Render an [`ObjectId`] back into its mount-relative path. Inverse of
-/// [`path_to_object`].
-pub fn object_to_path(obj: &ObjectId) -> String {
-    obj.to_path()
-}
-
 /// Resolve a read at `offset` into the block that holds it.
 ///
 /// `block_size` is the file's logical block size and `version` its current
@@ -105,7 +100,7 @@ mod tests {
         ] {
             let obj = path_to_object(path).unwrap();
             assert_eq!(obj.backend, backend);
-            assert_eq!(object_to_path(&obj), path);
+            assert_eq!(obj.to_path(), path);
         }
     }
 
@@ -131,7 +126,7 @@ mod tests {
         let path = "/s3/bucket/weird name (v2)/日本語.bin";
         let obj = path_to_object(path).unwrap();
         assert_eq!(obj.object_path, "weird name (v2)/日本語.bin");
-        assert_eq!(object_to_path(&obj), path);
+        assert_eq!(obj.to_path(), path);
     }
 
     #[test]

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -247,21 +247,6 @@ impl ReadOnlyFs {
         Ok(fh)
     }
 
-    /// Resolve which inode + size a `read` on handle `fh` targets, clamping
-    /// `[offset, offset+size)` to the file length.
-    ///
-    /// Returns `(ino, clamped_len)`; the caller performs the actual GET/GET_RANGE
-    /// on the owning worker for that inode's object. A zero `clamped_len` means
-    /// the read is entirely past EOF.
-    pub fn read_plan(&self, fh: u64, offset: u64, size: u32) -> Result<(u64, u64), FsError> {
-        let g = self.inner.lock().unwrap();
-        let ino = *g.handles.get(&fh).ok_or(FsError::BadHandle)?;
-        let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
-        let end = offset.saturating_add(size as u64).min(node.size);
-        let clamped = end.saturating_sub(offset);
-        Ok((ino, clamped))
-    }
-
     /// `release`: drop a previously opened handle.
     pub fn release(&self, fh: u64) -> Result<(), FsError> {
         let mut g = self.inner.lock().unwrap();
@@ -282,12 +267,6 @@ impl ReadOnlyFs {
             return Err(FsError::Unsupported);
         }
         Ok((node.path.clone(), node.size))
-    }
-
-    /// Any mutating operation (write/create/unlink/rename/chmod/…): always
-    /// rejected on the read-only filesystem.
-    pub fn mutate(&self) -> FsError {
-        FsError::ReadOnly
     }
 }
 
@@ -336,7 +315,7 @@ mod tests {
     }
 
     #[test]
-    fn open_read_plan_release_flow() {
+    fn open_file_meta_release_flow() {
         let fs = fs();
         let s3 = fs.lookup(ROOT_INO, "s3").unwrap();
         let bucket = fs.lookup(s3.ino, "bucket").unwrap();
@@ -347,23 +326,15 @@ mod tests {
         assert_eq!(fs.open(data.ino), Err(FsError::Unsupported));
 
         let fh = fs.open(a.ino).unwrap();
-        // Full read within bounds.
-        assert_eq!(fs.read_plan(fh, 0, 256).unwrap(), (a.ino, 256));
-        // Partial read near EOF (footer): clamp to file size.
-        assert_eq!(fs.read_plan(fh, 900, 256).unwrap(), (a.ino, 100));
-        // Entirely past EOF.
-        assert_eq!(fs.read_plan(fh, 2000, 10).unwrap(), (a.ino, 0));
+        // file_meta yields the object path + size for the open handle.
+        let (path, size) = fs.file_meta(fh).unwrap();
+        assert_eq!(path, "s3/bucket/data/a.bin");
+        assert_eq!(size, 1000);
 
         fs.release(fh).unwrap();
         // Handle no longer valid.
-        assert_eq!(fs.read_plan(fh, 0, 1), Err(FsError::BadHandle));
+        assert_eq!(fs.file_meta(fh), Err(FsError::BadHandle));
         assert_eq!(fs.release(fh), Err(FsError::BadHandle));
-    }
-
-    #[test]
-    fn mutating_ops_are_read_only() {
-        let fs = fs();
-        assert_eq!(fs.mutate(), FsError::ReadOnly);
     }
 
     #[test]

--- a/crates/talon-fuse/src/placement_cache.rs
+++ b/crates/talon-fuse/src/placement_cache.rs
@@ -9,9 +9,9 @@
 //! - **Wrong owner / NOT_FOUND** — the contacted worker doesn't have the block.
 //! - **Connect failure** — the contacted worker is unreachable.
 //!
-//! On `LOADING` / unavailable, the client walks the ordered replica list via
-//! [`Cached::next_replica`] before giving up and refreshing. Time is injected as
-//! a monotonic millisecond value for deterministic tests.
+//! On `LOADING` / unavailable, the client walks the cached entry's ordered
+//! [`Cached::replicas`] list before giving up and refreshing. Time is injected
+//! as a monotonic millisecond value for deterministic tests.
 
 use std::collections::HashMap;
 use std::sync::RwLock;
@@ -42,21 +42,6 @@ pub struct Cached {
     /// set), **not** a monotonically increasing counter. Clients compare it for
     /// equality only — see [`PlacementCache::observe_epoch`].
     pub epoch: u64,
-}
-
-impl Cached {
-    /// The primary (first) replica, if any.
-    pub fn primary(&self) -> Option<&str> {
-        self.replicas.first().map(String::as_str)
-    }
-
-    /// The replica after `current` in the ordered list, for fallback.
-    ///
-    /// Returns `None` once the list is exhausted (caller should refresh).
-    pub fn next_replica(&self, current: &str) -> Option<&str> {
-        let pos = self.replicas.iter().position(|r| r == current)?;
-        self.replicas.get(pos + 1).map(String::as_str)
-    }
 }
 
 struct Entry {
@@ -177,20 +162,17 @@ mod tests {
     fn hit_within_ttl_miss_after() {
         let c = PlacementCache::new(1000);
         c.insert(block(1), cached(1, &["a", "b"]), 0);
-        assert_eq!(c.get(&block(1), 500).unwrap().primary(), Some("a"));
+        assert_eq!(
+            c.get(&block(1), 500)
+                .unwrap()
+                .replicas
+                .first()
+                .map(String::as_str),
+            Some("a")
+        );
         // Past TTL -> miss, and the stale entry is dropped.
         assert!(c.get(&block(1), 1001).is_none());
         assert!(c.is_empty());
-    }
-
-    #[test]
-    fn replica_fallback_walks_ordered_list() {
-        let cc = cached(1, &["a", "b", "c"]);
-        assert_eq!(cc.primary(), Some("a"));
-        assert_eq!(cc.next_replica("a"), Some("b"));
-        assert_eq!(cc.next_replica("b"), Some("c"));
-        assert_eq!(cc.next_replica("c"), None); // exhausted -> refresh
-        assert_eq!(cc.next_replica("unknown"), None);
     }
 
     #[test]


### PR DESCRIPTION
Part of #205. Closes #208.

## Summary
Several `talon-fuse` public items had no non-test callers on the live read path. Resolved each:

- **Removed `ReadOnlyFs::read_plan`** — superseded by `file_meta` (what the mount `read` callback actually uses); its test now exercises open→file_meta→release.
- **Removed `ReadOnlyFs::mutate`** — a read-only sentinel with no caller (write callbacks take the default ENOSYS path).
- **Removed `Cached::primary` / `Cached::next_replica`** — `BlockReader` walks `cached.replicas` directly; tests use the field directly.
- **Removed `mapping::object_to_path`** — a one-line wrapper over `ObjectId::to_path` with no production caller; tests/docs use `obj.to_path()` directly.
- **Kept `CoordinatorClient::stat_object` / `ObjectStat`** with a doc note marking it forward-surface: it corresponds to the `StatObject`/`ObjectStat` control messages and is the natural entry point for real per-object version resolution if the mount becomes version-aware (#182).

## Testing
Build (default + `--features mount`), `clippy -D warnings`, `test --all-features`, `doc -D warnings` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)