### PR TITLE
test: S3 backend e2e against LocalStack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,47 @@ jobs:
             echo "::error::memory backend with HA should have failed"; exit 1
           fi
 
+  s3-e2e:
+    name: s3 backend e2e (localstack)
+    runs-on: ubuntu-latest
+    # Exercises the real S3Backend (SigV4 signing + path-style endpoint) against
+    # LocalStack, reading bytes an object actually contains. The test skips when
+    # TALON_S3_TEST_ENDPOINT is unset; this job sets it after seeding the bucket.
+    services:
+      localstack:
+        image: localstack/localstack:3.8
+        ports:
+          - 4566:4566
+        env:
+          SERVICES: s3
+        options: >-
+          --health-cmd "curl -sf http://localhost:4566/_localstack/health || exit 1"
+          --health-interval 5s --health-timeout 5s --health-retries 20
+    env:
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_DEFAULT_REGION: us-east-1
+      TALON_S3_TEST_ENDPOINT: http://127.0.0.1:4566
+      TALON_S3_TEST_BUCKET: talon-e2e
+      TALON_S3_TEST_KEY: e2e/object.bin
+      TALON_S3_TEST_REGION: us-east-1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Seed the bucket with a deterministic object
+        run: |
+          # 4096 bytes where byte i == i % 251 (matches the test's expectation).
+          python3 - <<'PY'
+          data = bytes((i % 251) for i in range(4096))
+          open("/tmp/object.bin", "wb").write(data)
+          PY
+          aws --endpoint-url http://127.0.0.1:4566 s3 mb s3://talon-e2e
+          aws --endpoint-url http://127.0.0.1:4566 s3 cp /tmp/object.bin s3://talon-e2e/e2e/object.bin
+      - uses: Swatinem/rust-cache@v2
+      - name: Run the S3 e2e test
+        run: cargo test -p talon-backend --test s3_e2e --locked -- --nocapture
+
   bench:
     name: bench (informational)
     runs-on: ubuntu-latest

--- a/crates/talon-backend/tests/s3_e2e.rs
+++ b/crates/talon-backend/tests/s3_e2e.rs
@@ -1,0 +1,90 @@
+//! S3 backend end-to-end test against a real S3-compatible emulator (LocalStack).
+//!
+//! Unlike the offline unit tests (which inject a mock `HttpClient`), this drives
+//! the real [`S3Backend`] over [`ReqwestClient`] against a live endpoint: it
+//! exercises **AWS SigV4 request signing** (#264) and the path-style endpoint
+//! wiring end to end, reading bytes an object actually contains.
+//!
+//! The test is **skipped** unless `TALON_S3_TEST_ENDPOINT` points at a reachable
+//! S3 endpoint (e.g. `http://127.0.0.1:4566` for LocalStack). CI launches
+//! LocalStack, creates a bucket, uploads a known object, and sets the env vars;
+//! locally you can do the same with the AWS CLI against LocalStack.
+//!
+//! Required env:
+//!   TALON_S3_TEST_ENDPOINT     e.g. http://127.0.0.1:4566
+//!   TALON_S3_TEST_BUCKET       bucket that already contains the object
+//!   TALON_S3_TEST_KEY          object key (defaults to "e2e/object.bin")
+//!   AWS_ACCESS_KEY_ID          credentials the emulator accepts (test/test)
+//!   AWS_SECRET_ACCESS_KEY
+//!   TALON_S3_TEST_REGION       defaults to us-east-1
+//!
+//! The uploaded object is expected to be 4096 bytes where byte i == (i % 251).
+
+use std::sync::Arc;
+
+use talon_backend::{ReqwestClient, S3Backend, S3Config, S3Credentials};
+use talon_core::{Backend, BackendStore, ObjectId};
+
+/// Deterministic content byte for absolute offset `i` — matches what CI uploads.
+fn content_byte(i: u64) -> u8 {
+    (i % 251) as u8
+}
+
+fn env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|s| !s.is_empty())
+}
+
+#[tokio::test]
+async fn s3_backend_reads_real_object_end_to_end() {
+    let Some(endpoint) = env("TALON_S3_TEST_ENDPOINT") else {
+        eprintln!("skipping S3 e2e: TALON_S3_TEST_ENDPOINT is not set");
+        return;
+    };
+    let bucket = env("TALON_S3_TEST_BUCKET").expect("TALON_S3_TEST_BUCKET must be set");
+    let key = env("TALON_S3_TEST_KEY").unwrap_or_else(|| "e2e/object.bin".to_string());
+    let region = env("TALON_S3_TEST_REGION").unwrap_or_else(|| "us-east-1".to_string());
+    let access_key_id = env("AWS_ACCESS_KEY_ID").expect("AWS_ACCESS_KEY_ID must be set");
+    let secret_access_key =
+        env("AWS_SECRET_ACCESS_KEY").expect("AWS_SECRET_ACCESS_KEY must be set");
+
+    // Point at the emulator: http:// selects plaintext, path-style for LocalStack.
+    let host = endpoint
+        .strip_prefix("http://")
+        .or_else(|| endpoint.strip_prefix("https://"))
+        .unwrap_or(&endpoint)
+        .to_string();
+    let tls = !endpoint.starts_with("http://");
+    let config = S3Config {
+        region,
+        endpoint: host,
+        path_style: true,
+        tls,
+    };
+    let creds = S3Credentials {
+        access_key_id,
+        secret_access_key,
+        session_token: None,
+    };
+    let backend = S3Backend::new(config, creds, Arc::new(ReqwestClient::new()));
+
+    let obj = ObjectId::new(Backend::S3, bucket, key);
+
+    // HEAD resolves size + ETag (the version). SigV4 must sign this correctly.
+    let stat = backend.head(&obj).await.expect("HEAD should succeed");
+    assert_eq!(stat.len, 4096, "unexpected object size");
+    assert!(!stat.version.as_str().is_empty(), "HEAD returned no ETag");
+
+    // A ranged GET in the middle of the object returns exactly those bytes.
+    let got = backend
+        .fetch_range(&obj, 1000, 256)
+        .await
+        .expect("ranged GET should succeed");
+    assert_eq!(got.len(), 256, "unexpected range length");
+    let expected: Vec<u8> = (1000..1256).map(content_byte).collect();
+    assert_eq!(&got[..], &expected[..], "range bytes mismatch");
+
+    // A read of the first bytes too, to cover offset 0.
+    let head_bytes = backend.fetch_range(&obj, 0, 16).await.expect("GET head");
+    let expected_head: Vec<u8> = (0..16).map(content_byte).collect();
+    assert_eq!(&head_bytes[..], &expected_head[..]);
+}

