### PR TITLE
feat(fuse): writable FS layer with per-handle dirty buffer

### DIFF
--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -1,15 +1,17 @@
-//! Read-only FUSE operation logic.
+//! FUSE operation logic (read + write).
 //!
-//! v1 exposes the cache as a **read-only** filesystem. This module implements
-//! the request-handling logic behind the six read ops — `lookup`, `getattr`,
-//! `readdir`, `open`, `read`, `release` — decoupled from the `fuser` mount
-//! callbacks so it is unit-testable without a kernel mount. The mount layer is a
-//! thin adapter that translates `fuser` calls into these methods and back.
+//! This module implements the request-handling logic behind the filesystem ops
+//! — `lookup`, `getattr`, `readdir`, `open`, `read`, `release` for the read path,
+//! and `create`, `write`, `truncate`, `unlink` for the write path (#226/#231) —
+//! decoupled from the `fuser` mount callbacks so it is unit-testable without a
+//! kernel mount. The mount layer is a thin adapter that translates `fuser` calls
+//! into these methods and back.
 //!
 //! Paths under the mount mirror the backend namespace (`/s3/<bucket>/<key…>`,
-//! see [`crate::mapping`]). Directories are synthesized from the path
-//! hierarchy; files correspond to objects. Every mutating operation is rejected
-//! with [`FsError::ReadOnly`] so the filesystem is enforced read-only.
+//! see [`crate::mapping`]). Directories are synthesized from the path hierarchy;
+//! files correspond to objects. Writes accumulate into a per-handle whole-object
+//! buffer (object stores replace whole objects, not byte ranges); the assembled
+//! object is written through to the backend at flush.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -92,6 +94,21 @@ struct Inner {
     // Open file handles -> the inode they reference.
     handles: HashMap<u64, u64>,
     next_fh: u64,
+    // Write handles -> their in-progress whole-object buffer. A handle opened for
+    // write accumulates bytes here (random-offset writes land by position); the
+    // assembled object is taken at flush/release and written through to the
+    // backend (#226/#231). v1 buffers in memory (objects are single-block/small);
+    // a temp-file-backed buffer for large objects is future work.
+    dirty: HashMap<u64, DirtyFile>,
+}
+
+/// A per-write-handle whole-object buffer.
+struct DirtyFile {
+    /// The file inode this handle writes.
+    ino: u64,
+    /// The object contents assembled so far (extended with zeros for sparse
+    /// writes past the current end).
+    buf: Vec<u8>,
 }
 
 impl Default for ReadOnlyFs {
@@ -122,6 +139,7 @@ impl ReadOnlyFs {
                 next_ino: ROOT_INO + 1,
                 handles: HashMap::new(),
                 next_fh: 1,
+                dirty: HashMap::new(),
             }),
         }
     }
@@ -247,10 +265,18 @@ impl ReadOnlyFs {
         Ok(fh)
     }
 
-    /// `release`: drop a previously opened handle.
+    /// `release`: drop a previously opened handle (read or write), discarding any
+    /// write buffer. The caller is expected to have already flushed a dirty write
+    /// handle's contents (writeback happens on flush, #232).
     pub fn release(&self, fh: u64) -> Result<(), FsError> {
         let mut g = self.inner.lock().unwrap();
-        g.handles.remove(&fh).map(|_| ()).ok_or(FsError::BadHandle)
+        let had_dirty = g.dirty.remove(&fh).is_some();
+        let had_handle = g.handles.remove(&fh).is_some();
+        if had_handle || had_dirty {
+            Ok(())
+        } else {
+            Err(FsError::BadHandle)
+        }
     }
 
     /// The mount-relative object path + size for an open file handle.
@@ -267,6 +293,187 @@ impl ReadOnlyFs {
             return Err(FsError::Unsupported);
         }
         Ok((node.path.clone(), node.size))
