### PR TITLE
feat: add Helm chart for Talon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,47 @@ jobs:
           cache-from: type=gha,scope=fuse
           cache-to: type=gha,scope=fuse,mode=max
 
+  helm:
+    name: helm chart
+    runs-on: ubuntu-latest
+    # Lint and render the Talon chart across every state backend so a broken
+    # template or invalid values fails CI. No cluster is required — helm renders
+    # locally and we structurally validate the output.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+      - name: Lint (all backends)
+        run: |
+          for be in memory kubernetes etcd; do
+            rp=3; [ "$be" = memory ] && rp=1
+            echo "::group::lint $be"
+            helm lint deploy/helm/talon --strict \
+              --set coordinator.backend="$be" --set coordinator.replicas="$rp"
+            echo "::endgroup::"
+          done
+      - name: Render (all backends) and validate YAML
+        run: |
+          for be in memory kubernetes etcd; do
+            rp=3; [ "$be" = memory ] && rp=1
+            echo "::group::template $be"
+            helm template t deploy/helm/talon \
+              --set coordinator.backend="$be" --set coordinator.replicas="$rp" \
+              | python3 -c "import sys,yaml; list(yaml.safe_load_all(sys.stdin))"
+            echo "::endgroup::"
+          done
+      - name: Reject invalid configurations
+        run: |
+          if helm template t deploy/helm/talon --set coordinator.backend=redis >/dev/null 2>&1; then
+            echo "::error::unknown backend should have failed"; exit 1
+          fi
+          if helm template t deploy/helm/talon \
+              --set coordinator.backend=memory --set coordinator.replicas=3 >/dev/null 2>&1; then
+            echo "::error::memory backend with HA should have failed"; exit 1
+          fi
+
   bench:
     name: bench (informational)
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -57,8 +57,15 @@ spell:
 linkcheck:
     lychee --offline --no-progress README.md DESIGN.md CONTRIBUTING.md BENCHMARKS.md 'docs/**/*.md' '.github/**/*.md'
 
-# --- benchmarks (performance feedback loop) ---
+# Lint + render the Helm chart across every backend (install: helm v3).
+helm-check:
+    for be in memory kubernetes etcd; do \
+      rp=3; [ "$be" = memory ] && rp=1; \
+      helm lint deploy/helm/talon --strict --set coordinator.backend=$be --set coordinator.replicas=$rp; \
+      helm template t deploy/helm/talon --set coordinator.backend=$be --set coordinator.replicas=$rp >/dev/null; \
+    done
 
+# --- benchmarks (performance feedback loop) ---
 # Run all microbenchmarks and write bench/results/latest.json.
 bench *ARGS:
     python3 scripts/bench.py run {{ARGS}}

--- a/deploy/helm/talon/Chart.yaml
+++ b/deploy/helm/talon/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: talon
+description: Distributed object-store cache — active-active coordinators and horizontally scalable cache workers.
+type: application
+# Chart version — bump on chart changes. appVersion tracks the container images.
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/milvus-io/talon
+sources:
+  - https://github.com/milvus-io/talon
+keywords:
+  - cache
+  - object-store
+  - milvus
+maintainers:
+  - name: Talon maintainers
+    url: https://github.com/milvus-io/talon

