### PR TITLE
fix(fuse): bound the write buffer instead of trusting the offset

### DIFF
--- a/crates/talon-fuse/src/lib.rs
+++ b/crates/talon-fuse/src/lib.rs
@@ -27,7 +27,7 @@ pub use mapping::{path_to_object, resolve_read, ReadTarget};
 pub use metrics::{ReadStats, ReadStatsSnapshot};
 #[cfg(feature = "mount")]
 pub use mount::{TalonFuse, CANONICAL_MOUNT_VERSION};
-pub use ops::{Attr, DirEntry, FileKind, FsError, ReadOnlyFs, ROOT_INO};
+pub use ops::{Attr, DirEntry, FileKind, FsError, ReadOnlyFs, DEFAULT_MAX_OBJECT_BYTES, ROOT_INO};
 pub use placement_cache::{Cached, PlacementCache, RefreshReason};
 pub use pool::{ConnectionPool, DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT};
 pub use prefetch::Prefetcher;

--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -56,6 +56,7 @@ pub(crate) fn errno(err: FsError) -> i32 {
         FsError::ReadOnly => libc::EROFS,
         FsError::Unsupported => libc::ENOSYS,
         FsError::BadHandle => libc::EBADF,
+        FsError::TooLarge => libc::EFBIG,
     }
 }
 
@@ -825,6 +826,7 @@ mod tests {
         assert_eq!(errno(FsError::ReadOnly), libc::EROFS);
         assert_eq!(errno(FsError::Unsupported), libc::ENOSYS);
         assert_eq!(errno(FsError::BadHandle), libc::EBADF);
+        assert_eq!(errno(FsError::TooLarge), libc::EFBIG);
     }
 
     #[test]

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -53,7 +53,19 @@ pub enum FsError {
     Unsupported,
     /// A read used a bad handle (`EBADF`).
     BadHandle,
+    /// The write would grow a buffered object past the allowed maximum, or the
+    /// requested offset is not representable (`EFBIG`).
+    TooLarge,
 }
+
+/// Default cap on a single in-memory write buffer (1 GiB).
+///
+/// v1 buffers a whole object in RAM, so the buffer length is attacker-reachable
+/// from an unprivileged `pwrite`/`ftruncate` at an arbitrary offset. Without a
+/// cap, `pwrite(fd, buf, 1, 1<<40)` asks for a 1 TiB zero-filled allocation and
+/// takes the mount (and likely the host) down. See
+/// [`ReadOnlyFs::with_max_object_bytes`] to tune.
+pub const DEFAULT_MAX_OBJECT_BYTES: u64 = 1 << 30;
 
 /// A directory entry yielded by `readdir`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -85,6 +97,8 @@ struct Node {
 /// directories is created on demand.
 pub struct ReadOnlyFs {
     inner: Mutex<Inner>,
+    /// Cap on the length of any single write handle's in-memory buffer.
+    max_object_bytes: u64,
 }
 
 struct Inner {
@@ -142,7 +156,21 @@ impl ReadOnlyFs {
                 next_fh: 1,
                 dirty: HashMap::new(),
             }),
+            max_object_bytes: DEFAULT_MAX_OBJECT_BYTES,
         }
+    }
+
+    /// Override the per-object write-buffer cap (see
+    /// [`DEFAULT_MAX_OBJECT_BYTES`]). Writes or truncates that would push a
+    /// buffer past this fail with [`FsError::TooLarge`] (`EFBIG`).
+    pub fn with_max_object_bytes(mut self, max: u64) -> Self {
+        self.max_object_bytes = max;
+        self
+    }
+
+    /// The configured per-object write-buffer cap.
+    pub fn max_object_bytes(&self) -> u64 {
+        self.max_object_bytes
     }
 
     /// Register an object at `path` (e.g. `/s3/bucket/a/b/file.bin`) with `size`,
