### PR TITLE
doc: add use-case guides and the data-plane runtime explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,14 @@ Start with the section that matches what you're doing:
 - **Installing Talon** — [Docker](docs/installation/docker.md) (fastest),
   [Kubernetes](docs/installation/kubernetes.md) (production), or
   [from source](docs/installation/source.md) (contributors).
+- **Deciding if Talon fits** — [Use cases](docs/use-cases/overview.md): model
+  training, checkpointing, notebooks and data sharing, cross-cloud reads, and
+  analytics — including where it does *not* help.
 - **Using Talon** — the [Getting started tutorial](docs/tutorials/getting-started.md)
   builds the workspace, runs a cluster, and opens the management console;
-  [DESIGN.md](DESIGN.md) explains what each component does.
+  [DESIGN.md](DESIGN.md) explains what each component does, and
+  [Data-plane runtime](docs/explanation/data-plane-runtime.md) covers the
+  zero-copy path and the io_uring measurements.
 - **Operating Talon** — [Operator runbook](docs/operations/runbook.md) (HA,
   etcd/Kubernetes backends, configuration, upgrades, alerts) and
   [security hardening](docs/operations/security.md).

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -2,6 +2,15 @@
 
 [Introduction](./introduction.md)
 
+# Use cases
+
+- [Overview](./use-cases/overview.md)
+- [Model training](./use-cases/training.md)
+- [Checkpointing](./use-cases/checkpointing.md)
+- [Notebooks and data sharing](./use-cases/notebooks.md)
+- [Cross-cloud and remote data](./use-cases/cross-cloud.md)
+- [Analytics and shuffle](./use-cases/analytics.md)
+
 # Installation
 
 - [Docker](./installation/docker.md)
@@ -26,6 +35,7 @@
 # Explanation
 
 - [Design (v1)](./explanation/design.md)
+- [Data-plane runtime: choosing io_uring](./explanation/data-plane-runtime.md)
 - [ADR 0001: Management-plane HA](./explanation/adr-0001-management-plane-ha.md)
 
 # Contributing