--- a/deploy/helm/talon/README.md
+++ b/deploy/helm/talon/README.md
@@ -1,0 +1,64 @@
+# Talon Helm chart
+
+Deploys the Talon distributed object-store cache: active-active coordinators and
+horizontally scalable cache workers. This chart parameterizes the raw manifests
+under `deploy/kubernetes/`.
+
+## Install
+
+```sh
+helm install talon deploy/helm/talon -n talon --create-namespace
+```
+
+The default backend is `kubernetes` (Lease-based HA, no external datastore). The
+chart never contains credentials — create the required Secrets out-of-band.
+
+### Backends
+
+| `coordinator.backend` | HA | Extra setup |
+|-----------------------|----|-------------|
+| `memory` | no (single replica) | none — dev/demo only |
+| `kubernetes` (default) | yes | none; the chart adds a namespaced Lease Role/RoleBinding |
+| `etcd` | yes | create the etcd Secret first (see `deploy/kubernetes/etcd-secret.example.yaml`) |
+
+```sh
+# etcd backend
+kubectl create secret generic talon-etcd -n talon \
+  --from-literal=endpoints=https://etcd-0:2379 \
+  --from-literal=username=talon --from-literal=password="$PW" \
+  --from-file=ca.crt --from-file=client.crt --from-file=client.key
+helm install talon deploy/helm/talon -n talon --set coordinator.backend=etcd
+```
+
+### Workers
+
+Workers are enabled by default and need object-store credentials from a Secret:
+
+```sh
+kubectl create secret generic talon-worker-backend -n talon \
+  --from-literal=azure-account="$ACCOUNT" --from-literal=azure-sas="$SAS"
+```
+
+Set `worker.persistence.enabled=true` to back the cache with a PVC (node-local
+SSD) instead of an `emptyDir`. Disable workers entirely with
+`worker.enabled=false`.
+
+## Key values
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `coordinator.backend` | `kubernetes` | State backend: `memory`/`kubernetes`/`etcd` |
+| `coordinator.replicas` | `3` | Coordinator replicas (forced to 1 for `memory`) |
+| `worker.enabled` | `true` | Deploy cache workers |
+| `worker.replicas` | `3` | Worker replicas |
+| `worker.capacityBytes` | `8589934592` | Per-worker cache capacity |
+| `image.registry` / `image.tag` | `ghcr.io/milvus-io` / chart appVersion | Image source |
+| `serviceMonitor.enabled` | `false` | Prometheus Operator ServiceMonitor |
+
+See `values.yaml` for the full list.
+
+## Validation
+
+`helm lint` and `helm template` (all three backends) run in CI. The chart
+rejects invalid configurations at render time — an unknown backend, or the
+`memory` backend with more than one replica.

--- a/deploy/helm/talon/templates/NOTES.txt
+++ b/deploy/helm/talon/templates/NOTES.txt
@@ -1,0 +1,22 @@
+Talon has been deployed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+Coordinator backend: {{ .Values.coordinator.backend }}
+Coordinator replicas: {{ include "talon.coordinatorReplicas" . }}
+Worker enabled: {{ .Values.worker.enabled }}
+
+{{- if eq .Values.coordinator.backend "etcd" }}
+
+NOTE: the etcd backend expects a Secret named "{{ .Values.coordinator.etcd.existingSecret }}"
+with the etcd endpoints/credentials/TLS. Create it before the pods start — see
+deploy/kubernetes/etcd-secret.example.yaml.
+{{- end }}
+{{- if .Values.worker.enabled }}
+
+NOTE: workers expect a Secret named "{{ .Values.worker.backend.existingSecret }}"
+with the object-store credentials. Create it before the pods start — see
+deploy/kubernetes/worker-secret.example.yaml.
+{{- end }}
+
+Reach the management API/UI via the coordinator Service:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ .Release.Name }}-coordinator 8000:8000
+  # then open http://127.0.0.1:8000/ui

--- a/deploy/helm/talon/templates/_helpers.tpl
+++ b/deploy/helm/talon/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Common helpers for the Talon chart.
+*/}}
+
+{{- define "talon.name" -}}
+talon
+{{- end -}}
+
+{{/*
+Standard labels applied to every object.
+*/}}
+{{- define "talon.labels" -}}
+app.kubernetes.io/name: talon
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: talon-{{ .Chart.Version }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Component selector labels (name + component only — stable across upgrades).
+*/}}
+{{- define "talon.selectorLabels" -}}
+app.kubernetes.io/name: talon
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{/*
+Resolve the image tag: explicit override or the chart appVersion.
+*/}}
+{{- define "talon.imageTag" -}}
+{{- .Values.image.tag | default .Chart.AppVersion -}}
+{{- end -}}
+
+{{- define "talon.coordinatorImage" -}}
+{{ .Values.image.registry }}/{{ .Values.image.coordinator }}:{{ include "talon.imageTag" . }}
+{{- end -}}
+
+{{- define "talon.workerImage" -}}
+{{ .Values.image.registry }}/{{ .Values.image.worker }}:{{ include "talon.imageTag" . }}
+{{- end -}}
+
+{{/*
+Validate the state backend and HA/replica invariants once, early.
+*/}}
+{{- define "talon.validateBackend" -}}
+{{- $b := .Values.coordinator.backend -}}
+{{- if not (has $b (list "memory" "kubernetes" "etcd")) -}}
+{{- fail (printf "coordinator.backend must be one of memory|kubernetes|etcd, got %q" $b) -}}
+{{- end -}}
+{{- if and (eq $b "memory") (gt (int .Values.coordinator.replicas) 1) -}}
+{{- fail "coordinator.backend=memory does not support HA; set coordinator.replicas=1 or choose kubernetes/etcd" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Effective coordinator replica count (memory backend is single-node).
+*/}}
+{{- define "talon.coordinatorReplicas" -}}
+{{- if eq .Values.coordinator.backend "memory" -}}1{{- else -}}{{ .Values.coordinator.replicas }}{{- end -}}
+{{- end -}}

