### PR TITLE
feat: add worker Kubernetes Deployment manifest

### DIFF
--- a/crates/talon-observability/src/deploy.rs
+++ b/crates/talon-observability/src/deploy.rs
@@ -17,6 +17,11 @@ pub const COORDINATOR_KUBERNETES_YAML: &str =
 /// etcd-backend coordinator Deployment.
 pub const COORDINATOR_ETCD_YAML: &str =
     include_str!("../../../deploy/kubernetes/coordinator-etcd.yaml");
+/// Worker Deployment (cache nodes), shared by both coordinator backends.
+pub const WORKER_YAML: &str = include_str!("../../../deploy/kubernetes/worker.yaml");
+/// Example Secret template for the worker's object-store credentials.
+pub const WORKER_SECRET_EXAMPLE_YAML: &str =
+    include_str!("../../../deploy/kubernetes/worker-secret.example.yaml");
 /// Service + PodDisruptionBudget.
 pub const SERVICE_YAML: &str = include_str!("../../../deploy/kubernetes/service.yaml");
 /// Least-privilege RBAC for the Kubernetes backend.
@@ -51,6 +56,8 @@ mod tests {
         for (name, yaml) in [
             ("coordinator-kubernetes", COORDINATOR_KUBERNETES_YAML),
             ("coordinator-etcd", COORDINATOR_ETCD_YAML),
+            ("worker", WORKER_YAML),
+            ("worker-secret.example", WORKER_SECRET_EXAMPLE_YAML),
             ("service", SERVICE_YAML),
             ("rbac", RBAC_YAML),
             ("etcd-secret.example", ETCD_SECRET_EXAMPLE_YAML),
@@ -170,27 +177,66 @@ mod tests {
     }
 
     #[test]
+    fn worker_deployment_is_valid_and_uses_secret_credentials() {
+        let docs = parse_documents(WORKER_YAML);
+        let dep = docs
+            .iter()
+            .find(|d| d.get("kind").and_then(|k| k.as_str()) == Some("Deployment"))
+            .expect("a worker Deployment");
+        // Horizontally scalable.
+        assert!(dep["spec"]["replicas"].as_u64().unwrap() >= 1);
+        let spec = &dep["spec"]["template"]["spec"];
+        assert!(spec["terminationGracePeriodSeconds"].as_u64().unwrap() >= 20);
+        // Runs as the image's non-root user.
+        assert_eq!(
+            spec["securityContext"]["runAsNonRoot"].as_bool(),
+            Some(true)
+        );
+        let c = &spec["containers"][0];
+        for probe in ["startupProbe", "livenessProbe", "readinessProbe"] {
+            assert!(!c[probe].is_null(), "worker missing {probe}");
+        }
+        let envs = c["env"].as_sequence().unwrap();
+        // Object-store credentials must be secretKeyRefs, never inline.
+        for key in ["TALON_WORKER_AZURE_ACCOUNT", "TALON_WORKER_AZURE_SAS"] {
+            let e = envs
+                .iter()
+                .find(|e| e["name"].as_str() == Some(key))
+                .unwrap_or_else(|| panic!("worker env {key}"));
+            assert!(e.get("value").is_none(), "{key} must not be inline");
+            assert!(!e["valueFrom"]["secretKeyRef"].is_null());
+        }
+        // The worker must point at the coordinator Service.
+        let args = c["args"].as_sequence().unwrap();
+        assert!(args
+            .iter()
+            .any(|a| a.as_str() == Some("talon-coordinator:7000")));
+    }
+
+    #[test]
     fn example_secret_contains_no_real_looking_values() {
         // The committed example must be an obvious placeholder, never a real
         // credential. Every non-endpoint secret value is REPLACE_ME.
-        let docs = parse_documents(ETCD_SECRET_EXAMPLE_YAML);
-        for doc in docs {
-            if doc.get("kind").and_then(|k| k.as_str()) != Some("Secret") {
-                continue;
-            }
-            if let Some(data) = doc.get("stringData").and_then(|d| d.as_mapping()) {
-                for (k, v) in data {
-                    let key = k.as_str().unwrap_or("");
-                    let val = v.as_str().unwrap_or("");
-                    // Only credential/material keys must be placeholders;
-                    // endpoints and username are not sensitive.
-                    if matches!(key, "endpoints" | "username") {
-                        continue;
+        for yaml in [ETCD_SECRET_EXAMPLE_YAML, WORKER_SECRET_EXAMPLE_YAML] {
+            let docs = parse_documents(yaml);
+            for doc in docs {
+                if doc.get("kind").and_then(|k| k.as_str()) != Some("Secret") {
+                    continue;
+                }
+                if let Some(data) = doc.get("stringData").and_then(|d| d.as_mapping()) {
+                    for (k, v) in data {
+                        let key = k.as_str().unwrap_or("");
+                        let val = v.as_str().unwrap_or("");
+                        // Only credential/material keys must be placeholders;
+                        // endpoints and username are not sensitive.
+                        if matches!(key, "endpoints" | "username") {
+                            continue;
+                        }
+                        assert!(
+                            val.contains("REPLACE_ME"),
+                            "example secret key {key} must be a placeholder"
+                        );
                     }
-                    assert!(
-                        val.contains("REPLACE_ME"),
-                        "example secret key {key} must be a placeholder"
-                    );
                 }
             }
         }

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -12,6 +12,8 @@ external etcd); deploying both is a misconfiguration.
 | `service.yaml` | ClusterIP Service + PodDisruptionBudget (`minAvailable: 2`). Apply for either backend. |
 | `coordinator-kubernetes.yaml` | Coordinator Deployment using the Kubernetes Lease backend (no external creds). |
 | `coordinator-etcd.yaml` | Coordinator Deployment using an external etcd backend (Secret-mounted creds/TLS). |
+| `worker.yaml` | Worker Deployment (cache nodes) + ServiceAccount. Shared by both coordinator backends. |
+| `worker-secret.example.yaml` | Template Secret for the worker's object-store (Azure account/SAS) credentials. |
 | `rbac.yaml` | Least-privilege namespaced Lease RBAC. **Kubernetes backend only.** |
 | `etcd-secret.example.yaml` | Template Secret for etcd endpoints/credentials/TLS and the optional management token. **etcd backend only.** |
 | `servicemonitor.yaml` | Prometheus Operator ServiceMonitor (or use the pod scrape annotations). |
@@ -25,6 +27,22 @@ kubectl apply -n talon -f rbac.yaml -f service.yaml -f coordinator-kubernetes.ya
 
 The pods authenticate to the API server with their mounted ServiceAccount token
 and write one Lease per node. No external datastore is required.
+
+## Workers
+
+Cache nodes register with the coordinator Service and serve object ranges. Apply
+`worker.yaml` alongside whichever coordinator you chose, after creating the
+object-store Secret (never commit it) — see `worker-secret.example.yaml`:
+
+```sh
+kubectl create secret generic talon-worker-backend -n talon \
+  --from-literal=azure-account="$ACCOUNT" --from-literal=azure-sas="$SAS"
+kubectl apply -n talon -f worker.yaml
+```
+
+The workers are horizontally scalable (`kubectl scale deployment/talon-worker
+--replicas=N`) and independent of the coordinator's HA backend. The cache is an
+`emptyDir`; swap in a PVC for a node-local SSD in production.
 
 ## Quick start — external etcd backend
 
@@ -72,4 +90,5 @@ coordinator Deployments run ≥3 replicas with all three probes and a quorum-saf
 rollout, exactly one backend is selected per Deployment, the RBAC is a
 namespaced Lease-only Role (no ClusterRole, no secrets), etcd credentials are
 `secretKeyRef`s (never inline), and the example Secret contains only
-placeholders.
+placeholders. The worker Deployment is validated too: it runs non-root with all
+three probes and takes its object-store credentials from a Secret, never inline.

--- a/deploy/kubernetes/worker-secret.example.yaml
+++ b/deploy/kubernetes/worker-secret.example.yaml
@@ -1,0 +1,22 @@
+# Example Secret for the worker's object-store backend. DO NOT commit real
+# credentials — this is a template. Create the real Secret out-of-band, e.g.:
+#
+#   kubectl create secret generic talon-worker-backend -n talon \
+#     --from-literal=azure-account=<storage-account> \
+#     --from-literal=azure-sas='<sas-token>'
+#
+# The worker reads these via env references (see worker.yaml) and never logs the
+# values. The SAS token grants read access to the backing container; scope it to
+# the minimum needed and rotate it independently of the deployment.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: talon-worker-backend
+  namespace: talon
+  labels:
+    app.kubernetes.io/name: talon
+    app.kubernetes.io/component: worker
+type: Opaque
+stringData:
+  azure-account: "REPLACE_ME"
+  azure-sas: "REPLACE_ME"

--- a/deploy/kubernetes/worker.yaml
+++ b/deploy/kubernetes/worker.yaml
@@ -1,0 +1,141 @@
+# Talon worker Deployment — cache nodes that register with the coordinator
+# Service and serve object ranges from a local cache backed by an object store.
+#
+# Workers are horizontally scalable and independent of the coordinator's HA
+# backend, so this manifest is shared by BOTH coordinator variants
+# (coordinator-kubernetes.yaml and coordinator-etcd.yaml). Apply it alongside
+# whichever coordinator you chose:
+#   kubectl apply -n talon -f service.yaml -f coordinator-etcd.yaml -f worker.yaml
+#
+# Object-store credentials (Azure account + SAS) come from a Secret
+# (talon-worker-backend, see worker-secret.example.yaml) — never baked into the
+# image or committed. The cache is an emptyDir here; swap in a PVC for a
+# node-local SSD in production.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: talon-worker
+  namespace: talon
+  labels:
+    app.kubernetes.io/name: talon
+    app.kubernetes.io/component: worker
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: talon-worker
+  namespace: talon
+  labels:
+    app.kubernetes.io/name: talon
+    app.kubernetes.io/component: worker
+spec:
+  replicas: 3
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: talon
+      app.kubernetes.io/component: worker
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: talon
+        app.kubernetes.io/component: worker
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8001"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: talon-worker
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: talon
+              app.kubernetes.io/component: worker
+      volumes:
+        # Local cache. Swap this emptyDir for a PVC (node-local SSD) in
+        # production; the worker rebuilds its cache on restart either way.
+        - name: cache
+          emptyDir: {}
+      containers:
+        - name: worker
+          image: ghcr.io/milvus-io/talon-worker:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--coordinator"
+            - "talon-coordinator:7000"
+            - "--listen"
+            - "0.0.0.0:7001"
+            - "--admin-listen"
+            - "0.0.0.0:8001"
+          ports:
+            - name: data
+              containerPort: 7001
+            - name: admin
+              containerPort: 8001
+          env:
+            - name: TALON_WORKER_CLUSTER_ID
+              value: "talon"
+            - name: TALON_WORKER_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # Advertise the pod IP so the coordinator routes peers to this pod.
+            - name: TALON_WORKER_ADVERTISE_ADDR
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: TALON_WORKER_CACHE_DIRS
+              value: /var/cache/talon
+            # Cache capacity the worker is allowed to fill (8 GiB). Keep this
+            # below the emptyDir/PVC size and the container memory limit.
+            - name: TALON_WORKER_CAPACITY_BYTES
+              value: "8589934592"
+            # Object-store backend credentials from the Secret — never logged.
+            - name: TALON_WORKER_AZURE_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: talon-worker-backend
+                  key: azure-account
+            - name: TALON_WORKER_AZURE_SAS
+              valueFrom:
+                secretKeyRef:
+                  name: talon-worker-backend
+                  key: azure-sas
+          volumeMounts:
+            - name: cache
+              mountPath: /var/cache/talon
+          startupProbe:
+            httpGet: { path: /healthz, port: admin }
+            failureThreshold: 30
+            periodSeconds: 2
+          livenessProbe:
+            httpGet: { path: /healthz, port: admin }
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet: { path: /readyz, port: admin }
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+            limits:
+              cpu: "2"
+              memory: "1Gi"


### PR DESCRIPTION
## Summary
- Add `deploy/kubernetes/worker.yaml`: a horizontally scalable worker Deployment (cache nodes registering with the coordinator Service) + ServiceAccount, runs non-root (uid 10001) with startup/liveness/readiness probes and prometheus scrape annotations.
- Add `deploy/kubernetes/worker-secret.example.yaml`: template Secret for the worker's object-store (Azure account/SAS) credentials — placeholders only.
- Object-store credentials come from a Secret, never inline. Cache is an emptyDir (swap a PVC in production).
- Embed + structurally validate both files in the `talon-observability` cargo test job; update `deploy/kubernetes/README.md`.

Closes the gap that only coordinator manifests existed. Part of #213 (Wave 2), sub-issue #217.

## Test plan
- [x] `cargo test -p talon-observability deploy` — 8 tests green, incl. new worker validation
- [ ] CI green