### PR TITLE
feat(transport): add Put/Delete data-plane codec for write-through

### DIFF
--- a/crates/talon-transport/src/data.rs
+++ b/crates/talon-transport/src/data.rs
@@ -27,6 +27,27 @@ pub struct RangeRequest {
     pub len: u64,
 }
 
+/// A client→worker request to write a whole object (write-through, #226).
+///
+/// This is the framed **header**; the raw object bytes (`body_len` of them)
+/// follow the frame on the wire, so the worker can `splice` them straight to a
+/// staging file without buffering them through the codec. `object` names the
+/// destination and `body_len` is the exact number of trailing raw bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PutRequest {
+    /// The destination object to (over)write.
+    pub object: ObjectId,
+    /// Number of raw object bytes that follow this header on the wire.
+    pub body_len: u64,
+}
+
+/// A client→worker request to delete an object (#226). No body follows.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeleteRequest {
+    /// The object to delete.
+    pub object: ObjectId,
+}
+
 /// Errors from data-plane range encode/decode.
 #[derive(Debug, thiserror::Error)]
 pub enum DataError {
@@ -36,6 +57,12 @@ pub enum DataError {
     /// A non-`GetRange` frame was handed to the data codec.
     #[error("expected a GetRange frame, got {0:?}")]
     NotGetRange(MsgType),
+    /// A non-`Put` frame was handed to the put codec.
+    #[error("expected a Put frame, got {0:?}")]
+    NotPut(MsgType),
+    /// A non-`Delete` frame was handed to the delete codec.
+    #[error("expected a Delete frame, got {0:?}")]
+    NotDelete(MsgType),
     /// The header's declared length did not match the available payload bytes.
     #[error("length mismatch: header says {declared}, have {actual}")]
     LengthMismatch {
@@ -74,6 +101,71 @@ pub fn decode_request(buf: &[u8]) -> Result<(FrameHeader, RangeRequest), DataErr
         });
     }
     let req: RangeRequest = bincode::deserialize(body)?;
+    Ok((header, req))
+}
+
+/// Encode a [`PutRequest`] header into `header || bincode(req)`.
+///
+/// The caller then writes exactly `req.body_len` raw object bytes after this
+/// buffer (streamed, not buffered here). The frame header's `length` covers only
+/// the small bincode header, so the receiver reads the header first and then
+/// streams the trailing body.
+pub fn encode_put_header(request_id: u32, req: &PutRequest) -> Result<Vec<u8>, DataError> {
+    let body = bincode::serialize(req)?;
+    let header = FrameHeader::new(MsgType::Put, request_id, body.len() as u32);
+    let mut buf = Vec::with_capacity(HEADER_LEN + body.len());
+    buf.extend_from_slice(&header.encode());
+    buf.extend_from_slice(&body);
+    Ok(buf)
+}
+
+/// Decode a framed [`PutRequest`] header (header + bincode, no body).
+///
+/// `buf` must contain exactly the header frame (16-byte header + the bincode
+/// `PutRequest`); the raw object body is read separately from the stream using
+/// the returned `body_len`.
+pub fn decode_put_header(buf: &[u8]) -> Result<(FrameHeader, PutRequest), DataError> {
+    let header = FrameHeader::decode(buf)?;
+    if header.msg_type != MsgType::Put {
+        return Err(DataError::NotPut(header.msg_type));
+    }
+    let declared = header.length as usize;
+    let body = &buf[HEADER_LEN..];
+    if body.len() != declared {
+        return Err(DataError::LengthMismatch {
+            declared,
+            actual: body.len(),
+        });
+    }
+    let req: PutRequest = bincode::deserialize(body)?;
+    Ok((header, req))
+}
+
+/// Encode a [`DeleteRequest`] into `header || bincode(req)` (no body follows).
+pub fn encode_delete(request_id: u32, req: &DeleteRequest) -> Result<Vec<u8>, DataError> {
+    let body = bincode::serialize(req)?;
+    let header = FrameHeader::new(MsgType::Delete, request_id, body.len() as u32);
+    let mut buf = Vec::with_capacity(HEADER_LEN + body.len());
+    buf.extend_from_slice(&header.encode());
+    buf.extend_from_slice(&body);
+    Ok(buf)
+}
+
+/// Decode a framed [`DeleteRequest`] buffer into its header and request.
+pub fn decode_delete(buf: &[u8]) -> Result<(FrameHeader, DeleteRequest), DataError> {
+    let header = FrameHeader::decode(buf)?;
+    if header.msg_type != MsgType::Delete {
+        return Err(DataError::NotDelete(header.msg_type));
+    }
+    let declared = header.length as usize;
+    let body = &buf[HEADER_LEN..];
+    if body.len() != declared {
+        return Err(DataError::LengthMismatch {
+            declared,
+            actual: body.len(),
+        });
+    }
+    let req: DeleteRequest = bincode::deserialize(body)?;
     Ok((header, req))
 }
 
