### PR TITLE
feat(backend): add PUT/DELETE to BackendStore + S3/GCS/Azure

### DIFF
--- a/crates/talon-backend/src/azure.rs
+++ b/crates/talon-backend/src/azure.rs
@@ -118,6 +118,7 @@ impl AzureBackend {
             method: Method::Get,
             url: self.blob_url(obj),
             headers,
+            body: bytes::Bytes::new(),
         }
     }
 
@@ -127,6 +128,42 @@ impl AzureBackend {
             method: Method::Head,
             url: self.blob_url(obj),
             headers: self.common_headers(),
+            body: bytes::Bytes::new(),
+        }
+    }
+
+    /// Build the whole-blob PUT request (exposed for testing).
+    ///
+    /// Azure block-blob upload requires `x-ms-blob-type: BlockBlob`. When
+    /// `if_match` is set, adds `If-Match` so the blob is only replaced if its ETag
+    /// still matches (`412` otherwise, #226).
+    pub fn build_put(
+        &self,
+        obj: &ObjectId,
+        body: bytes::Bytes,
+        if_match: Option<&Version>,
+    ) -> HttpRequest {
+        let mut headers = self.common_headers();
+        headers.push(("x-ms-blob-type".to_string(), "BlockBlob".to_string()));
+        headers.push(("Content-Length".to_string(), body.len().to_string()));
+        if let Some(version) = if_match {
+            headers.push(("If-Match".to_string(), format!("\"{}\"", version.as_str())));
+        }
+        HttpRequest {
+            method: Method::Put,
+            url: self.blob_url(obj),
+            headers,
+            body,
+        }
+    }
+
+    /// Build the DELETE request (exposed for testing).
+    pub fn build_delete(&self, obj: &ObjectId) -> HttpRequest {
+        HttpRequest {
+            method: Method::Delete,
+            url: self.blob_url(obj),
+            headers: self.common_headers(),
+            body: bytes::Bytes::new(),
         }
     }
 }
@@ -212,6 +249,64 @@ impl BackendStore for AzureBackend {
                 ))
             })?;
         Ok(ObjectStat { len, version })
+    }
+
+    async fn put(&self, obj: &ObjectId, body: bytes::Bytes) -> Result<Version> {
+        self.put_if_match(obj, body, None).await
+    }
+
+    async fn put_if_match(
+        &self,
+        obj: &ObjectId,
+        body: bytes::Bytes,
+        if_match: Option<&Version>,
+    ) -> Result<Version> {
+        let resp = self
+            .http
+            .execute(self.build_put(obj, body, if_match))
+            .await
+            .map_err(Error::Backend)?;
+        if resp.status == 412 {
+            return Err(Error::VersionMismatch {
+                expected: if_match.map(|v| v.0.clone()).unwrap_or_default(),
+                found: resp
+                    .header("etag")
+                    .map(|e| e.trim_matches('"').to_string())
+                    .unwrap_or_default(),
+            });
+        }
+        if !resp.is_success() {
+            return Err(Error::Backend(format!(
+                "Azure PUT {} -> HTTP {}",
+                obj.to_path(),
+                resp.status
+            )));
+        }
+        match resp
+            .header("etag")
+            .map(|v| Version::new(v.trim_matches('"').to_string()))
+            .filter(|v| !v.0.trim().is_empty())
+        {
+            Some(version) => Ok(version),
+            None => Ok(self.head(obj).await?.version),
+        }
+    }
+
+    async fn delete(&self, obj: &ObjectId) -> Result<()> {
+        let resp = self
+            .http
+            .execute(self.build_delete(obj))
+            .await
+            .map_err(Error::Backend)?;
+        if resp.is_success() || resp.status == 404 {
+            Ok(())
+        } else {
+            Err(Error::Backend(format!(
+                "Azure DELETE {} -> HTTP {}",
+                obj.to_path(),
+                resp.status
+            )))
+        }
     }
 }
 