+    }
+
+    // ----- write path (#231) -----------------------------------------------
+
+    /// `create`: make a new empty file `name` under directory `parent_ino` and
+    /// open it for writing.
+    ///
+    /// Inserts a `File` node (size 0) into the namespace and returns
+    /// `(attr, fh)` where `fh` is a write handle backed by an empty dirty buffer.
+    /// Fails with [`FsError::NotFound`] if `parent_ino` is not a directory, or
+    /// [`FsError::ReadOnly`] if the name already exists (v1 uses O_TRUNC-style
+    /// whole-object creation; opening an existing file for write is
+    /// [`open_write`](Self::open_write)).
+    pub fn create(&self, parent_ino: u64, name: &str) -> Result<(Attr, u64), FsError> {
+        let mut g = self.inner.lock().unwrap();
+        let parent = g.nodes.get(&parent_ino).ok_or(FsError::NotFound)?;
+        if parent.kind != FileKind::Directory {
+            return Err(FsError::NotFound);
+        }
+        if g.index.contains_key(&(parent_ino, name.to_string())) {
+            return Err(FsError::ReadOnly);
+        }
+        // Build the child's mount-relative path from its ancestors.
+        let path = {
+            let mut parts = Self::ancestry(&g, parent_ino);
+            parts.push(name.to_string());
+            parts.join("/")
+        };
+        let ino = g.next_ino;
+        g.next_ino += 1;
+        let node = Node {
+            ino,
+            name: name.to_string(),
+            kind: FileKind::File,
+            size: 0,
+            children: Vec::new(),
+            path,
+        };
+        g.nodes.insert(ino, node);
+        g.index.insert((parent_ino, name.to_string()), ino);
+        g.nodes.get_mut(&parent_ino).unwrap().children.push(ino);
+        let fh = g.next_fh;
+        g.next_fh += 1;
+        g.handles.insert(fh, ino);
+        g.dirty.insert(
+            fh,
+            DirtyFile {
+                ino,
+                buf: Vec::new(),
+            },
+        );
+        let attr = Self::attr_of(g.nodes.get(&ino).unwrap());
+        Ok((attr, fh))
+    }
+
+    /// Open an existing file `ino` for writing, starting from an empty buffer
+    /// (whole-object rewrite, `O_TRUNC` semantics for v1). Returns a write handle.
+    ///
+    /// In-place edit of existing contents (`O_RDWR` without truncate) would need
+    /// to first fetch the current object into the buffer; that is future work.
+    pub fn open_write(&self, ino: u64) -> Result<u64, FsError> {
+        let mut g = self.inner.lock().unwrap();
+        let kind = g.nodes.get(&ino).ok_or(FsError::NotFound)?.kind;
+        if kind != FileKind::File {
+            return Err(FsError::Unsupported);
+        }
+        let fh = g.next_fh;
+        g.next_fh += 1;
+        g.handles.insert(fh, ino);
+        g.dirty.insert(
+            fh,
+            DirtyFile {
+                ino,
+                buf: Vec::new(),
+            },
+        );
+        // A truncating open resets the visible size immediately.
+        if let Some(node) = g.nodes.get_mut(&ino) {
+            node.size = 0;
+        }
+        Ok(fh)
+    }
+
+    /// `write`: write `data` at `offset` into the write handle's buffer.
+    ///
+    /// Random-offset writes land by position; a write past the current end
+    /// extends the buffer with zeros (sparse). Updates the node's visible size.
+    /// Returns the number of bytes written. Fails with [`FsError::BadHandle`] for
+    /// a handle not opened for write.
+    pub fn write(&self, fh: u64, offset: u64, data: &[u8]) -> Result<u32, FsError> {
+        let mut g = self.inner.lock().unwrap();
+        let dirty = g.dirty.get_mut(&fh).ok_or(FsError::BadHandle)?;
+        let start = offset as usize;
+        let end = start + data.len();
+        if dirty.buf.len() < end {
+            dirty.buf.resize(end, 0);
+        }
+        dirty.buf[start..end].copy_from_slice(data);
+        let ino = dirty.ino;
+        let new_size = g.dirty.get(&fh).unwrap().buf.len() as u64;
+        if let Some(node) = g.nodes.get_mut(&ino) {
+            node.size = node.size.max(new_size);
+        }
+        Ok(data.len() as u32)
+    }
+
+    /// `setattr(size)`: truncate/extend the write handle's buffer to `size`.
+    pub fn truncate(&self, fh: u64, size: u64) -> Result<(), FsError> {
+        let mut g = self.inner.lock().unwrap();
+        let dirty = g.dirty.get_mut(&fh).ok_or(FsError::BadHandle)?;
+        dirty.buf.resize(size as usize, 0);
+        let ino = dirty.ino;
+        if let Some(node) = g.nodes.get_mut(&ino) {
+            node.size = size;
+        }
+        Ok(())
+    }
+
+    /// Return the assembled object bytes for a write handle (for writeback at
+    /// flush/release), leaving the handle's buffer in place so a later flush is a
+    /// no-op unless more is written. Returns `None` for a non-write handle.
+    pub fn dirty_bytes(&self, fh: u64) -> Option<Vec<u8>> {
+        let g = self.inner.lock().unwrap();
+        g.dirty.get(&fh).map(|d| d.buf.clone())
+    }
+
+    /// The mount-relative object path a write handle targets.
+    pub fn dirty_path(&self, fh: u64) -> Option<String> {
+        let g = self.inner.lock().unwrap();
+        let ino = g.dirty.get(&fh)?.ino;
+        g.nodes.get(&ino).map(|n| n.path.clone())
+    }
+
+    /// `unlink`: remove file `name` under directory `parent_ino` from the
+    /// namespace. Returns the removed file's mount-relative path so the caller
+    /// can delete the backend object. Directories are not removed here.
+    pub fn unlink(&self, parent_ino: u64, name: &str) -> Result<String, FsError> {
+        let mut g = self.inner.lock().unwrap();
+        let ino = *g
+            .index
+            .get(&(parent_ino, name.to_string()))
+            .ok_or(FsError::NotFound)?;
+        let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
+        if node.kind != FileKind::File {
+            return Err(FsError::Unsupported);
+        }
+        let path = node.path.clone();
+        g.nodes.remove(&ino);
+        g.index.remove(&(parent_ino, name.to_string()));
+        if let Some(parent) = g.nodes.get_mut(&parent_ino) {
+            parent.children.retain(|c| *c != ino);
+        }
+        Ok(path)
+    }
+
+    /// Build the ancestry name chain (root-excluded) of `ino`, e.g.
+    /// `["s3", "bucket", "data"]`, so a child path can be formed on `create`.
+    fn ancestry(g: &Inner, ino: u64) -> Vec<String> {
+        // Walk children from root is O(n); instead find each node's parent by
+        // scanning the index. For the shallow synthetic tree this is fine.
+        let mut names = Vec::new();
+        let mut cur = ino;
+        while cur != ROOT_INO {
+            let node = match g.nodes.get(&cur) {
+                Some(n) => n,
+                None => break,
+            };
+            names.push(node.name.clone());
+            // Find the parent whose children contain `cur`.
+            let parent = g
+                .nodes
+                .iter()
+                .find(|(_, n)| n.children.contains(&cur))
+                .map(|(p, _)| *p);
+            match parent {
+                Some(p) => cur = p,
+                None => break,
+            }
+        }
+        names.reverse();
+        names
     }
 }
 