@@ -153,5 +245,73 @@ mod tests {
         let header = FrameHeader::decode(&h).unwrap();
         assert_eq!(header.length, 8192);
         assert!(!header.flags.contains(Flags::ERROR));
+    }
+
+    fn obj() -> ObjectId {
+        ObjectId::new(Backend::S3, "bucket", "path/to/object.bin")
+    }
+
+    #[test]
+    fn put_header_round_trips() {
+        let req = PutRequest {
+            object: obj(),
+            body_len: 1 << 30, // 1 GiB body streamed separately
+        };
+        let buf = encode_put_header(42, &req).unwrap();
+        let (header, back) = decode_put_header(&buf).unwrap();
+        assert_eq!(header.msg_type, MsgType::Put);
+        assert_eq!(header.request_id, 42);
+        assert_eq!(back, req);
+        // The frame length covers only the small header, NOT the body.
+        assert!((header.length as usize) < 1024);
+    }
+
+    #[test]
+    fn delete_round_trips() {
+        let req = DeleteRequest { object: obj() };
+        let buf = encode_delete(9, &req).unwrap();
+        let (header, back) = decode_delete(&buf).unwrap();
+        assert_eq!(header.msg_type, MsgType::Delete);
+        assert_eq!(header.request_id, 9);
+        assert_eq!(back, req);
+    }
+
+    #[test]
+    fn put_codec_rejects_wrong_frame_type() {
+        // A Delete frame handed to the put decoder is rejected, and vice versa.
+        let del = encode_delete(1, &DeleteRequest { object: obj() }).unwrap();
+        assert!(matches!(
+            decode_put_header(&del),
+            Err(DataError::NotPut(MsgType::Delete))
+        ));
+        let put = encode_put_header(
+            1,
+            &PutRequest {
+                object: obj(),
+                body_len: 0,
+            },
+        )
+        .unwrap();
+        assert!(matches!(
+            decode_delete(&put),
+            Err(DataError::NotDelete(MsgType::Put))
+        ));
+    }
+
+    #[test]
+    fn put_header_truncated_body_rejected() {
+        let mut buf = encode_put_header(
+            1,
+            &PutRequest {
+                object: obj(),
+                body_len: 10,
+            },
+        )
+        .unwrap();
+        buf.pop();
+        assert!(matches!(
+            decode_put_header(&buf),
+            Err(DataError::LengthMismatch { .. })
+        ));
     }
 }

