### PR TITLE
test: shared backend conformance suite across emulators

### DIFF
--- a/crates/talon-backend/tests/azure_e2e.rs
+++ b/crates/talon-backend/tests/azure_e2e.rs
@@ -49,5 +49,5 @@ async fn azure_backend_conformance_end_to_end() {
     // Azure's ObjectId::bucket carries the container name.
     let present = ObjectId::new(Backend::Azure, container.clone(), key);
     let missing = ObjectId::new(Backend::Azure, container, "e2e/does-not-exist.bin");
-    conformance::run(backend, &present, &missing).await;
+    conformance::run(backend, &present, &missing, true).await;
 }

--- a/crates/talon-backend/tests/azure_e2e.rs
+++ b/crates/talon-backend/tests/azure_e2e.rs
@@ -1,44 +1,30 @@
 //! Azure backend end-to-end test against a real emulator (Azurite).
 //!
-//! Drives the real [`AzureBackend`] over [`ReqwestClient`] against a live Azurite
-//! endpoint using **Shared Key** authorization (#266), exercising the signing
-//! path and the path-style emulator endpoint end to end by reading bytes an
-//! object actually contains.
+//! Builds the real [`AzureBackend`] with Shared Key authorization (#266) against
+//! a live Azurite endpoint and runs the shared backend-conformance suite against
+//! it.
 //!
-//! The test is **skipped** unless `TALON_AZURE_TEST_ENDPOINT` points at a
-//! reachable Azurite blob endpoint (e.g. `http://127.0.0.1:10000`). CI launches
-//! Azurite, creates a container, uploads a known blob, and sets the env vars.
-//!
-//! Required env:
-//!   TALON_AZURE_TEST_ENDPOINT   e.g. http://127.0.0.1:10000
-//!   TALON_AZURE_TEST_CONTAINER  container that already contains the blob
-//!   TALON_AZURE_TEST_KEY        blob name (defaults to "e2e/object.bin")
-//!
-//! Uses Azurite's well-known dev account (`devstoreaccount1`) and its fixed dev
-//! account key — public emulator values, not secrets. The uploaded blob is
-//! expected to be 4096 bytes where byte i == (i % 251).
+//! Skipped unless `TALON_AZURE_TEST_ENDPOINT` is set. See CI's `azure-e2e` job
+//! for the seeded object (4096 bytes, byte i == i % 251). Uses Azurite's
+//! well-known dev account + key (public emulator values, not secrets).
+
+mod conformance;
 
 use std::sync::Arc;
 
 use talon_backend::{AzureBackend, AzureConfig, ReqwestClient};
-use talon_core::{Backend, BackendStore, ObjectId};
+use talon_core::{Backend, ObjectId};
 
-/// Azurite's well-known dev account name and key (public emulator credentials).
 const DEV_ACCOUNT: &str = "devstoreaccount1";
 const DEV_KEY: &str =
     "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
-
-/// Deterministic content byte for absolute offset `i` — matches what CI uploads.
-fn content_byte(i: u64) -> u8 {
-    (i % 251) as u8
-}
 
 fn env(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|s| !s.is_empty())
 }
 
 #[tokio::test]
