### PR TITLE
feat(transport): add io_uring frame reader for the monoio data plane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-const-array"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd73835ad7deb4bd2b389e6f10333b143f025d607c55ca04c66a0bcc6bb2fc6d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +231,12 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -568,6 +585,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +720,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +842,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hmac"
@@ -957,7 +1001,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -1083,6 +1127,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595a0399f411a508feb2ec1e970a4a30c249351e30208960d58298de8660b0e5"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -1333,10 +1387,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "mio"
@@ -1350,10 +1425,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "monoio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd0f8bcde87b1949f95338b547543fcab187bc7e7a5024247e359a5e828ba6a"
+dependencies = [
+ "auto-const-array",
+ "bytes",
+ "flume",
+ "fxhash",
+ "io-uring",
+ "libc",
+ "memchr",
+ "mio 0.8.11",
+ "monoio-macros",
+ "nix",
+ "once_cell",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "threadpool",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "monoio-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176a5f5e69613d9e88337cf2a65e11135332b4efbcc628404a7c555e4452084c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1371,6 +1502,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1535,6 +1676,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,7 +1777,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "memchr",
  "unicase",
 ]
@@ -1657,7 +1804,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -1695,7 +1842,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -1783,7 +1930,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1885,7 +2032,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1991,7 +2138,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2167,12 +2314,31 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -2335,6 +2501,7 @@ name = "talon-transport"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "monoio",
  "serde",
  "talon-core",
  "thiserror 2.0.19",
@@ -2436,6 +2603,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,11 +2644,11 @@ checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.2",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2585,7 +2761,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
- "socket2",
+ "socket2 0.6.5",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2661,7 +2837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "base64",
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -2965,11 +3141,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2983,19 +3168,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3005,9 +3211,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3023,9 +3241,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3035,9 +3265,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 libc = "0.2"
 clap = { version = "4", features = ["derive"] }
 divan = "0.1"
+# Thread-per-core io_uring runtime for the data plane (#273, #285). The "sync"
+# feature provides spawn_blocking, which the zero-copy sendfile/splice path
+# needs to stay off the ring; it requires an explicitly attached thread pool.
+monoio = { version = "0.2.4", features = ["sync"] }
 axum = "0.8"
 serde_yaml = "0.9"
 # Kubernetes client for the Lease-based ClusterStateStore backend (feature

--- a/crates/talon-transport/Cargo.toml
+++ b/crates/talon-transport/Cargo.toml
@@ -13,5 +13,6 @@ serde.workspace = true
 bincode.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+monoio.workspace = true
 
 [dev-dependencies]

--- a/crates/talon-transport/src/lib.rs
+++ b/crates/talon-transport/src/lib.rs
@@ -15,6 +15,7 @@ pub mod data;
 pub mod frame;
 pub mod limits;
 pub mod pool;
