### PR TITLE
doc: clarify one-PR-at-a-time contributor loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,17 @@ Remotes:
 - `origin` = **beinan/talon** (the contributor fork) — push branches here.
 - `upstream` = **milvus-io/talon** — push is DISABLED. This is where PRs and issues live.
 
-**The rule for every change:**
+**The loop — ONE PR at a time, repeat for every sub-task:**
 1. Branch from `upstream/main` (NOT fork main): `git fetch upstream main && git checkout -B <branch> upstream/main`.
-2. Push the branch to the **fork**: `git push -u origin <branch>`.
-3. Open the PR to **upstream**: `gh pr create --repo milvus-io/talon --base main --head beinan:<branch> ...`.
+2. Implement + commit.
+3. Push the branch to the **fork**: `git push -u origin <branch>`.
+4. Open the PR to **upstream**: `gh pr create --repo milvus-io/talon --base main --head beinan:<branch> ...`.
    - upstream CI runs on the PR. Do NOT open PRs inside the fork (`--repo beinan/talon`) — fork PR CI does not auto-trigger, and it is the wrong target.
-4. Wait for upstream CI green, then merge the PR **on upstream** (`gh pr merge <n> --repo milvus-io/talon --squash --delete-branch`).
-5. Issues (parent epics + sub-issues) are created and closed on **upstream** (`--repo milvus-io/talon`), because the fork has Issues disabled.
+5. **Wait for upstream CI to go green** (a Docker Hub timeout is infra flake → `gh run rerun <run-id> --failed`, not a code issue).
+6. **Merge on upstream**: `gh pr merge <n> --repo milvus-io/talon --squash --delete-branch`. Close the sub-issue.
+7. **Go back to step 1** for the next sub-task — always re-branch fresh from the now-updated `upstream/main`. Never stack the next branch on the previous one.
+
+Issues (parent epics + sub-issues) are created and closed on **upstream** (`--repo milvus-io/talon`), because the fork has Issues disabled.
 
 **Never:**
 - Never open a PR with base = the fork (`beinan/talon`). Always base = `milvus-io/talon`.


### PR DESCRIPTION
## Summary
- Expand `CLAUDE.md` with the explicit per-PR loop: branch from `upstream/main` → push to fork → PR to upstream → wait for CI green → merge on upstream → re-branch fresh for the next task.
- Note that a Docker Hub pull timeout is infra flake (rerun the failed job), not a code failure.

Process doc only.