### PR TITLE
doc: add install pages and lead quick start with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,36 +13,39 @@ applications.
 
 ## Quick start
 
-Requirements: the Rust toolchain (pinned in `rust-toolchain.toml`; `rustup`
-picks it up automatically) and a Linux host for the FUSE client.
+The fastest way to run Talon is with Docker — one command starts a coordinator,
+a worker, and the management UI:
 
 ```sh
-git clone https://github.com/milvus-io/talon.git
-cd talon
-cargo build --workspace
+docker compose up
 ```
 
-Run a single-node cluster with the development **memory** backend — one
-coordinator and one worker:
-
-```sh
-# Coordinator: control plane on :7000, admin API + management UI on :8000.
-cargo run -p talon-coordinator -- \
-  --listen 127.0.0.1:7000 --admin-listen 127.0.0.1:8000 \
-  --cluster-id demo --node-id coord-0
-
-# Worker (in another shell): registers with the coordinator above.
-cargo run -p talon-worker -- \
-  --listen 127.0.0.1:7001 --admin-listen 127.0.0.1:8001 \
-  --coordinator 127.0.0.1:7000 --cluster-id demo --node-id worker-0
-```
-
-Check the cluster is healthy:
+Then open the management console at **http://127.0.0.1:8000/ui**, or check health:
 
 ```sh
 curl -s http://127.0.0.1:8000/readyz           # {"ready":true}
 curl -s http://127.0.0.1:8000/api/v1/cluster    # cluster summary JSON
 ```
+
+This runs a single-node cluster with the development **memory** backend. For the
+active-active HA topology (etcd, three coordinators), use `docker compose
+--profile ha up`. Full details: [install with Docker](docs/installation/docker.md).
+
+### Kubernetes
+
+For production, deploy with the Helm chart — active-active coordinators, scalable
+workers, and a choice of state backend:
+
+```sh
+helm install talon deploy/helm/talon -n talon --create-namespace
+```
+
+See [install with Kubernetes](docs/installation/kubernetes.md).
+
+### From source
+
+Building from source (Rust toolchain) is the contributor path — see
+[installing from source](docs/installation/source.md).
 
 ### Management console
 
@@ -57,6 +60,9 @@ panel, and a searchable fleet table.
 
 Start with the section that matches what you're doing:
 
+- **Installing Talon** — [Docker](docs/installation/docker.md) (fastest),
+  [Kubernetes](docs/installation/kubernetes.md) (production), or
+  [from source](docs/installation/source.md) (contributors).
 - **Using Talon** — the [Getting started tutorial](docs/tutorials/getting-started.md)
   builds the workspace, runs a cluster, and opens the management console;
   [DESIGN.md](DESIGN.md) explains what each component does.

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -2,6 +2,12 @@
 
 [Introduction](./introduction.md)
 
+# Installation
+
+- [Docker](./installation/docker.md)
+- [Kubernetes](./installation/kubernetes.md)
+- [From source](./installation/source.md)
+
 # Tutorials
 
 - [Getting started](./tutorials/getting-started.md)

