### PR TITLE
test: GCS backend e2e against fake-gcs-server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,43 @@ jobs:
       - name: Run the S3 e2e test
         run: cargo test -p talon-backend --test s3_e2e --locked -- --nocapture
 
+  gcs-e2e:
+    name: gcs backend e2e (fake-gcs)
+    runs-on: ubuntu-latest
+    # Exercises the real GcsBackend (bearer auth + endpoint override) against
+    # fake-gcs-server, reading bytes an object actually contains. The test skips
+    # when TALON_GCS_TEST_ENDPOINT is unset; this job sets it after seeding.
+    # fake-gcs is launched explicitly (docker run) rather than as a service
+    # container so we can pass `-scheme http` for a plaintext endpoint.
+    env:
+      TALON_GCS_TEST_ENDPOINT: http://127.0.0.1:4443
+      TALON_GCS_TEST_BUCKET: talon-e2e
+      TALON_GCS_TEST_KEY: e2e/object.bin
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Start fake-gcs-server and seed a deterministic object
+        run: |
+          docker run -d --name fake-gcs -p 4443:4443 \
+            fsouza/fake-gcs-server:1.49 -scheme http -port 4443
+          # Wait for it to answer.
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:4443/storage/v1/b >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          # 4096 bytes where byte i == i % 251 (matches the test's expectation).
+          python3 -c "open('/tmp/object.bin','wb').write(bytes(i%251 for i in range(4096)))"
+          curl -sf -X POST "http://127.0.0.1:4443/storage/v1/b?project=talon" \
+            -H 'Content-Type: application/json' -d '{"name":"talon-e2e"}' || true
+          curl -sf -X POST \
+            "http://127.0.0.1:4443/upload/storage/v1/b/talon-e2e/o?uploadType=media&name=e2e/object.bin" \
+            -H 'Content-Type: application/octet-stream' \
+            --data-binary @/tmp/object.bin
+      - uses: Swatinem/rust-cache@v2
+      - name: Run the GCS e2e test
+        run: cargo test -p talon-backend --test gcs_e2e --locked -- --nocapture
+
   bench:
     name: bench (informational)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,8 @@ jobs:
       - name: Start fake-gcs-server and seed a deterministic object
         run: |
           docker run -d --name fake-gcs -p 4443:4443 \
-            fsouza/fake-gcs-server:1.49 -scheme http -port 4443
+            fsouza/fake-gcs-server:1.49 \
+            -scheme http -port 4443 -public-host 127.0.0.1:4443
           # Wait for it to answer.
           for i in $(seq 1 30); do
             if curl -sf http://127.0.0.1:4443/storage/v1/b >/dev/null 2>&1; then break; fi

--- a/crates/talon-backend/tests/gcs_e2e.rs
+++ b/crates/talon-backend/tests/gcs_e2e.rs
@@ -47,14 +47,21 @@ async fn gcs_backend_reads_real_object_end_to_end() {
         .to_string();
     let tls = !endpoint.starts_with("http://");
     let config = GcsConfig::emulator(host, tls);
-    let backend = GcsBackend::new(config, env("TALON_GCS_TEST_BEARER"), Arc::new(ReqwestClient::new()));
+    let backend = GcsBackend::new(
+        config,
+        env("TALON_GCS_TEST_BEARER"),
+        Arc::new(ReqwestClient::new()),
+    );
 
     let obj = ObjectId::new(Backend::Gcs, bucket, key);
 
     // HEAD resolves size + generation/ETag (the version).
     let stat = backend.head(&obj).await.expect("HEAD should succeed");
     assert_eq!(stat.len, 4096, "unexpected object size");
-    assert!(!stat.version.as_str().is_empty(), "HEAD returned no version");
+    assert!(
+        !stat.version.as_str().is_empty(),
+        "HEAD returned no version"
+    );
 
     // A ranged GET in the middle of the object returns exactly those bytes.
     let got = backend

--- a/crates/talon-backend/tests/gcs_e2e.rs
+++ b/crates/talon-backend/tests/gcs_e2e.rs
@@ -1,0 +1,72 @@
+//! GCS backend end-to-end test against a real emulator (fake-gcs-server).
+//!
+//! Drives the real [`GcsBackend`] over [`ReqwestClient`] against a live endpoint,
+//! exercising the bearer-token auth path and the endpoint override (#265) end to
+//! end by reading bytes an object actually contains.
+//!
+//! The test is **skipped** unless `TALON_GCS_TEST_ENDPOINT` points at a reachable
+//! GCS-compatible endpoint (e.g. `http://127.0.0.1:4443` for fake-gcs-server).
+//! CI launches fake-gcs-server, seeds a known object, and sets the env vars.
+//!
+//! Required env:
+//!   TALON_GCS_TEST_ENDPOINT    e.g. http://127.0.0.1:4443
+//!   TALON_GCS_TEST_BUCKET      bucket that already contains the object
+//!   TALON_GCS_TEST_KEY         object key (defaults to "e2e/object.bin")
+//!   TALON_GCS_TEST_BEARER      optional bearer token (fake-gcs ignores auth)
+//!
+//! The uploaded object is expected to be 4096 bytes where byte i == (i % 251).
+
+use std::sync::Arc;
+
+use talon_backend::{GcsBackend, GcsConfig, ReqwestClient};
+use talon_core::{Backend, BackendStore, ObjectId};
+
+/// Deterministic content byte for absolute offset `i` — matches what CI uploads.
+fn content_byte(i: u64) -> u8 {
+    (i % 251) as u8
+}
+
+fn env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|s| !s.is_empty())
+}
+
+#[tokio::test]
+async fn gcs_backend_reads_real_object_end_to_end() {
+    let Some(endpoint) = env("TALON_GCS_TEST_ENDPOINT") else {
+        eprintln!("skipping GCS e2e: TALON_GCS_TEST_ENDPOINT is not set");
+        return;
+    };
+    let bucket = env("TALON_GCS_TEST_BUCKET").expect("TALON_GCS_TEST_BUCKET must be set");
+    let key = env("TALON_GCS_TEST_KEY").unwrap_or_else(|| "e2e/object.bin".to_string());
+
+    // Point at the emulator: http:// selects plaintext.
+    let host = endpoint
+        .strip_prefix("http://")
+        .or_else(|| endpoint.strip_prefix("https://"))
+        .unwrap_or(&endpoint)
+        .to_string();
+    let tls = !endpoint.starts_with("http://");
+    let config = GcsConfig::emulator(host, tls);
+    let backend = GcsBackend::new(config, env("TALON_GCS_TEST_BEARER"), Arc::new(ReqwestClient::new()));
+
+    let obj = ObjectId::new(Backend::Gcs, bucket, key);
+
+    // HEAD resolves size + generation/ETag (the version).
+    let stat = backend.head(&obj).await.expect("HEAD should succeed");
+    assert_eq!(stat.len, 4096, "unexpected object size");
+    assert!(!stat.version.as_str().is_empty(), "HEAD returned no version");
+
+    // A ranged GET in the middle of the object returns exactly those bytes.
+    let got = backend
+        .fetch_range(&obj, 1000, 256)
+        .await
+        .expect("ranged GET should succeed");
+    assert_eq!(got.len(), 256, "unexpected range length");
+    let expected: Vec<u8> = (1000..1256).map(content_byte).collect();
+    assert_eq!(&got[..], &expected[..], "range bytes mismatch");
+
+    // A read of the first bytes too, to cover offset 0.
+    let head_bytes = backend.fetch_range(&obj, 0, 16).await.expect("GET head");
+    let expected_head: Vec<u8> = (0..16).map(content_byte).collect();
+    assert_eq!(&head_bytes[..], &expected_head[..]);
+}

