### PR TITLE
feat(worker): wire the io_uring data plane behind data_plane_rings

### DIFF
--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -33,6 +33,7 @@ use talon_core::{
 use talon_transport::data;
 use talon_transport::frame::{MsgType, HEADER_LEN};
 use talon_transport::{codec, ControlMessage, FrameHeader};
+use talon_worker::uring_conn;
 use talon_worker::{
     send_file_range, serve_admin, BlockIndex, InFlightLoads, ServeOutcome, WholeBlockStore,
     WorkerObservability, WorkerRuntime, DEFAULT_CHUNK,
@@ -46,6 +47,11 @@ const CONTROL_OPERATION_TIMEOUT: Duration = Duration::from_secs(3);
 /// for an in-flight connection to finish rather than each spawning an unbounded
 /// task that could pin a payload buffer (issue #111).
 const MAX_DATA_PLANE_CONNECTIONS: usize = 1024;
+
+/// Blocking helper threads per io_uring ring, for the zero-copy `sendfile`
+/// path. Kept small because every ring has its own pool and the rings are
+/// pinned: a large pool per ring would oversubscribe the cores they sit on.
+const URING_BLOCKING_THREADS_PER_RING: usize = 4;
 
 /// Command-line arguments for a Talon worker.
 #[derive(Debug, Parser)]
@@ -279,7 +285,42 @@ async fn main() -> anyhow::Result<()> {
         Duration::from_millis(cfg.heartbeat_interval_ms),
     );
 
-    // Serve the data plane.
+    // Serve the data plane, on io_uring rings if configured (#285) or on the
+    // portable Tokio path otherwise.
+    if let Some(configured) = cfg.data_plane_rings {
+        let rings = talon_worker::uring_serve::resolve_ring_count(configured);
+        tracing::info!(
+            listen = %cfg.listen,
+            rings,
+            "worker serving data plane on io_uring rings"
+        );
+        // `serve` blocks until the ring threads exit, and it must run off the
+        // Tokio worker threads it is handing out — so drive it on a dedicated
+        // thread and park this task on the join.
+        let addr = cfg.listen.clone();
+        // The cap is per ring, so divide the global budget across them; the
+        // total admitted stays MAX_DATA_PLANE_CONNECTIONS regardless of how many
+        // rings are configured (#111).
+        let per_ring_connections = MAX_DATA_PLANE_CONNECTIONS.div_ceil(rings).max(1);
+        let handler = uring_conn::RingConnHandler::new(
+            Arc::clone(&worker),
+            Arc::clone(&observability),
+            per_ring_connections,
+        );
+        let tokio_handle = tokio::runtime::Handle::current();
+        let joined = tokio::task::spawn_blocking(move || {
+            talon_worker::uring_serve::serve(
+                addr,
+                rings,
+                URING_BLOCKING_THREADS_PER_RING,
+                handler,
+                tokio_handle,
+            )
+        })
+        .await?;
+        return joined;
+    }
+
     let listener = TcpListener::bind(&cfg.listen).await?;
     tracing::info!(listen = %cfg.listen, "worker serving data plane");
     // Bound concurrent connections so a flood of idle peers cannot exhaust

--- a/crates/talon-worker/src/uring_conn.rs
+++ b/crates/talon-worker/src/uring_conn.rs
@@ -336,7 +336,8 @@ async fn handle_delete(
     Ok(())
 }
 
-/// Adapts [`handle_conn`] to the ring runtime's [`RingHandler`] trait.
+/// Adapts [`handle_conn`] to the ring runtime's [`crate::uring_serve::RingHandler`]
+/// trait.
 ///
 /// Carries the shared worker state and enforces the same connection cap as the
 /// Tokio path (#111). The cap is **per ring**, not global: each ring owns an

--- a/crates/talon-worker/src/uring_conn.rs
+++ b/crates/talon-worker/src/uring_conn.rs
@@ -336,6 +336,49 @@ async fn handle_delete(
     Ok(())
 }
 
+/// Adapts [`handle_conn`] to the ring runtime's [`RingHandler`] trait.
+///
+/// Carries the shared worker state and enforces the same connection cap as the
+/// Tokio path (#111). The cap is **per ring**, not global: each ring owns an
+/// independent semaphore, so N rings admit `N * max_connections` in total.
+/// Callers should divide the global budget by the ring count.
+#[derive(Clone)]
+pub struct RingConnHandler {
+    worker: Arc<WorkerRuntime>,
+    observability: Arc<WorkerObservability>,
+    limit: Arc<tokio::sync::Semaphore>,
+}
+
+impl RingConnHandler {
+    /// Build a handler admitting at most `max_connections` concurrent
+    /// connections on the ring that owns it.
+    pub fn new(
+        worker: Arc<WorkerRuntime>,
+        observability: Arc<WorkerObservability>,
+        max_connections: usize,
+    ) -> Self {
+        Self {
+            worker,
+            observability,
+            limit: Arc::new(tokio::sync::Semaphore::new(max_connections)),
+        }
+    }
+}
+
+impl crate::uring_serve::RingHandler for RingConnHandler {
+    async fn handle(&self, stream: TcpStream) -> anyhow::Result<()> {
+        // Acquire before serving and hold for the connection's lifetime, so a
+        // flood of idle peers cannot exhaust memory or file descriptors.
+        let _permit = self.limit.clone().acquire_owned().await?;
+        handle_conn(
+            stream,
+            Arc::clone(&self.worker),
+            Arc::clone(&self.observability),
+        )
+        .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -760,6 +803,63 @@ mod tests {
             drop(c);
             assert!(served.await.is_ok());
         });
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    /// The RingConnHandler admits up to its cap and serves real traffic through
+    /// the ring runtime — the wiring main.rs uses.
+    #[test]
+    fn ring_handler_serves_through_the_ring_runtime() {
+        use crate::uring_serve::serve;
+        let root = tmp_root("ringwire");
+        let tokio_rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+        let (worker, obs) = {
+            let _g = tokio_rt.enter();
+            build(&root, Arc::new(RampBackend), 16)
+        };
+
+        // Reserve then release a port so the rings can SO_REUSEPORT bind it.
+        let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = probe.local_addr().unwrap().to_string();
+        drop(probe);
+
+        let handler = RingConnHandler::new(worker, obs, 8);
+        let handle = tokio_rt.handle().clone();
+        let serve_addr = addr.clone();
+        std::thread::spawn(move || {
+            let _ = serve(serve_addr, 2, 2, handler, handle);
+        });
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while std::net::TcpStream::connect(&addr).is_err() {
+            assert!(std::time::Instant::now() < deadline, "rings never bound");
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        // Drive a real request/response with a plain std client, proving a
+        // Tokio-side client interoperates with the ring data plane unchanged.
+        use std::io::{Read, Write};
+        let obj = ObjectId::new(talon_core::Backend::Azure, "c", "obj");
+        let req = RangeRequest {
+            object: obj,
+            offset: 3,
+            len: 8,
+        };
+        let expected: Vec<u8> = (0..8u64).map(|i| ((3 + i) % 251) as u8).collect();
+        let mut c = std::net::TcpStream::connect(&addr).unwrap();
+        c.write_all(&encode_request(0, &req).unwrap()).unwrap();
+        let mut hdr = [0u8; HEADER_LEN];
+        c.read_exact(&mut hdr).unwrap();
+        let header = FrameHeader::decode(&hdr).unwrap();
+        assert!(!header.flags.contains(Flags::ERROR));
+        let mut body = vec![0u8; header.length as usize];
+        c.read_exact(&mut body).unwrap();
+        assert_eq!(body, expected);
+
         std::fs::remove_dir_all(root).ok();
     }
 }

--- a/crates/talon-worker/src/uring_serve.rs
+++ b/crates/talon-worker/src/uring_serve.rs
@@ -65,6 +65,20 @@ pub trait RingHandler: Clone + 'static {
 ///
 /// `handler` is cloned per ring; share state through an `Arc` inside it.
 ///
+/// # Tokio coexistence
+///
+/// `tokio_handle` is entered on every ring thread before the ring runs. This is
+/// required, not optional: `WorkerRuntime` reaches Tokio internally —
+/// `block_store` runs filesystem I/O on `tokio::task::spawn_blocking` so a large
+/// read or write-plus-fsync never stalls the reactor (#115), and parts of the
+/// miss path use Tokio timers and sync primitives. Without an entered handle
+/// those calls panic with *"there is no reactor running"*.
+///
+/// The split is deliberate: the ring owns protocol scheduling and hands
+/// `sendfile` to its own blocking pool, while Tokio's blocking pool absorbs
+/// filesystem work that belongs on neither. Note this means two blocking pools
+/// coexist, so size them with the pinned ring count in mind.
+///
 /// # Errors
 ///
 /// Returns an error if a ring thread fails to bind. A bind failure on *any*
@@ -75,6 +89,7 @@ pub fn serve<H>(
     rings: usize,
     blocking_threads: usize,
     handler: H,
+    tokio_handle: tokio::runtime::Handle,
 ) -> anyhow::Result<()>
 where
     H: RingHandler + Send,
@@ -86,10 +101,15 @@ where
         let addr = addr.clone();
         let handler = handler.clone();
         let ready = Arc::clone(&ready);
+        let tokio_handle = tokio_handle.clone();
         threads.push(
             std::thread::Builder::new()
                 .name(format!("talon-ring-{ring_id}"))
                 .spawn(move || {
+                    // Required before the ring runs: WorkerRuntime reaches Tokio
+                    // internally. See "Tokio coexistence" on this function.
+                    let _tokio_guard = tokio_handle.enter();
+
                     // Pin before building the ring so its memory is allocated on the
                     // node this thread will actually run on. A failure here is not
                     // fatal — pinning is an optimization, not a correctness
@@ -249,7 +269,8 @@ mod tests {
 
         let serve_addr = addr.clone();
         std::thread::spawn(move || {
-            let _ = serve(serve_addr, 4, 2, handler);
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            let _ = serve(serve_addr, 4, 2, handler, rt.handle().clone());
         });
 
         // Wait for at least one ring to bind.
@@ -293,7 +314,8 @@ mod tests {
         };
         let serve_addr = addr.clone();
         std::thread::spawn(move || {
-            let _ = serve(serve_addr, 2, 1, handler);
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            let _ = serve(serve_addr, 2, 1, handler, rt.handle().clone());
         });
 
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);


### PR DESCRIPTION
Fourth step of #285. Connects the pieces from #286, #287, and #288 so the `data_plane_rings` knob actually selects the io_uring data plane. **Unset, the worker serves on Tokio exactly as before — the default does not change.**

## What it does

```
--data-plane-rings 2   →  2 io_uring rings, SO_REUSEPORT, pinned per core
--data-plane-rings 0   →  one ring per available core
(unset)                →  portable Tokio path, unchanged
```

`RingConnHandler` adapts `handle_conn` to the ring runtime's `RingHandler` trait and carries the connection cap from #111.

## Two things worth reviewer attention

**1. The connection cap is per-ring, so the budget is divided.** Each ring owns an independent semaphore. Left alone, N rings would silently admit **N × `MAX_DATA_PLANE_CONNECTIONS`** — an invisible loosening of a DoS control. `main.rs` divides:

```rust
let per_ring_connections = MAX_DATA_PLANE_CONNECTIONS.div_ceil(rings).max(1);
```

**2. Two blocking pools now coexist on pinned cores.** `serve()` takes a `tokio::runtime::Handle` and enters it on every ring thread — required, not incidental, because `WorkerRuntime` reaches Tokio internally (`block_store` on `tokio::task::spawn_blocking` per #115, plus Tokio timers in the miss path). Without it, those calls panic on a bare ring.

The split is deliberate: the ring owns protocol scheduling and hands `sendfile` to *its* blocking pool, while Tokio's absorbs filesystem work belonging to neither. Since both sit on pinned cores, the per-ring pool is kept small (4) with the reasoning recorded at the constant.

`serve()` blocks until its ring threads exit and must not occupy a Tokio worker thread while handing that runtime out, so `main.rs` drives it on `spawn_blocking` and parks on the join.

## fuse::worker_client is not a prerequisite

The new wiring test uses a plain `std::net::TcpStream` client against the ring runtime and completes a real range request. The protocol is plain framed TCP, so **Tokio-side clients interoperate with the ring data plane unchanged**. Porting `fuse::worker_client` becomes an optimization for the client side rather than a blocker — worth reordering the epic around.

## Verified on the built binary

```
--data-plane-rings 2  →  2 listening sockets on one port (SO_REUSEPORT), both rings log
(unset)               →  1 listening socket, "worker serving data plane"
```

## Verification

- `cargo test --workspace --all-features --locked` — all pass, 8 in `uring_conn`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- 15 consecutive runs of the uring tests — no flakes

## Next in #285

An in-repo benchmark comparing both data planes on real sockets, then flipping the default once it demonstrates the win. The default deliberately stays on Tokio until that gate exists.

Refs #285, #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