@@ -352,5 +447,70 @@ mod tests {
             Err(Error::NotFound(_))
         ));
         assert!(matches!(a.head(&obj()).await, Err(Error::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn put_sends_block_blob_body_and_returns_etag() {
+        let http = MockHttp::new(HttpResponse {
+            status: 201,
+            headers: vec![("ETag".into(), "\"0xNEW\"".into())],
+            body: bytes::Bytes::new(),
+        });
+        let a = AzureBackend::new(AzureConfig::new("acct"), None, http.clone());
+        let body = bytes::Bytes::from_static(b"az-object");
+        let version = a.put(&obj(), body.clone()).await.unwrap();
+        assert_eq!(version, Version::new("0xNEW"));
+        let req = http.last.lock().unwrap().clone().unwrap();
+        assert_eq!(req.method, Method::Put);
+        assert_eq!(req.body, body);
+        assert_eq!(req.header("x-ms-blob-type"), Some("BlockBlob"));
+    }
+
+    #[tokio::test]
+    async fn put_if_match_maps_412() {
+        let http = MockHttp::new(HttpResponse {
+            status: 412,
+            headers: vec![("ETag".into(), "\"0xB\"".into())],
+            body: bytes::Bytes::new(),
+        });
+        let a = AzureBackend::new(AzureConfig::new("acct"), None, http.clone());
+        match a
+            .put_if_match(
+                &obj(),
+                bytes::Bytes::from_static(b"x"),
+                Some(&Version::new("0xA")),
+            )
+            .await
+        {
+            Err(Error::VersionMismatch { expected, found }) => {
+                assert_eq!(expected, "0xA");
+                assert_eq!(found, "0xB");
+            }
+            other => panic!("expected VersionMismatch, got {other:?}"),
+        }
+        assert_eq!(
+            http.last
+                .lock()
+                .unwrap()
+                .clone()
+                .unwrap()
+                .header("If-Match"),
+            Some("\"0xA\"")
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_is_idempotent() {
+        let http = MockHttp::new(HttpResponse {
+            status: 202,
+            headers: vec![],
+            body: bytes::Bytes::new(),
+        });
+        let a = AzureBackend::new(AzureConfig::new("acct"), None, http.clone());
+        a.delete(&obj()).await.unwrap();
+        assert_eq!(
+            http.last.lock().unwrap().clone().unwrap().method,
+            Method::Delete
+        );
     }
 }

--- a/crates/talon-backend/src/gcs.rs
+++ b/crates/talon-backend/src/gcs.rs
@@ -110,6 +110,7 @@ impl GcsBackend {
             method: Method::Get,
             url: self.object_url(obj),
             headers,
+            body: bytes::Bytes::new(),
         }
     }
 
@@ -119,6 +120,46 @@ impl GcsBackend {
             method: Method::Head,
             url: self.object_url(obj),
             headers: self.auth_headers(),
+            body: bytes::Bytes::new(),
+        }
+    }
+
+    /// Build the whole-object PUT request (exposed for testing).
+    ///
+    /// A numeric `if_match` is an object generation (`x-goog-if-generation-match`);
+    /// a non-numeric one is an ETag (`If-Match`). Either makes GCS reject the
+    /// write with `412` if the object changed since it was read (#226).
+    pub fn build_put(
+        &self,
+        obj: &ObjectId,
+        body: bytes::Bytes,
+        if_match: Option<&Version>,
+    ) -> HttpRequest {
+        let mut headers = self.auth_headers();
+        headers.push(("Content-Length".to_string(), body.len().to_string()));
+        if let Some(version) = if_match {
+            let v = version.as_str();
+            if !v.is_empty() && v.bytes().all(|b| b.is_ascii_digit()) {
+                headers.push(("x-goog-if-generation-match".to_string(), v.to_string()));
+            } else {
+                headers.push(("If-Match".to_string(), format!("\"{v}\"")));
+            }
+        }
+        HttpRequest {
+            method: Method::Put,
+            url: self.object_url(obj),
+            headers,
+            body,
+        }
+    }
+
+    /// Build the DELETE request (exposed for testing).
+    pub fn build_delete(&self, obj: &ObjectId) -> HttpRequest {
+        HttpRequest {
+            method: Method::Delete,
+            url: self.object_url(obj),
+            headers: self.auth_headers(),
+            body: bytes::Bytes::new(),
         }
     }
 }
@@ -207,6 +248,66 @@ impl BackendStore for GcsBackend {
                 ))
             })?;
         Ok(ObjectStat { len, version })
