### PR TITLE
feat(worker): thread-per-core io_uring data-plane runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2520,6 +2520,7 @@ dependencies = [
  "clap",
  "divan",
  "libc",
+ "monoio",
  "serde_json",
  "talon-backend",
  "talon-core",

--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -103,6 +103,15 @@ pub struct WorkerConfig {
     pub backend_jitter_ms: Option<u64>,
     /// Optional bandwidth ceiling (bytes/second) modeled by the delay decorator.
     pub backend_throughput_bytes: Option<u64>,
+    /// Number of io_uring rings serving the data plane, or `None` for the
+    /// portable Tokio path.
+    ///
+    /// `Some(n)` runs the thread-per-core data plane: `n` threads, each with its
+    /// own `monoio` ring pinned to a core, all binding the listen address with
+    /// `SO_REUSEPORT` so the kernel distributes accepts. `Some(0)` means one
+    /// ring per available core. Defaults to `None` while the Tokio path remains
+    /// the shipped default (#285).
+    pub data_plane_rings: Option<usize>,
 }
 
 /// Read the Azure SAS token from the environment (`TALON_WORKER_AZURE_SAS`).
@@ -134,6 +143,7 @@ impl Default for WorkerConfig {
             backend_delay_ms: None,
             backend_jitter_ms: None,
             backend_throughput_bytes: None,
+            data_plane_rings: None,
         }
     }
 }
@@ -175,6 +185,8 @@ pub struct WorkerConfigPatch {
     pub backend_jitter_ms: Option<u64>,
     /// Override for [`WorkerConfig::backend_throughput_bytes`].
     pub backend_throughput_bytes: Option<u64>,
+    /// Override for [`WorkerConfig::data_plane_rings`].
+    pub data_plane_rings: Option<usize>,
 }
 
 impl Patch for WorkerConfigPatch {
@@ -197,6 +209,7 @@ impl Patch for WorkerConfigPatch {
             backend_throughput_bytes: self
                 .backend_throughput_bytes
                 .or(base.backend_throughput_bytes),
+            data_plane_rings: self.data_plane_rings.or(base.data_plane_rings),
         }
     }
 }