--- a/deploy/helm/talon/templates/coordinator.yaml
+++ b/deploy/helm/talon/templates/coordinator.yaml
@@ -1,0 +1,197 @@
+{{- include "talon.validateBackend" . -}}
+{{- $isEtcd := eq .Values.coordinator.backend "etcd" -}}
+{{- $isK8s := eq .Values.coordinator.backend "kubernetes" -}}
+{{- $ha := ne .Values.coordinator.backend "memory" -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-coordinator
+  labels:
+    {{- include "talon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinator
+{{- if $isK8s }}
+---
+# The Kubernetes Lease backend manages one Lease per node in this namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-coordinator-state
+  labels:
+    {{- include "talon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinator
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-coordinator-state
+  labels:
+    {{- include "talon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-coordinator-state
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-coordinator
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-coordinator
+  labels:
+    {{- include "talon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinator
+spec:
+  replicas: {{ include "talon.coordinatorReplicas" . }}
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      {{- include "talon.selectorLabels" (dict "component" "coordinator") | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ if $ha }}0{{ else }}1{{ end }}
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        {{- include "talon.labels" . | nindent 8 }}
+        app.kubernetes.io/component: coordinator
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: {{ .Release.Name }}-coordinator
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      {{- if $ha }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "talon.selectorLabels" (dict "component" "coordinator") | nindent 14 }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    {{- include "talon.selectorLabels" (dict "component" "coordinator") | nindent 20 }}
+      {{- end }}
+      {{- if and $isEtcd .Values.coordinator.etcd.tls.enabled }}
+      volumes:
+        - name: etcd-tls
+          secret:
+            secretName: {{ .Values.coordinator.etcd.existingSecret }}
+            items:
+              - key: {{ .Values.coordinator.etcd.tls.caKey }}
+                path: ca.crt
+              - key: {{ .Values.coordinator.etcd.tls.certKey }}
+                path: client.crt
+              - key: {{ .Values.coordinator.etcd.tls.keyKey }}
+                path: client.key
+            optional: true
+      {{- end }}
+      containers:
+        - name: coordinator
+          image: {{ include "talon.coordinatorImage" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["--listen", "0.0.0.0:7000", "--admin-listen", "0.0.0.0:8000"]
+          ports:
+            - name: control
+              containerPort: 7000
+            - name: admin
+              containerPort: 8000
+          env:
+            - name: TALON_COORDINATOR_STATE_BACKEND
+              value: {{ .Values.coordinator.backend | quote }}
+            - name: TALON_COORDINATOR_HA_ENABLED
+              value: {{ $ha | quote }}
+            {{- if $ha }}
+            - name: TALON_COORDINATOR_REPLICAS
+              value: {{ include "talon.coordinatorReplicas" . | quote }}
+            {{- end }}
+            - name: TALON_COORDINATOR_CLUSTER_ID
+              value: {{ .Values.coordinator.clusterId | quote }}
+            - name: TALON_COORDINATOR_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- if $isK8s }}
+            - name: TALON_COORDINATOR_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
+            {{- if $isEtcd }}
+            - name: TALON_COORDINATOR_ETCD_ENDPOINTS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.coordinator.etcd.existingSecret }}
+                  key: {{ .Values.coordinator.etcd.endpointsKey }}
+            - name: TALON_COORDINATOR_ETCD_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.coordinator.etcd.existingSecret }}
+                  key: {{ .Values.coordinator.etcd.usernameKey }}
+                  optional: true
+            - name: TALON_COORDINATOR_ETCD_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.coordinator.etcd.existingSecret }}
+                  key: {{ .Values.coordinator.etcd.passwordKey }}
+                  optional: true
+            {{- if .Values.coordinator.etcd.tls.enabled }}
+            - name: TALON_COORDINATOR_ETCD_CA_CERT_PATH
+              value: /etc/talon/etcd/ca.crt
+            - name: TALON_COORDINATOR_ETCD_CLIENT_CERT_PATH
+              value: /etc/talon/etcd/client.crt
+            - name: TALON_COORDINATOR_ETCD_CLIENT_KEY_PATH
+              value: /etc/talon/etcd/client.key
+            {{- end }}
+            {{- end }}
+            {{- if .Values.coordinator.auth.existingSecret }}
+            - name: TALON_COORDINATOR_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.coordinator.auth.existingSecret }}
+                  key: {{ .Values.coordinator.auth.tokenKey }}
+                  optional: true
+            {{- end }}
+          {{- if and $isEtcd .Values.coordinator.etcd.tls.enabled }}
+          volumeMounts:
+            - name: etcd-tls
+              mountPath: /etc/talon/etcd
+              readOnly: true
+          {{- end }}
+          startupProbe:
+            httpGet: { path: /healthz, port: admin }
+            failureThreshold: 30
+            periodSeconds: 2
+          livenessProbe:
+            httpGet: { path: /healthz, port: admin }
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet: { path: /readyz, port: admin }
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            {{- toYaml .Values.coordinator.resources | nindent 12 }}

--- a/deploy/helm/talon/templates/service.yaml
+++ b/deploy/helm/talon/templates/service.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-coordinator
+  labels:
+    {{- include "talon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinator
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "talon.selectorLabels" (dict "component" "coordinator") | nindent 4 }}
+  ports:
+    - name: control
+      port: 7000
+      targetPort: control
+    - name: admin
+      port: 8000
+      targetPort: admin
+{{- if and .Values.podDisruptionBudget.enabled (ne .Values.coordinator.backend "memory") }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-coordinator
+  labels:
+    {{- include "talon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinator
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "talon.selectorLabels" (dict "component" "coordinator") | nindent 6 }}
+{{- end }}

--- a/deploy/helm/talon/templates/servicemonitor.yaml
+++ b/deploy/helm/talon/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-coordinator
+  labels:
+    {{- include "talon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinator
+spec:
+  namespaceSelector:
+    matchNames: [{{ .Release.Namespace }}]
+  selector:
+    matchLabels:
+      {{- include "talon.selectorLabels" (dict "component" "coordinator") | nindent 6 }}
+  endpoints:
+    - port: admin
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/deploy/helm/talon/templates/worker.yaml
+++ b/deploy/helm/talon/templates/worker.yaml
@@ -1,0 +1,128 @@
+{{- if .Values.worker.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-worker
+  labels:
+    {{- include "talon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-worker
+  labels:
+    {{- include "talon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.worker.replicas }}
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      {{- include "talon.selectorLabels" (dict "component" "worker") | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        {{- include "talon.labels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8001"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: {{ .Release.Name }}-worker
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "talon.selectorLabels" (dict "component" "worker") | nindent 14 }}
+      volumes:
+        - name: cache
+        {{- if .Values.worker.persistence.enabled }}
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes: ["ReadWriteOnce"]
+                {{- with .Values.worker.persistence.storageClass }}
+                storageClassName: {{ . }}
+                {{- end }}
+                resources:
+                  requests:
+                    storage: {{ .Values.worker.persistence.size }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+      containers:
+        - name: worker
+          image: {{ include "talon.workerImage" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--coordinator"
+            - "{{ .Release.Name }}-coordinator:7000"
+            - "--listen"
+            - "0.0.0.0:7001"
+            - "--admin-listen"
+            - "0.0.0.0:8001"
+          ports:
+            - name: data
+              containerPort: 7001
+            - name: admin
+              containerPort: 8001
+          env:
+            - name: TALON_WORKER_CLUSTER_ID
+              value: {{ .Values.coordinator.clusterId | quote }}
+            - name: TALON_WORKER_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: TALON_WORKER_ADVERTISE_ADDR
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: TALON_WORKER_CACHE_DIRS
+              value: /var/cache/talon
+            - name: TALON_WORKER_CAPACITY_BYTES
+              value: {{ .Values.worker.capacityBytes | quote }}
+            - name: TALON_WORKER_AZURE_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.worker.backend.existingSecret }}
+                  key: {{ .Values.worker.backend.azureAccountKey }}
+            - name: TALON_WORKER_AZURE_SAS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.worker.backend.existingSecret }}
+                  key: {{ .Values.worker.backend.azureSasKey }}
+          volumeMounts:
+            - name: cache
+              mountPath: /var/cache/talon
+          startupProbe:
+            httpGet: { path: /healthz, port: admin }
+            failureThreshold: 30
+            periodSeconds: 2
+          livenessProbe:
+            httpGet: { path: /healthz, port: admin }
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet: { path: /readyz, port: admin }
+            periodSeconds: 5
+            failureThreshold: 2
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+{{- end }}

--- a/deploy/helm/talon/values.yaml
+++ b/deploy/helm/talon/values.yaml
@@ -1,0 +1,92 @@
+# Default values for the Talon chart.
+#
+# The most important choice is the coordinator state backend:
+#   memory     — single replica, no HA (dev/demo only)
+#   kubernetes — Lease backend, no external datastore (adds RBAC)
+#   etcd       — external etcd, credentials from a Secret
+# See values.schema.json for the full contract.
+
+# -- Image registry/repository/tag applied to every component. The tag defaults
+# to the chart appVersion when left empty.
+image:
+  registry: ghcr.io/milvus-io
+  # Per-component repository names appended to the registry.
+  coordinator: talon-coordinator
+  worker: talon-worker
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# -- Extra labels merged onto every rendered object.
+commonLabels: {}
+
+coordinator:
+  # -- State backend: memory | kubernetes | etcd.
+  backend: kubernetes
+  clusterId: talon
+  # -- Coordinator replica count. Forced to 1 for the memory backend (no HA).
+  replicas: 3
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: "1"
+      memory: 512Mi
+  # -- etcd backend settings. endpoints/credentials/TLS come from a Secret you
+  # create out-of-band (see deploy/kubernetes/etcd-secret.example.yaml); set the
+  # name here. Leave existingSecret empty for memory/kubernetes backends.
+  etcd:
+    existingSecret: talon-etcd
+    # Keys within the Secret.
+    endpointsKey: endpoints
+    usernameKey: username
+    passwordKey: password
+    # Mounted TLS material (optional). Set to false for a plaintext etcd.
+    tls:
+      enabled: true
+      caKey: ca.crt
+      certKey: client.crt
+      keyKey: client.key
+  # -- Optional management API/UI bearer token from an existing Secret.
+  auth:
+    existingSecret: ""
+    tokenKey: token
+
+worker:
+  # -- Deploy cache workers alongside the coordinator.
+  enabled: true
+  replicas: 3
+  # -- Cache capacity in bytes the worker is allowed to fill.
+  capacityBytes: 8589934592
+  # -- Object-store credentials. Reference a Secret you create out-of-band (see
+  # deploy/kubernetes/worker-secret.example.yaml).
+  backend:
+    existingSecret: talon-worker-backend
+    azureAccountKey: azure-account
+    azureSasKey: azure-sas
+  # -- Cache volume. When persistence is disabled an emptyDir is used.
+  persistence:
+    enabled: false
+    size: 20Gi
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: "2"
+      memory: 1Gi
+
+service:
+  type: ClusterIP
+
+# -- PodDisruptionBudget for the coordinator (HA backends only).
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2
+
+# -- Prometheus Operator ServiceMonitor. Requires the monitoring.coreos.com CRDs.
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s


### PR DESCRIPTION
## Summary
- Add `deploy/helm/talon/` — a Helm chart parameterizing the raw `deploy/kubernetes/` manifests.
- Supports all three coordinator state backends: `memory` (single-node), `kubernetes` (Lease + RBAC, default), `etcd` (Secret-wired creds/TLS).
- Toggleable worker Deployment (`emptyDir` or PVC cache), Service + PDB, optional Prometheus ServiceMonitor.
- Fails fast on invalid config at render time: unknown backend, or `memory` backend with >1 replica.
- CI `helm` job lints + renders every backend and validates the invalid-config guards; `just helm-check` for local parity.

Part of #213 (Wave 2), sub-issue #218. No credentials in the chart — Secrets are created out-of-band.

## Test plan
- [x] `helm lint --strict` clean for memory/kubernetes/etcd
- [x] `helm template` renders valid manifests per backend; invalid configs rejected
- [ ] CI green