@@ -394,5 +601,91 @@ mod tests {
 
         // Unknown handle → BadHandle; directory open is rejected upstream.
         assert_eq!(fs.file_meta(9999), Err(FsError::BadHandle));
+    }
+
+    #[test]
+    fn create_write_assembles_object_and_updates_size() {
+        let fs = fs();
+        let data = fs
+            .lookup(fs.lookup(ROOT_INO, "s3").unwrap().ino, "bucket")
+            .unwrap();
+        let dir = fs.lookup(data.ino, "data").unwrap();
+        let (attr, fh) = fs.create(dir.ino, "new.bin").unwrap();
+        assert_eq!(attr.kind, FileKind::File);
+        assert_eq!(attr.size, 0);
+        // The new file is visible in the namespace at its full path.
+        assert_eq!(fs.dirty_path(fh).as_deref(), Some("s3/bucket/data/new.bin"));
+
+        // Sequential then random-offset writes assemble the whole object.
+        assert_eq!(fs.write(fh, 0, b"hello ").unwrap(), 6);
+        assert_eq!(fs.write(fh, 6, b"world").unwrap(), 5);
+        // Overwrite a slice in the middle.
+        assert_eq!(fs.write(fh, 0, b"HELLO").unwrap(), 5);
+        assert_eq!(fs.dirty_bytes(fh).unwrap(), b"HELLO world");
+        // Node size reflects the assembled length.
+        assert_eq!(fs.getattr(attr.ino).unwrap().size, 11);
+    }
+
+    #[test]
+    fn write_past_end_extends_with_zeros() {
+        let fs = ReadOnlyFs::new();
+        let (_, fh) = fs.create(ROOT_INO, "sparse.bin").unwrap();
+        // Write at offset 5 with nothing before → bytes 0..5 are zero-filled.
+        fs.write(fh, 5, b"XY").unwrap();
+        assert_eq!(fs.dirty_bytes(fh).unwrap(), vec![0, 0, 0, 0, 0, b'X', b'Y']);
+    }
+
+    #[test]
+    fn truncate_resizes_buffer_and_size() {
+        let fs = ReadOnlyFs::new();
+        let (attr, fh) = fs.create(ROOT_INO, "t.bin").unwrap();
+        fs.write(fh, 0, b"0123456789").unwrap();
+        fs.truncate(fh, 4).unwrap();
+        assert_eq!(fs.dirty_bytes(fh).unwrap(), b"0123");
+        assert_eq!(fs.getattr(attr.ino).unwrap().size, 4);
+        // Extend.
+        fs.truncate(fh, 6).unwrap();
+        assert_eq!(
+            fs.dirty_bytes(fh).unwrap(),
+            vec![b'0', b'1', b'2', b'3', 0, 0]
+        );
+    }
+
+    #[test]
+    fn unlink_removes_node_and_returns_path() {
+        let fs = fs();
+        let bucket = fs
+            .lookup(fs.lookup(ROOT_INO, "s3").unwrap().ino, "bucket")
+            .unwrap();
+        let dir = fs.lookup(bucket.ino, "data").unwrap();
+        // a.bin exists.
+        assert!(fs.lookup(dir.ino, "a.bin").is_ok());
+        let path = fs.unlink(dir.ino, "a.bin").unwrap();
+        assert_eq!(path, "s3/bucket/data/a.bin");
+        // Now gone from the namespace.
+        assert_eq!(fs.lookup(dir.ino, "a.bin"), Err(FsError::NotFound));
+        // Unlinking a missing name errors.
+        assert_eq!(fs.unlink(dir.ino, "a.bin"), Err(FsError::NotFound));
+    }
+
+    #[test]
+    fn write_and_release_handle_lifecycle() {
+        let fs = ReadOnlyFs::new();
+        let (_, fh) = fs.create(ROOT_INO, "x.bin").unwrap();
+        assert!(fs.dirty_bytes(fh).is_some());
+        fs.release(fh).unwrap();
+        // After release the write buffer is gone.
+        assert!(fs.dirty_bytes(fh).is_none());
+        assert_eq!(fs.write(fh, 0, b"z"), Err(FsError::BadHandle));
+    }
+
+    #[test]
+    fn create_rejects_existing_name() {
+        let fs = fs();
+        let bucket = fs
+            .lookup(fs.lookup(ROOT_INO, "s3").unwrap().ino, "bucket")
+            .unwrap();
+        let dir = fs.lookup(bucket.ino, "data").unwrap();
+        assert_eq!(fs.create(dir.ino, "a.bin"), Err(FsError::ReadOnly));
     }
 }