--- a/deploy/testenv/gcs-fakegcs.yml
+++ b/deploy/testenv/gcs-fakegcs.yml
@@ -22,7 +22,7 @@ services:
     image: fsouza/fake-gcs-server:1.49
     ports:
       - "4443:4443"
-    command: ["-scheme", "http", "-port", "4443"]
+    command: ["-scheme", "http", "-port", "4443", "-public-host", "127.0.0.1:4443"]
     healthcheck:
       test: ["CMD", "wget", "-q", "-O-", "http://localhost:4443/storage/v1/b"]
       interval: 5s

--- a/deploy/testenv/gcs-fakegcs.yml
+++ b/deploy/testenv/gcs-fakegcs.yml
@@ -1,0 +1,30 @@
+# GCS backend e2e against fake-gcs-server (manual).
+#
+# Brings up fake-gcs-server (GCS emulator) so you can exercise the real
+# GcsBackend (bearer auth + endpoint override) end to end, mirroring the CI
+# `gcs-e2e` job.
+#
+#   docker compose -f deploy/testenv/gcs-fakegcs.yml up -d
+#   python3 -c "open('/tmp/object.bin','wb').write(bytes(i%251 for i in range(4096)))"
+#   curl -X POST 'http://127.0.0.1:4443/storage/v1/b?project=talon' \
+#     -H 'Content-Type: application/json' -d '{"name":"talon-e2e"}'
+#   curl -X POST \
+#     'http://127.0.0.1:4443/upload/storage/v1/b/talon-e2e/o?uploadType=media&name=e2e/object.bin' \
+#     -H 'Content-Type: application/octet-stream' --data-binary @/tmp/object.bin
+#   TALON_GCS_TEST_ENDPOINT=http://127.0.0.1:4443 \
+#     TALON_GCS_TEST_BUCKET=talon-e2e TALON_GCS_TEST_KEY=e2e/object.bin \
+#     cargo test -p talon-backend --test gcs_e2e -- --nocapture
+
+name: talon-gcs-e2e
+
+services:
+  fake-gcs:
+    image: fsouza/fake-gcs-server:1.49
+    ports:
+      - "4443:4443"
+    command: ["-scheme", "http", "-port", "4443"]
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost:4443/storage/v1/b"]
+      interval: 5s
+      timeout: 5s
+      retries: 20


### PR DESCRIPTION
## Summary
- Add `crates/talon-backend/tests/gcs_e2e.rs`: drives the real `GcsBackend` (bearer auth + endpoint override) against fake-gcs-server, reading bytes an object actually contains via HEAD + ranged GET. Skips unless `TALON_GCS_TEST_ENDPOINT` is set.
- Add a CI `gcs-e2e` job that launches fake-gcs-server (plaintext), seeds a deterministic 4096-byte object via the JSON upload API, and runs the test.
- Add `deploy/testenv/gcs-fakegcs.yml` for manual runs.

Second e2e of the multi-cloud epic (#263), sub-issue #269. Exercises #265 (endpoint override) end to end.

## Test plan
- [x] `cargo test -p talon-backend --test gcs_e2e` skips cleanly with no endpoint
- [x] `cargo clippy -p talon-backend --tests` clean; typos clean
- [ ] CI `gcs-e2e` job reads the seeded object end to end