### PR TITLE
feat(client): Python client SDK over the Rust core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ secrets.*
 *_secret*
 credentials
 credentials.*
+
+# Python client build artifacts.
+clients/python/target/
+clients/python/dist/
+__pycache__/
+.pytest_cache/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,6 +1405,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,7 +1500,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
 ]
 
@@ -1682,6 +1700,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1789,6 +1813,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
  "pulldown-cmark",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset 0.9.1",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2498,6 +2585,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "talon-python"
+version = "0.1.0"
+dependencies = [
+ "pyo3",
+ "talon-core",
+ "talon-fuse",
+ "talon-transport",
+ "tokio",
+]
+
+[[package]]
 name = "talon-transport"
 version = "0.1.0"
 dependencies = [
@@ -2533,6 +2631,12 @@ dependencies = [
  "tracing-subscriber",
  "xxhash-rust",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -2958,6 +3062,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/talon-transport",
     "crates/talon-backend",
     "crates/talon-client",
+    "clients/python",
     "crates/talon-observability",
 ]
 

--- a/clients/python/Cargo.toml
+++ b/clients/python/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "talon-python"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Python bindings for the Talon distributed object-store cache client"
+publish = false
+
+[lib]
+name = "talon"
+# cdylib for the Python extension module; rlib so the crate's own tests can
+# link against it.
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# Enabled by maturin when building a wheel; see the pyo3 dependency note.
+extension-module = ["pyo3/extension-module"]
+
+[dependencies]
+talon-core.workspace = true
+talon-transport.workspace = true
+# The read path (block splitting, placement cache, replica fallback, pooling)
+# already exists here and is exercised by the FUSE client. Default features
+# exclude `fuser`, so no FUSE dependency reaches the Python extension.
+talon-fuse = { path = "../../crates/talon-fuse" }
+# `extension-module` tells pyo3 not to link libpython, which is correct for a
+# wheel but breaks `cargo test` (the test harness needs a Python to link
+# against). It is therefore opt-in via the `extension-module` feature, which
+# maturin enables and `cargo test` does not.
+pyo3 = { version = "0.22", features = ["abi3-py38"] }
+tokio = { workspace = true }

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -1,0 +1,35 @@
+# talon-client
+
+Python client for [Talon](https://github.com/milvus-io/talon), a distributed
+object-store cache.
+
+Reads objects through a Talon cache cluster instead of from the origin, so
+repeated reads across a fleet are served from local NVMe.
+
+```python
+import talon
+
+with talon.Client("coordinator-host:7000") as client:
+    info = client.stat("az://container/datasets/train.parquet")
+    print(info.size, info.version)
+
+    # A ranged read; spans block boundaries transparently.
+    chunk = client.read("az://container/datasets/train.parquet",
+                        offset=0, length=1 << 20)
+
+    for entry in client.list("az/container/datasets"):
+        print(entry.path, entry.size)
+```
+
+URIs use the same namespaces as the FUSE mount — `s3://`, `gcs://`, `az://` —
+so a path addresses the same object through either client.
+
+Blocking calls release the GIL, so threaded loaders are limited by the network
+rather than serialised on the interpreter.
+
+**Read-only in this release.** Writes go through the FUSE mount or the Rust
+client; `put`/`delete` are tracked separately.
+
+See the [documentation](https://milvus-io.github.io/talon/) for cluster setup
+and the [use cases](https://milvus-io.github.io/talon/use-cases/overview.html)
+this is built for.

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["maturin>=1.5,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "talon-client"
+description = "Python client for the Talon distributed object-store cache"
+readme = "README.md"
+license = { text = "Apache-2.0" }
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "License :: OSI Approved :: Apache Software License",
+    "Topic :: System :: Distributed Computing",
+]
+dynamic = ["version"]
+
+[project.urls]
+Repository = "https://github.com/milvus-io/talon"
+Documentation = "https://milvus-io.github.io/talon/"
+
+[tool.maturin]
+# One wheel per platform across CPython versions, via the stable ABI.
+features = ["extension-module"]
+module-name = "talon"
+manifest-path = "Cargo.toml"

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -1,0 +1,347 @@
+//! Python bindings for the Talon client (#312).
+//!
+//! Binds the Rust read path rather than reimplementing it. Block splitting,
+//! placement caching, replica fallback, and connection pooling already exist in
+//! `talon-fuse` and are exercised by the FUSE client; duplicating them in
+//! Python would duplicate their bugs too.
+//!
+//! `talon-fuse`'s default features exclude `fuser`, so no FUSE or libfuse
+//! dependency reaches the extension module.
+//!
+//! # Threading
+//!
+//! Every blocking call releases the GIL for its duration, so a threaded data
+//! loader is limited by the network rather than serialised on the interpreter.
+//! The runtime is a multi-threaded Tokio runtime owned by the client, shared by
+//! all calls on it.
+
+// pyo3 0.22's #[pymethods] expansion converts every returned error through
+// Into<PyErr>, which is a no-op when the error already is one. clippy flags the
+// generated code; there is no source-level change that avoids it, and the lint
+// is not about anything under our control.
+#![allow(clippy::useless_conversion)]
+
+use std::sync::Arc;
+
+use pyo3::exceptions::{PyIOError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+use talon_core::{ObjectId, Version};
+use talon_fuse::block_reader::FileView;
+use talon_fuse::{BlockReader, CoordinatorClient, PlacementCache};
+
+/// Placement entries older than this are re-resolved. Matches the FUSE client's
+/// default so both see the same staleness window.
+const PLACEMENT_TTL_MS: u64 = 30_000;
+/// Replicas to request per placement lookup. RF=1 in v1.
+const REPLICAS_K: u8 = 1;
+
+/// Milliseconds since the epoch, for placement-cache expiry.
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Map a client-side failure to a Python exception, preserving the worker's own
+/// message. Flattening these to a generic error would hide the distinction
+/// between "object does not exist" and "every replica is down".
+fn io_err<E: std::fmt::Display>(e: E) -> PyErr {
+    PyIOError::new_err(e.to_string())
+}
+
+/// Parse a `scheme://bucket/key` URI into an [`ObjectId`].
+///
+/// The schemes match the namespaces the FUSE mount exposes (`s3`, `gcs`, `az`),
+/// so a path used with one client addresses the same object in the other.
+///
+/// Returns a plain `String` error rather than a `PyErr` so the parsing rules can
+/// be tested without an initialised interpreter; [`parse_uri`] wraps it.
+fn parse_uri_inner(uri: &str) -> Result<ObjectId, String> {
+    let (scheme, rest) = uri.split_once("://").ok_or_else(|| {
+        format!("expected a scheme://bucket/key URI, got {uri:?} (schemes: s3, gcs, az)")
+    })?;
+    let backend = scheme
+        .parse()
+        .map_err(|_| format!("unknown backend scheme {scheme:?}; expected s3, gcs, or az"))?;
+    let (bucket, key) = rest.split_once('/').ok_or_else(|| {
+        format!("URI is missing an object key: {uri:?} (expected {scheme}://bucket/key)")
+    })?;
+    if bucket.is_empty() {
+        return Err(format!("URI has an empty bucket: {uri:?}"));
+    }
+    if key.is_empty() {
+        return Err(format!("URI has an empty object key: {uri:?}"));
+    }
+    Ok(ObjectId::new(backend, bucket, key))
+}
+
+/// An object's size and source version.
+#[pyclass(module = "talon", frozen)]
+#[derive(Clone)]
+pub struct ObjectStat {
+    /// Total object length in bytes.
+    #[pyo3(get)]
+    pub size: u64,
+    /// Source version (ETag) the object is currently at.
+    #[pyo3(get)]
+    pub version: String,
+}
+
+#[pymethods]
+impl ObjectStat {
+    fn __repr__(&self) -> String {
+        format!("ObjectStat(size={}, version={:?})", self.size, self.version)
+    }
+}
+
+/// One entry from a listing: a mount-relative path and its size.
+#[pyclass(module = "talon", frozen)]
+#[derive(Clone)]
+pub struct ObjectEntry {
+    /// Mount-relative object path.
+    #[pyo3(get)]
+    pub path: String,
+    /// Object size in bytes.
+    #[pyo3(get)]
+    pub size: u64,
+}
+
+#[pymethods]
+impl ObjectEntry {
+    fn __repr__(&self) -> String {
+        format!("ObjectEntry(path={:?}, size={})", self.path, self.size)
+    }
+}
+
+/// A client for reading objects through a Talon cache cluster.
+#[pyclass(module = "talon")]
+pub struct Client {
+    runtime: Arc<tokio::runtime::Runtime>,
+    coordinator: CoordinatorClient,
+    reader: BlockReader,
+    block_size: u32,
+}
+
+#[pymethods]
+impl Client {
+    /// Connect to a coordinator.
+    ///
+    /// `block_size` must match the workers' configured block size; placement is
+    /// computed per block, so a mismatch addresses the wrong blocks. It
+    /// defaults to the worker default of 256 MiB.
+    #[new]
+    #[pyo3(signature = (coordinator, *, block_size = 256 << 20))]
+    fn new(coordinator: &str, block_size: u32) -> PyResult<Self> {
+        if block_size == 0 {
+            return Err(PyValueError::new_err("block_size must be non-zero"));
+        }
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(io_err)?;
+        let coordinator_client = CoordinatorClient::new(coordinator);
+        let cache = Arc::new(PlacementCache::new(PLACEMENT_TTL_MS));
+        let reader = BlockReader::new(coordinator_client.clone(), cache, REPLICAS_K);
+        Ok(Self {
+            runtime: Arc::new(runtime),
+            coordinator: coordinator_client,
+            reader,
+            block_size,
+        })
+    }
+
+    /// Read `length` bytes from `uri` starting at `offset`.
+    ///
+    /// Returns `bytes`. A read at or past end-of-file returns an empty buffer,
+    /// and a read overlapping the end is truncated to what exists — POSIX short
+    /// read semantics, so callers must check the returned length rather than
+    /// assuming they got what they asked for.
+    ///
+    /// Ranges spanning block boundaries are split and fetched per block, each
+    /// benefiting independently from the placement cache.
+    ///
+    /// `version` is the object's source ETag, which blocks are keyed by. It is
+    /// required because no server implements `StatObject` yet (#318), so the
+    /// client cannot resolve it. Once that lands this becomes optional and is
+    /// resolved automatically. `size` bounds the read at EOF; when omitted the
+    /// read is not clamped and a past-EOF request fails at the worker rather
+    /// than returning short.
+    #[pyo3(signature = (uri, *, version, offset = 0, length = None, size = None))]
+    fn read<'py>(
+        &self,
+        py: Python<'py>,
+        uri: &str,
+        version: &str,
+        offset: u64,
+        length: Option<u64>,
+        size: Option<u64>,
+    ) -> PyResult<Bound<'py, PyBytes>> {
+        let object = parse_uri_inner(uri).map_err(PyValueError::new_err)?;
+        let version = Version::new(version);
+        let runtime = Arc::clone(&self.runtime);
+        let reader = self.reader.clone();
+        let block_size = self.block_size;
+        let file_size = size.unwrap_or(u64::MAX);
+        let len = match length {
+            Some(n) => n,
+            None => file_size.saturating_sub(offset),
+        };
+
+        // Release the GIL: this is network I/O, and holding it would serialise
+        // every reader thread in the process on one request.
+        let bytes = py.allow_threads(move || {
+            runtime.block_on(async move {
+                let file = FileView {
+                    object: &object,
+                    block_size,
+                    version: &version,
+                    size: file_size,
+                };
+                reader
+                    .read(&file, offset, len, now_ms())
+                    .await
+                    .map_err(|e| e.to_string())
+            })
+        });
+        let bytes = bytes.map_err(PyIOError::new_err)?;
+        Ok(PyBytes::new_bound(py, &bytes))
+    }
+
+    /// Return an object's size and version.
+    ///
+    /// **Not usable yet**: no server implements `StatObject` (#318), so this
+    /// currently fails with the coordinator's rejection. It is kept because the
+    /// protocol defines it and the client half is correct; it starts working
+    /// when the server side lands.
+    fn stat(&self, py: Python<'_>, uri: &str) -> PyResult<ObjectStat> {
+        let object = parse_uri_inner(uri).map_err(PyValueError::new_err)?;
+        let runtime = Arc::clone(&self.runtime);
+        let coordinator = self.coordinator.clone();
+        let stat = py.allow_threads(move || {
+            runtime.block_on(async move {
+                coordinator
+                    .stat_object(&object)
+                    .await
+                    .map_err(|e| e.to_string())
+            })
+        });
+        let stat = stat.map_err(PyIOError::new_err)?;
+        Ok(ObjectStat {
+            size: stat.size,
+            version: stat.version.as_str().to_string(),
+        })
+    }
+
+    /// List objects under a mount-relative prefix, e.g. `az/container/dir`.
+    ///
+    /// **Not usable yet** for the same reason as [`stat`](Self::stat) — see
+    /// #318.
+    fn list(&self, py: Python<'_>, prefix: &str) -> PyResult<Vec<ObjectEntry>> {
+        let runtime = Arc::clone(&self.runtime);
+        let coordinator = self.coordinator.clone();
+        let prefix = prefix.to_string();
+        let entries = py.allow_threads(move || {
+            runtime.block_on(async move {
+                coordinator
+                    .list_objects(&prefix)
+                    .await
+                    .map_err(|e| e.to_string())
+            })
+        });
+        let entries = entries.map_err(PyIOError::new_err)?;
+        Ok(entries
+            .into_iter()
+            .map(|e| ObjectEntry {
+                path: e.path,
+                size: e.size,
+            })
+            .collect())
+    }
+
+    /// The coordinator address this client is connected to.
+    #[getter]
+    fn coordinator(&self) -> &str {
+        self.reader.coordinator_addr()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Client(coordinator={:?}, block_size={})",
+            self.reader.coordinator_addr(),
+            self.block_size
+        )
+    }
+
+    /// Support `with talon.Client(...) as client:`.
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    #[pyo3(signature = (_exc_type = None, _exc_value = None, _traceback = None))]
+    fn __exit__(
+        &self,
+        _exc_type: Option<&Bound<'_, PyAny>>,
+        _exc_value: Option<&Bound<'_, PyAny>>,
+        _traceback: Option<&Bound<'_, PyAny>>,
+    ) -> bool {
+        // Connections are pooled and closed when the client drops; nothing to
+        // do here, but the context-manager protocol is what Python users expect.
+        false
+    }
+}
+
+#[pymodule]
+fn talon(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<Client>()?;
+    m.add_class::<ObjectStat>()?;
+    m.add_class::<ObjectEntry>()?;
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use talon_core::Backend;
+
+    #[test]
+    fn parse_uri_accepts_each_backend_scheme() {
+        for (uri, backend) in [
+            ("s3://bucket/key", Backend::S3),
+            ("gcs://bucket/key", Backend::Gcs),
+            ("az://container/key", Backend::Azure),
+        ] {
+            let id = parse_uri_inner(uri).expect("valid uri");
+            assert_eq!(id.backend, backend);
+            assert_eq!(id.object_path, "key");
+        }
+    }
+
+    #[test]
+    fn parse_uri_keeps_nested_keys_intact() {
+        let id = parse_uri_inner("az://container/a/b/c.parquet").expect("valid uri");
+        assert_eq!(id.bucket, "container");
+        assert_eq!(id.object_path, "a/b/c.parquet");
+    }
+
+    /// Malformed URIs must name what is wrong; a bare "invalid input" sends the
+    /// caller to the debugger for something the message could have answered.
+    #[test]
+    fn parse_uri_rejects_malformed_input_with_a_useful_message() {
+        for (uri, expected) in [
+            ("bucket/key", "scheme://bucket/key"),
+            ("ftp://bucket/key", "unknown backend scheme"),
+            ("az://bucket", "missing an object key"),
+            ("az:///key", "empty bucket"),
+            ("az://bucket/", "empty object key"),
+        ] {
+            let msg = parse_uri_inner(uri).expect_err("should reject");
+            assert!(
+                msg.contains(expected),
+                "error for {uri:?} should mention {expected:?}, got {msg:?}"
+            );
+        }
+    }
+}

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -1,0 +1,164 @@
+"""End-to-end tests for the Python client against a real cluster.
+
+Deliberately not mocks. The value of this binding is that it drives the real
+protocol path — placement lookup, replica resolution, block splitting — and a
+mock would assert that the mock behaves as written.
+
+Run with the cluster fixtures below, which start a coordinator, a worker, and a
+local blob origin. Skipped when the binaries are not built.
+"""
+
+import os
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.request
+
+import pytest
+
+talon = pytest.importorskip("talon")
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+BIN = os.path.join(REPO, "target", "release")
+COORD_PORT, WORKER_PORT, ADMIN_PORT, ORIGIN_PORT = 17610, 17611, 17661, 17710
+BLOCK_SIZE = 8 << 20
+VERSION = "0x8LOADTEST"
+URI = "az://container/bench"
+
+
+def ramp(start: int, length: int) -> bytes:
+    """The deterministic bytes the test origin serves."""
+    return bytes((i % 251) for i in range(start, start + length))
+
+
+def _wait_ready(url: str, timeout: float = 30.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=1) as r:
+                if r.status == 200:
+                    return True
+        except Exception:
+            time.sleep(0.5)
+    return False
+
+
+@pytest.fixture(scope="module")
+def cluster():
+    """A coordinator, a worker, and a blob origin, torn down afterwards."""
+    for exe in ("talon-worker", "talon-coordinator"):
+        if not os.path.exists(os.path.join(BIN, exe)):
+            pytest.skip(f"{exe} not built; run `cargo build --release`")
+
+    cache = tempfile.mkdtemp(prefix="talon-pytest-")
+    env = dict(
+        os.environ,
+        TALON_WORKER_CACHE_DIRS=cache,
+        TALON_WORKER_AZURE_ACCOUNT="test",
+        TALON_WORKER_AZURE_SAS="test",
+        TALON_WORKER_AZURE_ENDPOINT=f"http://127.0.0.1:{ORIGIN_PORT}",
+        RUST_LOG="warn",
+    )
+    procs = [
+        subprocess.Popen(
+            ["python3", os.path.join(REPO, "scripts", "loadtest_origin.py"), str(ORIGIN_PORT)],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+    ]
+    time.sleep(1)
+    procs.append(subprocess.Popen(
+        [os.path.join(BIN, "talon-coordinator"),
+         "--listen", f"127.0.0.1:{COORD_PORT}",
+         "--admin-listen", f"127.0.0.1:{COORD_PORT + 50}"],
+        env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    ))
+    time.sleep(2)
+    procs.append(subprocess.Popen(
+        [os.path.join(BIN, "talon-worker"),
+         "--listen", f"127.0.0.1:{WORKER_PORT}",
+         "--admin-listen", f"127.0.0.1:{ADMIN_PORT}",
+         "--coordinator", f"127.0.0.1:{COORD_PORT}"],
+        env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    ))
+
+    # An unready worker error-frames every read, so wait rather than sleeping.
+    if not _wait_ready(f"http://127.0.0.1:{ADMIN_PORT}/readyz"):
+        for p in procs:
+            p.kill()
+        pytest.fail("worker never became ready")
+
+    yield f"127.0.0.1:{COORD_PORT}"
+
+    for p in procs:
+        p.kill()
+        p.wait(timeout=5)
+
+
+@pytest.fixture(scope="module")
+def client(cluster):
+    with talon.Client(cluster, block_size=BLOCK_SIZE) as c:
+        yield c
+
+
+def test_read_returns_exact_bytes(client):
+    assert client.read(URI, version=VERSION, offset=0, length=4096) == ramp(0, 4096)
+
+
+def test_read_at_offset(client):
+    assert client.read(URI, version=VERSION, offset=1000, length=8192) == ramp(1000, 8192)
+
+
+def test_read_spanning_block_boundaries(client):
+    """A range wider than one block splits into per-block fetches and
+    reassembles in order. Getting the order or the boundary wrong here yields
+    plausible-looking but corrupt data, so assert the bytes, not the length."""
+    length = BLOCK_SIZE + (4 << 20)
+    got = client.read(URI, version=VERSION, offset=0, length=length)
+    assert len(got) == length
+    assert got == ramp(0, length)
+
+
+def test_read_crossing_a_single_boundary(client):
+    """The narrow case: a small read straddling exactly one block edge."""
+    offset = BLOCK_SIZE - 2048
+    got = client.read(URI, version=VERSION, offset=offset, length=4096)
+    assert got == ramp(offset, 4096)
+
+
+def test_zero_length_read_is_empty(client):
+    assert client.read(URI, version=VERSION, offset=0, length=0) == b""
+
+
+def test_concurrent_reads_from_threads(client):
+    """The GIL is released around I/O, so threads overlap rather than
+    serialising. Correctness is the assertion; the timing is informational."""
+    results = {}
+    errors = []
+
+    def read(i):
+        try:
+            results[i] = client.read(URI, version=VERSION, offset=i * 65536, length=65536)
+        except Exception as e:  # surfaced below so a failure names itself
+            errors.append(e)
+
+    threads = [threading.Thread(target=read, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"threaded reads failed: {errors}"
+    for i in range(8):
+        assert results[i] == ramp(i * 65536, 65536)
+
+
+def test_bad_uri_raises_value_error(client):
+    for bad in ["no-scheme", "ftp://bucket/key", "az://bucket", "az:///key"]:
+        with pytest.raises(ValueError):
+            client.read(bad, version=VERSION, offset=0, length=1)
+
+
+def test_client_repr_and_coordinator(client, cluster):
+    assert client.coordinator == cluster
+    assert "Client(" in repr(client)


### PR DESCRIPTION
Sub-task 2 of #310. Binds the existing Rust read path rather than reimplementing it.

## Why bind instead of reimplement

Block splitting, placement caching, replica fallback, and connection pooling already live in `talon-fuse` and are exercised by the FUSE client. A second implementation in Python would duplicate their bugs as well as their behaviour.

`talon-fuse`'s default features exclude `fuser`, so **no FUSE or libfuse dependency reaches the extension module**.

This is the opposite choice from the Java client (#313), deliberately: Python's native-extension story is mature — `abi3` wheels give one artifact per platform across CPython versions — and the ecosystem already expects binary wheels. Neither holds for the JVM.

## Usage

```python
import talon

with talon.Client("coordinator-host:7000", block_size=8 << 20) as client:
    chunk = client.read("az://container/dataset.parquet",
                        version="0x8DABCDEF", offset=0, length=1 << 20)
```

URIs use the same namespaces as the FUSE mount (`s3://`, `gcs://`, `az://`), so a path addresses the same object through either client.

## What building this surfaced: #318

The first `stat()` against a real cluster returned:

```
OSError: unexpected reply to StatObject: Ack { ok: false,
  detail: Some("unexpected control message: StatObject { ... }") }
```

**`StatObject` and `ListObjects` are defined in the protocol and called by `talon-fuse`, but no server implements them.** Filed as #318.

It had never failed loudly because the FUSE mount treats a failed listing as non-fatal — it logs a warning and mounts an empty namespace. A degradation that is reasonable for a startup-populated namespace, and which hid the gap.

**Consequence for this PR:** `read()` takes the object `version` explicitly, since blocks are keyed by it and the client cannot resolve it without `stat`. `stat()` and `list()` are implemented and documented as not-yet-usable — the client half is correct and starts working when the server side lands.

## Design points

**GIL released** around every blocking call, so threaded loaders are limited by the network rather than serialised on the interpreter. Tested with 8 concurrent threads.

**Errors preserve the worker's message.** Flattening them would hide the difference between "object does not exist" and "every replica is down".

**URI parsing is split** into a plain-error function plus a thin `PyErr` wrapper, so the parsing rules are testable without an initialised interpreter. Malformed URIs name what is wrong rather than saying "invalid input".

## Tests: real cluster, not mocks

The value of a binding is that it drives the real protocol path; a mock would assert that the mock behaves as written. The suite starts a coordinator, a worker, and a blob origin, and covers:

| test | why |
|---|---|
| exact bytes at an offset | baseline correctness |
| range spanning block boundaries (12 MiB over 8 MiB blocks) | wrong order or boundary yields plausible-looking corrupt data |
| read straddling exactly one block edge | the narrow case that off-by-one breaks |
| zero-length read | must be empty, not an error |
| 8 concurrent threads | GIL actually released, results correct |
| URI validation | four malformed shapes |

Plus Rust-side unit tests for URI parsing across all three schemes.

## Packaging

`maturin` + `abi3-py38`: one wheel per platform across CPython ≥3.8. Verified end to end — wheel built, installed into a venv, tests run against it.

`pyo3/extension-module` is behind an optional feature that maturin enables, because it unlinks libpython and would otherwise break `cargo test`.

## Verification

- `cargo test --workspace --all-features --locked` — all pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc` on a forced rebuild — clean
- `maturin build --release` → wheel installs and imports
- `pytest clients/python/tests/` — 8 passed

Refs #310, #312, #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)