### PR DESCRIPTION
Part of #226 (FUSE write-through). Closes #231.

## Summary
Extends the ops layer with the write path that makes arbitrary-offset writes possible over a whole-object-PUT backend: a write handle accumulates all writes into a **per-handle whole-object buffer**, materialized at flush (#232 does the writeback).

- **`create(parent, name)`**: new File node (size 0) + write handle with an empty buffer; rejects an existing name.
- **`open_write(ino)`**: existing file, truncating whole-object rewrite (O_TRUNC). In-place O_RDWR edit is future work.
- **`write(fh, offset, data)`**: writes at offset; random-offset writes land by position, past-end zero-fills (sparse); updates node size.
- **`truncate`/`unlink`** (unlink returns the path so the caller deletes the backend object); **`dirty_bytes`/`dirty_path`** for writeback; `release` drops the buffer.

**Notes:** v1 buffers in memory (single-block/small objects, matching the worker limit); temp-file-backed buffering for large objects is future work. The `ReadOnlyFs` name is kept to avoid a wide rename; its doc now states it supports writes.

## Testing
create + sequential/random/overwrite assembly + size; past-end zero-fill; truncate; unlink returns path; release drops buffer; create rejects existing name. `fmt`/`clippy -D warnings`/`test`/`doc` clean (fuse lib 68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)