--- a/deploy/testenv/s3-localstack.yml
+++ b/deploy/testenv/s3-localstack.yml
@@ -1,0 +1,32 @@
+# S3 backend e2e against LocalStack (manual).
+#
+# Brings up LocalStack (S3 emulator) so you can exercise the real S3Backend
+# (SigV4 signing + path-style endpoint) end to end, mirroring the CI `s3-e2e`
+# job. The dev credentials below are LocalStack's well-known test values — not
+# secrets.
+#
+#   docker compose -f deploy/testenv/s3-localstack.yml up -d
+#   # seed a deterministic 4096-byte object (byte i == i % 251):
+#   python3 -c "open('/tmp/object.bin','wb').write(bytes(i%251 for i in range(4096)))"
+#   aws --endpoint-url http://127.0.0.1:4566 s3 mb s3://talon-e2e
+#   aws --endpoint-url http://127.0.0.1:4566 s3 cp /tmp/object.bin s3://talon-e2e/e2e/object.bin
+#   # run the gated test:
+#   AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+#     TALON_S3_TEST_ENDPOINT=http://127.0.0.1:4566 \
+#     TALON_S3_TEST_BUCKET=talon-e2e TALON_S3_TEST_KEY=e2e/object.bin \
+#     cargo test -p talon-backend --test s3_e2e -- --nocapture
+
+name: talon-s3-e2e
+
+services:
+  localstack:
+    image: localstack/localstack:3.8
+    ports:
+      - "4566:4566"
+    environment:
+      SERVICES: s3
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:4566/_localstack/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 20


### PR DESCRIPTION
## Summary
- Add `crates/talon-backend/tests/s3_e2e.rs`: drives the real `S3Backend` (SigV4 signing + path-style endpoint) against a live S3 emulator, reading bytes an object actually contains via HEAD + ranged GET. Skips unless `TALON_S3_TEST_ENDPOINT` is set.
- Add a CI `s3-e2e` job running LocalStack as a service container, seeding a deterministic 4096-byte object (byte i == i % 251), and running the test.
- Add `deploy/testenv/s3-localstack.yml` for manual runs.

First e2e of the multi-cloud epic (#263), sub-issue #268. Exercises #264 (SigV4) end to end.

## Test plan
- [x] `cargo test -p talon-backend --test s3_e2e` skips cleanly with no endpoint
- [x] `cargo clippy -p talon-backend --tests` clean; typos clean
- [ ] CI `s3-e2e` job reads the seeded object end to end