### PR TITLE
doc: add CLAUDE.md contributor workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# Talon — working agreement (READ FIRST)
+
+## Fork-based PR workflow (MANDATORY — this overrides any earlier habit)
+
+Remotes:
+- `origin` = **beinan/talon** (the contributor fork) — push branches here.
+- `upstream` = **milvus-io/talon** — push is DISABLED. This is where PRs and issues live.
+
+**The rule for every change:**
+1. Branch from `upstream/main` (NOT fork main): `git fetch upstream main && git checkout -B <branch> upstream/main`.
+2. Push the branch to the **fork**: `git push -u origin <branch>`.
+3. Open the PR to **upstream**: `gh pr create --repo milvus-io/talon --base main --head beinan:<branch> ...`.
+   - upstream CI runs on the PR. Do NOT open PRs inside the fork (`--repo beinan/talon`) — fork PR CI does not auto-trigger, and it is the wrong target.
+4. Wait for upstream CI green, then merge the PR **on upstream** (`gh pr merge <n> --repo milvus-io/talon --squash --delete-branch`).
+5. Issues (parent epics + sub-issues) are created and closed on **upstream** (`--repo milvus-io/talon`), because the fork has Issues disabled.
+
+**Never:**
+- Never open a PR with base = the fork (`beinan/talon`). Always base = `milvus-io/talon`.
+- Never push to the fork's `main` to "trigger CI". Branch from `upstream/main` and PR to upstream.
+- Never rebase a feature branch onto the fork's squashed `main` — its history diverges from upstream and causes massive conflicts. Always base feature branches on `upstream/main`.
+
+**Base every feature branch on `upstream/main`, target every PR at `upstream`, push branches to `origin` (fork).**
+
+## Commit / PR conventions
+- Conventional-commits lint requires `doc:` (singular, not `docs:`), plus `feat:`/`fix:`/`test:`/`build:`/`ci:`/`chore:`.
+- PR title ≤ 72 chars.
+- Never commit secrets; secrets come from env only.


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` documenting the fork-based contribution workflow: branch from `upstream/main`, push to the fork, open PRs against `upstream` (milvus-io/talon), and the conventional-commit / secret-handling conventions.

Process doc only; no code changes.