### PR TITLE
feat(worker): dispatch Put/Delete for write-through to the backend

### DIFF
--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -370,10 +370,39 @@ async fn handle_conn(
                 Err(e) => return Err(anyhow::anyhow!(e)),
             };
 
+        // A write (Put) or delete (Delete) is handled here and loops; only a
+        // GetRange falls through to the read-serve path below.
+        if header.msg_type == MsgType::Put {
+            handle_put(
+                &mut stream,
+                &header,
+                &payload,
+                &worker,
+                &observability,
+                request_started,
+            )
+            .await?;
+            continue;
+        }
+        if header.msg_type == MsgType::Delete {
+            handle_delete(
+                &mut stream,
+                &header,
+                &payload,
+                &worker,
+                &observability,
+                request_started,
+            )
+            .await?;
+            continue;
+        }
+
         // Type check BEFORE any per-request work; a data listener only serves
-        // GetRange, and non-data frames are already capped tightly by read_frame.
+        // GetRange (plus the Put/Delete handled above); other frames are capped
+        // tightly by read_frame.
         if header.msg_type != MsgType::GetRange {
-            let err = data::encode_error(header.request_id, "worker only serves GetRange");
+            let err =
+                data::encode_error(header.request_id, "worker only serves GetRange/Put/Delete");
             stream.write_all(&err).await?;
             stream.flush().await?;
             observability
@@ -454,6 +483,125 @@ async fn handle_conn(
             }
         }
     }
+}
+
+/// Handle a `Put` frame: read the whole object body, write it through to the
+/// backend, and cache it (#229).
+///
+/// The frame `payload` is the small bincode [`PutRequest`] header; the raw object
+/// bytes (`body_len` of them) follow on the stream, so we read exactly that many
+/// into memory (v1 objects are single-block) and hand them to
+/// [`WorkerRuntime::write_object`], which PUTs to the origin then caches the
+/// bytes. Replies OK with the committed version, or an `ERROR` frame.
+async fn handle_put(
+    stream: &mut TcpStream,
+    header: &FrameHeader,
+    payload: &[u8],
+    worker: &Arc<WorkerRuntime>,
+    observability: &Arc<WorkerObservability>,
+    request_started: Instant,
+) -> anyhow::Result<()> {
+    let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
+    full.extend_from_slice(&header.encode());
+    full.extend_from_slice(payload);
+    let (h, req) = match data::decode_put_header(&full) {
+        Ok(v) => v,
+        Err(e) => {
+            let err = data::encode_error(header.request_id, &format!("bad put: {e}"));
+            stream.write_all(&err).await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+            return Ok(());
+        }
+    };
+    if !observability.is_ready() {
+        let err = data::encode_error(h.request_id, "worker is not ready");
+        stream.write_all(&err).await?;
+        stream.flush().await?;
+        return Ok(());
+    }
+    // Read exactly body_len raw object bytes that follow the header on the wire.
+    let mut body = vec![0u8; req.body_len as usize];
+    stream.read_exact(&mut body).await?;
+    match worker
+        .write_object(&req.object, bytes::Bytes::from(body))
+        .await
+    {
+        Ok(version) => {
+            // Reply OK; the body carries the committed version so the client can
+            // record read-after-write consistency.
+            let vbytes = version.as_str().as_bytes();
+            let hdr = data::response_header_ok(h.request_id, vbytes.len() as u32);
+            stream.write_all(&hdr).await?;
+            stream.write_all(vbytes).await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_request_success(req.body_len, request_started.elapsed());
+        }
+        Err(error) => {
+            let err = data::encode_error(h.request_id, &error.to_string());
+            stream.write_all(&err).await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+        }
+    }
+    Ok(())
+}
+
+/// Handle a `Delete` frame: delete the object at the backend and evict locally.
+async fn handle_delete(
+    stream: &mut TcpStream,
+    header: &FrameHeader,
+    payload: &[u8],
+    worker: &Arc<WorkerRuntime>,
+    observability: &Arc<WorkerObservability>,
+    request_started: Instant,
+) -> anyhow::Result<()> {
+    let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
+    full.extend_from_slice(&header.encode());
+    full.extend_from_slice(payload);
+    let (h, req) = match data::decode_delete(&full) {
+        Ok(v) => v,
+        Err(e) => {
+            let err = data::encode_error(header.request_id, &format!("bad delete: {e}"));
+            stream.write_all(&err).await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+            return Ok(());
+        }
+    };
+    if !observability.is_ready() {
+        let err = data::encode_error(h.request_id, "worker is not ready");
+        stream.write_all(&err).await?;
+        stream.flush().await?;
+        return Ok(());
+    }
+    match worker.delete_object(&req.object).await {
+        Ok(()) => {
+            let hdr = data::response_header_ok(h.request_id, 0);
+            stream.write_all(&hdr).await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_request_success(0, request_started.elapsed());
+        }
+        Err(error) => {
+            let err = data::encode_error(h.request_id, &error.to_string());
+            stream.write_all(&err).await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+        }
+    }
+    Ok(())
 }
 
 /// Stream a resident block's bytes to the client with `sendfile(2)`.