+pub mod uring;
 
 pub use codec::{
     decode, encode, encode_for_schema, CodecError, ControlMessage, ObjectEntry,

--- a/crates/talon-transport/src/uring.rs
+++ b/crates/talon-transport/src/uring.rs
@@ -1,0 +1,334 @@
+//! Frame I/O for the io_uring (monoio) data plane.
+//!
+//! This is the completion-based counterpart to [`crate::limits::read_frame`].
+//! The two exist side by side because the runtimes have incompatible I/O
+//! models, not because the wire format differs — both read the identical
+//! [`FrameHeader`] and payload bytes, and both enforce the identical limits.
+//!
+//! # Why a separate function
+//!
+//! Tokio's `AsyncRead` **borrows** a buffer for the duration of a read. io_uring
+//! is completion-based: the kernel owns the buffer while the operation is in
+//! flight, so monoio's [`AsyncReadRent`] instead **moves** the buffer in and
+//! hands it back with the result. A borrowed-buffer signature cannot be made
+//! sound over a completion ring, so the reader is rewritten rather than
+//! abstracted over both.
+//!
+//! # Limits are preserved verbatim
+//!
+//! The DoS protections from issue #111 are the reason this module cannot be a
+//! thin wrapper, and they are reimplemented exactly:
+//!
+//! - the advertised length is checked against the **per-message-type cap**
+//!   ([`max_payload_for`]) *before* the payload buffer is allocated, so a peer
+//!   cannot pin a 320 MiB allocation by lying about a control frame's size;
+//! - both the header and payload reads are bounded by a **timeout**, so a peer
+//!   that stalls mid-frame is dropped rather than holding the buffer forever;
+//! - a clean EOF at a frame boundary is [`ReadFrameError::Eof`], not an error.
+//!
+//! Connection-count limiting is orthogonal and still provided by
+//! [`crate::limits::ConnectionLimit`], which is runtime-agnostic.
+
+use std::io;
+use std::time::Duration;
+
+use monoio::io::{AsyncReadRent, AsyncReadRentExt, AsyncWriteRent, AsyncWriteRentExt};
+
+use crate::frame::{FrameHeader, HEADER_LEN};
+use crate::limits::{max_payload_for, ReadFrameError};
+
+/// Read exactly one frame from `stream`, allocating the payload buffer **only
+/// after** the message type's size cap is satisfied, and bounding each read
+/// with `timeout`.
+///
+/// Returns the decoded header and the raw payload bytes. A clean EOF at a frame
+/// boundary is [`ReadFrameError::Eof`].
+///
+/// This is [`crate::limits::read_frame`] for a monoio stream; see the module
+/// docs for why the two cannot share an implementation.
+pub async fn read_frame<S>(
+    stream: &mut S,
+    timeout: Duration,
+) -> Result<(FrameHeader, Vec<u8>), ReadFrameError>
+where
+    S: AsyncReadRent,
+{
+    // Header. `read_exact` returns (result, buffer) because the kernel owned
+    // the buffer for the duration of the operation.
+    let header_buf = vec![0u8; HEADER_LEN];
+    let (res, header_buf) =
+        match monoio::time::timeout(timeout, stream.read_exact(header_buf)).await {
+            Ok(pair) => pair,
+            Err(_) => return Err(ReadFrameError::Timeout),
+        };
+    match res {
+        Ok(n) if n == HEADER_LEN => {}
+        // A short read at a frame boundary is a clean disconnect.
+        Ok(_) => return Err(ReadFrameError::Eof),
+        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Err(ReadFrameError::Eof),
+        Err(e) => return Err(ReadFrameError::Io(e)),
+    }
+
+    // Decode (validates magic/version/type and the global max), then enforce the
+    // per-type cap BEFORE allocating the payload.
+    let header = FrameHeader::decode(&header_buf)?;
+    let cap = max_payload_for(header.msg_type);
+    if header.length > cap {
+        return Err(ReadFrameError::PayloadTooLarge {
+            msg_type: header.msg_type,
+            length: header.length,
+            cap,
+        });
+    }
+
+    if header.length == 0 {
+        return Ok((header, Vec::new()));
+    }
+
+    let payload = vec![0u8; header.length as usize];
+    let (res, payload) = match monoio::time::timeout(timeout, stream.read_exact(payload)).await {
+        Ok(pair) => pair,
+        Err(_) => return Err(ReadFrameError::Timeout),
+    };
+    match res {
+        Ok(n) if n == header.length as usize => Ok((header, payload)),
+        // The header promised more than arrived: the peer went away mid-frame.
+        Ok(_) => Err(ReadFrameError::Io(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "payload truncated",
+        ))),
+        Err(e) => Err(ReadFrameError::Io(e)),
+    }
+}
+
+/// Write a whole buffer to a monoio stream, returning the buffer.
+///
+/// monoio's `write_all` moves the buffer into the kernel and returns it, so
+/// callers that reuse a buffer get it back; callers that do not can drop it.
+/// Errors are surfaced as [`io::Error`], matching the Tokio path.
+pub async fn write_all<S>(stream: &mut S, buf: Vec<u8>) -> io::Result<Vec<u8>>
+where
+    S: AsyncWriteRent,
+{
+    let (res, buf) = stream.write_all(buf).await;
+    res?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frame::MsgType;
+    use crate::limits::{MAX_CONTROL_PAYLOAD_LEN, MAX_PING_PAYLOAD_LEN};
+    use monoio::net::{TcpListener, TcpStream};
+
+    const T: Duration = Duration::from_secs(5);
+
+    /// Build a runtime with a blocking pool attached (monoio panics without one).
+    /// Run `fut` on a fresh io_uring runtime with the timer enabled.
+    fn run<F: std::future::Future>(fut: F) -> F::Output {
+        monoio::RuntimeBuilder::<monoio::IoUringDriver>::new()
+            .enable_timer()
+            .build()
+            .expect("io_uring runtime")
+            .block_on(fut)
+    }
+
+    fn frame(msg_type: MsgType, payload: &[u8]) -> Vec<u8> {
+        let header = FrameHeader::new(msg_type, 7, payload.len() as u32);
+        let mut buf = header.encode().to_vec();
+        buf.extend_from_slice(payload);
+        buf
+    }
+
+    /// Serve `script` bytes to one client, then optionally hold the connection
+    /// open so the reader hits its timeout rather than EOF.
+    async fn serve_once(listener: TcpListener, script: Vec<u8>, hold: bool) {
+        let (mut s, _) = listener.accept().await.unwrap();
+        let (r, _) = s.write_all(script).await;
+        r.unwrap();
+        if hold {
+            // Never send the rest; let the reader time out.
+            monoio::time::sleep(Duration::from_secs(30)).await;
+        }
+    }
+
+    #[test]
+    fn reads_a_frame_and_its_payload() {
+        run(async {
+            let l = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = l.local_addr().unwrap();
+            let payload = b"hello uring".to_vec();
+            let script = frame(MsgType::GetRange, &payload);
+            monoio::spawn(serve_once(l, script, false));
+
+            let mut c = TcpStream::connect(addr).await.unwrap();
+            let (h, p) = read_frame(&mut c, T).await.unwrap();
+            assert_eq!(h.msg_type, MsgType::GetRange);
+            assert_eq!(h.request_id, 7);
+            assert_eq!(p, payload);
+        });
+    }
+
+    /// A zero-length payload must not allocate or block on a second read.
+    #[test]
+    fn reads_an_empty_payload_frame() {
+        run(async {
+            let l = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = l.local_addr().unwrap();
+            monoio::spawn(serve_once(l, frame(MsgType::Ping, &[]), false));
+
+            let mut c = TcpStream::connect(addr).await.unwrap();
+            let (h, p) = read_frame(&mut c, T).await.unwrap();
+            assert_eq!(h.msg_type, MsgType::Ping);
+            assert!(p.is_empty());
+        });
+    }
+
+    /// Clean disconnect at a frame boundary is Eof, not an error.
+    #[test]
+    fn clean_eof_at_frame_boundary() {
+        run(async {
+            let l = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = l.local_addr().unwrap();
+            monoio::spawn(async move {
+                let (s, _) = l.accept().await.unwrap();
+                drop(s);
+            });
+
+            let mut c = TcpStream::connect(addr).await.unwrap();
+            assert!(matches!(
+                read_frame(&mut c, T).await,
+                Err(ReadFrameError::Eof)
+            ));
+        });
+    }
+
+    /// The per-type cap is enforced BEFORE the payload is allocated — the whole
+    /// point of issue #111. A control frame advertising a data-plane-sized
+    /// payload must be rejected without committing that memory.
+    #[test]
+    fn rejects_oversized_control_payload_before_allocating() {
+        run(async {
+            let l = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = l.local_addr().unwrap();
+            // Header only: advertise a huge length and send no payload at all.
+            // If the reader allocated first, it would block here instead of
+            // returning immediately.
+            let header = FrameHeader::new(MsgType::Control, 1, MAX_CONTROL_PAYLOAD_LEN + 1);
+            monoio::spawn(serve_once(l, header.encode().to_vec(), true));
+
+            let mut c = TcpStream::connect(addr).await.unwrap();
+            match read_frame(&mut c, T).await {
+                Err(ReadFrameError::PayloadTooLarge {
+                    msg_type,
+                    length,
+                    cap,
+                }) => {
+                    assert_eq!(msg_type, MsgType::Control);
+                    assert_eq!(length, MAX_CONTROL_PAYLOAD_LEN + 1);
+                    assert_eq!(cap, MAX_CONTROL_PAYLOAD_LEN);
+                }
+                other => panic!("expected PayloadTooLarge, got {other:?}"),
+            }
+        });
+    }
+
+    /// A Ping carries no payload, so any advertised length is over its cap.
+    #[test]
+    fn rejects_ping_with_payload() {
+        run(async {
+            let l = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = l.local_addr().unwrap();
+            let header = FrameHeader::new(MsgType::Ping, 1, 1);
+            monoio::spawn(serve_once(l, header.encode().to_vec(), true));
+
+            let mut c = TcpStream::connect(addr).await.unwrap();
+            match read_frame(&mut c, T).await {
+                Err(ReadFrameError::PayloadTooLarge { cap, .. }) => {
+                    assert_eq!(cap, MAX_PING_PAYLOAD_LEN);
+                }
+                other => panic!("expected PayloadTooLarge, got {other:?}"),
+            }
+        });
+    }
+
+    /// A peer that sends a header and then stalls must be dropped, not allowed
+    /// to pin the payload buffer indefinitely.
+    #[test]
+    fn times_out_a_stalled_payload() {
+        run(async {
+            let l = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = l.local_addr().unwrap();
+            // Valid header promising 64 bytes, then silence.
+            let header = FrameHeader::new(MsgType::GetRange, 1, 64);
+            monoio::spawn(serve_once(l, header.encode().to_vec(), true));
+
+            let mut c = TcpStream::connect(addr).await.unwrap();
+            let started = std::time::Instant::now();
+            assert!(matches!(
+                read_frame(&mut c, Duration::from_millis(200)).await,
+                Err(ReadFrameError::Timeout)
+            ));
+            assert!(started.elapsed() < Duration::from_secs(5));
+        });
+    }
+
+    /// A truncated payload (peer disconnects mid-frame) is an I/O error, not a
+    /// silently short frame that would desync the protocol.
+    #[test]
+    fn truncated_payload_is_an_error() {
+        run(async {
+            let l = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = l.local_addr().unwrap();
+            let header = FrameHeader::new(MsgType::GetRange, 1, 64);
+            let mut script = header.encode().to_vec();
+            script.extend_from_slice(&[0u8; 10]); // 10 of the promised 64
+            monoio::spawn(serve_once(l, script, false));
+
+            let mut c = TcpStream::connect(addr).await.unwrap();
+            assert!(matches!(
+                read_frame(&mut c, T).await,
+                Err(ReadFrameError::Io(_))
+            ));
+        });
+    }
+
+    /// Two frames on one connection: the reader must leave the stream positioned
+    /// exactly at the next frame boundary.
+    #[test]
+    fn reads_consecutive_frames() {
+        run(async {
+            let l = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = l.local_addr().unwrap();
+            let mut script = frame(MsgType::GetRange, b"first");
+            script.extend_from_slice(&frame(MsgType::GetRange, b"second"));
+            monoio::spawn(serve_once(l, script, false));
+
+            let mut c = TcpStream::connect(addr).await.unwrap();
+            let (_, p1) = read_frame(&mut c, T).await.unwrap();
+            let (_, p2) = read_frame(&mut c, T).await.unwrap();
+            assert_eq!(p1, b"first");
+            assert_eq!(p2, b"second");
+        });
+    }
+
+    /// The write helper returns the buffer so callers can reuse it.
+    #[test]
+    fn write_all_returns_the_buffer() {
+        run(async {
+            let l = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = l.local_addr().unwrap();
+            monoio::spawn(async move {
+                let (mut s, _) = l.accept().await.unwrap();
+                let (r, b) = s.read_exact(vec![0u8; 4]).await;
+                r.unwrap();
+                assert_eq!(b, b"ping");
+            });
+
+            let mut c = TcpStream::connect(addr).await.unwrap();
+            let returned = write_all(&mut c, b"ping".to_vec()).await.unwrap();
+            assert_eq!(returned, b"ping");
+        });
+    }
+}


