### PR TITLE
fix(worker): saturate LRU byte accounting

### DIFF
--- a/crates/talon-worker/src/eviction.rs
+++ b/crates/talon-worker/src/eviction.rs
@@ -46,6 +46,19 @@ struct Inner {
 }
 
 impl Lru {
+    fn add_bytes(total: &mut u64, bytes: u64) {
+        debug_assert!(
+            total.checked_add(bytes).is_some(),
+            "LRU byte accounting overflow"
+        );
+        *total = total.saturating_add(bytes);
+    }
+
+    fn subtract_bytes(total: &mut u64, bytes: u64) {
+        debug_assert!(*total >= bytes, "LRU byte accounting underflow");
+        *total = total.saturating_sub(bytes);
+    }
+
     /// Create an empty tracker.
     pub fn new() -> Self {
         Self {
@@ -81,9 +94,10 @@ impl Lru {
             let old = e.bytes;
             e.bytes = bytes;
             e.last_used = tick;
-            g.total_bytes = g.total_bytes - old + bytes;
+            Self::subtract_bytes(&mut g.total_bytes, old);
+            Self::add_bytes(&mut g.total_bytes, bytes);
         } else {
-            g.total_bytes += bytes;
+            Self::add_bytes(&mut g.total_bytes, bytes);
             g.entries.insert(
                 unit,
                 Entry {
@@ -131,7 +145,7 @@ impl Lru {
     pub fn remove(&self, unit: &CacheUnit) -> Option<u64> {
         let mut g = self.inner.lock().unwrap();
         let e = g.entries.remove(unit)?;
-        g.total_bytes -= e.bytes;
+        Self::subtract_bytes(&mut g.total_bytes, e.bytes);
         Some(e.bytes)
     }
 
@@ -164,7 +178,7 @@ impl Lru {
             .collect();
         for unit in &victims {
             if let Some(e) = g.entries.remove(unit) {
-                g.total_bytes -= e.bytes;
+                Self::subtract_bytes(&mut g.total_bytes, e.bytes);
             }
         }
         victims
@@ -189,7 +203,7 @@ impl Lru {
             match victim {
                 Some(unit) => {
                     if let Some(e) = g.entries.remove(&unit) {
-                        g.total_bytes -= e.bytes;
+                        Self::subtract_bytes(&mut g.total_bytes, e.bytes);
                     }
                     evicted.push(unit);
                 }
@@ -268,11 +282,19 @@ mod tests {
         lru.insert(whole(1), 100);
         lru.insert(whole(1), 250); // update same unit
         assert_eq!(lru.total_bytes(), 250);
+        lru.insert(whole(1), 50); // shrink same unit
+        assert_eq!(lru.total_bytes(), 50);
         assert_eq!(lru.len(), 1);
 
-        assert_eq!(lru.remove(&whole(1)), Some(250));
+        assert_eq!(lru.remove(&whole(1)), Some(50));
         assert_eq!(lru.total_bytes(), 0);
         assert_eq!(lru.remove(&whole(1)), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "LRU byte accounting underflow")]
+    fn accounting_underflow_is_detected_in_debug_builds() {
+        Lru::subtract_bytes(&mut 0, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Make the worker LRU's byte accounting saturating at every update site, while retaining debug assertions that surface accounting drift during development. This prevents release-mode wraparound from turning a bad counter into near-`u64::MAX` and evicting the cache.

## Related issues

Closes #307.

## Type of change

- [x] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [ ] Docs / tests / tooling

## Design alignment

This preserves the global byte-accounting model described in `DESIGN.md` under the worker-state discussion. It does not change the eviction policy; it makes the existing global counter fail loudly in debug builds and remain bounded in release builds.

## Changes

- Added saturating add/subtract helpers with debug overflow/underflow assertions.
- Routed all `total_bytes` mutations through those helpers.
- Extended accounting coverage for shrinking entries and underflow detection.

## Test plan

- [ ] `just ci` passes locally (fmt + clippy + test)
- [ ] Workspace compiles (`cargo build --workspace`)
- [x] Added/updated tests for new behavior

Additional local checks:

- `cargo fmt --all --check`
- Exact `eviction.rs` unit suite through a standalone module harness: 7 passed
- `clippy-driver -D warnings -D clippy::all` on the same exact module and tests: passed

The full `talon-worker` test target cannot compile on this macOS host because existing worker modules use Linux-only `splice`, CPU-affinity, and io_uring APIs; no tests reached execution in that command.

## Performance impact

- [x] Not performance-sensitive, OR
- [ ] `just bench-check` run; results below (baseline refreshed if the change is intentional)

The change only affects byte-accounting operations when cache units are inserted, removed, or evicted; it does not alter the read data path or eviction complexity.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`<type>(<scope>): <description>`) — it becomes the squash-merge commit subject and is checked by CI
- [x] Public items are documented; no broken intra-doc links
- [x] No new dependencies without discussion
- [x] Rebased on the latest `main`
