### PR TITLE
build: Azurite + Toxiproxy latency lab compose stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,9 @@ jobs:
         run: |
           docker compose config --quiet
           docker compose --profile ha config --quiet
+          # The latency lab is a standalone stack; validate it parses too.
+          docker compose -f deploy/testenv/docker-compose.yml config --quiet
+          docker compose -f deploy/testenv/docker-compose.yml --profile tools config --quiet
       - name: Build coordinator image
         uses: docker/build-push-action@v6
         with:

--- a/deploy/testenv/README.md
+++ b/deploy/testenv/README.md
@@ -1,0 +1,70 @@
+# Talon object-store latency lab
+
+A self-contained stack that serves real object bytes from **Azurite** (the Azure
+Blob emulator) and reproduces the *latency pattern* of a real object store, so
+you can see how Talon's cache masks backend latency.
+
+Two composable latency layers:
+
+1. **Toxiproxy** in front of Azurite — network-layer latency + jitter, bandwidth
+   throttling, timeouts, connection resets. Added/removed at runtime with
+   [`toxics.sh`](./toxics.sh).
+2. The **worker's in-process delay decorator** — precise per-request first-byte
+   latency and a bandwidth ceiling, via `TALON_WORKER_BACKEND_*` env in the
+   compose file. Independent of the proxy; the two stack.
+
+> The Azurite account name/key here are Microsoft's well-known **public**
+> emulator credentials — not secrets. Never point this stack at real data.
+
+## Launch
+
+```sh
+# From the repo root:
+docker compose -f deploy/testenv/docker-compose.yml up -d --build
+
+# Seed a container with three 8 MiB sample objects:
+docker compose -f deploy/testenv/docker-compose.yml run --rm seed
+
+# Management UI + API:
+open http://127.0.0.1:8000/ui
+```
+
+## Dial the latency
+
+```sh
+./deploy/testenv/toxics.sh s3-warm           # ~30ms first byte, small jitter
+./deploy/testenv/toxics.sh s3-cold-longtail  # ~150ms + heavy tail jitter
+./deploy/testenv/toxics.sh throttled         # 50ms + ~10 MB/s bandwidth ceiling
+./deploy/testenv/toxics.sh flaky             # 80ms + 20% of conns time out
+./deploy/testenv/toxics.sh clear             # remove all toxics
+./deploy/testenv/toxics.sh list              # show current toxics
+```
+
+Watch the effect on the worker's backend-fetch latency in the UI (node detail
+traffic) or directly:
+
+```sh
+curl -s http://127.0.0.1:8001/metrics | grep talon_worker_backend_fetch_duration_seconds
+```
+
+A first read of an object is a cache **miss** and pays the backend latency; a
+repeat read of the same block is a local **hit** and does not — which is the
+whole point of the cache, now visible under controlled latency.
+
+## In-process layer only
+
+To model latency inside the worker instead of (or on top of) the proxy,
+uncomment the `TALON_WORKER_BACKEND_*` env in the compose file and recreate the
+worker:
+
+```sh
+docker compose -f deploy/testenv/docker-compose.yml up -d worker
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.yml` | The stack: azurite, toxiproxy, coordinator, worker, seed. |
+| `toxiproxy.json` | Preloads the `azurite` proxy (the image has no shell). |
+| `toxics.sh` | Attach/remove named latency presets via the Toxiproxy API. |