+    }
+
+    async fn put(&self, obj: &ObjectId, body: bytes::Bytes) -> Result<Version> {
+        self.put_if_match(obj, body, None).await
+    }
+
+    async fn put_if_match(
+        &self,
+        obj: &ObjectId,
+        body: bytes::Bytes,
+        if_match: Option<&Version>,
+    ) -> Result<Version> {
+        let resp = self
+            .http
+            .execute(self.build_put(obj, body, if_match))
+            .await
+            .map_err(Error::Backend)?;
+        if resp.status == 412 {
+            return Err(Error::VersionMismatch {
+                expected: if_match.map(|v| v.0.clone()).unwrap_or_default(),
+                found: resp
+                    .header("x-goog-generation")
+                    .or_else(|| resp.header("etag"))
+                    .map(|e| e.trim_matches('"').to_string())
+                    .unwrap_or_default(),
+            });
+        }
+        if !resp.is_success() {
+            return Err(Error::Backend(format!(
+                "GCS PUT {} -> HTTP {}",
+                obj.to_path(),
+                resp.status
+            )));
+        }
+        match resp
+            .header("x-goog-generation")
+            .or_else(|| resp.header("etag"))
+            .map(|v| Version::new(v.trim_matches('"').to_string()))
+            .filter(|v| !v.0.trim().is_empty())
+        {
+            Some(version) => Ok(version),
+            None => Ok(self.head(obj).await?.version),
+        }
+    }
+
+    async fn delete(&self, obj: &ObjectId) -> Result<()> {
+        let resp = self
+            .http
+            .execute(self.build_delete(obj))
+            .await
+            .map_err(Error::Backend)?;
+        if resp.is_success() || resp.status == 404 {
+            Ok(())
+        } else {
+            Err(Error::Backend(format!(
+                "GCS DELETE {} -> HTTP {}",
+                obj.to_path(),
+                resp.status
+            )))
+        }
     }
 }
 
@@ -372,5 +473,63 @@ mod tests {
             Err(Error::NotFound(_))
         ));
         assert!(matches!(g.head(&obj()).await, Err(Error::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn put_sends_body_and_returns_generation() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![("x-goog-generation".into(), "1700000009".into())],
+            body: bytes::Bytes::new(),
+        });
+        let g = GcsBackend::new(GcsConfig::default(), Some("tok".into()), http.clone());
+        let body = bytes::Bytes::from_static(b"gcs-object");
+        let version = g.put(&obj(), body.clone()).await.unwrap();
+        assert_eq!(version, Version::new("1700000009"));
+        let req = http.last.lock().unwrap().clone().unwrap();
+        assert_eq!(req.method, Method::Put);
+        assert_eq!(req.body, body);
+        assert_eq!(req.header("Authorization"), Some("Bearer tok"));
+    }
+
+    #[tokio::test]
+    async fn put_if_match_numeric_uses_generation_precondition_and_maps_412() {
+        let http = MockHttp::new(HttpResponse {
+            status: 412,
+            headers: vec![("x-goog-generation".into(), "1700000010".into())],
+            body: bytes::Bytes::new(),
+        });
+        let g = GcsBackend::new(GcsConfig::default(), None, http.clone());
+        match g
+            .put_if_match(
+                &obj(),
+                bytes::Bytes::from_static(b"x"),
+                Some(&Version::new("1700000009")),
+            )
+            .await
+        {
+            Err(Error::VersionMismatch { expected, found }) => {
+                assert_eq!(expected, "1700000009");
+                assert_eq!(found, "1700000010");
+            }
+            other => panic!("expected VersionMismatch, got {other:?}"),
+        }
+        let req = http.last.lock().unwrap().clone().unwrap();
+        assert_eq!(req.header("x-goog-if-generation-match"), Some("1700000009"));
+    }
+
+    #[tokio::test]
+    async fn delete_is_idempotent() {
+        let http = MockHttp::new(HttpResponse {
+            status: 204,
+            headers: vec![],
+            body: bytes::Bytes::new(),
+        });
+        let g = GcsBackend::new(GcsConfig::default(), None, http.clone());
+        g.delete(&obj()).await.unwrap();
+        assert_eq!(
+            http.last.lock().unwrap().clone().unwrap().method,
+            Method::Delete
+        );
     }
 }

--- a/crates/talon-backend/src/http.rs
+++ b/crates/talon-backend/src/http.rs
@@ -16,6 +16,10 @@ pub enum Method {
     Get,
     /// HEAD, used to fetch size + etag without the body.
     Head,
+    /// PUT, used to upload a whole object (write-through, #226).
+    Put,
+    /// DELETE, used to remove an object.
+    Delete,
 }
 
 /// An outgoing HTTP request built by a backend.
