### PR TITLE
ci(docker): publish images to GHCR on version tags

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -1,0 +1,74 @@
+name: Release images
+
+# Build and publish the Talon container images to GHCR.
+#
+# On a version tag (vX.Y.Z) each image is pushed to
+# ghcr.io/<owner>/talon-<binary> with semver, major.minor, sha, and `latest`
+# tags. Pull requests do NOT run this workflow — the docker-build job in ci.yml
+# already smoke-builds every image (no push) on PRs.
+
+on:
+  push:
+    tags:
+      - "v*"
+  # Allow a manual publish of `latest` from the default branch.
+  workflow_dispatch:
+
+# Least-privilege: only the GHCR push needs package write; the built-in
+# GITHUB_TOKEN authenticates to the registry.
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: release-images-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: publish ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: coordinator
+            dockerfile: deploy/docker/coordinator.Dockerfile
+          - image: worker
+            dockerfile: deploy/docker/worker.Dockerfile
+          - image: fuse
+            dockerfile: deploy/docker/fuse.Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/talon-${{ matrix.image }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max


### PR DESCRIPTION
## Summary

Wave 1 of #213. Publishes the container images from #214.

- **`.github/workflows/release-images.yml`** — on a `vX.Y.Z` tag (or a manual
  `workflow_dispatch`), a matrix job builds and pushes
  `ghcr.io/<owner>/talon-{coordinator,worker,fuse}` with **semver, major.minor,
  sha, and `latest`** tags, via `docker/metadata-action` +
  `docker/build-push-action` (buildx, gha layer cache).
- **Least-privilege**: `contents: read` + `packages: write`, authenticated with
  the built-in `GITHUB_TOKEN`.
- **PRs don't run this** — the `docker-build` job in `ci.yml` (added in #214)
  already smoke-builds every image without pushing on PRs.

## Test plan

- [x] Workflow YAML validates.
- [x] The actual image build is already verified by the `docker-build` CI job on
      every PR (green on #214).
- [ ] Publishing runs only on tags, so it can't execute on this PR; the first
      `vX.Y.Z` tag exercises the push path. Standard `metadata-action` /
      `build-push-action` usage.

Closes #215