--- a/docs/book/src/installation/docker.md
+++ b/docs/book/src/installation/docker.md
@@ -1,0 +1,1 @@
+{{#include ../../../installation/docker.md}}

--- a/docs/book/src/installation/kubernetes.md
+++ b/docs/book/src/installation/kubernetes.md
@@ -1,0 +1,1 @@
+{{#include ../../../installation/kubernetes.md}}

--- a/docs/book/src/installation/source.md
+++ b/docs/book/src/installation/source.md
@@ -1,0 +1,1 @@
+{{#include ../../../installation/source.md}}

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -1,0 +1,99 @@
+# Install with Docker
+
+Docker is the fastest way to get a Talon cluster running — one command starts a
+coordinator, a worker, and the management UI. No Rust toolchain required.
+
+## Prerequisites
+
+- Docker Engine 24+ with the Compose plugin (`docker compose version`).
+
+## Quick start
+
+From a checkout of the repository:
+
+```sh
+docker compose up
+```
+
+This starts a single-node cluster with the development **memory** backend:
+
+- **coordinator** — control plane on `:7000`, admin API + management UI on `:8000`
+- **worker** — registers with the coordinator (placeholder object-store
+  credentials so it starts; reading real objects needs real credentials)
+
+Open the management console at **http://127.0.0.1:8000/ui**, or check health:
+
+```sh
+curl -s http://127.0.0.1:8000/readyz            # {"ready":true}
+curl -s http://127.0.0.1:8000/api/v1/cluster     # cluster summary JSON
+```
+
+Stop with `Ctrl-C`, or `docker compose down` to remove the containers.
+
+## Images
+
+The Compose file pulls the published images from GitHub Container Registry:
+
+- `ghcr.io/milvus-io/talon-coordinator`
+- `ghcr.io/milvus-io/talon-worker`
+- `ghcr.io/milvus-io/talon-fuse`
+
+Each is tagged with `latest`, the release version (`X.Y.Z`), and the commit SHA.
+To build them locally from source instead of pulling:
+
+```sh
+docker compose build       # or: docker compose up --build
+```
+
+## HA profile (etcd, three coordinators)
+
+To exercise the active-active topology shown in the management console, start the
+`ha` profile — an etcd backend with three coordinators and a worker:
+
+```sh
+docker compose --profile ha up
+```
+
+The UI is published from one coordinator at **http://127.0.0.1:8000/ui**; the
+HA topology panel lists all three.
+
+## Real object-store credentials
+
+The default worker ships with placeholder Azure credentials so the control
+plane, API, and UI work for exploration. To read real objects, supply genuine
+credentials via environment variables (never bake them into an image):
+
+```sh
+TALON_WORKER_AZURE_ACCOUNT=<account> \
+TALON_WORKER_AZURE_SAS='<sas-token>' \
+docker compose up
+```
+
+The SAS token is read only from the environment, never from a committed file.
+See [security hardening](../operations/security.md) for handling secrets.
+
+## Running a single image
+
+Each image runs standalone. For example, a coordinator with the memory backend:
+
+```sh
+docker run --rm -p 8000:8000 -p 7000:7000 \
+  ghcr.io/milvus-io/talon-coordinator:latest \
+  --cluster-id demo --node-id coord-0
+```
+
+The FUSE client image mounts through the kernel and therefore needs `/dev/fuse`
+and the `SYS_ADMIN` capability:
+
+```sh
+docker run --rm --device /dev/fuse --cap-add SYS_ADMIN \
+  ghcr.io/milvus-io/talon-fuse:latest \
+  --mountpoint /mnt/talon --coordinator coordinator:7000
+```
+
+## Next steps
+
+- **Production on Kubernetes** — [install with Kubernetes](./kubernetes.md).
+- **Understand the cluster** — the [getting started tutorial](../tutorials/getting-started.md)
+  walks through the API, UI, and FUSE client in detail.
+- **Build from source** — [installing from source](./source.md) (contributors).

--- a/docs/installation/kubernetes.md
+++ b/docs/installation/kubernetes.md
@@ -1,0 +1,88 @@
+# Install with Kubernetes
+
+For production, deploy Talon on Kubernetes with the Helm chart. It runs
+active-active coordinators behind a Service, horizontally scalable cache
+workers, and your choice of shared-state backend.
+
+## Prerequisites
+
+- A Kubernetes cluster and `kubectl` context.
+- Helm 3 (`helm version`).
+
+## Quick start (Helm)
+
+```sh
+helm install talon deploy/helm/talon -n talon --create-namespace
+```
+
+The default backend is **kubernetes** (a Lease-based HA backend needing no
+external datastore; the chart adds a namespaced Lease Role/RoleBinding).
+
+Reach the management API/UI by port-forwarding the coordinator Service:
+
+```sh
+kubectl -n talon port-forward svc/talon-coordinator 8000:8000
+# then open http://127.0.0.1:8000/ui
+```
+
+## Choosing a state backend
+
+| `coordinator.backend` | HA | Extra setup |
+|-----------------------|----|-------------|
+| `memory` | no (single replica) | none — dev/demo only |
+| `kubernetes` (default) | yes | none; chart adds Lease RBAC |
+| `etcd` | yes | create the etcd Secret first |
+
+For the external etcd backend, create the credential Secret before installing
+(never commit it):
+
+```sh
+kubectl create secret generic talon-etcd -n talon \
+  --from-literal=endpoints=https://etcd-0:2379 \
+  --from-literal=username=talon --from-literal=password="$PW" \
+  --from-file=ca.crt --from-file=client.crt --from-file=client.key
+
+helm install talon deploy/helm/talon -n talon --create-namespace \
+  --set coordinator.backend=etcd
+```
+
+## Workers
+
+Workers are enabled by default and need object-store credentials from a Secret:
+
+```sh
+kubectl create secret generic talon-worker-backend -n talon \
+  --from-literal=azure-account="$ACCOUNT" --from-literal=azure-sas="$SAS"
+```
+
+Scale workers with `--set worker.replicas=N`, and back their cache with a
+node-local PVC instead of an `emptyDir` via `--set worker.persistence.enabled=true`.
+Disable workers with `--set worker.enabled=false`.
+
+See the [chart README](https://github.com/milvus-io/talon/tree/main/deploy/helm/talon)
+for the full list of values.
+
+## Raw manifests (without Helm)
+
+If you don't use Helm, apply the raw manifests under `deploy/kubernetes/`
+directly. Pick exactly one coordinator backend:
+
+```sh
+kubectl create namespace talon
+# Kubernetes Lease backend:
+kubectl apply -n talon -f deploy/kubernetes/rbac.yaml \
+  -f deploy/kubernetes/service.yaml \
+  -f deploy/kubernetes/coordinator-kubernetes.yaml
+# Workers (after creating the talon-worker-backend Secret):
+kubectl apply -n talon -f deploy/kubernetes/worker.yaml
+```
+
+The [`deploy/kubernetes/README.md`](https://github.com/milvus-io/talon/tree/main/deploy/kubernetes)
+documents the etcd variant, RBAC, and HA properties.
+
+## Next steps
+
+- **Operate it** — HA, backends, upgrades, and alerts in the
+  [operator runbook](../operations/runbook.md).
+- **Secure it** — authentication, TLS, and secret handling in
+  [security hardening](../operations/security.md).

--- a/docs/installation/source.md
+++ b/docs/installation/source.md
@@ -1,0 +1,65 @@
+# Install from source
+
+Building from source is the hardcore path — aimed at contributors and anyone who
+wants to run unreleased code. If you just want to run Talon, [Docker](./docker.md)
+or [Kubernetes](./kubernetes.md) are quicker.
+
+## Prerequisites
+
+- **Rust** — the toolchain is pinned in `rust-toolchain.toml`; `rustup` selects
+  it automatically, so no manual version juggling.
+- **A Linux host** — required for the FUSE client. The coordinator and worker
+  run anywhere Rust does.
+- **`protoc`** — the Protocol Buffers compiler, needed to build the coordinator
+  with the `etcd`/`kubernetes` backends.
+
+## Build
+
+```sh
+git clone https://github.com/milvus-io/talon.git
+cd talon
+cargo build --workspace
+```
+
+The first build compiles all crates and may take a few minutes; later builds are
+incremental.
+
+## Run a single-node cluster
+
+Start a coordinator and a worker with the development **memory** backend:
+
+```sh
+# Coordinator: control plane on :7000, admin API + UI on :8000.
+cargo run -p talon-coordinator -- \
+  --listen 127.0.0.1:7000 --admin-listen 127.0.0.1:8000 \
+  --cluster-id demo --node-id coord-0
+
+# Worker (in another shell): registers with the coordinator above.
+TALON_WORKER_AZURE_ACCOUNT=demo \
+TALON_WORKER_AZURE_SAS="sv=demo&sig=demo" \
+TALON_WORKER_CACHE_DIRS=/tmp/talon-cache \
+cargo run -p talon-worker -- \
+  --listen 127.0.0.1:7001 --admin-listen 127.0.0.1:8001 \
+  --coordinator 127.0.0.1:7000 --cluster-id demo --node-id worker-0
+```
+
+Then open **http://127.0.0.1:8000/ui** or check `curl -s http://127.0.0.1:8000/readyz`.
+
+The [getting started tutorial](../tutorials/getting-started.md) walks through the
+API, the management console, and the FUSE client step by step.
+
+## FUSE client
+
+Mounting talks to the kernel, so `talon-fuse` is compiled behind a `mount`
+feature and needs `/dev/fuse` (Linux with FUSE and `libfuse3-dev` installed):
+
+```sh
+cargo run -p talon-fuse --features mount -- \
+  --mountpoint /tmp/talon-mnt --coordinator 127.0.0.1:7000
+```
+
+## Developing
+
+See [CONTRIBUTING.md](https://github.com/milvus-io/talon/blob/main/CONTRIBUTING.md)
+for the full workflow — running the test suite, linting, the benchmark harness,
+and submitting changes. Run `just` to list common development tasks.


### PR DESCRIPTION
## Summary
- Add `docs/installation/{docker,kubernetes,source}.md` — install pages ordered by ease of use.
- README quick start now **leads with Docker** (`docker compose up`), a short **Kubernetes/Helm** pointer, and a one-line **from source** link (demoted to the contributor path).
- Wire the pages into the mdBook `SUMMARY` under a new **Installation** section.
- Link + spell clean; mdBook builds.

Completes #213 (Wave 3), sub-issue #219. Operator (CRD + controller) remains a tracked follow-up on the parent.

## Test plan
- [x] `mdbook build docs/book`
- [x] `typos` + `lychee --offline` clean
- [ ] CI green