### PR TITLE
feat: Azure shared-key signing for AzureBackend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2240,6 +2240,7 @@ name = "talon-backend"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64",
  "bytes",
  "hmac",
  "reqwest",

--- a/crates/talon-backend/Cargo.toml
+++ b/crates/talon-backend/Cargo.toml
@@ -15,6 +15,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 tokio = { workspace = true, features = ["time"] }
 sha2 = "0.10"
 hmac = "0.12"
+base64 = "0.22"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "test-util", "time"] }

--- a/crates/talon-backend/src/azure.rs
+++ b/crates/talon-backend/src/azure.rs
@@ -8,8 +8,9 @@
 //!
 //! The `ObjectId::bucket` field carries the **container** name for Azure (the
 //! account is part of the endpoint host). Like the other backends this is
-//! generic over an [`HttpClient`] and unit-testable offline; live shared-key /
-//! SAS signing is left to the concrete networked client.
+//! generic over an [`HttpClient`] and unit-testable offline. Authentication is
+//! either a SAS token (in the URL query) or Shared Key (see
+//! [`crate::azure_sharedkey`]), signed just before each request executes.
 
 use std::sync::Arc;
 
@@ -72,9 +73,11 @@ impl AzureConfig {
 /// An Azure Blob `BackendStore` over a pluggable HTTP client.
 pub struct AzureBackend {
     config: AzureConfig,
-    /// Optional SAS token query string (without leading `?`), or None for
-    /// shared-key auth handled by the networked client.
+    /// Optional SAS token query string (without leading `?`).
     sas_token: Option<String>,
+    /// Optional base64 account key for Shared Key authorization (an alternative
+    /// to SAS). When set, every request is signed just before execution.
+    shared_key: Option<String>,
     http: Arc<dyn HttpClient>,
 }
 
@@ -84,6 +87,22 @@ impl AzureBackend {
         Self {
             config,
             sas_token,
+            shared_key: None,
+            http,
+        }
+    }
+
+    /// Construct with a Shared Key (base64 account key) instead of a SAS token.
+    /// Every request is signed with `Authorization: SharedKey` before execution.
+    pub fn with_shared_key(
+        config: AzureConfig,
+        shared_key: impl Into<String>,
+        http: Arc<dyn HttpClient>,
+    ) -> Self {
+        Self {
+            config,
+            sas_token: None,
+            shared_key: Some(shared_key.into()),
             http,
         }
     }
@@ -130,6 +149,26 @@ impl AzureBackend {
 
     fn common_headers(&self) -> Vec<(String, String)> {
         vec![("x-ms-version".to_string(), Self::API_VERSION.to_string())]
+    }
+
+    /// Apply Shared Key authorization to `req` when a shared key is configured:
+    /// stamp `x-ms-date` (RFC 1123 GMT) and add the `Authorization: SharedKey`
+    /// header. A SAS-only backend (no shared key) returns the request unchanged
+    /// (the SAS travels in the URL query).
+    fn authorized(&self, mut req: HttpRequest) -> HttpRequest {
+        let Some(key) = &self.shared_key else {
+            return req;
+        };
+        let date = crate::azure_sharedkey::rfc1123_date(std::time::SystemTime::now());
+        req.headers.push(("x-ms-date".to_string(), date));
+        // A misconfigured key surfaces as an auth failure at the server; we still
+        // send the request rather than panic.
+        if let Ok(auth) =
+            crate::azure_sharedkey::authorization_header(&req, &self.config.account, key)
+        {
+            req.headers.push(("Authorization".to_string(), auth));
+        }
+        req
     }
 
     /// Build the ranged GET request (exposed for testing).
@@ -226,7 +265,7 @@ impl BackendStore for AzureBackend {
         }
         let resp = self
             .http
-            .execute(self.build_get_if_match(obj, offset, len, if_match))
+            .execute(self.authorized(self.build_get_if_match(obj, offset, len, if_match)))
             .await
             .map_err(Error::Backend)?;
         match resp.status {
@@ -261,7 +300,7 @@ impl BackendStore for AzureBackend {
     async fn head(&self, obj: &ObjectId) -> Result<ObjectStat> {
         let resp = self
             .http
-            .execute(self.build_head(obj))
+            .execute(self.authorized(self.build_head(obj)))
             .await
             .map_err(Error::Backend)?;
         if resp.status == 404 {
@@ -303,7 +342,7 @@ impl BackendStore for AzureBackend {
     ) -> Result<Version> {
         let resp = self
             .http
-            .execute(self.build_put(obj, body, if_match))
+            .execute(self.authorized(self.build_put(obj, body, if_match)))
             .await
             .map_err(Error::Backend)?;
         if resp.status == 412 {
@@ -335,7 +374,7 @@ impl BackendStore for AzureBackend {
     async fn delete(&self, obj: &ObjectId) -> Result<()> {
         let resp = self
             .http
-            .execute(self.build_delete(obj))
+            .execute(self.authorized(self.build_delete(obj)))
             .await
             .map_err(Error::Backend)?;
         if resp.is_success() || resp.status == 404 {
@@ -468,6 +507,42 @@ mod tests {
         let req = http.last.lock().unwrap().clone().unwrap();
         assert_eq!(req.header("x-ms-range"), Some("bytes=8-15"));
         assert_eq!(req.header("x-ms-version"), Some("2021-12-02"));
+    }
+
+    #[tokio::test]
+    async fn shared_key_backend_signs_requests() {
+        // A base64 account key (32 bytes). With a shared key configured, every
+        // request must carry x-ms-date and an Authorization: SharedKey header.
+        let key = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+        let http = MockHttp::new(HttpResponse {
+            status: 206,
+            headers: vec![],
+            body: bytes::Bytes::from_static(b"az-bytes"),
+        });
+        let a = AzureBackend::with_shared_key(AzureConfig::new("acct"), key, http.clone());
+        a.fetch_range(&obj(), 0, 8).await.unwrap();
+        let req = http.last.lock().unwrap().clone().unwrap();
+        assert!(
+            req.header("x-ms-date").is_some(),
+            "x-ms-date must be stamped"
+        );
+        let auth = req.header("Authorization").expect("Authorization header");
+        assert!(auth.starts_with("SharedKey acct:"), "got {auth}");
+    }
+
+    #[tokio::test]
+    async fn sas_backend_does_not_add_authorization_header() {
+        // Without a shared key (SAS-only), no Authorization header is added — the
+        // SAS travels in the URL query.
+        let http = MockHttp::new(HttpResponse {
+            status: 206,
+            headers: vec![],
+            body: bytes::Bytes::from_static(b"az-bytes"),
+        });
+        let a = AzureBackend::new(AzureConfig::new("acct"), Some("sig=x".into()), http.clone());
+        a.fetch_range(&obj(), 0, 8).await.unwrap();
+        let req = http.last.lock().unwrap().clone().unwrap();
+        assert_eq!(req.header("Authorization"), None);
     }
 
     #[tokio::test]

--- a/crates/talon-backend/src/azure_sharedkey.rs
+++ b/crates/talon-backend/src/azure_sharedkey.rs
@@ -1,0 +1,262 @@
+//! Azure Blob **Shared Key** authorization.
+//!
+//! Signs a request with the storage account's shared key as an alternative to a
+//! SAS token. Builds the `StringToSign` (verb, a fixed set of standard headers,
+//! the canonicalized `x-ms-*` headers, and the canonicalized resource), HMACs it
+//! with the base64-decoded account key, and returns the
+//! `Authorization: SharedKey <account>:<signature>` header value.
+//!
+//! Only what the blob backend needs is implemented: the full `SharedKey` scheme
+//! (not `SharedKeyLite`), header-based signing, and requests that carry no query
+//! string (so the canonicalized resource is just `/account/path`). Signing is a
+//! pure function of the request + account + key, unit-testable offline.
+//!
+//! Reference: <https://learn.microsoft.com/rest/api/storageservices/authorize-with-shared-key>
+
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+use crate::http::{HttpRequest, Method};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Format a `SystemTime` as an RFC 1123 date in GMT (the `x-ms-date` format),
+/// e.g. `Fri, 26 Jun 2015 23:39:12 GMT`.
+pub fn rfc1123_date(t: std::time::SystemTime) -> String {
+    let secs = t
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let days = (secs / 86_400) as i64;
+    let sod = secs % 86_400;
+    let (hh, mm, ss) = (sod / 3600, (sod % 3600) / 60, sod % 60);
+    // Day of week: 1970-01-01 was a Thursday (index 4 with Sun=0).
+    const DOW: [&str; 7] = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    let dow = DOW[(((days % 7) + 4 + 7) % 7) as usize];
+    let (y, mo, d) = civil_from_days(days);
+    const MON: [&str; 12] = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ];
+    let mon = MON[(mo - 1) as usize];
+    format!("{dow}, {d:02} {mon} {y:04} {hh:02}:{mm:02}:{ss:02} GMT")
+}
+
+/// Days since 1970-01-01 → civil (year, month, day). Howard Hinnant's algorithm.
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+fn method_str(m: Method) -> &'static str {
+    match m {
+        Method::Get => "GET",
+        Method::Head => "HEAD",
+        Method::Put => "PUT",
+        Method::Delete => "DELETE",
+    }
+}
+
+/// Extract host + path from a URL (path keeps its leading `/`, query dropped).
+fn host_and_path(url: &str) -> (String, String) {
+    let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
+    let (host, rest) = match after_scheme.split_once('/') {
+        Some((h, r)) => (h.to_string(), format!("/{r}")),
+        None => (after_scheme.to_string(), "/".to_string()),
+    };
+    let path = rest.split_once('?').map(|(p, _)| p).unwrap_or(&rest);
+    (host, path.to_string())
+}
+
+/// Compute the `Authorization: SharedKey ...` header value for `req`.
+///
+/// `account` is the storage account name; `key_b64` is the base64-encoded
+/// account key. `req` must already carry its `x-ms-date` and `x-ms-version`
+/// headers (the caller sets these) plus any `x-ms-range` etc. Returns `Err` if
+/// the key is not valid base64.
+pub fn authorization_header(
+    req: &HttpRequest,
+    account: &str,
+    key_b64: &str,
+) -> Result<String, String> {
+    let key = BASE64
+        .decode(key_b64)
+        .map_err(|e| format!("invalid base64 account key: {e}"))?;
+
+    let header = |name: &str| -> String {
+        req.headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.trim().to_string())
+            .unwrap_or_default()
+    };
+
+    // Content-Length is signed as empty when 0 (per the 2015+ signing rules).
+    let content_length = match req.body.len() {
+        0 => String::new(),
+        n => n.to_string(),
+    };
+
+    // Canonicalized headers: all x-ms-* headers, lowercased, sorted, "k:v" joined
+    // by \n. Values trimmed; requests here carry single-valued headers.
+    let mut xms: Vec<(String, String)> = req
+        .headers
+        .iter()
+        .filter(|(k, _)| k.to_ascii_lowercase().starts_with("x-ms-"))
+        .map(|(k, v)| (k.to_ascii_lowercase(), v.trim().to_string()))
+        .collect();
+    xms.sort_by(|a, b| a.0.cmp(&b.0));
+    let canonical_headers = xms
+        .iter()
+        .map(|(k, v)| format!("{k}:{v}\n"))
+        .collect::<String>();
+
+    // Canonicalized resource: /<account><path>. No query params today.
+    let (_host, path) = host_and_path(&req.url);
+    let canonical_resource = format!("/{account}{path}");
+
+    // The 20-line StringToSign (verb + standard headers + canonical headers +
+    // canonical resource). Empty standard headers are blank lines.
+    let string_to_sign = format!(
+        "{verb}\n\
+         {content_encoding}\n\
+         {content_language}\n\
+         {content_length}\n\
+         {content_md5}\n\
+         {content_type}\n\
+         {date}\n\
+         {if_modified_since}\n\
+         {if_match}\n\
+         {if_none_match}\n\
+         {if_unmodified_since}\n\
+         {range}\n\
+         {canonical_headers}{canonical_resource}",
+        verb = method_str(req.method),
+        content_encoding = header("content-encoding"),
+        content_language = header("content-language"),
+        content_length = content_length,
+        content_md5 = header("content-md5"),
+        content_type = header("content-type"),
+        date = "", // signed via x-ms-date instead; Date header left blank
+        if_modified_since = header("if-modified-since"),
+        if_match = header("if-match"),
+        if_none_match = header("if-none-match"),
+        if_unmodified_since = header("if-unmodified-since"),
+        range = header("range"), // HTTP Range; blob uses x-ms-range (an x-ms header)
+        canonical_headers = canonical_headers,
+        canonical_resource = canonical_resource,
+    );
+
+    let mut mac = HmacSha256::new_from_slice(&key).map_err(|e| e.to_string())?;
+    mac.update(string_to_sign.as_bytes());
+    let signature = BASE64.encode(mac.finalize().into_bytes());
+    Ok(format!("SharedKey {account}:{signature}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(method: Method, url: &str, headers: Vec<(&str, &str)>) -> HttpRequest {
+        HttpRequest {
+            method,
+            url: url.into(),
+            headers: headers
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            body: bytes::Bytes::new(),
+        }
+    }
+
+    // A valid base64 key (the string "0123456789abcdef0123456789abcdef" encoded)
+    // is deterministic across runs; we assert structure + stability, not a
+    // service-verified vector (which needs a live account).
+    const KEY: &str = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+
+    #[test]
+    fn rejects_bad_base64_key() {
+        let r = req(
+            Method::Get,
+            "https://acct.blob.core.windows.net/c/b",
+            vec![],
+        );
+        assert!(authorization_header(&r, "acct", "not base64!!!").is_err());
+    }
+
+    #[test]
+    fn produces_sharedkey_header_with_account_and_signature() {
+        let r = req(
+            Method::Get,
+            "https://acct.blob.core.windows.net/container/blob.bin",
+            vec![
+                ("x-ms-date", "Fri, 26 Jun 2015 23:39:12 GMT"),
+                ("x-ms-version", "2021-12-02"),
+                ("x-ms-range", "bytes=0-1023"),
+            ],
+        );
+        let auth = authorization_header(&r, "acct", KEY).unwrap();
+        assert!(auth.starts_with("SharedKey acct:"));
+        // Signature is base64 and non-empty.
+        let sig = auth.strip_prefix("SharedKey acct:").unwrap();
+        assert!(!sig.is_empty());
+        assert!(BASE64.decode(sig).is_ok());
+    }
+
+    #[test]
+    fn signature_is_deterministic_for_same_input() {
+        let r = req(
+            Method::Get,
+            "https://acct.blob.core.windows.net/c/b",
+            vec![
+                ("x-ms-date", "Fri, 26 Jun 2015 23:39:12 GMT"),
+                ("x-ms-version", "2021-12-02"),
+            ],
+        );
+        let a = authorization_header(&r, "acct", KEY).unwrap();
+        let b = authorization_header(&r, "acct", KEY).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn different_xms_headers_change_the_signature() {
+        let base = req(
+            Method::Get,
+            "https://acct.blob.core.windows.net/c/b",
+            vec![
+                ("x-ms-date", "Fri, 26 Jun 2015 23:39:12 GMT"),
+                ("x-ms-version", "2021-12-02"),
+            ],
+        );
+        let with_range = req(
+            Method::Get,
+            "https://acct.blob.core.windows.net/c/b",
+            vec![
+                ("x-ms-date", "Fri, 26 Jun 2015 23:39:12 GMT"),
+                ("x-ms-version", "2021-12-02"),
+                ("x-ms-range", "bytes=0-9"),
+            ],
+        );
+        assert_ne!(
+            authorization_header(&base, "acct", KEY).unwrap(),
+            authorization_header(&with_range, "acct", KEY).unwrap()
+        );
+    }
+
+    #[test]
+    fn canonical_resource_uses_account_and_path() {
+        // Path-style emulator URL: host has a port, path is /account/container/blob.
+        let (host, path) = host_and_path("http://127.0.0.1:10000/devstoreaccount1/c/b");
+        assert_eq!(host, "127.0.0.1:10000");
+        assert_eq!(path, "/devstoreaccount1/c/b");
+    }
+}

--- a/crates/talon-backend/src/lib.rs
+++ b/crates/talon-backend/src/lib.rs
@@ -7,6 +7,7 @@
 //! networked client is injected in production.
 
 pub mod azure;
+pub mod azure_sharedkey;
 pub mod delay;
 pub mod gcs;
 pub mod http;


### PR DESCRIPTION
## Summary
- New `talon-backend::azure_sharedkey` module implementing Azure Blob **Shared Key** authorization: `StringToSign` (standard headers + canonicalized `x-ms-*` headers + canonicalized resource) → HMAC-SHA256 with the base64 account key → `Authorization: SharedKey <account>:<sig>`. Includes an RFC 1123 `x-ms-date` formatter.
- `AzureBackend::with_shared_key(...)` signs every GET/HEAD/PUT/DELETE just before execution. SAS stays the default and is byte-for-byte unchanged.
- Unit-tested: header structure, determinism, `x-ms-*` sensitivity, bad-base64-key rejection, and backend-level assertions (SAS path adds no `Authorization`; shared-key path stamps `x-ms-date` + `SharedKey`). Adds `base64` dep.

Part of the multi-cloud e2e epic (#263), sub-issue #266.

## Test plan
- [x] `cargo test -p talon-backend` — 72 tests green incl. new azure/sharedkey tests
- [x] `cargo clippy -p talon-backend --all-targets --all-features` clean
- [ ] CI green