@@ -27,9 +31,36 @@ pub struct HttpRequest {
     pub url: String,
     /// Header name/value pairs (in insertion order).
     pub headers: Vec<(String, String)>,
+    /// Request body. Empty for GET/HEAD/DELETE; carries the object bytes for PUT.
+    pub body: bytes::Bytes,
 }
 
 impl HttpRequest {
+    /// Build a request with no body (GET/HEAD/DELETE).
+    pub fn new(method: Method, url: String, headers: Vec<(String, String)>) -> Self {
+        Self {
+            method,
+            url,
+            headers,
+            body: bytes::Bytes::new(),
+        }
+    }
+
+    /// Build a request carrying a body (PUT).
+    pub fn with_body(
+        method: Method,
+        url: String,
+        headers: Vec<(String, String)>,
+        body: bytes::Bytes,
+    ) -> Self {
+        Self {
+            method,
+            url,
+            headers,
+            body,
+        }
+    }
+
     /// Look up the first header value with a case-insensitive name match.
     pub fn header(&self, name: &str) -> Option<&str> {
         self.headers

--- a/crates/talon-backend/src/reqwest_client.rs
+++ b/crates/talon-backend/src/reqwest_client.rs
@@ -46,10 +46,16 @@ impl HttpClient for ReqwestClient {
         let method = match req.method {
             Method::Get => reqwest::Method::GET,
             Method::Head => reqwest::Method::HEAD,
+            Method::Put => reqwest::Method::PUT,
+            Method::Delete => reqwest::Method::DELETE,
         };
         let mut builder = self.inner.request(method, &req.url);
         for (k, v) in &req.headers {
             builder = builder.header(k.as_str(), v.as_str());
+        }
+        // Attach the request body for PUT (empty for the other verbs).
+        if !req.body.is_empty() {
+            builder = builder.body(req.body.clone());
         }
         let resp = builder.send().await.map_err(sanitize_error)?;
         let status = resp.status().as_u16();
@@ -95,6 +101,7 @@ mod tests {
                 method: Method::Get,
                 url,
                 headers: Vec::new(),
+                body: bytes::Bytes::new(),
             })
             .await
             .expect_err("request to an unresolvable host must fail");

--- a/crates/talon-backend/src/s3.rs
+++ b/crates/talon-backend/src/s3.rs
@@ -134,6 +134,7 @@ impl S3Backend {
             method: Method::Get,
             url: self.object_url(obj),
             headers,
+            body: bytes::Bytes::new(),
         }
     }
 
@@ -147,6 +148,46 @@ impl S3Backend {
             method: Method::Head,
             url: self.object_url(obj),
             headers,
+            body: bytes::Bytes::new(),
+        }
+    }
+
+    /// Build the whole-object PUT request (exposed for testing).
+    ///
+    /// When `if_match` is set, adds an `If-Match` header so the origin rejects the
+    /// write with `412` if the object changed since it was read (#226).
+    pub fn build_put(
+        &self,
+        obj: &ObjectId,
+        body: bytes::Bytes,
+        if_match: Option<&Version>,
+    ) -> HttpRequest {
+        let mut headers = vec![("Content-Length".to_string(), body.len().to_string())];
+        if let Some(tok) = &self.creds.session_token {
+            headers.push(("x-amz-security-token".to_string(), tok.clone()));
+        }
+        if let Some(version) = if_match {
+            headers.push(("If-Match".to_string(), format!("\"{}\"", version.as_str())));
+        }
+        HttpRequest {
+            method: Method::Put,
+            url: self.object_url(obj),
+            headers,
+            body,
+        }
+    }
+
+    /// Build the DELETE request (exposed for testing).
+    pub fn build_delete(&self, obj: &ObjectId) -> HttpRequest {
+        let mut headers = Vec::new();
+        if let Some(tok) = &self.creds.session_token {
+            headers.push(("x-amz-security-token".to_string(), tok.clone()));
+        }
+        HttpRequest {
+            method: Method::Delete,
+            url: self.object_url(obj),
+            headers,
+            body: bytes::Bytes::new(),
         }
     }
 }
@@ -238,6 +279,63 @@ impl BackendStore for S3Backend {
                 ))
             })?;
         Ok(ObjectStat { len, version })