--- a/docs/book/src/explanation/data-plane-runtime.md
+++ b/docs/book/src/explanation/data-plane-runtime.md
@@ -1,0 +1,1 @@
+{{#include ../../../explanation/data-plane-runtime.md}}

--- a/docs/book/src/use-cases/analytics.md
+++ b/docs/book/src/use-cases/analytics.md
@@ -1,0 +1,1 @@
+{{#include ../../../use-cases/analytics.md}}

--- a/docs/book/src/use-cases/checkpointing.md
+++ b/docs/book/src/use-cases/checkpointing.md
@@ -1,0 +1,1 @@
+{{#include ../../../use-cases/checkpointing.md}}

--- a/docs/book/src/use-cases/cross-cloud.md
+++ b/docs/book/src/use-cases/cross-cloud.md
@@ -1,0 +1,1 @@
+{{#include ../../../use-cases/cross-cloud.md}}

--- a/docs/book/src/use-cases/notebooks.md
+++ b/docs/book/src/use-cases/notebooks.md
@@ -1,0 +1,1 @@
+{{#include ../../../use-cases/notebooks.md}}

--- a/docs/book/src/use-cases/overview.md
+++ b/docs/book/src/use-cases/overview.md
@@ -1,0 +1,1 @@
+{{#include ../../../use-cases/overview.md}}

--- a/docs/book/src/use-cases/training.md
+++ b/docs/book/src/use-cases/training.md
@@ -1,0 +1,1 @@
+{{#include ../../../use-cases/training.md}}

--- a/docs/explanation/data-plane-runtime.md
+++ b/docs/explanation/data-plane-runtime.md
@@ -1,0 +1,220 @@
+# Data-plane runtime: choosing io_uring
+
+Talon's data plane moves large blocks between NVMe and the network. This page
+explains how that path is built, why it is split into two layers, and what
+happened when the design was measured — including the parts that were measured
+and **rejected**.
+
+## The two-layer model
+
+The central constraint is that **large object bytes must never enter userspace**.
+A 256 MiB block read into a `Vec<u8>` and written back out costs two copies,
+heap pressure, and buffer bloat on whatever runtime is scheduling the
+connection. So the data plane splits into two layers with different jobs:
+
+**Layer 1 — protocol scheduling.** Accepts connections, reads and writes 16-byte
+frame headers, decodes small control messages, runs timers and metrics. This is
+where connection management lives, and it handles a few dozen bytes per request.
+
+**Layer 2 — bulk movement.** Moves the payload with Linux zero-copy syscalls:
+`sendfile(2)` from the block file into the socket on a read, `splice(2)` from the
+socket through a pipe into a staged file on ingest. The bytes go
+`NVMe → page cache → kernel → socket` and are never in a Rust buffer.
+
+The layers are deliberately decoupled. Layer 2 depends on no runtime types —
+`send_file_range` and `splice_to_file` take `&impl AsRawFd` — which is what made
+the runtime experiment below possible without touching the zero-copy path at all.
+
+### Why sendfile runs off the reactor
+
+`sendfile` and `splice` are **blocking** syscalls. They can block on socket
+backpressure, on disk, or on pipe readiness. Running them on the thread that
+schedules connections means one slow client stalls every connection multiplexed
+onto that thread.
+
+So they run on a blocking helper pool. This matters more, not less, on a
+thread-per-core runtime: blocking one worker thread of a work-stealing pool is
+survivable, but blocking a single-threaded ring stalls everything it owns.
+
+## The runtime question
+
+Layer 1's job — many concurrent connections, small messages, high syscall rate —
+is what `io_uring` is designed for. It submits and completes operations in
+batches through shared ring buffers rather than one syscall per operation, and a
+thread-per-core design removes cross-thread scheduling from the path entirely.
+
+Talon ships a Tokio Layer 1 and an optional `io_uring` one, selectable per
+worker:
+
+```sh
+talon-worker --data-plane-rings 0   # one ring per core
+talon-worker --data-plane-rings 4   # exactly four
+talon-worker                        # portable Tokio path (default)
+```
+
+The rest of this page is how that second implementation was designed and what
+measuring it revealed.
+
+## Thread-per-core, and how accepts are distributed
+
+`monoio` has no work-stealing scheduler. It scales by running N independent
+single-threaded runtimes that share nothing. Each ring thread:
+
+1. **pins itself to a core**, so a connection's protocol scheduling never
+   migrates and its state stays in that core's caches;
+2. **builds its own ring** with its own blocking pool for `sendfile`;
+3. **binds the listen address with `SO_REUSEPORT`**.
+
+That last point is the mechanism the whole design rests on. Every ring binds the
+*same* address, and the **kernel** distributes incoming connections across them
+by hashing the TCP 4-tuple. There is no shared accept queue, no lock, and no
+thundering herd — a connection is assigned to a ring at accept time and stays
+there for its lifetime.
+
+Measured scaling on an 8-core host:
+
+| rings | throughput | scaling | per-core |
+|---|---|---|---|
+| 1 | 13,415 rps | 1.00× | 14,271 |
+| 2 | 24,447 rps | 1.82× | 12,867 |
+| 4 | 50,587 rps | 3.77× | 13,072 |
+| **8** | **107,993 rps** | **8.05×** | **13,935** |
+| 16 | 118,137 rps | 8.81× | 12,204 |
+
+Per-core throughput is flat from 1 to 16 rings, which is the number that matters:
+it means there is **no cross-ring contention** to amortise. The fall-off at 16 is
+SMT — this host has 8 physical cores, so the extra rings land on hyperthread
+siblings. The useful setting is one ring per *physical* core.
+
+## What was measured and rejected
+
+Three plausible-sounding design decisions did not survive contact with a
+benchmark. They are recorded here because the negative results shaped the
+implementation more than the positive ones.
+
+### Sharding cache state per ring — rejected
+
+Thread-per-core suggests an obvious companion: shard `BlockIndex` per ring so
+each owns its slice with no locking, using `Rc<RefCell<...>>` instead of
+`Arc<Mutex<...>>`. It loses on two independent counts.
+
+**Cross-ring forwarding costs 30–67% of throughput.** Connections are
+distributed by TCP 4-tuple; blocks are keyed by `block_id`. The two hashes are
+unrelated, so only ~1/N of requests arrive at the ring that owns the block —
+**87.5% need forwarding at 8 shards**, and forwarding is not free.
+
+**Per-shard eviction budgets waste capacity.** With 256 MiB blocks and 64 GiB per
+worker there are only ~256 block slots, or 32 per shard at 8 rings. That is far
+too few for hash uniformity: measured skew reached 47–59%, so some shards evict
+while others sit below capacity. Simulated against realistic workloads, this cost
+up to **5.1 percentage points of hit rate** when the working set sat near
+capacity — and each avoidable miss is a 256 MiB refetch.
+
+Worth separating the two ideas: sharding the eviction *policy* is free — hit rate
+was identical to global LRU across every distribution tested, including an
+adversarial one concentrating all hot blocks in one shard. Sharding the *budget*
+is what costs.
+
+So worker state stays shared behind an `Arc`. This is sound on a thread-per-core
+runtime because `!Send` constrains *futures crossing threads*, not shared state
+read from within a ring.
+
+### fd ownership across the ring/blocking boundary — not a problem
+
+This was expected to be the hardest part of the design, and it turned out to be
+the opposite.
+
+The Tokio path cannot `sendfile` directly onto its socket: a Tokio `TcpStream` is
+non-blocking, so a blocking `sendfile` on it would spuriously `EAGAIN`. It
+therefore round-trips the socket out of and back into the runtime **on every
+single transfer** — `into_std`, `set_nonblocking(false)`, move to a blocking
+thread, move back, `set_nonblocking(true)`, `from_std`.
+
+A ring-owned fd needs none of that. It is passed straight to the blocking pool
+and the ring resumes on the same stream afterwards. The `io_uring` implementation
+of this path is *smaller* than the Tokio one.
+
+### A single ring — rejected
+
+A single ring caps at roughly 13k rps per core regardless of connection count. It
+is the simplest thing to build and it is a throughput ceiling on a machine meant
+to saturate NVMe and a NIC. Thread-per-core is not an optimisation here; it is
+the point.
+
+## Benchmark results, and what they do not show
+
+Two independent measurements exist, at different concurrency levels, and they
+disagree in an instructive way.
+
+**At 1024 concurrent connections**, measured in a standalone harness against a
+full-integration setup (real framed protocol, real `sendfile`, real loopback TCP,
+connection reuse):
+
+| comparison | throughput | per-core | p50 | p99 | RSS |
+|---|---|---|---|---|---|
+| 1 ring vs 1 Tokio worker | +85% | +23–35% | −46% | −44% | −15% |
+| 16 rings vs full Tokio | +35% | +34% | −19% | −26% | −34% |
+
+Latency, CPU efficiency, and memory all improve together — there is no trade
+being made.
+
+**At concurrency 1**, measured by the in-repo benchmark
+(`cargo bench -p talon-worker --bench dataplane_benches`), the two runtimes are
+**statistically indistinguishable**. Across seven runs, medians landed between
+218 and 295 µs for both, and the sign of the difference flipped run to run. The
+spread *within* one implementation exceeded the gap between them.
+
+That is not a contradiction — it is the expected shape of the result.
+`io_uring`'s advantage is amortising syscalls across many in-flight operations.
+With one request in flight there is nothing to amortise, and the bulk bytes
+bypass the ring via `sendfile` on both paths anyway, leaving a 16-byte header
+exchange as the only work that differs.
+
+### Why the default is still Tokio
+
+The `io_uring` data plane is complete, tested, and byte-exact against the Tokio
+path — the test suite mirrors both implementations assertion-for-assertion. It is
+not the default because **the evidence for flipping it is not yet reproducible in
+this repository**. The 1024-connection numbers come from a harness that lives
+outside the tree; the in-repo benchmark measures a concurrency where no
+difference is expected.
+
+A microbenchmark harness cannot honestly model 1024 concurrent connections — it
+drives one client serially, and a synthetic fan-out would mostly measure the
+harness's own scheduling. Closing that gap needs a concurrent load test, which is
+tracked separately. Until then the default stays on the portable path, and the
+faster one is opt-in.
+
+## Coexistence with Tokio
+
+Even on a ring, the worker is not Tokio-free, and the reason is worth stating.
+
+`block_store` runs its filesystem I/O on `tokio::task::spawn_blocking` so a large
+read or a write-plus-fsync never stalls the reactor, and parts of the miss path
+use Tokio timers and synchronisation primitives. Driven from a bare ring, those
+calls panic. Ring threads therefore enter a Tokio runtime handle before running.
+
+This is coexistence by design rather than a workaround: the ring owns protocol
+scheduling and hands `sendfile` to its own blocking pool, while Tokio's blocking
+pool absorbs filesystem work that belongs on neither. It does mean two blocking
+pools share pinned cores, so the per-ring pool is kept deliberately small.
+
+The same reasoning applies at the cluster level. The control plane, coordinator
+admin API, management UI, etcd and Kubernetes clients, the miss loader, and the
+metrics endpoints all stay on Tokio — they are not the hot path, and their
+ecosystems are Tokio-bound. The ring is used precisely where its advantage is
+measurable.
+
+## Reproducing this
+
+```sh
+# Both data planes, same block, real loopback TCP
+cargo bench -p talon-worker --bench dataplane_benches
+
+# Run a worker on rings and confirm SO_REUSEPORT: N listeners, one port
+talon-worker --data-plane-rings 2 --listen 127.0.0.1:7001
+ss -ltn | grep 7001
+```
+
+See [BENCHMARKS.md](../../BENCHMARKS.md) for the harness, the committed
+baselines, and why the benchmark CI job is informational rather than gating.

--- a/docs/use-cases/analytics.md
+++ b/docs/use-cases/analytics.md
@@ -1,0 +1,80 @@
+# Analytics and shuffle
+
+## The problem
+
+Query engines read columnar data — Parquet, Lance, ORC — with an access pattern
+object stores handle poorly:
+
+- **Reads are partial and structured.** A query reads a footer to find row
+  groups, then specific column chunks. Whole-file transfer is waste.
+- **Many small ranged reads.** Each is a separate request with full round-trip
+  latency, and per-request cost adds up faster than bytes do.
+- **Hot files are read by every worker.** Dimension tables and recent partitions
+  are read by the whole cluster, repeatedly.
+
+## What Talon does
+
+**Serves byte ranges without whole-object transfer.** `GET_RANGE` maps directly
+onto `sendfile` with an offset and length, so once a block is resident, reading
+a footer moves the footer — not the file, and not through userspace.
+
+**Deduplicates the hot-file stampede.** When every query worker reads the same
+dimension table, concurrent misses for a block collapse to a single origin
+fetch rather than one per reader.
+
+**Caches by object version.** Blocks are keyed by the origin's ETag, so
+republishing a partition at the same key does not serve stale data to a query.
+
+## Shuffle: read the caveat
+
+Shuffle intermediates are a **partial fit**, and it is worth being direct about
+why:
+
+Talon's design centres on large, immutable, repeatedly-read objects. Shuffle
+data is written once, read once or twice, and then discarded. That inverts two
+of the three assumptions — reuse is low and lifetime is short — so the cache
+stores bytes it will not serve again, and eviction pressure rises without a
+corresponding hit-rate gain.
+
+Where it *does* help is the case of shuffle data read by more than one consumer,
+or re-read after a task retry: the second read is local, and the write-through
+path means the data is already in cache when that happens. Where it does not
+help is the common single-consumer case, which is better served by local
+scratch.
+
+If shuffle is the primary workload, measure hit rate before committing to it.
+The per-worker metrics exposed to Prometheus make this straightforward.
+
+## Current limitation: block granularity
+
+This is the most important caveat on this page, and it is a real one today.
+
+Blocks are currently materialised **whole**. A read that touches a block fetches
+the entire block — 256 MiB at the default size — even if the query wanted a few
+kilobytes of one column chunk. For a sequential scan that is exactly right, and
+the cost is amortised immediately. For sparse random access across a large file
+it is not: the first touch of each block pays a full block fetch.
+
+The design anticipates this. `DESIGN.md` specifies **paged blocks**, where a
+block is materialised page by page against a present bitmap, and a range
+touching absent pages fetches only those pages' byte ranges rather than the
+whole block. The supporting pieces exist in the tree — the block form enum, the
+present bitmap, a paged store implementation — but the serve path does not yet
+resolve reads through them, so the behaviour above is what actually ships.
+
+Practical consequence: **Talon suits analytics workloads that scan more than
+they seek.** Full-partition scans, repeated reads of hot dimension tables, and
+range reads that align with block boundaries all benefit now. Highly selective
+point lookups scattered across a large file will over-fetch until paged blocks
+are wired through.
+
+## Practical notes
+
+- **Tune block size to the access pattern.** The 256 MiB default targets
+  sequential scans. A smaller block size trades bookkeeping for less
+  over-fetch on selective workloads, and is configurable per worker.
+- **Eviction is byte-accounted with reader pinning.** A block being streamed by
+  an in-flight `sendfile` is never evicted underneath the reader.
+- **Watch hit rate, not throughput.** For analytics the interesting metric is
+  whether the working set fits; capacity and hit rate are both exported to
+  Prometheus.

--- a/docs/use-cases/checkpointing.md
+++ b/docs/use-cases/checkpointing.md
@@ -1,0 +1,49 @@
+# Model checkpointing
+
+## The problem
+
+Checkpointing is the inverse of training's read pattern, and it is bursty:
+
+- **Writes are large and synchronised.** A job checkpoints from every rank at
+  once, and the origin absorbs the whole burst while training stalls.
+- **Restores are latency-critical.** After a failure, the fleet reads the same
+  checkpoint simultaneously — a thundering herd against one prefix.
+- **Reads are often partial.** Inspecting a checkpoint's metadata or a single
+  tensor means reading a footer or a byte range, not the whole file.
+
+## What Talon does
+
+**Write-through to the origin, cached on write.** A `Put` streams the object to
+the backing store and caches it locally in the same operation. Durability is the
+object store's, unchanged — but the bytes are already resident for the read that
+usually follows.
+
+**Serves the restore stampede from cache.** When every rank reads the same
+checkpoint, the first read populates the cache and the rest are NVMe hits.
+Concurrent misses for the same block are deduplicated, so a stampede produces
+**one** origin fetch, not one per reader.
+
+**Range reads without whole-file transfer.** `GET_RANGE` is served with
+`sendfile` at an offset, so once a block is resident, reading a checkpoint
+footer transfers the footer — not the checkpoint, and not through userspace.
+Note that the *first* touch of a block still fetches the whole block from the
+origin; see [the granularity note](./analytics.md#current-limitation-block-granularity).
+
+**Version-correct caching.** Blocks are keyed by the object's real ETag, and the
+worker sends a conditional `If-Match` on the miss path. Overwriting a checkpoint
+at the same key produces a new version, and readers do not get served the old
+bytes.
+
+## Practical notes
+
+- **Write path is write-through, not write-back.** Talon does not buffer writes
+  and flush later; a `Put` returns after the origin commits. This bounds the
+  failure mode (no unflushed data to lose) but means Talon does not accelerate
+  the write itself — it removes the *read-back* cost.
+- **Checkpoint restore is the good case.** Whole-block materialisation pairs
+  with readahead for a sequential restore, which is what a full checkpoint load
+  does. Workloads that only ever poke at footers over-fetch on first touch.
+- **Zero-copy ingest has a tradeoff.** The `splice`-based ingest path never
+  brings bytes into userspace, which also means a streaming checksum cannot be
+  computed on that path. The loader path, which downloads into memory, does
+  checksum.

--- a/docs/use-cases/cross-cloud.md
+++ b/docs/use-cases/cross-cloud.md
@@ -1,0 +1,52 @@
+# Cross-cloud and remote data
+
+## The problem
+
+Data and compute increasingly live in different places — a dataset in S3, GPUs
+in another cloud, an on-prem cluster reading from a cloud bucket. Reading across
+that boundary is the worst case for an object store:
+
+- **WAN latency on every read.** Round trips are tens of milliseconds, not
+  single digits, and they land in the critical path of every fetch.
+- **Egress is billed per byte, every time.** Re-reading the same object across
+  clouds is the single most expensive way to move data.
+- **Bandwidth is contended and variable**, so throughput is unpredictable in a
+  way local storage is not.
+
+Each of these gets multiplied by the number of readers.
+
+## What Talon does
+
+**Pays the crossing once.** The first read pulls the object across the boundary
+and commits it to local NVMe. Every subsequent read — by any worker in the
+cluster — is local. For a dataset read by a fleet, this turns N crossings into
+one.
+
+**Speaks all three major backends.** S3, GCS, and Azure Blob are implemented
+behind one `BackendStore` trait, so the same cluster can front buckets in
+different clouds, and the FUSE namespace exposes them side by side under
+`/s3`, `/gcs`, and `/az`.
+
+**Supports custom endpoints.** Endpoint overrides and path-style addressing
+allow S3-compatible stores and emulators, so this is not restricted to the three
+public clouds.
+
+**Isolates the slow path.** Backend fetches run on a dedicated loader pool with
+bounded concurrency, never on the data-plane runtime. A burst of misses against
+a slow remote origin applies backpressure instead of stalling readers that are
+hitting cache.
+
+**Prewarms deliberately.** The coordinator's LOAD path can pull a prefix into
+the cache before a job starts, so the WAN crossing happens on a schedule rather
+than in the critical path of the first read.
+
+## Practical notes
+
+- **This is a read-through cache, not a replication tool.** Talon does not sync
+  buckets or maintain a mirror; it caches what is actually read. If you need a
+  full copy in the second location regardless of access, use a transfer service.
+- **Egress is saved on re-reads, not first reads.** The saving is proportional
+  to reuse. A workload that reads each object exactly once saves nothing.
+- **Latency simulation is available for testing.** The
+  [latency lab](../testing/latency-lab.md) injects modelled backend latency, so
+  cross-region behaviour can be exercised without a cross-region bill.

--- a/docs/use-cases/notebooks.md
+++ b/docs/use-cases/notebooks.md
@@ -1,0 +1,47 @@
+# Notebooks and data sharing
+
+## The problem
+
+Interactive analysis has a different profile from batch compute:
+
+- **Exploration is repetitive.** The same file is opened repeatedly as a query
+  is refined, and each open pays origin latency again.
+- **Tools expect a filesystem.** Notebooks, pandas, and command-line utilities
+  open paths; making them speak an object-store SDK means rewriting analysis
+  code.
+- **Teams read the same data.** Several people exploring one dataset each pull
+  their own copy from the origin.
+- **Credentials spread.** Every notebook that talks to the origin directly needs
+  its own storage credentials.
+
+## What Talon does
+
+**Presents object storage as a POSIX filesystem.** The FUSE mount maps backend
+namespaces to paths — `/s3/<bucket>/<key>`, `/gcs/...`, `/az/...` — so
+`open()`, `read()`, and `ls` work against object storage with no client library
+and no code change.
+
+**Shares one cache across a team.** A colleague opening the same file reads from
+NVMe, because someone already pulled it. The cache is a fleet resource, not a
+per-user copy.
+
+**Keeps the second open fast.** Iterative exploration re-reads the same bytes;
+after the first read they are local.
+
+**Centralises credentials.** Workers hold the storage credentials and clients
+talk to workers, so notebooks need access to the cluster rather than to the
+bucket. Credentials are read from the environment at use time and are kept out
+of config structs and logs.
+
+## Practical notes
+
+- **Mount tuning is applied for large reads.** The kernel mount is configured
+  for large reads and cached immutable data rather than general-purpose
+  filesystem semantics.
+- **This is a cache view, not a filesystem.** Directory listings are synthesised
+  from the object namespace; POSIX metadata beyond size and type is
+  approximated. It is a good way to *read* object storage, not a replacement for
+  a shared filesystem.
+- **Writes go through to the origin.** Creating or writing a file under the
+  mount writes through to the backing store on release, and the object is cached
+  on the way past.

--- a/docs/use-cases/overview.md
+++ b/docs/use-cases/overview.md
@@ -1,0 +1,45 @@
+# Use cases
+
+Talon is built for one shape of problem: **the same large, immutable objects are
+read repeatedly by compute that is not co-located with the storage.** Object
+stores are durable and cheap, but every read crosses a network boundary and is
+billed per request. When a fleet of GPUs or query workers reads the same
+dataset, the origin becomes both the latency floor and the cost centre.
+
+Talon puts a shared NVMe cache between them. The pages below describe the
+workloads this helps, what specifically Talon does for each, and — where support
+is partial — what it does not do yet.
+
+## When Talon helps
+
+The pattern to look for is **repeated reads of immutable data across a fleet**:
+
+- The same objects are read more than once, by more than one machine.
+- Objects are large enough that transfer time dominates request overhead.
+- Data is written once and not mutated in place — new versions get new keys.
+- Compute is elastic, so re-reading from origin on every scale-up is wasteful.
+
+## When it does not
+
+Talon is a cache, not a storage system, and being explicit about the boundary
+saves disappointment:
+
+- **Small-object, high-fanout metadata access.** The design targets large
+  sequential reads; a workload dominated by kilobyte objects pays cache
+  bookkeeping without recovering it in transfer savings.
+- **Read-modify-write on cached data.** Writes go through to the origin
+  (write-through); Talon is not a write-back buffer and does not merge partial
+  updates.
+- **Strong cross-client consistency.** Cache coherence is by object version
+  (ETag). A reader holding an older version keeps reading it until its cached
+  entry is invalidated — correct for immutable data, wrong for mutable state.
+- **Single-read workloads.** If each object is read exactly once, a cache adds a
+  hop and stores bytes nobody asks for again.
+
+## Use cases
+
+- [Model training](./training.md) — feeding a GPU fleet from a shared dataset.
+- [Checkpointing](./checkpointing.md) — writing and restoring model state.
+- [Notebooks and data sharing](./notebooks.md) — interactive access to shared data.
+- [Cross-cloud transfer](./cross-cloud.md) — reading data that lives in another cloud.
+- [Analytics and shuffle](./analytics.md) — columnar scans and intermediate data.

--- a/docs/use-cases/training.md
+++ b/docs/use-cases/training.md
@@ -1,0 +1,51 @@
+# Model training
+
+## The problem
+
+A training job reads the same dataset every epoch, and a fleet of workers reads
+overlapping shards of it. Reading from the object store each time means:
+
+- **Latency in the critical path.** Every batch fetch is a network round trip to
+  the origin, and GPUs idle while it completes.
+- **Repeated egress and request cost.** The same bytes are billed on every
+  epoch, and again for every worker that reads them.
+- **Throughput capped by the origin**, not by local hardware — object stores
+  throttle per-account and per-prefix.
+
+The data itself is immutable: a dataset version is written once and read many
+times. That is exactly what a cache is for.
+
+## What Talon does
+
+**Serves repeated reads from local NVMe.** The first read of a block pulls it
+from the origin and commits it to a worker's cache; subsequent reads across the
+fleet are served from NVMe over the data plane. Epoch two onwards does not touch
+the origin.
+
+**Keeps bytes out of userspace.** A cache hit is served with `sendfile(2)`
+straight from the block file into the socket — the block is never copied into a
+buffer on the way past. See [Data-plane runtime](../explanation/data-plane-runtime.md).
+
+**Scales cache capacity with the fleet.** Blocks are placed across workers by
+rendezvous hashing, so adding a worker adds capacity and moves a minimal share
+of existing placements. A dataset larger than one node's NVMe is still fully
+cacheable.
+
+**Reads ahead on sequential scans.** The FUSE client detects sequential access
+and prefetches subsequent blocks, so a scan is not serialised on per-block
+misses.
+
+**Requires no application change.** Training code opens files under the FUSE
+mount; the framework's existing data loader works unmodified.
+
+## Practical notes
+
+- **Block size matters.** The 256 MiB default suits large shard files. Datasets
+  made of many small files see less benefit — the cost is per-object bookkeeping
+  rather than transfer.
+- **Prewarm before the job starts.** The coordinator's LOAD path can pull an
+  object's blocks into the cache ahead of time, so epoch one is also a hit
+  rather than paying the miss penalty across the fleet.
+- **Capacity planning.** Total cache should exceed the working set, or eviction
+  will churn the dataset out between epochs. Per-worker capacity and usage are
+  visible in the management console and in Prometheus metrics.


### PR DESCRIPTION
Adds two sections to the published book: **Use cases** and a **Data-plane runtime** explanation page covering the io_uring design and its measurements.

## Use cases

Answers "does Talon fit my workload" before a reader commits to an install — six pages under a new top-level section:

| page | covers |
|---|---|
| Overview | when Talon helps, **and when it does not** |
| Model training | feeding a GPU fleet from a shared dataset |
| Checkpointing | write-through, restore stampedes, range reads |
| Notebooks and data sharing | POSIX access, team-shared cache, credential centralisation |
| Cross-cloud and remote data | paying the WAN crossing once, three backends |
| Analytics and shuffle | columnar scans, hot dimension tables, and the shuffle caveat |

The overview opens with **when Talon does not help** — small-object access, read-modify-write, strong cross-client consistency, single-read workloads. A cache recommended indiscriminately gets deployed where it cannot win, and the resulting disappointment is worse than the lost adoption.

## Data-plane runtime

The technical page. It covers the two-layer split that keeps object bytes out of userspace, why `sendfile`/`splice` run off the reactor, and how thread-per-core distributes accepts through `SO_REUSEPORT` — the kernel hashing the TCP 4-tuple rather than a shared accept queue — with the 8.05× scaling table.

**The negative results are included deliberately**, because they shaped the implementation more than the positive ones:

- **Sharding cache state per ring — rejected.** Cross-ring forwarding costs 30–67% of throughput (connections hash by 4-tuple, blocks by `block_id`, so only ~1/N arrive at the owning ring), and per-shard eviction budgets cost up to 5.1pt of hit rate with only ~256 block slots to divide.
- **fd ownership across the ring boundary — not a problem.** Expected to be the hard part; turned out the io_uring path is *smaller* than the Tokio one, which round-trips the socket in and out of the runtime on every transfer.
- **A single ring — rejected.** Caps at ~13k rps/core.

## On the benchmark numbers

Both measurements are reported, including the one that does not support the feature:

- **1024 concurrent connections** (standalone harness): +35% throughput, −19% p50, −26% p99, −34% RSS.
- **Concurrency 1** (in-repo `dataplane_benches`): statistically indistinguishable — seven runs, medians overlapping, sign of the difference flipping run to run.

The page explains why both are true (nothing to amortise at concurrency 1; bulk bytes bypass the ring via `sendfile` on both paths) and states plainly why **the default is still Tokio**: the 1024-connection evidence lives in a harness outside this tree and is not yet reproducible by a reader.

Given this repository's history with a design document that described a runtime the code did not have, publishing a favourable number without its caveat seemed like the wrong lesson to draw.

## A correction this surfaced

Writing the analytics page turned up an overclaim I had to fix before publishing. I initially described **page-level miss handling** — fetching only absent pages rather than a whole block — because `DESIGN.md` specifies it and the supporting types exist (`BlockForm`, `PresentBitmap`, `PagedBlockStore`).

Checking the code: `grep -c "PagedBlockStore" crates/talon-worker/src/runtime.rs` → **0**. The serve path only ever uses `WholeBlockStore` and `Presence::Whole`. Paged blocks are built but not wired.

The page now documents the granularity limit as it actually ships — a selective read pays a full block fetch on first touch — and says which analytics shapes benefit today (scans, hot dimension tables, block-aligned ranges) versus which over-fetch (scattered point lookups). The checkpointing page's footer-read claim got the same correction.

Every other capability claim was checked against the code the same way: rendezvous placement, readahead, LOAD prewarm, miss dedup, `If-Match` conditional GET, reader-pinned eviction, the `/s3` `/gcs` `/az` namespace mapping, mount tuning, env-only credentials, endpoint overrides, and bounded loader concurrency.

The **shuffle** section also states that it is a *partial* fit rather than listing it as a supported workload — shuffle data is written once, read once, and discarded, which inverts two of the three assumptions the cache is built on.

## Verification

- `mdbook build docs/book` — clean, all 7 pages render
- `lychee --offline` over the same file set as CI — 115 links, **0 errors** (caught and fixed one broken cross-reference)
- `typos` — clean

Book pages use the established `{{#include}}` stub pattern so `docs/` stays the single source and the book has no second copy to drift.

Refs #273, #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)