--- a/deploy/testenv/docker-compose.yml
+++ b/deploy/testenv/docker-compose.yml
@@ -1,0 +1,125 @@
+# Talon object-store latency lab.
+#
+# A self-contained stack that serves real object bytes from Azurite (the Azure
+# Blob emulator) and lets you reproduce the *latency pattern* of a real object
+# store through two composable layers:
+#
+#   1. Toxiproxy in front of Azurite — network-layer latency+jitter, bandwidth
+#      throttling, slow-close, timeout, reset-peer (added at runtime via toxics).
+#   2. The worker's in-process delay decorator — precise per-request first-byte
+#      latency and a bandwidth ceiling (TALON_WORKER_BACKEND_* below).
+#
+# Bring it up, seed sample objects, then dial latency:
+#   docker compose -f deploy/testenv/docker-compose.yml up -d
+#   docker compose -f deploy/testenv/docker-compose.yml run --rm seed
+#   ./deploy/testenv/toxics.sh s3-cold-longtail       # add network latency
+#   # UI: http://127.0.0.1:8000/ui  — watch backend fetch duration rise
+#
+# The Azurite dev account name/key below are Microsoft's well-known public
+# emulator credentials — NOT secrets. Never use this stack with real data.
+
+name: talon-latency-lab
+
+services:
+  # --- origin: Azure Blob emulator -----------------------------------------
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:3.33.0
+    command: ["azurite-blob", "--blobHost", "0.0.0.0", "--blobPort", "10000"]
+    expose:
+      - "10000"
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('net').connect(10000,'127.0.0.1').on('connect',()=>process.exit(0)).on('error',()=>process.exit(1))"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # --- latency proxy: sits between the worker and Azurite -------------------
+  toxiproxy:
+    image: ghcr.io/shopify/toxiproxy:2.11.0
+    ports:
+      - "8474:8474" # Toxiproxy admin API (add/remove toxics at runtime)
+    expose:
+      - "10000" # the proxied Azurite blob endpoint the worker dials
+    depends_on:
+      azurite:
+        condition: service_healthy
+    # The image is FROM scratch (no shell), so preload the azurite proxy from a
+    # config file rather than scripting the admin API. toxics.sh then attaches
+    # latency/bandwidth toxics to this proxy at runtime.
+    command: ["-host=0.0.0.0", "-config=/config/toxiproxy.json"]
+    volumes:
+      - ./toxiproxy.json:/config/toxiproxy.json:ro
+
+  # --- control plane -------------------------------------------------------
+  coordinator:
+    image: ghcr.io/milvus-io/talon-coordinator:latest
+    build:
+      context: ../..
+      dockerfile: deploy/docker/coordinator.Dockerfile
+    command: ["--cluster-id", "lab", "--node-id", "coord-0"]
+    environment:
+      TALON_COORDINATOR_STATE_BACKEND: memory
+    ports:
+      - "7000:7000"
+      - "8000:8000" # UI + API: http://127.0.0.1:8000/ui
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8000/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+  # --- cache worker: reads from Azurite THROUGH the proxy ------------------
+  worker:
+    image: ghcr.io/milvus-io/talon-worker:latest
+    build:
+      context: ../..
+      dockerfile: deploy/docker/worker.Dockerfile
+    command:
+      - "--coordinator"
+      - "coordinator:7000"
+      - "--cluster-id"
+      - "lab"
+      - "--node-id"
+      - "worker-0"
+    environment:
+      # Azurite well-known dev account (public, not a secret).
+      TALON_WORKER_AZURE_ACCOUNT: devstoreaccount1
+      TALON_WORKER_AZURE_SAS: "sv=lab&sig=lab"
+      # Target the emulator THROUGH the proxy: http -> plaintext + path-style.
+      TALON_WORKER_AZURE_ENDPOINT: "http://toxiproxy:10000"
+      # In-process latency layer (independent of the proxy). Off by default —
+      # uncomment to model first-byte latency + a bandwidth ceiling in the worker.
+      # TALON_WORKER_BACKEND_DELAY_MS: "200"
+      # TALON_WORKER_BACKEND_JITTER_MS: "80"
+      # TALON_WORKER_BACKEND_THROUGHPUT_BYTES: "104857600"  # 100 MB/s
+    ports:
+      - "8001:8001" # worker admin (metrics/health/status)
+    depends_on:
+      coordinator:
+        condition: service_healthy
+      toxiproxy:
+        condition: service_started
+
+  # --- one-shot: create a container + upload sample objects into Azurite ----
+  # Run explicitly: docker compose -f ... run --rm seed
+  seed:
+    image: mcr.microsoft.com/azure-cli:2.64.0
+    profiles: ["tools"]
+    depends_on:
+      azurite:
+        condition: service_healthy
+    environment:
+      # Full well-known Azurite connection string (public emulator credentials).
+      AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        az storage container create --name cache-demo
+        for i in 1 2 3; do
+          head -c 8388608 /dev/urandom > /tmp/obj-$i.bin
+          az storage blob upload --container-name cache-demo \
+            --name "obj-$i.bin" --file /tmp/obj-$i.bin --overwrite
+        done
+        echo "seeded cache-demo with 3x 8MiB objects"