+    }
+
+    async fn put(&self, obj: &ObjectId, body: bytes::Bytes) -> Result<Version> {
+        self.put_if_match(obj, body, None).await
+    }
+
+    async fn put_if_match(
+        &self,
+        obj: &ObjectId,
+        body: bytes::Bytes,
+        if_match: Option<&Version>,
+    ) -> Result<Version> {
+        let req = self.build_put(obj, body, if_match);
+        let resp = self.http.execute(req).await.map_err(Error::Backend)?;
+        if resp.status == 412 {
+            // The If-Match precondition failed: the object changed since it was
+            // read (#226). Report the new ETag if present.
+            return Err(Error::VersionMismatch {
+                expected: if_match.map(|v| v.0.clone()).unwrap_or_default(),
+                found: resp
+                    .header("etag")
+                    .map(|e| e.trim_matches('"').to_string())
+                    .unwrap_or_default(),
+            });
+        }
+        if !resp.is_success() {
+            return Err(Error::Backend(format!(
+                "S3 PUT {} -> HTTP {}",
+                obj.to_path(),
+                resp.status
+            )));
+        }
+        // The PUT response's ETag is the committed object version. Fall back to a
+        // HEAD only if the PUT response didn't carry one.
+        match resp
+            .header("etag")
+            .map(etag_to_version)
+            .filter(|v| !v.0.trim().is_empty())
+        {
+            Some(version) => Ok(version),
+            None => Ok(self.head(obj).await?.version),
+        }
+    }
+
+    async fn delete(&self, obj: &ObjectId) -> Result<()> {
+        let req = self.build_delete(obj);
+        let resp = self.http.execute(req).await.map_err(Error::Backend)?;
+        // 2xx or 404 are both success (delete is idempotent).
+        if resp.is_success() || resp.status == 404 {
+            Ok(())
+        } else {
+            Err(Error::Backend(format!(
+                "S3 DELETE {} -> HTTP {}",
+                obj.to_path(),
+                resp.status
+            )))
+        }
     }
 }
 
@@ -476,5 +574,74 @@ mod tests {
         let _ = s3.fetch_range(&obj(), 0, 8).await.unwrap();
         let req = http.last.lock().unwrap().clone().unwrap();
         assert_eq!(req.header("x-amz-security-token"), Some("token123"));
+    }
+
+    #[tokio::test]
+    async fn put_sends_body_and_returns_committed_version() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![("ETag".into(), "\"newetag\"".into())],
+            body: bytes::Bytes::new(),
+        });
+        let s3 = S3Backend::new(S3Config::aws("us-east-1"), creds(), http.clone());
+        let body = bytes::Bytes::from_static(b"hello object");
+        let version = s3.put(&obj(), body.clone()).await.unwrap();
+        // Committed version is parsed from the PUT response ETag (quotes stripped).
+        assert_eq!(version, Version::new("newetag"));
+        let req = http.last.lock().unwrap().clone().unwrap();
+        assert_eq!(req.method, Method::Put);
+        assert_eq!(req.body, body);
+        assert_eq!(req.header("Content-Length"), Some("12"));
+    }
+
+    #[tokio::test]
+    async fn put_if_match_sends_precondition_and_maps_412() {
+        let http = MockHttp::new(HttpResponse {
+            status: 412,
+            headers: vec![("ETag".into(), "\"v2\"".into())],
+            body: bytes::Bytes::new(),
+        });
+        let s3 = S3Backend::new(S3Config::aws("us-east-1"), creds(), http.clone());
+        match s3
+            .put_if_match(
+                &obj(),
+                bytes::Bytes::from_static(b"x"),
+                Some(&Version::new("v1")),
+            )
+            .await
+        {
+            Err(Error::VersionMismatch { expected, found }) => {
+                assert_eq!(expected, "v1");
+                assert_eq!(found, "v2");
+            }
+            other => panic!("expected VersionMismatch, got {other:?}"),
+        }
+        let req = http.last.lock().unwrap().clone().unwrap();
+        assert_eq!(req.header("If-Match"), Some("\"v1\""));
+    }
+
+    #[tokio::test]
+    async fn delete_sends_delete_and_is_idempotent() {
+        // 2xx -> Ok.
+        let http = MockHttp::new(HttpResponse {
+            status: 204,
+            headers: vec![],
+            body: bytes::Bytes::new(),
+        });
+        let s3 = S3Backend::new(S3Config::aws("us-east-1"), creds(), http.clone());
+        s3.delete(&obj()).await.unwrap();
+        assert_eq!(
+            http.last.lock().unwrap().clone().unwrap().method,
+            Method::Delete
+        );
+
+        // 404 -> also Ok (idempotent).
+        let http404 = MockHttp::new(HttpResponse {
+            status: 404,
+            headers: vec![],
+            body: bytes::Bytes::new(),
+        });
+        let s3 = S3Backend::new(S3Config::aws("us-east-1"), creds(), http404);
+        s3.delete(&obj()).await.unwrap();
     }
 }

