### PR TITLE
fix(fuse): recover poisoned locks instead of panicking

### DIFF
--- a/crates/talon-fuse/src/lib.rs
+++ b/crates/talon-fuse/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod block_reader;
 pub mod coordinator_client;
+pub(crate) mod lock;
 pub mod mapping;
 pub mod metrics;
 #[cfg(feature = "mount")]

--- a/crates/talon-fuse/src/lock.rs
+++ b/crates/talon-fuse/src/lock.rs
@@ -1,0 +1,98 @@
+//! Poison-tolerant lock accessors.
+//!
+//! Every piece of shared state in this crate is a plain data structure behind a
+//! `Mutex` or `RwLock` — a namespace map, an idle-connection bucket, a placement
+//! cache. None of them has a multi-step invariant that a panic could leave
+//! half-applied, so Rust's default poisoning behaviour buys nothing here and
+//! costs a great deal: `lock().unwrap()` turns *one* panic anywhere under the
+//! lock into a permanent, unrecoverable failure of every later access.
+//!
+//! On a FUSE mount that failure mode is severe. The namespace lives behind a
+//! single `Mutex`, so a poisoned lock means every subsequent `lookup`,
+//! `getattr`, `read` and `release` panics too — the mount hangs rather than
+//! returning an error, and it cannot be unmounted cleanly. A localized bug
+//! becomes a wedged filesystem.
+//!
+//! These extension traits recover the guard instead
+//! ([`PoisonError::into_inner`]), so a panic degrades to "possibly stale data in
+//! one entry" rather than "the mount is dead". Prefer them over
+//! `lock().unwrap()` throughout the crate.
+
+use std::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+/// Poison-tolerant access to a [`Mutex`].
+pub(crate) trait MutexExt<T> {
+    /// Lock, recovering the guard if the mutex was poisoned by a panic.
+    fn lock_recover(&self) -> MutexGuard<'_, T>;
+}
+
+impl<T> MutexExt<T> for Mutex<T> {
+    fn lock_recover(&self) -> MutexGuard<'_, T> {
+        self.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+/// Poison-tolerant access to an [`RwLock`].
+pub(crate) trait RwLockExt<T> {
+    /// Read-lock, recovering the guard if the lock was poisoned by a panic.
+    fn read_recover(&self) -> RwLockReadGuard<'_, T>;
+    /// Write-lock, recovering the guard if the lock was poisoned by a panic.
+    fn write_recover(&self) -> RwLockWriteGuard<'_, T>;
+}
+
+impl<T> RwLockExt<T> for RwLock<T> {
+    fn read_recover(&self) -> RwLockReadGuard<'_, T> {
+        self.read().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn write_recover(&self) -> RwLockWriteGuard<'_, T> {
+        self.write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    /// The whole point: a panic under the lock must not brick every later
+    /// access. With `lock().unwrap()` the second access panics too.
+    #[test]
+    fn mutex_survives_a_panic_under_the_lock() {
+        let m = Arc::new(Mutex::new(vec![1u32, 2, 3]));
+        let m2 = Arc::clone(&m);
+        let panicked = std::thread::spawn(move || {
+            let mut g = m2.lock_recover();
+            g.push(4);
+            panic!("boom while holding the lock");
+        })
+        .join();
+        assert!(panicked.is_err(), "the thread must actually have panicked");
+        assert!(m.is_poisoned(), "and the mutex must actually be poisoned");
+
+        // Still usable, and the pre-panic mutation is visible.
+        let mut g = m.lock_recover();
+        assert_eq!(*g, vec![1, 2, 3, 4]);
+        g.push(5);
+        assert_eq!(g.len(), 5);
+    }
+
+    #[test]
+    fn rwlock_survives_a_panic_under_the_write_lock() {
+        let l = Arc::new(RwLock::new(String::from("a")));
+        let l2 = Arc::clone(&l);
+        let panicked = std::thread::spawn(move || {
+            let mut g = l2.write_recover();
+            g.push('b');
+            panic!("boom");
+        })
+        .join();
+        assert!(panicked.is_err());
+        assert!(l.is_poisoned());
+
+        assert_eq!(&*l.read_recover(), "ab");
+        l.write_recover().push('c');
+        assert_eq!(&*l.read_recover(), "abc");
+    }
+}

--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -20,6 +20,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crate::block_reader::{BlockReader, FileView};
+use crate::lock::MutexExt;
 use crate::mapping::path_to_object;
 use crate::ops::{Attr, FileKind, FsError, ReadOnlyFs};
 use crate::prefetch::Prefetcher;
@@ -224,7 +225,7 @@ impl TalonFuse {
             None => return Vec::new(),
         };
         let block_index = offset / self.block_size as u64;
-        let mut prefetchers = self.prefetchers.lock().unwrap();
+        let mut prefetchers = self.prefetchers.lock_recover();
         let prefetcher = prefetchers.entry(fh).or_insert_with(|| {
             Prefetcher::new(
                 self.reader.clone(),
@@ -687,7 +688,7 @@ impl fuser::Filesystem for TalonFuse {
     ) {
         // Drop this handle's prefetch state (and its readahead cursor); any
         // in-flight speculative fetches finish on their own detached tasks.
-        self.prefetchers.lock().unwrap().remove(&fh);
+        self.prefetchers.lock_recover().remove(&fh);
         match self.fs.release(fh) {
             Ok(()) => reply.ok(),
             Err(e) => reply.error(errno(e)),

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -13,6 +13,7 @@
 //! buffer (object stores replace whole objects, not byte ranges); the assembled
 //! object is written through to the backend at flush.
 
+use crate::lock::MutexExt;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
@@ -148,7 +149,7 @@ impl ReadOnlyFs {
     /// creating intermediate directories. Returns the file's inode.
     pub fn insert_object(&self, path: &str, size: u64) -> u64 {
         let comps: Vec<&str> = path.split('/').filter(|c| !c.is_empty()).collect();
-        let mut g = self.inner.lock().unwrap();
+        let mut g = self.inner.lock_recover();
         let mut parent = ROOT_INO;
         for (i, comp) in comps.iter().enumerate() {
             let is_leaf = i == comps.len() - 1;
@@ -217,7 +218,7 @@ impl ReadOnlyFs {
 
     /// `lookup`: resolve a child `name` under directory `parent_ino`.
     pub fn lookup(&self, parent_ino: u64, name: &str) -> Result<Attr, FsError> {
-        let g = self.inner.lock().unwrap();
+        let g = self.inner.lock_recover();
         let ino = *g
             .index
             .get(&(parent_ino, name.to_string()))
@@ -227,13 +228,13 @@ impl ReadOnlyFs {
 
     /// `getattr`: attributes for an inode.
     pub fn getattr(&self, ino: u64) -> Result<Attr, FsError> {
-        let g = self.inner.lock().unwrap();
+        let g = self.inner.lock_recover();
         Ok(Self::attr_of(g.nodes.get(&ino).ok_or(FsError::NotFound)?))
     }
 
     /// `readdir`: list children of a directory inode (excluding `.`/`..`).
     pub fn readdir(&self, ino: u64) -> Result<Vec<DirEntry>, FsError> {
-        let g = self.inner.lock().unwrap();
+        let g = self.inner.lock_recover();
         let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
         if node.kind != FileKind::Directory {
             return Err(FsError::NotFound);
@@ -254,7 +255,7 @@ impl ReadOnlyFs {
 
     /// `open`: obtain a read handle for a file inode. Directories are rejected.
     pub fn open(&self, ino: u64) -> Result<u64, FsError> {
-        let mut g = self.inner.lock().unwrap();
+        let mut g = self.inner.lock_recover();
         let kind = g.nodes.get(&ino).ok_or(FsError::NotFound)?.kind;
         if kind != FileKind::File {
             return Err(FsError::Unsupported);
@@ -269,7 +270,7 @@ impl ReadOnlyFs {
     /// write buffer. The caller is expected to have already flushed a dirty write
     /// handle's contents (writeback happens on flush, #232).
     pub fn release(&self, fh: u64) -> Result<(), FsError> {
-        let mut g = self.inner.lock().unwrap();
+        let mut g = self.inner.lock_recover();
         let had_dirty = g.dirty.remove(&fh).is_some();
         let had_handle = g.handles.remove(&fh).is_some();
         if had_handle || had_dirty {
@@ -286,7 +287,7 @@ impl ReadOnlyFs {
     /// Errors with [`FsError::BadHandle`] for an unknown handle or
     /// [`FsError::Unsupported`] if the handle somehow references a directory.
     pub fn file_meta(&self, fh: u64) -> Result<(String, u64), FsError> {
-        let g = self.inner.lock().unwrap();
+        let g = self.inner.lock_recover();
         let ino = *g.handles.get(&fh).ok_or(FsError::BadHandle)?;
         let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
         if node.kind != FileKind::File {
@@ -307,7 +308,7 @@ impl ReadOnlyFs {
     /// whole-object creation; opening an existing file for write is
     /// [`open_write`](Self::open_write)).
     pub fn create(&self, parent_ino: u64, name: &str) -> Result<(Attr, u64), FsError> {
-        let mut g = self.inner.lock().unwrap();
+        let mut g = self.inner.lock_recover();
         let parent = g.nodes.get(&parent_ino).ok_or(FsError::NotFound)?;
         if parent.kind != FileKind::Directory {
             return Err(FsError::NotFound);
@@ -354,7 +355,7 @@ impl ReadOnlyFs {
     /// In-place edit of existing contents (`O_RDWR` without truncate) would need
     /// to first fetch the current object into the buffer; that is future work.
     pub fn open_write(&self, ino: u64) -> Result<u64, FsError> {
-        let mut g = self.inner.lock().unwrap();
+        let mut g = self.inner.lock_recover();
         let kind = g.nodes.get(&ino).ok_or(FsError::NotFound)?.kind;
         if kind != FileKind::File {
             return Err(FsError::Unsupported);
@@ -383,7 +384,7 @@ impl ReadOnlyFs {
     /// Returns the number of bytes written. Fails with [`FsError::BadHandle`] for
     /// a handle not opened for write.
     pub fn write(&self, fh: u64, offset: u64, data: &[u8]) -> Result<u32, FsError> {
-        let mut g = self.inner.lock().unwrap();
+        let mut g = self.inner.lock_recover();
         let dirty = g.dirty.get_mut(&fh).ok_or(FsError::BadHandle)?;
         let start = offset as usize;
         let end = start + data.len();
@@ -401,7 +402,7 @@ impl ReadOnlyFs {
 
     /// `setattr(size)`: truncate/extend the write handle's buffer to `size`.
     pub fn truncate(&self, fh: u64, size: u64) -> Result<(), FsError> {
-        let mut g = self.inner.lock().unwrap();
+        let mut g = self.inner.lock_recover();
         let dirty = g.dirty.get_mut(&fh).ok_or(FsError::BadHandle)?;
         dirty.buf.resize(size as usize, 0);
         let ino = dirty.ino;
@@ -415,13 +416,13 @@ impl ReadOnlyFs {
     /// flush/release), leaving the handle's buffer in place so a later flush is a
     /// no-op unless more is written. Returns `None` for a non-write handle.
     pub fn dirty_bytes(&self, fh: u64) -> Option<Vec<u8>> {
-        let g = self.inner.lock().unwrap();
+        let g = self.inner.lock_recover();
         g.dirty.get(&fh).map(|d| d.buf.clone())
     }
 
     /// The mount-relative object path a write handle targets.
     pub fn dirty_path(&self, fh: u64) -> Option<String> {
-        let g = self.inner.lock().unwrap();
+        let g = self.inner.lock_recover();
         let ino = g.dirty.get(&fh)?.ino;
         g.nodes.get(&ino).map(|n| n.path.clone())
     }
@@ -429,7 +430,7 @@ impl ReadOnlyFs {
     /// The mount-relative object path of file `name` under `parent_ino`, without
     /// removing it. `None` if the name doesn't resolve to a file.
     pub fn file_path(&self, parent_ino: u64, name: &str) -> Option<String> {
-        let g = self.inner.lock().unwrap();
+        let g = self.inner.lock_recover();
         let ino = *g.index.get(&(parent_ino, name.to_string()))?;
         let node = g.nodes.get(&ino)?;
         if node.kind != FileKind::File {
@@ -442,7 +443,7 @@ impl ReadOnlyFs {
     /// namespace. Returns the removed file's mount-relative path so the caller
     /// can delete the backend object. Directories are not removed here.
     pub fn unlink(&self, parent_ino: u64, name: &str) -> Result<String, FsError> {
-        let mut g = self.inner.lock().unwrap();
+        let mut g = self.inner.lock_recover();
         let ino = *g
             .index
             .get(&(parent_ino, name.to_string()))
@@ -699,5 +700,49 @@ mod tests {
             .unwrap();
         let dir = fs.lookup(bucket.ino, "data").unwrap();
         assert_eq!(fs.create(dir.ino, "a.bin"), Err(FsError::ReadOnly));
+    }
+
+    /// The namespace lives behind a single Mutex, so with `lock().unwrap()` one
+    /// panic while holding it poisoned the lock and made *every* subsequent
+    /// FUSE op panic — the mount hung rather than erroring, and could not be
+    /// unmounted cleanly. Poison recovery degrades that to a normal error.
+    #[test]
+    fn namespace_survives_a_panic_under_its_lock() {
+        use std::sync::Arc;
+
+        let fs = Arc::new(fs());
+        let s3 = fs.lookup(ROOT_INO, "s3").unwrap();
+
+        // Panic while the namespace lock is actually held, exactly as a bug on
+        // the FUSE thread mid-operation would (e.g. an arithmetic overflow in
+        // an op that has already taken the guard).
+        let fs2 = Arc::clone(&fs);
+        let panicked = std::thread::spawn(move || {
+            let mut g = fs2.inner.lock_recover();
+            // A mutation lands before the panic, so we can also check the data
+            // is still there afterwards rather than silently reset.
+            g.next_fh += 100;
+            panic!("bug on the FUSE thread while holding the namespace lock");
+        })
+        .join();
+        assert!(panicked.is_err(), "the thread must actually have panicked");
+        assert!(
+            fs.inner.is_poisoned(),
+            "the namespace mutex must actually be poisoned"
+        );
+
+        // Every read op still works, and the pre-panic mutation is visible.
+        assert_eq!(fs.lookup(ROOT_INO, "s3").unwrap().ino, s3.ino);
+        let bucket = fs.lookup(s3.ino, "bucket").unwrap();
+        let dir = fs.lookup(bucket.ino, "data").unwrap();
+        assert!(fs.lookup(dir.ino, "a.bin").is_ok());
+        assert!(fs.getattr(ROOT_INO).is_ok());
+        assert!(fs.readdir(dir.ino).is_ok());
+
+        // And write ops: a fresh handle still opens, writes and releases.
+        let (_, fh) = fs.create(dir.ino, "after-panic.bin").unwrap();
+        assert_eq!(fs.write(fh, 0, b"ok").unwrap(), 2);
+        assert_eq!(fs.dirty_bytes(fh).unwrap(), b"ok");
+        fs.release(fh).unwrap();
     }
 }

--- a/crates/talon-fuse/src/placement_cache.rs
+++ b/crates/talon-fuse/src/placement_cache.rs
@@ -16,6 +16,7 @@
 use std::collections::HashMap;
 use std::sync::RwLock;
 
+use crate::lock::RwLockExt;
 use talon_core::BlockId;
 
 /// Why a cached placement entry was (or should be) invalidated.
@@ -66,7 +67,7 @@ impl PlacementCache {
 
     /// Insert/replace a fresh placement for `block` observed at `now_ms`.
     pub fn insert(&self, block: BlockId, cached: Cached, now_ms: u64) {
-        self.entries.write().unwrap().insert(
+        self.entries.write_recover().insert(
             block,
             Entry {
                 cached,
@@ -81,7 +82,7 @@ impl PlacementCache {
     pub fn get(&self, block: &BlockId, now_ms: u64) -> Option<Cached> {
         // Fast path: shared lock.
         {
-            let g = self.entries.read().unwrap();
+            let g = self.entries.read_recover();
             if let Some(e) = g.get(block) {
                 if now_ms.saturating_sub(e.inserted_ms) <= self.ttl_ms {
                     return Some(e.cached.clone());
@@ -91,7 +92,7 @@ impl PlacementCache {
             }
         }
         // Slow path: expired -> drop under a write lock.
-        self.entries.write().unwrap().remove(block);
+        self.entries.write_recover().remove(block);
         None
     }
 
@@ -99,7 +100,7 @@ impl PlacementCache {
     ///
     /// Returns `true` if an entry was present and removed.
     pub fn invalidate(&self, block: &BlockId, _reason: RefreshReason) -> bool {
-        self.entries.write().unwrap().remove(block).is_some()
+        self.entries.write_recover().remove(block).is_some()
     }
 
     /// Reconcile against an observed placement version: if the cached entry's
@@ -116,7 +117,7 @@ impl PlacementCache {
     ///
     /// Returns `true` if the entry was invalidated by the version check.
     pub fn observe_epoch(&self, block: &BlockId, observed_epoch: u64) -> bool {
-        let mut g = self.entries.write().unwrap();
+        let mut g = self.entries.write_recover();
         if let Some(e) = g.get(block) {
             if e.cached.epoch != observed_epoch {
                 g.remove(block);
@@ -128,12 +129,12 @@ impl PlacementCache {
 
     /// Number of entries currently held (including not-yet-collected expired).
     pub fn len(&self) -> usize {
-        self.entries.read().unwrap().len()
+        self.entries.read_recover().len()
     }
 
     /// Whether the cache is empty.
     pub fn is_empty(&self) -> bool {
-        self.entries.read().unwrap().is_empty()
+        self.entries.read_recover().is_empty()
     }
 }
 

--- a/crates/talon-fuse/src/pool.rs
+++ b/crates/talon-fuse/src/pool.rs
@@ -37,6 +37,7 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+use crate::lock::MutexExt;
 use tokio::net::TcpStream;
 
 /// Default maximum idle connections kept per peer address.
@@ -98,7 +99,7 @@ impl ConnectionPool {
 
     /// Pop a non-stale idle connection for `addr`, discarding expired ones.
     fn take_idle(&self, addr: &str) -> Option<TcpStream> {
-        let mut guard = self.idle.lock().unwrap();
+        let mut guard = self.idle.lock_recover();
         let bucket = guard.get_mut(addr)?;
         while let Some(idle) = bucket.pop() {
             if idle.returned_at.elapsed() < self.idle_ttl {
@@ -114,7 +115,7 @@ impl ConnectionPool {
     /// Call this only after a request/response completed without error. Extra
     /// connections beyond `max_idle_per_addr` are dropped rather than pooled.
     pub fn release(&self, addr: &str, stream: TcpStream) {
-        let mut guard = self.idle.lock().unwrap();
+        let mut guard = self.idle.lock_recover();
         let bucket = guard.entry(addr.to_string()).or_default();
         if bucket.len() < self.max_idle_per_addr {
             bucket.push(Idle {
@@ -145,7 +146,7 @@ impl Default for ConnectionPool {
 impl std::fmt::Debug for ConnectionPool {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // TcpStream is not Debug; summarize the pool without touching sockets.
-        let addrs = self.idle.lock().unwrap().len();
+        let addrs = self.idle.lock_recover().len();
         f.debug_struct("ConnectionPool")
             .field("max_idle_per_addr", &self.max_idle_per_addr)
             .field("idle_ttl", &self.idle_ttl)


### PR DESCRIPTION
## Problem

Every shared structure in the crate is accessed with `lock().unwrap()`, so a single panic anywhere under a lock poisons it and makes **every later access panic too**.

The namespace is one `Mutex<Inner>` behind ~20 such call sites. A poisoned namespace lock means every subsequent `lookup`, `getattr`, `read` and `release` panics: the mount **hangs** rather than returning an error, and cannot be unmounted cleanly. A localized bug becomes a wedged filesystem. The same applies to the `PlacementCache` `RwLock` and the `ConnectionPool` `Mutex`, where a poisoned lock takes down the whole read path.

This is not hypothetical — it compounds every other panic source in the crate, several of which are reachable from unprivileged user syscalls (see #314 for the write-path allocation panics).

## Fix

None of these structures has a multi-step invariant a panic could leave half-applied — they are a namespace map, a placement map, and an idle-connection bucket. Poisoning buys nothing here and costs a great deal.

Add `MutexExt::lock_recover` and `RwLockExt::{read,write}_recover`, which take the guard via `PoisonError::into_inner`, and use them at every non-test call site in `ops.rs`, `mount.rs`, `placement_cache.rs` and `pool.rs`. A panic now degrades to "possibly stale data in one entry" rather than "the mount is dead".

## Tests

- `mutex_survives_a_panic_under_the_lock` / `rwlock_survives_a_panic_under_the_write_lock` — assert the lock is genuinely poisoned, then that it is still usable and the pre-panic mutation is visible.
- `namespace_survives_a_panic_under_its_lock` — poisons the **real** namespace mutex, then asserts `lookup`/`getattr`/`readdir` and the whole `create`/`write`/`release` cycle still work.

**Verified all three fail with `lock().unwrap()` restored.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)