@@ -326,6 +339,14 @@ pub const WORKER_ENV_SCHEMA: &[ConfigVar] = &[
         help: "Synthetic backend bandwidth ceiling in bytes/sec (test/latency lab).",
     },
     ConfigVar {
+        env: "TALON_WORKER_DATA_PLANE_RINGS",
+        key: "data_plane_rings",
+        default: None,
+        cli: true,
+        secret: false,
+        help: "io_uring rings for the data plane; 0 = one per core, unset = Tokio path.",
+    },
+    ConfigVar {
         env: "TALON_WORKER_AZURE_SAS",
         key: "(env only)",
         default: None,
@@ -351,6 +372,7 @@ pub(crate) mod worker_env {
     pub const BACKEND_DELAY_MS: &str = "TALON_WORKER_BACKEND_DELAY_MS";
     pub const BACKEND_JITTER_MS: &str = "TALON_WORKER_BACKEND_JITTER_MS";
     pub const BACKEND_THROUGHPUT_BYTES: &str = "TALON_WORKER_BACKEND_THROUGHPUT_BYTES";
+    pub const DATA_PLANE_RINGS: &str = "TALON_WORKER_DATA_PLANE_RINGS";
     pub const AZURE_SAS: &str = "TALON_WORKER_AZURE_SAS";
 }
 
@@ -392,6 +414,10 @@ impl WorkerConfigPatch {
             v.parse::<u64>()
                 .map_err(|_| Error::Other(format!("{k}: invalid u64: {v:?}")))
         };
+        let parse_usize = |v: String, k: &str| {
+            v.parse::<usize>()
+                .map_err(|_| Error::Other(format!("{k}: invalid usize: {v:?}")))
+        };
         Ok(Self {
             listen: get(worker_env::LISTEN),
             advertise_addr: get(worker_env::ADVERTISE_ADDR),
@@ -417,6 +443,9 @@ impl WorkerConfigPatch {
                 .transpose()?,
             backend_jitter_ms: get(worker_env::BACKEND_JITTER_MS)
                 .map(|v| parse_u64(v, worker_env::BACKEND_JITTER_MS))
+                .transpose()?,
+            data_plane_rings: get(worker_env::DATA_PLANE_RINGS)
+                .map(|v| parse_usize(v, worker_env::DATA_PLANE_RINGS))
                 .transpose()?,
             backend_throughput_bytes: get(worker_env::BACKEND_THROUGHPUT_BYTES)
                 .map(|v| parse_u64(v, worker_env::BACKEND_THROUGHPUT_BYTES))
@@ -462,6 +491,7 @@ impl WorkerConfig {
             backend_throughput_bytes: merged
                 .backend_throughput_bytes
                 .or(d.backend_throughput_bytes),
+            data_plane_rings: merged.data_plane_rings.or(d.data_plane_rings),
         };
         cfg.validate()?;
         Ok(cfg)

--- a/crates/talon-worker/Cargo.toml
+++ b/crates/talon-worker/Cargo.toml
@@ -32,6 +32,7 @@ async-trait.workspace = true
 clap.workspace = true
 xxhash-rust.workspace = true
 libc.workspace = true
+monoio.workspace = true
 serde_json.workspace = true
 axum.workspace = true
 

--- a/crates/talon-worker/src/lib.rs
+++ b/crates/talon-worker/src/lib.rs
@@ -17,6 +17,7 @@ pub mod runtime;
 pub mod sendfile;
 pub mod splice;
 pub mod staging;
+pub mod uring_serve;
 
 pub use block_store::WholeBlockStore;
 pub use capacity::{CacheDirConfig, CacheDirs};

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -78,6 +78,12 @@ struct Args {
     /// Logical block size in bytes.
     #[arg(long)]
     block_size: Option<u32>,
+    /// Serve the data plane on N io_uring rings (thread-per-core).
+    ///
+    /// `0` means one ring per available core. Omit to use the portable Tokio
+    /// data plane, which remains the default (#285).
+    #[arg(long)]
+    data_plane_rings: Option<usize>,
 }
 
 impl Args {
@@ -91,6 +97,7 @@ impl Args {
             node_id: self.node_id,
             heartbeat_interval_ms: self.heartbeat_interval_ms,
             block_size: self.block_size,
+            data_plane_rings: self.data_plane_rings,
             cache_dirs: None,
             capacity_bytes: None,
             azure_account: None,

--- a/crates/talon-worker/src/uring_serve.rs
+++ b/crates/talon-worker/src/uring_serve.rs
@@ -204,6 +204,24 @@ mod tests {
         }
     }
 
+    /// Wait for `counter` to reach `want`, or panic after a deadline.
+    ///
+    /// The handler increments *after* writing its response, so a client can
+    /// observe its echo before the server-side increment is visible. Asserting
+    /// the count immediately is therefore racy — poll instead.
+    fn await_count(counter: &AtomicUsize, want: usize) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while counter.load(Ordering::Relaxed) < want {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "counter reached {} of {want}",
+                counter.load(Ordering::Relaxed)
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert_eq!(counter.load(Ordering::Relaxed), want);
+    }
+
     fn client_roundtrip(addr: &str, payload: &[u8; 4]) -> Vec<u8> {
         use std::io::{Read, Write};
         let mut s = std::net::TcpStream::connect(addr).unwrap();
@@ -248,7 +266,7 @@ mod tests {
             assert_eq!(client_roundtrip(&addr, b"ping"), b"ping");
         }
 
-        assert_eq!(served.load(Ordering::Relaxed), 40, "all requests served");
+        await_count(&served, 40);
         // The kernel hashes by 4-tuple, so distribution is not guaranteed to be
         // even — but with 40 distinct ephemeral ports across 4 rings it must
         // land on more than one thread. This is what proves the accepts really
@@ -291,6 +309,6 @@ mod tests {
             client_roundtrip(&addr, b"ping");
         }
         // One shared counter, incremented from whichever ring served.
-        assert_eq!(served.load(Ordering::Relaxed), 10);
+        await_count(&served, 10);
     }
 }

--- a/crates/talon-worker/src/uring_serve.rs
+++ b/crates/talon-worker/src/uring_serve.rs
@@ -1,0 +1,296 @@
+//! Thread-per-core io_uring data-plane runtime (#285).
+//!
+//! monoio has no work-stealing scheduler. It scales by running N independent
+//! single-threaded runtimes — one per core — that share nothing. This module
+//! provides that shape for the worker's data plane:
+//!
+//! - **one ring per thread**, each pinned to a core with `bind_to_cpu_set`, so
+//!   a connection's protocol scheduling never migrates between cores;
+//! - **`SO_REUSEPORT`**, so every ring binds the same listen address and the
+//!   *kernel* distributes accepts by 4-tuple hash. There is no shared accept
+//!   queue and no thundering herd;
+//! - **a per-ring blocking pool**, because the zero-copy `sendfile`/`splice`
+//!   syscalls are blocking and must never run on a ring (a slow client would
+//!   otherwise stall every connection that ring owns).
+//!
+//! Measured at 8.05x scaling on 8 rings, with per-core throughput flat from 1
+//! to 16 rings — i.e. no cross-ring contention (#273).
+//!
+//! # What is *not* sharded
+//!
+//! Shared worker state stays shared. Benchmarks showed that sharding
+//! `BlockIndex` per ring costs 30-67% in cross-ring forwarding (connections are
+//! distributed by TCP 4-tuple, blocks by `block_id`, so ~1/N of requests land
+//! on the owning ring), and that per-shard eviction budgets waste capacity —
+//! with 256 MiB blocks over 64 GiB there are only ~256 slots, far too few for
+//! hash uniformity. So each ring holds an `Arc` of the same `WorkerRuntime`.
+//! That is sound: `!Send` constrains *futures crossing threads*, not shared
+//! state read from within a ring.
+
+use std::sync::Arc;
+
+/// How many rings to run for a configured value.
+///
+/// `Some(0)` means "one per available core"; any other `Some(n)` is taken
+/// literally. Callers pass the resolved count to [`serve`].
+pub fn resolve_ring_count(configured: usize) -> usize {
+    if configured > 0 {
+        return configured;
+    }
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+}
+
+/// A per-ring connection handler.
+///
+/// Each ring calls this once per accepted connection, on its own thread, with
+/// its own ring driving the future. The future is deliberately **not** `Send`:
+/// it never leaves the thread that accepted the connection.
+pub trait RingHandler: Clone + 'static {
+    /// Serve one accepted connection to completion.
+    fn handle(
+        &self,
+        stream: monoio::net::TcpStream,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
+}
+
+/// Run the data plane on `rings` io_uring rings bound to `addr`.
+///
+/// Blocks until every ring thread exits. Each thread:
+/// 1. pins itself to a core,
+/// 2. builds an `IoUringDriver` runtime with `blocking_threads` helper threads
+///    for `sendfile`,
+/// 3. binds `addr` with `SO_REUSEPORT` and accepts forever.
+///
+/// `handler` is cloned per ring; share state through an `Arc` inside it.
+///
+/// # Errors
+///
+/// Returns an error if a ring thread fails to bind. A bind failure on *any*
+/// ring is fatal rather than degraded-but-running: a worker silently serving on
+/// fewer rings than configured would be an invisible capacity loss.
+pub fn serve<H>(
+    addr: String,
+    rings: usize,
+    blocking_threads: usize,
+    handler: H,
+) -> anyhow::Result<()>
+where
+    H: RingHandler + Send,
+{
+    let ready = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let mut threads = Vec::with_capacity(rings);
+
+    for ring_id in 0..rings {
+        let addr = addr.clone();
+        let handler = handler.clone();
+        let ready = Arc::clone(&ready);
+        threads.push(
+            std::thread::Builder::new()
+                .name(format!("talon-ring-{ring_id}"))
+                .spawn(move || {
+                    // Pin before building the ring so its memory is allocated on the
+                    // node this thread will actually run on. A failure here is not
+                    // fatal — pinning is an optimization, not a correctness
+                    // requirement — but it is worth surfacing.
+                    if let Err(e) = monoio::utils::bind_to_cpu_set(vec![ring_id]) {
+                        tracing::warn!(ring = ring_id, error = ?e, "could not pin ring to core");
+                    }
+
+                    // The blocking pool is what keeps sendfile off the ring. monoio
+                    // panics if spawn_blocking is called without one attached, so
+                    // this is not optional.
+                    let pool = monoio::blocking::DefaultThreadPool::new(blocking_threads);
+                    let mut rt = match monoio::RuntimeBuilder::<monoio::IoUringDriver>::new()
+                        .attach_thread_pool(Box::new(pool))
+                        .enable_timer()
+                        .build()
+                    {
+                        Ok(rt) => rt,
+                        Err(e) => {
+                            ready.lock().unwrap().push(format!("ring {ring_id}: {e}"));
+                            return;
+                        }
+                    };
+
+                    rt.block_on(async move {
+                        // SO_REUSEPORT is default-true in ListenerConfig: every ring
+                        // binds the same address and the kernel spreads accepts.
+                        let cfg = monoio::net::ListenerConfig::default();
+                        let listener =
+                            match monoio::net::TcpListener::bind_with_config(addr.as_str(), &cfg) {
+                                Ok(l) => l,
+                                Err(e) => {
+                                    ready.lock().unwrap().push(format!("ring {ring_id}: {e}"));
+                                    return;
+                                }
+                            };
+                        tracing::info!(ring = ring_id, %addr, "data-plane ring listening");
+
+                        loop {
+                            let (stream, peer) = match listener.accept().await {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    tracing::warn!(ring = ring_id, error = %e, "accept failed");
+                                    continue;
+                                }
+                            };
+                            let _ = stream.set_nodelay(true);
+                            let handler = handler.clone();
+                            monoio::spawn(async move {
+                                if let Err(e) = handler.handle(stream).await {
+                                    tracing::debug!(?peer, error = %e, "connection ended");
+                                }
+                            });
+                        }
+                    });
+                })?,
+        );
+    }
+
+    for t in threads {
+        let _ = t.join();
+    }
+    let errors = ready.lock().unwrap();
+    if !errors.is_empty() {
+        anyhow::bail!("data-plane ring startup failed: {}", errors.join("; "));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use monoio::io::{AsyncReadRentExt, AsyncWriteRentExt};
+    use std::collections::HashSet;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    #[test]
+    fn resolve_ring_count_honours_explicit_values() {
+        assert_eq!(resolve_ring_count(1), 1);
+        assert_eq!(resolve_ring_count(4), 4);
+    }
+
+    #[test]
+    fn resolve_ring_count_zero_means_one_per_core() {
+        let cores = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
+        assert_eq!(resolve_ring_count(0), cores);
+    }
+
+    /// Echo handler that records which OS thread served each connection and
+    /// counts connections through shared state.
+    #[derive(Clone)]
+    struct EchoHandler {
+        served: Arc<AtomicUsize>,
+        threads: Arc<Mutex<HashSet<std::thread::ThreadId>>>,
+    }
+
+    impl RingHandler for EchoHandler {
+        async fn handle(&self, mut stream: monoio::net::TcpStream) -> anyhow::Result<()> {
+            self.threads
+                .lock()
+                .unwrap()
+                .insert(std::thread::current().id());
+            let (res, buf) = stream.read_exact(vec![0u8; 4]).await;
+            res?;
+            let (res, _) = stream.write_all(buf).await;
+            res?;
+            self.served.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    fn client_roundtrip(addr: &str, payload: &[u8; 4]) -> Vec<u8> {
+        use std::io::{Read, Write};
+        let mut s = std::net::TcpStream::connect(addr).unwrap();
+        s.write_all(payload).unwrap();
+        let mut out = vec![0u8; 4];
+        s.read_exact(&mut out).unwrap();
+        out
+    }
+
+    /// Several rings bind the same port via SO_REUSEPORT, serve real traffic,
+    /// and share state through an Arc — the shape the data plane relies on.
+    #[test]
+    fn rings_share_a_port_and_serve_traffic() {
+        // Pick a free port, then release it so the rings can SO_REUSEPORT bind.
+        let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = probe.local_addr().unwrap().to_string();
+        drop(probe);
+
+        let served = Arc::new(AtomicUsize::new(0));
+        let threads = Arc::new(Mutex::new(HashSet::new()));
+        let handler = EchoHandler {
+            served: Arc::clone(&served),
+            threads: Arc::clone(&threads),
+        };
+
+        let serve_addr = addr.clone();
+        std::thread::spawn(move || {
+            let _ = serve(serve_addr, 4, 2, handler);
+        });
+
+        // Wait for at least one ring to bind.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            if std::net::TcpStream::connect(&addr).is_ok() {
+                break;
+            }
+            assert!(std::time::Instant::now() < deadline, "rings never bound");
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        for _ in 0..40 {
+            assert_eq!(client_roundtrip(&addr, b"ping"), b"ping");
+        }
+
+        assert_eq!(served.load(Ordering::Relaxed), 40, "all requests served");
+        // The kernel hashes by 4-tuple, so distribution is not guaranteed to be
+        // even — but with 40 distinct ephemeral ports across 4 rings it must
+        // land on more than one thread. This is what proves the accepts really
+        // are being spread rather than all handled by one ring.
+        let distinct = threads.lock().unwrap().len();
+        assert!(
+            distinct > 1,
+            "expected multiple rings to serve, got {distinct}"
+        );
+    }
+
+    /// A handler holding an Arc observes writes made from any ring: shared
+    /// state is genuinely shared, not per-ring copies.
+    #[test]
+    fn handler_state_is_shared_across_rings() {
+        let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = probe.local_addr().unwrap().to_string();
+        drop(probe);
+
+        let served = Arc::new(AtomicUsize::new(0));
+        let handler = EchoHandler {
+            served: Arc::clone(&served),
+            threads: Arc::new(Mutex::new(HashSet::new())),
+        };
+        let serve_addr = addr.clone();
+        std::thread::spawn(move || {
+            let _ = serve(serve_addr, 2, 1, handler);
+        });
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            if std::net::TcpStream::connect(&addr).is_ok() {
+                break;
+            }
+            assert!(std::time::Instant::now() < deadline, "rings never bound");
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        for _ in 0..10 {
+            client_roundtrip(&addr, b"ping");
+        }
+        // One shared counter, incremented from whichever ring served.
+        assert_eq!(served.load(Ordering::Relaxed), 10);
+    }
+}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -298,6 +298,14 @@ Synthetic backend bandwidth ceiling in bytes/sec (test/latency lab).
 - **Default:** none
 - **CLI flag:** not settable via CLI (config file or environment only)
 
+### `data_plane_rings`
+
+io_uring rings for the data plane; 0 = one per core, unset = Tokio path.
+
+- **Environment variable:** `TALON_WORKER_DATA_PLANE_RINGS`
+- **Default:** none
+- **CLI flag:** `--data_plane_rings`
+
 ### `(env only)` 🔒
 
 Azure SAS token; env-only, never from a config file or logged.


### PR DESCRIPTION
Second step of #285. Adds `talon_worker::uring_serve` — the thread-per-core runtime the data plane will run on — plus the `data_plane_rings` knob that selects it. **The Tokio path stays the default and is untouched**; nothing calls this module yet, so it lands and is verified in isolation.

## The model

monoio has no work-stealing scheduler. It scales by running N independent single-threaded runtimes that share nothing:

```rust
for ring_id in 0..rings {
    thread::spawn(move || {
        monoio::utils::bind_to_cpu_set(vec![ring_id]);           // pin to a core
        let pool = DefaultThreadPool::new(blocking_threads);      // sendfile stays off-ring
        RuntimeBuilder::<IoUringDriver>::new()
            .attach_thread_pool(Box::new(pool))
            .build()?
            .block_on(async {
                // SO_REUSEPORT is default-true: every ring binds the same addr
                let l = TcpListener::bind_with_config(&addr, &ListenerConfig::default())?;
                loop { monoio::spawn(handler.handle(l.accept().await?.0)); }
            });
    });
}
```

The kernel distributes accepts by 4-tuple hash — no shared accept queue, no thundering herd. Measured at **8.05× scaling on 8 rings**, per-core throughput flat from 1 to 16 (#273).

The per-ring blocking pool is **not optional**: `sendfile`/`splice` are blocking syscalls that must never run on a ring, or one slow client stalls every connection that ring owns. monoio also panics outright if `spawn_blocking` is called without a pool attached.

## What is deliberately *not* sharded

Shared worker state stays shared, because #273 measured the alternative and it loses twice:

- **Cross-ring forwarding: −30 to −67% throughput.** Connections are distributed by TCP 4-tuple; blocks key on `block_id`. The two hashes are independent, so only ~1/N of requests land on the owning ring — 75–87% forwarding at 8 shards.
- **Per-shard eviction budgets waste capacity: up to −5.1pt hit rate.** 256 MiB blocks over 64 GiB leave only ~256 slots (32/shard at 8 rings), far too few for hash uniformity, so some shards evict while others sit below capacity.

So each ring holds an `Arc` of the same `WorkerRuntime`. That is sound: **`!Send` constrains futures crossing threads, not shared state read from within a ring.** The `RingHandler` trait encodes this — its future is deliberately not `Send`.

## Failure semantics

A **bind failure on any ring is fatal**, not degraded-but-running: a worker silently serving on fewer rings than configured would be an invisible capacity loss. A **pinning failure only warns** — pinning is an optimization, not a correctness requirement.

## Configuration

| | |
|---|---|
| `--data-plane-rings <N>` / `TALON_WORKER_DATA_PLANE_RINGS` | |
| unset (default) | portable Tokio data plane |
| `0` | one ring per available core |
| `N` | exactly N rings |

Wired through all six config layers (struct, default, patch, merge, env parse, schema) and the reference docs regenerated.

## Tests

- `resolve_ring_count` — explicit values honoured; `0` resolves to core count
- `rings_share_a_port_and_serve_traffic` — 4 rings, 40 real TCP roundtrips, asserts **more than one thread served**. This is the test that matters: it proves `SO_REUSEPORT` is actually distributing accepts rather than one ring taking everything.
- `handler_state_is_shared_across_rings` — a counter behind an `Arc` sees increments from whichever ring served, proving shared state is genuinely shared rather than per-ring copies

## Verification

- `cargo test --workspace --all-features --locked` — 28 suites pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo doc --workspace --no-deps --all-features` — clean
- config reference regenerated and drift-checked against the schema

## Next in #285

Port `handle_conn` / `handle_put` / `handle_delete` to this runtime, where `sendfile_payload` *simplifies* — the `into_std` → `set_nonblocking` → `from_std` round-trip disappears.

Refs #285, #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
