### PR TITLE
build(docker): multi-stage Dockerfiles for the three binaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Keep the Docker build context small and reproducible: ship only what `cargo
+# build` needs (Cargo manifests, sources, toolchain pin). Everything below is
+# irrelevant to the build and would bloat the context or bust layer caching.
+
+# Rust build output — by far the largest directory.
+/target
+**/target
+
+# Version control and CI.
+/.git
+/.github
+
+# Documentation, deploy assets, and screenshots.
+/docs
+/deploy
+*.md
+/bench
+
+# Editor / OS cruft and local secrets.
+*.swp
+.DS_Store
+.env
+.env.*
+*.pem
+*.key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,39 @@ jobs:
           --features etcd,state-store-testkit
           --test etcd_contract --locked
 
+  docker-build:
+    name: docker image build
+    runs-on: ubuntu-latest
+    # Smoke-build every container image on PRs (no push) so a broken Dockerfile
+    # fails CI. Publishing to GHCR happens separately on tags (release-images.yml).
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build coordinator image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/coordinator.Dockerfile
+          push: false
+          cache-from: type=gha,scope=coordinator
+          cache-to: type=gha,scope=coordinator,mode=max
+      - name: Build worker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/worker.Dockerfile
+          push: false
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,scope=worker,mode=max
+      - name: Build fuse image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/fuse.Dockerfile
+          push: false
+          cache-from: type=gha,scope=fuse
+          cache-to: type=gha,scope=fuse,mode=max
+
   bench:
     name: bench (informational)
     runs-on: ubuntu-latest

--- a/deploy/docker/coordinator.Dockerfile
+++ b/deploy/docker/coordinator.Dockerfile
@@ -1,0 +1,51 @@
+# Talon coordinator image.
+#
+# Multi-stage: a Rust build stage compiles the release binary with both
+# production state-store backends (etcd + Kubernetes), and a slim Debian runtime
+# stage ships only the binary. The container runs as a non-root user and bakes
+# in no configuration or secrets — everything comes from TALON_COORDINATOR_*
+# environment variables or a mounted --config file at runtime.
+#
+# Build from the repository root:
+#   docker build -f deploy/docker/coordinator.Dockerfile -t talon-coordinator .
+
+# ---- build stage ---------------------------------------------------------
+FROM rust:1.96.1-bookworm AS build
+
+# protoc is required to compile the etcd client's generated protobuf code.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+# Both production backends compiled in; rustls (not OpenSSL) keeps the runtime
+# free of a system TLS dependency.
+RUN cargo build --release -p talon-coordinator --features etcd,kubernetes \
+    && strip target/release/talon-coordinator
+
+# ---- runtime stage -------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+# ca-certificates for TLS to etcd / the Kubernetes API; curl for HEALTHCHECK.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --uid 10001 --user-group --home-dir /nonexistent \
+       --no-create-home talon
+
+COPY --from=build /src/target/release/talon-coordinator /usr/local/bin/talon-coordinator
+
+USER 10001:10001
+
+# Control plane and admin (metrics/health/API/UI). Bind 0.0.0.0 in a container
+# so the ports are reachable; the loopback defaults are for local dev only.
+ENV TALON_COORDINATOR_LISTEN=0.0.0.0:7000 \
+    TALON_COORDINATOR_ADMIN_LISTEN=0.0.0.0:8000
+EXPOSE 7000 8000
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:8000/healthz || exit 1
+
+ENTRYPOINT ["talon-coordinator"]

--- a/deploy/docker/fuse.Dockerfile
+++ b/deploy/docker/fuse.Dockerfile
@@ -1,0 +1,44 @@
+# Talon FUSE client image.
+#
+# Multi-stage: a Rust build stage compiles the release binary with the `mount`
+# feature (kernel FUSE adapter), and a slim Debian runtime stage ships the
+# binary plus libfuse3.
+#
+# Mounting talks to the kernel, so a container running this image needs
+# `/dev/fuse` and the SYS_ADMIN capability, e.g.:
+#   docker run --rm --device /dev/fuse --cap-add SYS_ADMIN \
+#     -e TALON_FUSE_COORDINATOR=coordinator:7000 talon-fuse \
+#     --mountpoint /mnt/talon
+#
+# Build from the repository root:
+#   docker build -f deploy/docker/fuse.Dockerfile -t talon-fuse .
+
+# ---- build stage ---------------------------------------------------------
+FROM rust:1.96.1-bookworm AS build
+
+# fuser links libfuse via pkg-config; the -dev package provides the headers.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends pkg-config libfuse3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+RUN cargo build --release -p talon-fuse --features mount \
+    && strip target/release/talon-fuse
+
+# ---- runtime stage -------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+# fuse3 provides the runtime library and the fusermount3 helper.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates fuse3 \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --uid 10001 --user-group --home-dir /nonexistent \
+       --no-create-home talon
+
+COPY --from=build /src/target/release/talon-fuse /usr/local/bin/talon-fuse
+
+# The mount syscall requires elevated privileges; run this image with
+# --cap-add SYS_ADMIN --device /dev/fuse. It does not open network ports.
+ENTRYPOINT ["talon-fuse"]