@@ -382,18 +410,35 @@ impl ReadOnlyFs {
     /// Random-offset writes land by position; a write past the current end
     /// extends the buffer with zeros (sparse). Updates the node's visible size.
     /// Returns the number of bytes written. Fails with [`FsError::BadHandle`] for
-    /// a handle not opened for write.
+    /// a handle not opened for write, or [`FsError::TooLarge`] (`EFBIG`) if the
+    /// resulting buffer would exceed [`ReadOnlyFs::max_object_bytes`].
+    ///
+    /// The end offset is computed with a checked add: `offset` comes straight
+    /// from the kernel and `offset + len` would otherwise overflow `usize` (a
+    /// debug panic under the global lock, a wrap in release).
     pub fn write(&self, fh: u64, offset: u64, data: &[u8]) -> Result<u32, FsError> {
         let mut g = self.inner.lock_recover();
+        // EBADF outranks EFBIG, so validate the handle before the size checks.
+        if !g.dirty.contains_key(&fh) {
+            return Err(FsError::BadHandle);
+        }
+        let end = offset
+            .checked_add(data.len() as u64)
+            .ok_or(FsError::TooLarge)?;
+        if end > self.max_object_bytes {
+            return Err(FsError::TooLarge);
+        }
+        // Past the cap check, `end` fits in u64 and is bounded; on a 32-bit host
+        // it may still exceed usize, which is a legitimate EFBIG.
+        let end: usize = end.try_into().map_err(|_| FsError::TooLarge)?;
+        let start: usize = offset.try_into().map_err(|_| FsError::TooLarge)?;
         let dirty = g.dirty.get_mut(&fh).ok_or(FsError::BadHandle)?;
-        let start = offset as usize;
-        let end = start + data.len();
         if dirty.buf.len() < end {
             dirty.buf.resize(end, 0);
         }
         dirty.buf[start..end].copy_from_slice(data);
         let ino = dirty.ino;
-        let new_size = g.dirty.get(&fh).unwrap().buf.len() as u64;
+        let new_size = dirty.buf.len() as u64;
         if let Some(node) = g.nodes.get_mut(&ino) {
             node.size = node.size.max(new_size);
         }
@@ -401,10 +446,21 @@ impl ReadOnlyFs {
     }
 
     /// `setattr(size)`: truncate/extend the write handle's buffer to `size`.
+    ///
+    /// Fails with [`FsError::TooLarge`] (`EFBIG`) if `size` exceeds
+    /// [`ReadOnlyFs::max_object_bytes`] — `ftruncate` takes an arbitrary
+    /// user-supplied length and the buffer is zero-filled eagerly.
     pub fn truncate(&self, fh: u64, size: u64) -> Result<(), FsError> {
         let mut g = self.inner.lock_recover();
+        if !g.dirty.contains_key(&fh) {
+            return Err(FsError::BadHandle);
+        }
+        if size > self.max_object_bytes {
+            return Err(FsError::TooLarge);
+        }
+        let new_len: usize = size.try_into().map_err(|_| FsError::TooLarge)?;
         let dirty = g.dirty.get_mut(&fh).ok_or(FsError::BadHandle)?;
-        dirty.buf.resize(size as usize, 0);
+        dirty.buf.resize(new_len, 0);
         let ino = dirty.ino;
         if let Some(node) = g.nodes.get_mut(&ino) {
             node.size = size;
@@ -744,5 +800,84 @@ mod tests {
         assert_eq!(fs.write(fh, 0, b"ok").unwrap(), 2);
         assert_eq!(fs.dirty_bytes(fh).unwrap(), b"ok");
         fs.release(fh).unwrap();
+    }
+
+    /// Regression: `offset` comes from the kernel unvalidated, so a single
+    /// `pwrite` at a huge offset used to ask for a proportionally huge
+    /// zero-filled allocation (`buf.resize(offset + len)`) — a one-syscall DoS
+    /// of the whole mount. It is now bounded by `max_object_bytes`.
+    #[test]
+    fn write_past_the_cap_is_efbig_and_allocates_nothing() {
+        let fs = ReadOnlyFs::new().with_max_object_bytes(1024);
+        let (attr, fh) = fs.create(ROOT_INO, "big.bin").unwrap();
+
+        // 1 TiB offset: would have been a 1 TiB resize.
+        assert_eq!(fs.write(fh, 1 << 40, b"x"), Err(FsError::TooLarge));
+        // Just past the cap.
+        assert_eq!(fs.write(fh, 1024, b"x"), Err(FsError::TooLarge));
+        // Straddling the cap.
+        assert_eq!(fs.write(fh, 1020, b"12345"), Err(FsError::TooLarge));
+
+        // Nothing was buffered and the visible size never moved.
+        assert!(fs.dirty_bytes(fh).unwrap().is_empty());
+        assert_eq!(fs.getattr(attr.ino).unwrap().size, 0);
+
+        // Exactly at the cap still succeeds.
+        assert_eq!(fs.write(fh, 1023, b"x").unwrap(), 1);
+        assert_eq!(fs.dirty_bytes(fh).unwrap().len(), 1024);
+    }
+
+    /// `offset + data.len()` overflowed `usize`: a debug panic while holding the
+    /// global mutex (poisoning it and bricking every later op), a silent wrap in
+    /// release. It is now a checked add.
+    #[test]
+    fn write_offset_overflow_is_efbig_not_a_panic() {
+        let fs = ReadOnlyFs::new();
+        let (_, fh) = fs.create(ROOT_INO, "ovf.bin").unwrap();
+        assert_eq!(fs.write(fh, u64::MAX, b"xyz"), Err(FsError::TooLarge));
+        assert_eq!(fs.write(fh, u64::MAX - 1, b"xyz"), Err(FsError::TooLarge));
+        // The filesystem is still usable afterwards (no poisoned lock).
+        assert_eq!(fs.write(fh, 0, b"ok").unwrap(), 2);
+        assert_eq!(fs.dirty_bytes(fh).unwrap(), b"ok");
+    }
+
+    /// `truncate -s 1P file` reached `buf.resize(size)` directly.
+    #[test]
+    fn truncate_past_the_cap_is_efbig() {
+        let fs = ReadOnlyFs::new().with_max_object_bytes(1024);
+        let (attr, fh) = fs.create(ROOT_INO, "t.bin").unwrap();
+        fs.write(fh, 0, b"seed").unwrap();
+
+        assert_eq!(fs.truncate(fh, 1 << 50), Err(FsError::TooLarge));
+        assert_eq!(fs.truncate(fh, 1025), Err(FsError::TooLarge));
+        // Untouched by the rejected calls.
+        assert_eq!(fs.dirty_bytes(fh).unwrap(), b"seed");
+        assert_eq!(fs.getattr(attr.ino).unwrap().size, 4);
+
+        // At the cap is fine.
+        fs.truncate(fh, 1024).unwrap();
+        assert_eq!(fs.dirty_bytes(fh).unwrap().len(), 1024);
+    }
+
+    /// A bad handle is EBADF regardless of how absurd the size argument is.
+    #[test]
+    fn bad_handle_outranks_the_size_check() {
+        let fs = ReadOnlyFs::new().with_max_object_bytes(16);
+        assert_eq!(fs.write(9999, 1 << 40, b"x"), Err(FsError::BadHandle));
+        assert_eq!(fs.truncate(9999, 1 << 40), Err(FsError::BadHandle));
+    }
+
+    #[test]
+    fn default_cap_is_applied_and_overridable() {
+        assert_eq!(
+            ReadOnlyFs::new().max_object_bytes(),
+            DEFAULT_MAX_OBJECT_BYTES
+        );
+        assert_eq!(
+            ReadOnlyFs::new()
+                .with_max_object_bytes(7)
+                .max_object_bytes(),
+            7
+        );
     }
 }


### PR DESCRIPTION
## Problem

`ReadOnlyFs::write` did `buf.resize(offset + data.len(), 0)` with `offset` taken straight from the kernel, and `truncate` did `buf.resize(size, 0)` from `setattr`. One unprivileged syscall takes the mount (and likely the host) down:

```c
pwrite(fd, "x", 1, 1UL << 40);   /* asks for a 1 TiB zero-fill */
ftruncate(fd, 1UL << 50);        /* same, reachable as `truncate -s 1P` */
```

`offset + data.len()` could also overflow `usize` — a debug panic *while holding the single global `Inner` mutex*, poisoning it so every subsequent FUSE op panics too (the mount hangs rather than erroring); a silent wrap in release.

## Fix

- Per-object buffer cap `DEFAULT_MAX_OBJECT_BYTES` (1 GiB), tunable via `ReadOnlyFs::with_max_object_bytes`, enforced **before** any allocation in both `write` and `truncate`.
- Checked add for the end offset, plus a `try_into` for the 32-bit-host case.
- New `FsError::TooLarge` → `EFBIG`.
- `EBADF` still outranks the size checks, so a bad handle reports the handle error regardless of how absurd the size argument is.

The cap is a v1 stopgap consistent with the existing "buffer the whole object in RAM" design; a temp-file-backed buffer for large objects remains future work.

## Tests

`write_past_the_cap_is_efbig_and_allocates_nothing` (huge offset, just-past-cap, straddling; asserts nothing was buffered and the exact-cap write still succeeds), `write_offset_overflow_is_efbig_not_a_panic` (`u64::MAX` offset, and the fs is still usable afterwards — i.e. no poisoned lock), `truncate_past_the_cap_is_efbig`, `bad_handle_outranks_the_size_check`, `default_cap_is_applied_and_overridable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)