### PR DESCRIPTION
First step of #285. **Purely additive** — adds `transport::uring` alongside the existing Tokio frame reader, with no caller changes, so it can land and be verified in isolation.

## Why a second reader instead of an abstraction

Tokio's `AsyncRead` **borrows** a buffer for the duration of a read. io_uring is completion-based: the kernel owns the buffer while the operation is in flight, so monoio's `AsyncReadRent` **moves** it in and hands it back with the result:

```rust
// tokio
stream.read_exact(&mut buf).await?;

// monoio
let (res, buf) = stream.read_exact(buf).await;
```

A borrowed-buffer signature cannot be made sound over a completion ring, so the reader is rewritten rather than made generic over both. The wire format is identical — same `FrameHeader`, same payload bytes.

## The limits are the point

`read_frame`'s DoS protections (#111) are what make this more than a thin wrapper, and they are reimplemented verbatim with tests that fail if they regress:

| protection | test |
|---|---|
| per-type cap checked **before** allocating | `rejects_oversized_control_payload_before_allocating` — sends a header claiming `MAX_CONTROL_PAYLOAD_LEN + 1` and **no payload**; if the reader allocated first it would block instead of returning immediately |
| Ping carries no payload | `rejects_ping_with_payload` |
| timeout on a stalled peer | `times_out_a_stalled_payload` — header then silence; asserts it returns well inside the deadline |
| clean EOF is `Eof`, not an error | `clean_eof_at_frame_boundary` |
| truncated payload is an error, not a short frame | `truncated_payload_is_an_error` — would otherwise desync the protocol |
| stream left at the next frame boundary | `reads_consecutive_frames` |

Plus the happy paths: a normal frame, a zero-length payload (must not allocate or block on a second read), and the write helper returning its buffer for reuse.

Ten tests, all on a **real io_uring runtime over loopback TCP**. CI can execute them — the capability probe in #281 confirmed `PROBE_RESULT=SUPPORTED` on `ubuntu-latest`, which is why this needs no feature gate.

## Dependency note

`monoio` is added with the `sync` feature, which provides the `spawn_blocking` the zero-copy `sendfile` path will need to stay off the ring. Worth knowing for the next PR: unlike tokio's, it requires an explicitly attached thread pool and **panics at runtime without one** (`execute blocking task without thread pool attached`).

## Verification

- `cargo test --workspace --all-features --locked` — 28 suites pass, including the 10 new ones
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo doc --workspace --no-deps --all-features` — clean

## Next in #285

Thread-per-core accept loop behind a config flag, then porting `handle_conn`/`handle_put`/`handle_delete` to use this reader.

Refs #285, #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