--- a/deploy/testenv/toxics.sh
+++ b/deploy/testenv/toxics.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Attach a named latency/failure profile to the Azurite proxy via the Toxiproxy
+# admin API. Run against the latency lab (deploy/testenv/docker-compose.yml)
+# while it is up.
+#
+# Usage:
+#   ./deploy/testenv/toxics.sh <preset>
+#   ./deploy/testenv/toxics.sh clear        # remove all toxics
+#   ./deploy/testenv/toxics.sh list         # show current toxics
+#
+# Presets (model different object-store conditions):
+#   s3-warm           ~30ms first byte, small jitter — a nearby, warm bucket.
+#   s3-cold-longtail  ~150ms first byte + heavy tail jitter — cold/cross-region.
+#   throttled         ~50ms first byte + a ~10 MB/s bandwidth ceiling.
+#   flaky             adds a short timeout toxic so some requests stall out.
+#
+# The two latency layers compose: these network toxics stack on top of the
+# worker's in-process TALON_WORKER_BACKEND_* delay (if enabled).
+set -euo pipefail
+
+API="${TOXIPROXY_API:-http://127.0.0.1:8474}"
+PROXY="azurite"
+
+api() { # method path [data]
+  local method="$1" path="$2" data="${3:-}"
+  if [ -n "$data" ]; then
+    curl -fsS -X "$method" -H 'Content-Type: application/json' -d "$data" "$API$path"
+  else
+    curl -fsS -X "$method" "$API$path"
+  fi
+}
+
+clear_toxics() {
+  # Delete every toxic currently on the proxy.
+  local names
+  names=$(api GET "/proxies/$PROXY/toxics" | grep -o '"name":"[^"]*"' | cut -d'"' -f4 || true)
+  for n in $names; do
+    api DELETE "/proxies/$PROXY/toxics/$n" >/dev/null && echo "removed toxic: $n"
+  done
+}
+
+add() { # json
+  api POST "/proxies/$PROXY/toxics" "$1" >/dev/null
+}
+
+case "${1:-}" in
+  s3-warm)
+    clear_toxics
+    add '{"name":"latency","type":"latency","attributes":{"latency":30,"jitter":10}}'
+    echo "applied s3-warm: 30ms +/-10ms first-byte latency"
+    ;;
+  s3-cold-longtail)
+    clear_toxics
+    add '{"name":"latency","type":"latency","attributes":{"latency":150,"jitter":120}}'
+    echo "applied s3-cold-longtail: 150ms + heavy 120ms tail jitter"
+    ;;
+  throttled)
+    clear_toxics
+    add '{"name":"latency","type":"latency","attributes":{"latency":50,"jitter":15}}'
+    # bandwidth rate is in KB/s: 10240 KB/s ~= 10 MB/s.
+    add '{"name":"bandwidth","type":"bandwidth","attributes":{"rate":10240}}'
+    echo "applied throttled: 50ms latency + ~10 MB/s bandwidth ceiling"
+    ;;
+  flaky)
+    clear_toxics
+    add '{"name":"latency","type":"latency","attributes":{"latency":80,"jitter":40}}'
+    # Some connections stall for 2s then close, exercising the read timeout path.
+    add '{"name":"timeout","type":"timeout","toxicity":0.2,"attributes":{"timeout":2000}}'
+    echo "applied flaky: 80ms latency + 20% of connections time out after 2s"
+    ;;
+  clear)
+    clear_toxics
+    echo "cleared all toxics"
+    ;;
+  list)
+    api GET "/proxies/$PROXY/toxics"
+    echo
+    ;;
+  *)
+    echo "usage: $0 {s3-warm|s3-cold-longtail|throttled|flaky|clear|list}" >&2
+    exit 2
+    ;;
+esac

--- a/deploy/testenv/toxiproxy.json
+++ b/deploy/testenv/toxiproxy.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "azurite",
+    "listen": "0.0.0.0:10000",
+    "upstream": "azurite:10000",
+    "enabled": true
+  }
+]


### PR DESCRIPTION
## Summary
- Add `deploy/testenv/` — a self-contained object-store latency lab.
- **Azurite** serves real bytes locally; **Toxiproxy** in front injects network-layer latency/jitter/bandwidth/timeout; a memory coordinator + worker (pointed at the proxy via `TALON_WORKER_AZURE_ENDPOINT`) complete the stack.
- `seed` container uploads three 8 MiB sample objects; `toxics.sh` applies named presets (`s3-warm`, `s3-cold-longtail`, `throttled`, `flaky`).
- The worker's in-process delay decorator (from #243) can layer on top via commented `TALON_WORKER_BACKEND_*` env.
- CI `docker-build` job validates the compose file parses (default + `tools` profile).

Part of the object-store latency lab (#233), sub-issue #237.

## Test plan
- [x] `bash -n toxics.sh`; typos clean
- [ ] CI `docker image build` validates `docker compose config` for the new stack
- [ ] CI green