--- a/crates/talon-core/src/backend.rs
+++ b/crates/talon-core/src/backend.rs
@@ -57,4 +57,54 @@ pub trait BackendStore: Send + Sync {
 
     /// Fetch object metadata (size + version) without transferring data.
     async fn head(&self, obj: &ObjectId) -> Result<ObjectStat>;
+
+    /// Upload the whole object, replacing any existing one.
+    ///
+    /// Returns the version/etag the store assigns to the newly-written object, so
+    /// the caller (the write-through worker) can cache the bytes under the same
+    /// version the read path would resolve via [`head`](Self::head), keeping
+    /// read-after-write consistent with the #163 versioning.
+    ///
+    /// The default implementation refuses with [`Error::Backend`](crate::Error::Backend); real backends
+    /// (S3/GCS/Azure) override it. This keeps in-memory/test backends that only
+    /// serve reads compiling unchanged (write support, #226/#227).
+    async fn put(&self, obj: &ObjectId, body: Bytes) -> Result<Version> {
+        let _ = body;
+        Err(crate::Error::Backend(format!(
+            "backend does not support PUT for {}",
+            obj.to_path()
+        )))
+    }
+
+    /// Upload the whole object, optionally guarded by an `If-Match` precondition.
+    ///
+    /// When `if_match` is `Some`, the write is conditioned on the object still
+    /// being at that version (S3/Azure `If-Match`, GCS `x-goog-if-generation-match`),
+    /// so a concurrent overwrite between the client's read and this write is
+    /// rejected with [`Error::VersionMismatch`](crate::Error::VersionMismatch)
+    /// rather than clobbering newer bytes (the write analogue of
+    /// [`fetch_range_if_match`](Self::fetch_range_if_match)).
+    ///
+    /// The default implementation ignores the precondition and delegates to
+    /// [`put`](Self::put).
+    async fn put_if_match(
+        &self,
+        obj: &ObjectId,
+        body: Bytes,
+        if_match: Option<&Version>,
+    ) -> Result<Version> {
+        let _ = if_match;
+        self.put(obj, body).await
+    }
+
+    /// Delete the object. Idempotent: a missing object is `Ok(())`.
+    ///
+    /// The default implementation refuses with [`Error::Backend`](crate::Error::Backend); real backends
+    /// override it.
+    async fn delete(&self, obj: &ObjectId) -> Result<()> {
+        Err(crate::Error::Backend(format!(
+            "backend does not support DELETE for {}",
+            obj.to_path()
+        )))
+    }
 }


### PR DESCRIPTION
Part of #226 (FUSE write-through). Closes #227. Bottom layer — no deps on the other children.

## Summary
The backend abstraction was GET/HEAD only. Add whole-object PUT and DELETE so the write-through worker can upload to the origin.

- **HTTP layer**: `Method::Put`/`Delete`; `HttpRequest.body: Bytes` (+ `new`/`with_body`); `ReqwestClient` sends the body for PUT and maps the verbs.
- **`BackendStore` trait**: `put` (returns the store-assigned committed `Version` so the worker caches under the read-path version, #163), `put_if_match` (If-Match / `x-goog-if-generation-match`, `412 → VersionMismatch`, mirrors `fetch_range_if_match`), `delete` (idempotent). Default impls so the many in-memory test backends compile unchanged.
- **S3/GCS/Azure**: `build_put`/`build_delete` + impls. PUT parses the committed version from the response (ETag / generation), HEAD fallback if absent; Azure sends `x-ms-blob-type: BlockBlob`; DELETE treats 2xx and 404 as success.

## Testing
Per-backend: put sends the right method/URL/body + returns the version; put_if_match sends the precondition and maps 412; delete is idempotent. `fmt`/`clippy -D warnings`/`test --all-features`/`doc -D warnings` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)