--- a/deploy/docker/worker.Dockerfile
+++ b/deploy/docker/worker.Dockerfile
@@ -1,0 +1,45 @@
+# Talon worker image.
+#
+# Multi-stage: a Rust build stage compiles the release binary, and a slim Debian
+# runtime stage ships only the binary. Runs as a non-root user; configuration
+# and the object-store credentials come from TALON_WORKER_* environment
+# variables at runtime (the Azure SAS token is env-only and never baked in).
+#
+# Build from the repository root:
+#   docker build -f deploy/docker/worker.Dockerfile -t talon-worker .
+
+# ---- build stage ---------------------------------------------------------
+FROM rust:1.96.1-bookworm AS build
+
+WORKDIR /src
+COPY . .
+
+RUN cargo build --release -p talon-worker \
+    && strip target/release/talon-worker
+
+# ---- runtime stage -------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --uid 10001 --user-group --home-dir /nonexistent \
+       --no-create-home talon \
+    && mkdir -p /var/cache/talon \
+    && chown 10001:10001 /var/cache/talon
+
+COPY --from=build /src/target/release/talon-worker /usr/local/bin/talon-worker
+
+USER 10001:10001
+
+# Data plane and admin (metrics/health/status). Bind 0.0.0.0 in a container.
+ENV TALON_WORKER_LISTEN=0.0.0.0:7001 \
+    TALON_WORKER_ADMIN_LISTEN=0.0.0.0:8001 \
+    TALON_WORKER_CACHE_DIRS=/var/cache/talon
+EXPOSE 7001 8001
+VOLUME ["/var/cache/talon"]
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:8001/healthz || exit 1
+
+ENTRYPOINT ["talon-worker"]


### PR DESCRIPTION
## Summary

Wave 1 of Docker/Kubernetes support (#213). Adds production container images so
Talon can run without a Rust toolchain.

- **`deploy/docker/{coordinator,worker,fuse}.Dockerfile`** — multi-stage: a Rust
  build stage (pinned 1.96.1) compiles the release binary, then a slim
  `debian:bookworm-slim` runtime stage ships only the stripped binary as a
  **non-root** user (uid 10001).
- **Coordinator** built `--features etcd,kubernetes` (protoc installed in the
  build stage); **worker** plain; **fuse** built `--features mount` with
  `libfuse3` at runtime (mounting needs `/dev/fuse` + `SYS_ADMIN`, documented in
  the Dockerfile).
- No config/secrets baked in — everything comes from `TALON_*` env or a mounted
  `--config`. Ports bind `0.0.0.0` for container reachability; `HEALTHCHECK`
  hits `/healthz` on the admin port.
- **`.dockerignore`** trims the build context to the Cargo workspace.
- A **`docker-build` CI job** smoke-builds all three images on PRs (no push, with
  layer caching) so a broken Dockerfile fails CI.

## Test plan

- [x] `talon-fuse --features mount` compiles with `libfuse3-dev` + pkg-config
      (verified locally — this is the fuse image's build step).
- [x] Coordinator `--features etcd,kubernetes` and worker release builds compile
      (verified earlier this session).
- [x] `.dockerignore` keeps every build input (Cargo manifests, `crates/`,
      `rust-toolchain.toml`); no `readme =` declared in any Cargo.toml, so
      excluding `*.md` is safe.
- [ ] **The `docker-build` CI job is the authoritative check** — it runs a real
      `docker build` of all three images on this PR (I don't have a Docker daemon
      locally). Merging is gated on it going green.

Closes #214