@@ -768,6 +916,142 @@ mod tests {
             .metrics()
             .render()
             .contains("talon_worker_cache_hits_total{form=\"whole\"} 1"));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    /// A backend that stores whole-object PUTs in memory so a write-through can be
+    /// read back, and records deletes.
+    #[derive(Default)]
+    struct StoringBackend {
+        objects: std::sync::Mutex<std::collections::HashMap<String, Bytes>>,
+    }
+
+    #[async_trait]
+    impl BackendStore for StoringBackend {
+        async fn fetch_range(&self, object: &ObjectId, offset: u64, len: u64) -> Result<Bytes> {
+            let objs = self.objects.lock().unwrap();
+            let full = objs
+                .get(&object.to_path())
+                .ok_or_else(|| Error::NotFound(object.to_path()))?;
+            let start = offset as usize;
+            let end = (start + len as usize).min(full.len());
+            Ok(full.slice(start..end))
+        }
+        async fn head(&self, object: &ObjectId) -> Result<ObjectStat> {
+            let objs = self.objects.lock().unwrap();
+            let full = objs
+                .get(&object.to_path())
+                .ok_or_else(|| Error::NotFound(object.to_path()))?;
+            Ok(ObjectStat {
+                len: full.len() as u64,
+                version: Version::new("stored-v1"),
+            })
+        }
+        async fn put(&self, object: &ObjectId, body: Bytes) -> Result<Version> {
+            self.objects.lock().unwrap().insert(object.to_path(), body);
+            Ok(Version::new("stored-v1"))
+        }
+        async fn delete(&self, object: &ObjectId) -> Result<()> {
+            self.objects.lock().unwrap().remove(&object.to_path());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn handle_conn_write_through_then_read_back() {
+        use talon_transport::data::{encode_put_header, encode_request, PutRequest, RangeRequest};
+
+        let root = tmp_root();
+        let index = Arc::new(BlockIndex::new());
+        let inflight = Arc::new(InFlightLoads::new());
+        let node = NodeInfo {
+            id: NodeId::new("w"),
+            address: "127.0.0.1:7001".into(),
+            role: NodeRole::Worker,
+        };
+        let observability = Arc::new(
+            WorkerObservability::new(
+                "c".into(),
+                node,
+                "127.0.0.1:8001".into(),
+                1024,
+                Arc::clone(&index),
+                Arc::clone(&inflight),
+            )
+            .unwrap(),
+        );
+        observability.readiness().set_backend_ready(true);
+        observability.readiness().set_store_ready(true);
+        observability.readiness().set_control_registered(true);
+        let backend = Arc::new(StoringBackend::default());
+        let worker = Arc::new(WorkerRuntime::new(
+            WholeBlockStore::open(&root).unwrap(),
+            index,
+            inflight,
+            Arc::clone(&backend) as Arc<dyn BackendStore>,
+            256 << 20, // block_size big enough for the object
+            0,
+            observability.metrics().clone(),
+        ));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let srv_worker = Arc::clone(&worker);
+        let srv_obs = Arc::clone(&observability);
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let _ = handle_conn(stream, srv_worker, srv_obs).await;
+        });
+
+        let obj = ObjectId::new(talon_core::Backend::Azure, "c", "written.bin");
+        let object_bytes = bytes::Bytes::from_static(b"hello written object");
+        let mut client = TcpStream::connect(addr).await.unwrap();
+
+        // 1) PUT: header frame (object + body_len) then the raw object bytes.
+        let put = PutRequest {
+            object: obj.clone(),
+            body_len: object_bytes.len() as u64,
+        };
+        let hdr = encode_put_header(0, &put).unwrap();
+        client.write_all(&hdr).await.unwrap();
+        client.write_all(&object_bytes).await.unwrap();
+        client.flush().await.unwrap();
+        // Reply OK carrying the committed version.
+        let mut rhdr = [0u8; HEADER_LEN];
+        client.read_exact(&mut rhdr).await.unwrap();
+        let rheader = FrameHeader::decode(&rhdr).unwrap();
+        assert!(!rheader.flags.contains(talon_transport::Flags::ERROR));
+        let mut vbody = vec![0u8; rheader.length as usize];
+        client.read_exact(&mut vbody).await.unwrap();
+        assert_eq!(&vbody, b"stored-v1");
+        // The backend received the exact object bytes (write-through).
+        assert_eq!(
+            backend.objects.lock().unwrap().get(&obj.to_path()).unwrap(),
+            &object_bytes
+        );
+
+        // 2) GetRange the same object: served from cache (read-after-write).
+        let req = RangeRequest {
+            object: obj.clone(),
+            offset: 0,
+            len: object_bytes.len() as u64,
+        };
+        let out = encode_request(0, &req).unwrap();
+        client.write_all(&out).await.unwrap();
+        client.flush().await.unwrap();
+        let mut ghdr = [0u8; HEADER_LEN];
+        client.read_exact(&mut ghdr).await.unwrap();
+        let gheader = FrameHeader::decode(&ghdr).unwrap();
+        assert!(!gheader.flags.contains(talon_transport::Flags::ERROR));
+        let mut gbody = vec![0u8; gheader.length as usize];
+        client.read_exact(&mut gbody).await.unwrap();
+        assert_eq!(
+            gbody, object_bytes,
+            "read-after-write returns written bytes"
+        );
+
+        drop(client);
+        server.await.unwrap();
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/crates/talon-worker/src/observability.rs
+++ b/crates/talon-worker/src/observability.rs
@@ -37,6 +37,10 @@ pub struct WorkerMetrics {
     cache_misses_total: Counter,
     backend_fetch_bytes_total: Counter,
     backend_fetch_errors_total: Counter,
+    backend_write_bytes_total: Counter,
+    backend_write_errors_total: Counter,
+    backend_delete_total: Counter,
+    backend_delete_errors_total: Counter,
     evictions_total: Counter,
     heartbeat_success_total: Counter,
     heartbeat_failure_total: Counter,
@@ -107,6 +111,26 @@ impl WorkerMetrics {
         let backend_fetch_errors_total = registry.counter(
             "talon_worker_backend_fetch_errors_total",
             "Origin backend range fetch failures.",
+            labels(BACKEND_LABELS),
+        );
+        let backend_write_bytes_total = registry.counter(
+            "talon_worker_backend_write_bytes_total",
+            "Bytes written through to the origin backend.",
+            labels(BACKEND_LABELS),
+        );
+        let backend_write_errors_total = registry.counter(
+            "talon_worker_backend_write_errors_total",
+            "Origin backend object PUT failures.",
+            labels(BACKEND_LABELS),
+        );
+        let backend_delete_total = registry.counter(
+            "talon_worker_backend_delete_total",
+            "Objects deleted from the origin backend.",
+            labels(BACKEND_LABELS),
+        );
+        let backend_delete_errors_total = registry.counter(
+            "talon_worker_backend_delete_errors_total",
+            "Origin backend object DELETE failures.",
             labels(BACKEND_LABELS),
         );
         let evictions_total = registry.counter(
@@ -187,6 +211,10 @@ impl WorkerMetrics {
             cache_misses_total,
             backend_fetch_bytes_total,
             backend_fetch_errors_total,
+            backend_write_bytes_total,
+            backend_write_errors_total,
+            backend_delete_total,
+            backend_delete_errors_total,
             evictions_total,
             heartbeat_success_total,
             heartbeat_failure_total,
@@ -238,6 +266,26 @@ impl WorkerMetrics {
         self.backend_fetch_errors_total.inc();
         self.backend_fetch_duration_seconds
             .observe(elapsed.as_secs_f64());
+    }
+
+    /// Record a successful write-through PUT of `bytes` to the origin backend.
+    pub fn record_backend_write_success(&self, bytes: u64) {
+        self.backend_write_bytes_total.add(bytes);
+    }
+
+    /// Record a failed write-through PUT.
+    pub fn record_backend_write_error(&self) {
+        self.backend_write_errors_total.inc();
+    }
+
+    /// Record a successful object DELETE at the origin backend.
+    pub fn record_backend_delete_success(&self) {
+        self.backend_delete_total.inc();
+    }
+
+    /// Record a failed object DELETE.
+    pub fn record_backend_delete_error(&self) {
+        self.backend_delete_errors_total.inc();
     }
 
     /// Record a successful control-plane heartbeat cycle.

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -487,6 +487,93 @@ impl WorkerRuntime {
         Ok(bytes)
     }
 
+    /// Write a whole object through to the backend, then cache it (#226/#229).
+    ///
+    /// Uploads `body` to the origin (`backend.put`) and, on success, commits the
+    /// bytes to the local cache under the version the store assigned, so an
+    /// immediate read-after-write is a cache hit. If the backend PUT fails,
+    /// nothing is cached and the error propagates — a failed write is never
+    /// silently cached.
+    ///
+    /// v1 handles single-block objects (`body.len() <= block_size`); a larger
+    /// object is rejected with a clear error (multi-block write is future work).
+    /// Returns the committed version.
+    pub async fn write_object(
+        &self,
+        object: &ObjectId,
+        body: bytes::Bytes,
+    ) -> anyhow::Result<Version> {
+        if body.len() as u64 > self.block_size as u64 {
+            anyhow::bail!(
+                "object {} is {} bytes; v1 write supports at most one block ({} bytes)",
+                object.to_path(),
+                body.len(),
+                self.block_size
+            );
+        }
+        // Write through to the origin first; the backend PUT is the durability
+        // point. Only cache after it succeeds.
+        let version = match self.backend.put(object, body.clone()).await {
+            Ok(v) => {
+                self.metrics.record_backend_write_success(body.len() as u64);
+                v
+            }
+            Err(error) => {
+                self.metrics.record_backend_write_error();
+                return Err(error.into());
+            }
+        };
+        // Refresh the version cache so a subsequent read resolves the new version
+        // without a HEAD, and addresses the just-written block correctly (#163).
+        self.store_version(object, &version);
+        // Commit the written bytes to the local cache under the new version, so
+        // read-after-write is a hit. Mirrors the miss-commit path.
+        let block = self.block_for(object, 0, &version);
+        let len = body.len() as u64;
+        self.store
+            .put(&block, body)
+            .await
+            .map_err(|error| anyhow::anyhow!("commit written block failed: {error}"))?;
+        self.index.commit(BlockMeta {
+            id: block.clone(),
+            form: BlockForm::Whole,
+            len,
+        });
+        self.lru.insert(CacheUnit::Whole(block.clone()), len);
+        self.lru.pin(&CacheUnit::Whole(block.clone()));
+        // Drop any superseded prior version of this object from the cache.
+        let superseded = self.lru.evict_superseded(&block);
+        self.unlink_units(superseded).await;
+        self.enforce_capacity().await;
+        self.lru.unpin(&CacheUnit::Whole(block.clone()));
+        tracing::info!(object = %object.to_path(), bytes = len, version = %version, "wrote object");
+        Ok(version)
+    }
+
+    /// Delete an object from the backend and evict it locally (#226/#229).
+    ///
+    /// Deletes at the origin (`backend.delete`, idempotent), then invalidates the
+    /// cached version so a subsequent read re-resolves (and sees the object gone).
+    /// Best-effort evicts the object's currently-cached block.
+    pub async fn delete_object(&self, object: &ObjectId) -> anyhow::Result<()> {
+        match self.backend.delete(object).await {
+            Ok(()) => self.metrics.record_backend_delete_success(),
+            Err(error) => {
+                self.metrics.record_backend_delete_error();
+                return Err(error.into());
+            }
+        }
+        // Evict the locally-cached block for the last-known version, if any, and
+        // drop the cached version so the next read re-resolves.
+        if let Some(version) = self.cached_version(object) {
+            let block = self.block_for(object, 0, &version);
+            self.unlink_units(vec![CacheUnit::Whole(block)]).await;
+        }
+        self.invalidate_version(object);
+        tracing::info!(object = %object.to_path(), "deleted object");
+        Ok(())
+    }
+
     /// Evict the coldest unpinned blocks until resident bytes are back under the
     /// configured capacity, unlinking each evicted block's file and index entry.
     /// A `capacity_bytes` of `0` disables enforcement.


### PR DESCRIPTION
Part of #226 (FUSE write-through). Closes #229. Depends on #227 (backend PUT/DELETE) + #228 (Put/Delete codec), both merged.

## Summary
The worker serve loop rejected everything but GetRange. Add Put (write-through) and Delete.

- **`WorkerRuntime::write_object`**: PUTs the whole object to the backend (durability point), then — only on success — commits the bytes to the local cache under the store-assigned version and refreshes the version cache, so read-after-write is a hit. A failed PUT caches nothing. v1 handles single-block objects; larger is rejected clearly.
- **`WorkerRuntime::delete_object`**: backend DELETE (idempotent) + evict local block + drop cached version.
- **`handle_conn`** dispatches `MsgType::Put`/`Delete`. `handle_put` decodes the `PutRequest` header, reads the `body_len` raw bytes that follow the frame, calls `write_object`, replies OK + committed version. `handle_delete` → `delete_object`.
- Write/delete metrics counters.

**Note:** v1 reads the body into memory before the PUT (objects are single-block/small). The orphaned crash-safe splice ingest (`ingest_put`) is left for a future large-object streaming optimization, to keep this layer simple/correct first.

## Testing
`handle_conn_write_through_then_read_back` over a real socket: client sends a Put frame (header + body), the mock backend receives the exact object bytes, the reply carries the committed version, and a subsequent GetRange is served from cache byte-for-byte (read-after-write). Worker tests green (69 lib + 4 bin); `fmt`/`clippy -D warnings`/`doc -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)