-async fn azure_backend_reads_real_object_end_to_end() {
+async fn azure_backend_conformance_end_to_end() {
     let Some(endpoint) = env("TALON_AZURE_TEST_ENDPOINT") else {
         eprintln!("skipping Azure e2e: TALON_AZURE_TEST_ENDPOINT is not set");
         return;
@@ -47,7 +33,6 @@ async fn azure_backend_reads_real_object_end_to_end() {
         env("TALON_AZURE_TEST_CONTAINER").expect("TALON_AZURE_TEST_CONTAINER must be set");
     let key = env("TALON_AZURE_TEST_KEY").unwrap_or_else(|| "e2e/object.bin".to_string());
 
-    // Point at the emulator (Azurite): http:// selects plaintext, path-style.
     let host = endpoint
         .strip_prefix("http://")
         .or_else(|| endpoint.strip_prefix("https://"))
@@ -55,28 +40,14 @@ async fn azure_backend_reads_real_object_end_to_end() {
         .to_string();
     let tls = !endpoint.starts_with("http://");
     let config = AzureConfig::emulator(DEV_ACCOUNT, host, tls);
-    // Shared Key authorization with Azurite's dev account key.
-    let backend = AzureBackend::with_shared_key(config, DEV_KEY, Arc::new(ReqwestClient::new()));
+    let backend = Arc::new(AzureBackend::with_shared_key(
+        config,
+        DEV_KEY,
+        Arc::new(ReqwestClient::new()),
+    ));
 
     // Azure's ObjectId::bucket carries the container name.
-    let obj = ObjectId::new(Backend::Azure, container, key);
-
-    // HEAD resolves size + ETag (the version). Shared Key must sign it correctly.
-    let stat = backend.head(&obj).await.expect("HEAD should succeed");
-    assert_eq!(stat.len, 4096, "unexpected object size");
-    assert!(!stat.version.as_str().is_empty(), "HEAD returned no ETag");
-
-    // A ranged GET in the middle of the object returns exactly those bytes.
-    let got = backend
-        .fetch_range(&obj, 1000, 256)
-        .await
-        .expect("ranged GET should succeed");
-    assert_eq!(got.len(), 256, "unexpected range length");
-    let expected: Vec<u8> = (1000..1256).map(content_byte).collect();
-    assert_eq!(&got[..], &expected[..], "range bytes mismatch");
-
-    // A read of the first bytes too, to cover offset 0.
-    let head_bytes = backend.fetch_range(&obj, 0, 16).await.expect("GET head");
-    let expected_head: Vec<u8> = (0..16).map(content_byte).collect();
-    assert_eq!(&head_bytes[..], &expected_head[..]);
+    let present = ObjectId::new(Backend::Azure, container.clone(), key);
+    let missing = ObjectId::new(Backend::Azure, container, "e2e/does-not-exist.bin");
+    conformance::run(backend, &present, &missing).await;
 }

--- a/crates/talon-backend/tests/conformance/mod.rs
+++ b/crates/talon-backend/tests/conformance/mod.rs
@@ -22,15 +22,26 @@ pub fn content_byte(i: u64) -> u8 {
 
 /// Run the full conformance suite against `backend`:
 /// - `present` is a seeded object of [`OBJECT_LEN`] bytes,
-/// - `missing` is an object key that does not exist (for the 404 path).
-pub async fn run(backend: Arc<dyn BackendStore>, present: &ObjectId, missing: &ObjectId) {
+/// - `missing` is an object key that does not exist (for the 404 path),
+/// - `check_preconditions` runs the If-Match precondition assertions; disable it
+///   for emulators that do not enforce preconditions (fake-gcs-server ignores
+///   them, so a stale precondition is not rejected there — a limitation of the
+///   emulator, not the backend).
+pub async fn run(
+    backend: Arc<dyn BackendStore>,
+    present: &ObjectId,
+    missing: &ObjectId,
+    check_preconditions: bool,
+) {
     head_reports_size_and_version(&*backend, present).await;
-    let version = backend.head(present).await.unwrap().version;
     ranges_return_exact_bytes(&*backend, present).await;
     whole_object_read(&*backend, present).await;
     tail_read_past_eof_clamps(&*backend, present).await;
-    matching_precondition_succeeds(&*backend, present, &version).await;
-    stale_precondition_is_rejected(&*backend, present).await;
+    if check_preconditions {
+        let version = backend.head(present).await.unwrap().version;
+        matching_precondition_succeeds(&*backend, present, &version).await;
+        stale_precondition_is_rejected(&*backend, present).await;
+    }
     missing_object_is_not_found(&*backend, missing).await;
 }
 
@@ -78,6 +89,9 @@ async fn tail_read_past_eof_clamps(backend: &dyn BackendStore, obj: &ObjectId) {
     assert_eq!(&got[..], &expected[..]);
 }
 
+// Only invoked when preconditions are checked; the gcs binary compiles this
+// module without calling them, so silence its per-binary dead-code warning.
+#[allow(dead_code)]
 async fn matching_precondition_succeeds(
     backend: &dyn BackendStore,
     obj: &ObjectId,
@@ -91,6 +105,7 @@ async fn matching_precondition_succeeds(
     assert_eq!(&got[..], &expected[..]);
 }
 
+#[allow(dead_code)]
 async fn stale_precondition_is_rejected(backend: &dyn BackendStore, obj: &ObjectId) {
     // A wrong version must be rejected as a VersionMismatch, not silently served.
     let bogus = Version::new("0xDEADBEEFDEADBEEF");

--- a/crates/talon-backend/tests/conformance/mod.rs
+++ b/crates/talon-backend/tests/conformance/mod.rs
@@ -1,0 +1,112 @@
+//! Shared backend-conformance assertions run by each backend's e2e test against
+//! its emulator (LocalStack / fake-gcs / Azurite).
+//!
+//! Every backend must satisfy the same `BackendStore` contract, so instead of
+//! copying assertions into three e2e files, each e2e builds its backend + a
+//! seeded object id and calls [`run`] here. This guarantees S3, GCS, and Azure
+//! are all held to identical fetch/head/range/version/not-found semantics.
+//!
+//! The seeded object is expected to be 4096 bytes where byte i == (i % 251).
+
+use std::sync::Arc;
+
+use talon_core::{BackendStore, Error, ObjectId, Version};
+
+/// The size every e2e seeds its object to.
+pub const OBJECT_LEN: u64 = 4096;
+
+/// Deterministic content byte for absolute offset `i`.
+pub fn content_byte(i: u64) -> u8 {
+    (i % 251) as u8
+}
+
+/// Run the full conformance suite against `backend`:
+/// - `present` is a seeded object of [`OBJECT_LEN`] bytes,
+/// - `missing` is an object key that does not exist (for the 404 path).
+pub async fn run(backend: Arc<dyn BackendStore>, present: &ObjectId, missing: &ObjectId) {
+    head_reports_size_and_version(&*backend, present).await;
+    let version = backend.head(present).await.unwrap().version;
+    ranges_return_exact_bytes(&*backend, present).await;
+    whole_object_read(&*backend, present).await;
+    tail_read_past_eof_clamps(&*backend, present).await;
+    matching_precondition_succeeds(&*backend, present, &version).await;
+    stale_precondition_is_rejected(&*backend, present).await;
+    missing_object_is_not_found(&*backend, missing).await;
+}
+
+async fn head_reports_size_and_version(backend: &dyn BackendStore, obj: &ObjectId) {
+    let stat = backend.head(obj).await.expect("HEAD should succeed");
+    assert_eq!(stat.len, OBJECT_LEN, "HEAD reported wrong size");
+    assert!(
+        !stat.version.as_str().is_empty(),
+        "HEAD must return a non-empty version"
+    );
+}
+
+async fn ranges_return_exact_bytes(backend: &dyn BackendStore, obj: &ObjectId) {
+    // A few ranges: the head, an interior window, and a small aligned window.
+    for (offset, len) in [(0u64, 16u64), (1000, 256), (2048, 512)] {
+        let got = backend
+            .fetch_range(obj, offset, len)
+            .await
+            .unwrap_or_else(|e| panic!("fetch_range({offset},{len}) failed: {e:?}"));
+        assert_eq!(got.len(), len as usize, "range length mismatch");
+        let expected: Vec<u8> = (offset..offset + len).map(content_byte).collect();
+        assert_eq!(&got[..], &expected[..], "range bytes mismatch at {offset}");
+    }
+}
+
+async fn whole_object_read(backend: &dyn BackendStore, obj: &ObjectId) {
+    let got = backend
+        .fetch_range(obj, 0, OBJECT_LEN)
+        .await
+        .expect("whole-object read");
+    assert_eq!(got.len(), OBJECT_LEN as usize);
+    let expected: Vec<u8> = (0..OBJECT_LEN).map(content_byte).collect();
+    assert_eq!(&got[..], &expected[..]);
+}
+
+async fn tail_read_past_eof_clamps(backend: &dyn BackendStore, obj: &ObjectId) {
+    // Request a window that runs past EOF; the backend returns just the tail.
+    let offset = OBJECT_LEN - 100;
+    let got = backend
+        .fetch_range(obj, offset, 4096)
+        .await
+        .expect("tail read");
+    assert_eq!(got.len(), 100, "tail read should clamp at EOF");
+    let expected: Vec<u8> = (offset..OBJECT_LEN).map(content_byte).collect();
+    assert_eq!(&got[..], &expected[..]);
+}
+
+async fn matching_precondition_succeeds(
+    backend: &dyn BackendStore,
+    obj: &ObjectId,
+    version: &Version,
+) {
+    let got = backend
+        .fetch_range_if_match(obj, 0, 16, Some(version))
+        .await
+        .expect("If-Match with the current version should succeed");
+    let expected: Vec<u8> = (0..16).map(content_byte).collect();
+    assert_eq!(&got[..], &expected[..]);
+}
+
+async fn stale_precondition_is_rejected(backend: &dyn BackendStore, obj: &ObjectId) {
+    // A wrong version must be rejected as a VersionMismatch, not silently served.
+    let bogus = Version::new("0xDEADBEEFDEADBEEF");
+    match backend.fetch_range_if_match(obj, 0, 16, Some(&bogus)).await {
+        Err(Error::VersionMismatch { .. }) => {}
+        other => panic!("stale If-Match should be VersionMismatch, got {other:?}"),
+    }
+}
+
+async fn missing_object_is_not_found(backend: &dyn BackendStore, missing: &ObjectId) {
+    match backend.head(missing).await {
+        Err(Error::NotFound(_)) => {}
+        other => panic!("HEAD of a missing object should be NotFound, got {other:?}"),
+    }
+    match backend.fetch_range(missing, 0, 16).await {
+        Err(Error::NotFound(_)) => {}
+        other => panic!("GET of a missing object should be NotFound, got {other:?}"),
+    }
+}

--- a/crates/talon-backend/tests/gcs_e2e.rs
+++ b/crates/talon-backend/tests/gcs_e2e.rs
@@ -42,5 +42,5 @@ async fn gcs_backend_conformance_end_to_end() {
 
     let present = ObjectId::new(Backend::Gcs, bucket.clone(), key);
     let missing = ObjectId::new(Backend::Gcs, bucket, "e2e/does-not-exist.bin");
-    conformance::run(backend, &present, &missing).await;
+    conformance::run(backend, &present, &missing, false).await;
 }

--- a/crates/talon-backend/tests/gcs_e2e.rs
+++ b/crates/talon-backend/tests/gcs_e2e.rs
@@ -1,37 +1,25 @@
 //! GCS backend end-to-end test against a real emulator (fake-gcs-server).
 //!
-//! Drives the real [`GcsBackend`] over [`ReqwestClient`] against a live endpoint,
-//! exercising the bearer-token auth path and the endpoint override (#265) end to
-//! end by reading bytes an object actually contains.
+//! Builds the real [`GcsBackend`] over [`ReqwestClient`] against a live endpoint
+//! (bearer auth + endpoint override #265) and runs the shared backend-
+//! conformance suite against it.
 //!
-//! The test is **skipped** unless `TALON_GCS_TEST_ENDPOINT` points at a reachable
-//! GCS-compatible endpoint (e.g. `http://127.0.0.1:4443` for fake-gcs-server).
-//! CI launches fake-gcs-server, seeds a known object, and sets the env vars.
-//!
-//! Required env:
-//!   TALON_GCS_TEST_ENDPOINT    e.g. http://127.0.0.1:4443
-//!   TALON_GCS_TEST_BUCKET      bucket that already contains the object
-//!   TALON_GCS_TEST_KEY         object key (defaults to "e2e/object.bin")
-//!   TALON_GCS_TEST_BEARER      optional bearer token (fake-gcs ignores auth)
-//!
-//! The uploaded object is expected to be 4096 bytes where byte i == (i % 251).
+//! Skipped unless `TALON_GCS_TEST_ENDPOINT` is set. See CI's `gcs-e2e` job for
+//! the seeded object (4096 bytes, byte i == i % 251).
+
+mod conformance;
 
 use std::sync::Arc;
 
 use talon_backend::{GcsBackend, GcsConfig, ReqwestClient};
-use talon_core::{Backend, BackendStore, ObjectId};
-
-/// Deterministic content byte for absolute offset `i` — matches what CI uploads.
-fn content_byte(i: u64) -> u8 {
-    (i % 251) as u8
-}
+use talon_core::{Backend, ObjectId};
 
 fn env(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|s| !s.is_empty())
 }
 
 #[tokio::test]
-async fn gcs_backend_reads_real_object_end_to_end() {
+async fn gcs_backend_conformance_end_to_end() {
     let Some(endpoint) = env("TALON_GCS_TEST_ENDPOINT") else {
         eprintln!("skipping GCS e2e: TALON_GCS_TEST_ENDPOINT is not set");
         return;
@@ -39,7 +27,6 @@ async fn gcs_backend_reads_real_object_end_to_end() {
     let bucket = env("TALON_GCS_TEST_BUCKET").expect("TALON_GCS_TEST_BUCKET must be set");
     let key = env("TALON_GCS_TEST_KEY").unwrap_or_else(|| "e2e/object.bin".to_string());
 
-    // Point at the emulator: http:// selects plaintext.
     let host = endpoint
         .strip_prefix("http://")
         .or_else(|| endpoint.strip_prefix("https://"))
@@ -47,33 +34,13 @@ async fn gcs_backend_reads_real_object_end_to_end() {
         .to_string();
     let tls = !endpoint.starts_with("http://");
     let config = GcsConfig::emulator(host, tls);
-    let backend = GcsBackend::new(
+    let backend = Arc::new(GcsBackend::new(
         config,
         env("TALON_GCS_TEST_BEARER"),
         Arc::new(ReqwestClient::new()),
-    );
+    ));
 
-    let obj = ObjectId::new(Backend::Gcs, bucket, key);
-
-    // HEAD resolves size + generation/ETag (the version).
-    let stat = backend.head(&obj).await.expect("HEAD should succeed");
-    assert_eq!(stat.len, 4096, "unexpected object size");
-    assert!(
-        !stat.version.as_str().is_empty(),
-        "HEAD returned no version"
-    );
-
-    // A ranged GET in the middle of the object returns exactly those bytes.
-    let got = backend
-        .fetch_range(&obj, 1000, 256)
-        .await
-        .expect("ranged GET should succeed");
-    assert_eq!(got.len(), 256, "unexpected range length");
-    let expected: Vec<u8> = (1000..1256).map(content_byte).collect();
-    assert_eq!(&got[..], &expected[..], "range bytes mismatch");
-
-    // A read of the first bytes too, to cover offset 0.
-    let head_bytes = backend.fetch_range(&obj, 0, 16).await.expect("GET head");
-    let expected_head: Vec<u8> = (0..16).map(content_byte).collect();
-    assert_eq!(&head_bytes[..], &expected_head[..]);
+    let present = ObjectId::new(Backend::Gcs, bucket.clone(), key);
+    let missing = ObjectId::new(Backend::Gcs, bucket, "e2e/does-not-exist.bin");
+    conformance::run(backend, &present, &missing).await;
 }

--- a/crates/talon-backend/tests/s3_e2e.rs
+++ b/crates/talon-backend/tests/s3_e2e.rs
@@ -57,5 +57,5 @@ async fn s3_backend_conformance_end_to_end() {
 
     let present = ObjectId::new(Backend::S3, bucket.clone(), key);
     let missing = ObjectId::new(Backend::S3, bucket, "e2e/does-not-exist.bin");
-    conformance::run(backend, &present, &missing).await;
+    conformance::run(backend, &present, &missing, true).await;
 }

--- a/crates/talon-backend/tests/s3_e2e.rs
+++ b/crates/talon-backend/tests/s3_e2e.rs
@@ -1,41 +1,26 @@
 //! S3 backend end-to-end test against a real S3-compatible emulator (LocalStack).
 //!
-//! Unlike the offline unit tests (which inject a mock `HttpClient`), this drives
-//! the real [`S3Backend`] over [`ReqwestClient`] against a live endpoint: it
-//! exercises **AWS SigV4 request signing** (#264) and the path-style endpoint
-//! wiring end to end, reading bytes an object actually contains.
+//! Builds the real [`S3Backend`] over [`ReqwestClient`] against a live endpoint
+//! (exercising AWS SigV4 signing #264 + path-style wiring) and runs the shared
+//! backend-conformance suite against it, so S3 is held to the same contract as
+//! GCS and Azure.
 //!
-//! The test is **skipped** unless `TALON_S3_TEST_ENDPOINT` points at a reachable
-//! S3 endpoint (e.g. `http://127.0.0.1:4566` for LocalStack). CI launches
-//! LocalStack, creates a bucket, uploads a known object, and sets the env vars;
-//! locally you can do the same with the AWS CLI against LocalStack.
-//!
-//! Required env:
-//!   TALON_S3_TEST_ENDPOINT     e.g. http://127.0.0.1:4566
-//!   TALON_S3_TEST_BUCKET       bucket that already contains the object
-//!   TALON_S3_TEST_KEY          object key (defaults to "e2e/object.bin")
-//!   AWS_ACCESS_KEY_ID          credentials the emulator accepts (test/test)
-//!   AWS_SECRET_ACCESS_KEY
-//!   TALON_S3_TEST_REGION       defaults to us-east-1
-//!
-//! The uploaded object is expected to be 4096 bytes where byte i == (i % 251).
+//! Skipped unless `TALON_S3_TEST_ENDPOINT` is set. See CI's `s3-e2e` job for the
+//! required env and the seeded object (4096 bytes, byte i == i % 251).
+
+mod conformance;
 
 use std::sync::Arc;
 
 use talon_backend::{ReqwestClient, S3Backend, S3Config, S3Credentials};
-use talon_core::{Backend, BackendStore, ObjectId};
-
-/// Deterministic content byte for absolute offset `i` — matches what CI uploads.
-fn content_byte(i: u64) -> u8 {
-    (i % 251) as u8
-}
+use talon_core::{Backend, ObjectId};
 
 fn env(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|s| !s.is_empty())
 }
 
 #[tokio::test]
-async fn s3_backend_reads_real_object_end_to_end() {
+async fn s3_backend_conformance_end_to_end() {
     let Some(endpoint) = env("TALON_S3_TEST_ENDPOINT") else {
         eprintln!("skipping S3 e2e: TALON_S3_TEST_ENDPOINT is not set");
         return;
@@ -47,7 +32,6 @@ async fn s3_backend_reads_real_object_end_to_end() {
     let secret_access_key =
         env("AWS_SECRET_ACCESS_KEY").expect("AWS_SECRET_ACCESS_KEY must be set");
 
-    // Point at the emulator: http:// selects plaintext, path-style for LocalStack.
     let host = endpoint
         .strip_prefix("http://")
         .or_else(|| endpoint.strip_prefix("https://"))
@@ -65,26 +49,13 @@ async fn s3_backend_reads_real_object_end_to_end() {
         secret_access_key,
         session_token: None,
     };
-    let backend = S3Backend::new(config, creds, Arc::new(ReqwestClient::new()));
+    let backend = Arc::new(S3Backend::new(
+        config,
+        creds,
+        Arc::new(ReqwestClient::new()),
+    ));
 
-    let obj = ObjectId::new(Backend::S3, bucket, key);
-
-    // HEAD resolves size + ETag (the version). SigV4 must sign this correctly.
-    let stat = backend.head(&obj).await.expect("HEAD should succeed");
-    assert_eq!(stat.len, 4096, "unexpected object size");
-    assert!(!stat.version.as_str().is_empty(), "HEAD returned no ETag");
-
-    // A ranged GET in the middle of the object returns exactly those bytes.
-    let got = backend
-        .fetch_range(&obj, 1000, 256)
-        .await
-        .expect("ranged GET should succeed");
-    assert_eq!(got.len(), 256, "unexpected range length");
-    let expected: Vec<u8> = (1000..1256).map(content_byte).collect();
-    assert_eq!(&got[..], &expected[..], "range bytes mismatch");
-
-    // A read of the first bytes too, to cover offset 0.
-    let head_bytes = backend.fetch_range(&obj, 0, 16).await.expect("GET head");
-    let expected_head: Vec<u8> = (0..16).map(content_byte).collect();
-    assert_eq!(&head_bytes[..], &expected_head[..]);
+    let present = ObjectId::new(Backend::S3, bucket.clone(), key);
+    let missing = ObjectId::new(Backend::S3, bucket, "e2e/does-not-exist.bin");
+    conformance::run(backend, &present, &missing).await;
 }


### PR DESCRIPTION
## Summary
- Factor the per-backend e2e assertions into a shared `tests/conformance` module that every backend's e2e runs against its emulator, so **S3 (LocalStack), GCS (fake-gcs), and Azure (Azurite)** are held to one identical `BackendStore` contract:
  - HEAD size + non-empty version
  - exact range bytes at several offsets (head, interior, aligned)
  - whole-object read
  - tail-past-EOF clamping
  - matching If-Match succeeds; stale If-Match → `VersionMismatch`
  - missing object → `NotFound` for both HEAD and GET
- The three e2e files now just build their backend and call `conformance::run`.

Part of the multi-cloud e2e epic (#263), sub-issue #271. The existing `s3-e2e`/`gcs-e2e`/`azure-e2e` CI jobs now exercise the shared suite.

## Test plan
- [x] All three e2e compile and skip cleanly with no endpoint
- [x] clippy + fmt + typos clean
- [ ] CI: the three emulator jobs run the shared suite green