--- a/crates/talon-transport/src/frame.rs
+++ b/crates/talon-transport/src/frame.rs
@@ -49,10 +49,15 @@ pub enum MsgType {
     Get = 1,
     /// Data-plane sub-range fetch.
     GetRange = 2,
-    /// Data-plane ingest.
+    /// Data-plane ingest (whole-object write-through, #226): a bincode
+    /// [`PutRequest`](crate::data::PutRequest) header followed by the raw object
+    /// bytes.
     Put = 3,
     /// Ping/keepalive; no payload.
     Ping = 4,
+    /// Data-plane delete (#226): a bincode
+    /// [`DeleteRequest`](crate::data::DeleteRequest) header, no body.
+    Delete = 5,
 }
 
 impl MsgType {
@@ -64,6 +69,7 @@ impl MsgType {
             2 => MsgType::GetRange,
             3 => MsgType::Put,
             4 => MsgType::Ping,
+            5 => MsgType::Delete,
             other => return Err(FrameError::UnknownMsgType(other)),
         })
     }

--- a/crates/talon-transport/src/lib.rs
+++ b/crates/talon-transport/src/lib.rs
@@ -22,7 +22,9 @@ pub use codec::{
     CONTROL_SCHEMA_VERSION, MIN_CONTROL_SCHEMA_VERSION,
 };
 pub use data::{
-    decode_request, encode_error, encode_request, response_header_ok, DataError, RangeRequest,
+    decode_delete, decode_put_header, decode_request, encode_delete, encode_error,
+    encode_put_header, encode_request, response_header_ok, DataError, DeleteRequest, PutRequest,
+    RangeRequest,
 };
 pub use frame::{Flags, FrameError, FrameHeader, MsgType, HEADER_LEN, MAGIC, PROTOCOL_VERSION};
 pub use limits::{

--- a/crates/talon-transport/src/limits.rs
+++ b/crates/talon-transport/src/limits.rs
@@ -39,13 +39,17 @@ pub const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// The maximum accepted payload length for a given message type.
 ///
-/// Data-plane frames (`Get`/`GetRange`/`Put`) may be large (a block), so they
-/// keep the transport maximum; control and ping frames are capped tightly.
+/// `Get`/`GetRange` data frames may be large (a block), so they keep the
+/// transport maximum. A `Put`/`Delete` *frame* only carries a small bincode
+/// header (the raw object body for a Put streams separately and is length-capped
+/// by the worker, not by this frame limit), so they are capped tightly like
+/// control frames. Ping frames are capped tightly too.
 pub fn max_payload_for(msg_type: MsgType) -> u32 {
     match msg_type {
         MsgType::Control => MAX_CONTROL_PAYLOAD_LEN,
         MsgType::Ping => MAX_PING_PAYLOAD_LEN,
-        MsgType::Get | MsgType::GetRange | MsgType::Put => MAX_PAYLOAD_LEN,
+        MsgType::Put | MsgType::Delete => MAX_CONTROL_PAYLOAD_LEN,
+        MsgType::Get | MsgType::GetRange => MAX_PAYLOAD_LEN,
     }
 }
 


### PR DESCRIPTION
Part of #226 (FUSE write-through). Closes #228.

## Summary
Wire format for FUSE writes: Put and Delete request framing so the client can stream a whole object to a worker.

- **frame.rs**: `MsgType::Delete = 5` (+ `from_u8`).
- **data.rs**:
  - `PutRequest { object, body_len }` — the framed **header**; the raw object bytes (`body_len` of them) follow the frame on the wire, so the worker can `splice` them straight to a staging file without buffering through the codec. `encode_put_header`/`decode_put_header`; the frame length covers only the small header, never the body.
  - `DeleteRequest { object }` — `encode_delete`/`decode_delete`, no body.
  - `DataError::NotPut`/`NotDelete`.
- **limits.rs**: a Put/Delete *frame* carries only the small bincode header → capped like control (`MAX_CONTROL_PAYLOAD_LEN`); the large raw body streams separately, length-capped by the worker. Get/GetRange keep `MAX_PAYLOAD_LEN`.

Read path (`RangeRequest`/`encode_request`) untouched.

## Testing
Put header round-trip (frame length excludes body), delete round-trip, wrong-frame-type rejection, truncated-header `LengthMismatch`. Per-crate tests green; `fmt`/`clippy -D warnings`/`doc -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)