### PR TITLE
feat(client): pure-JVM Java client SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ clients/python/target/
 clients/python/dist/
 __pycache__/
 .pytest_cache/
+
+# Java client build artifacts.
+clients/java/target/

--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -1,0 +1,46 @@
+# Talon Java client
+
+Pure-JVM client for [Talon](https://github.com/milvus-io/talon), a distributed
+object-store cache. **No native dependency** — a plain jar that drops into any
+JVM build, with no per-platform artifact, no `System.loadLibrary`, and no JNI
+crash surface.
+
+```java
+try (TalonClient client = TalonClient.connect("coordinator-host:7000", 8 << 20)) {
+    byte[] data = client.read("az://container/dataset.parquet",
+                              "0x8DABCDEF",   // object version (ETag)
+                              0, 1 << 20);
+}
+```
+
+URIs use the same namespaces as the FUSE mount — `s3://`, `gcs://`, `az://` —
+so a path addresses the same object through either client.
+
+## How correctness is maintained
+
+The wire protocol is implemented twice: here and in Rust. That duplication is
+the cost of a native-free jar, and the failure mode of drift is subtle — a
+client that occasionally reads a stale version rather than one that crashes.
+
+So this client is validated against **conformance vectors** generated from the
+Rust implementation. A change that alters the wire fails a test rather than
+silently breaking a deployment.
+
+```sh
+JAVA_HOME=/path/to/jdk scripts/java_client_e2e.sh
+```
+
+That runs both suites: the vectors, and an end-to-end read against a live
+cluster.
+
+## Current scope
+
+Read-only. `read` works; `stat` and `list` are implemented but not yet usable,
+because no server implements those endpoints
+([#318](https://github.com/milvus-io/talon/issues/318)). Until that lands,
+`read` takes the object version explicitly, since blocks are keyed by it.
+
+Requires Java 17 or newer.
+
+See the [wire protocol reference](https://milvus-io.github.io/talon/reference/wire-protocol.html)
+for the format this implements.

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.milvus</groupId>
+  <artifactId>talon-client</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Talon Java client</name>
+  <description>
+    Pure-JVM client for the Talon distributed object-store cache. No native
+    dependency: the wire protocol is implemented in Java and validated against
+    conformance vectors generated from the Rust implementation.
+  </description>
+  <url>https://github.com/milvus-io/talon</url>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <!--
+    No dependencies, deliberately. The client is a plain jar that drops into any
+    JVM build; the test suites are dependency-free too, so nothing test-only
+    leaks into a consumer's classpath.
+  -->
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/clients/java/src/main/java/io/milvus/talon/Bincode.java
+++ b/clients/java/src/main/java/io/milvus/talon/Bincode.java
@@ -1,0 +1,192 @@
+package io.milvus.talon;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Reader and writer for the subset of bincode 1.3 the control plane uses.
+ *
+ * <p>This is not a general bincode library. It implements exactly the rules the
+ * wire protocol reference specifies, and nothing else:
+ *
+ * <ul>
+ *   <li>integers are fixed-width and <b>little-endian</b> — note this differs
+ *       from the frame header, which is big-endian;
+ *   <li>enum variants are a {@code u32} tag in declaration order starting at 0;
+ *   <li>strings and sequences carry a {@code u64} length prefix, counting
+ *       <b>bytes</b> for strings rather than characters;
+ *   <li>an empty string or sequence is a {@code u64} zero followed by nothing —
+ *       not an absent field and not a null.
+ * </ul>
+ *
+ * <p>Lengths arrive as {@code u64} but Java arrays are indexed by {@code int}.
+ * Rather than silently truncating, {@link #readLength} rejects anything that
+ * would not fit, which also bounds allocation from a malformed or hostile peer.
+ */
+final class Bincode {
+
+    private Bincode() {}
+
+    /** Sequential reader over a bincode-encoded buffer. */
+    static final class Reader {
+        private final ByteBuffer buf;
+
+        Reader(byte[] bytes) {
+            this(bytes, 0, bytes.length);
+        }
+
+        Reader(byte[] bytes, int offset, int length) {
+            this.buf = ByteBuffer.wrap(bytes, offset, length).order(ByteOrder.LITTLE_ENDIAN);
+        }
+
+        byte u8() {
+            require(1);
+            return buf.get();
+        }
+
+        int u16() {
+            require(2);
+            return buf.getShort() & 0xFFFF;
+        }
+
+        /** A {@code u32}, widened to {@code long} so values above 2^31 survive. */
+        long u32() {
+            require(4);
+            return buf.getInt() & 0xFFFF_FFFFL;
+        }
+
+        /**
+         * A {@code u64}. Returned as a signed {@code long}: values above 2^63
+         * would wrap, but no field in this protocol legitimately reaches that
+         * range, and treating one as negative is more visible than truncating.
+         */
+        long u64() {
+            require(8);
+            return buf.getLong();
+        }
+
+        boolean bool() {
+            byte b = u8();
+            if (b != 0 && b != 1) {
+                throw new ProtocolException("bincode bool must be 0 or 1, got " + b);
+            }
+            return b == 1;
+        }
+
+        /** An enum variant tag. */
+        int variant() {
+            long tag = u32();
+            if (tag > Integer.MAX_VALUE) {
+                throw new ProtocolException("enum variant tag out of range: " + tag);
+            }
+            return (int) tag;
+        }
+
+        String string() {
+            int len = readLength("string");
+            require(len);
+            byte[] bytes = new byte[len];
+            buf.get(bytes);
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+
+        /** The element count of a sequence, validated as an array length. */
+        int seqLen() {
+            return readLength("sequence");
+        }
+
+        int remaining() {
+            return buf.remaining();
+        }
+
+        /**
+         * Read a {@code u64} length and validate it fits an {@code int} and the
+         * remaining buffer, so a corrupt length cannot drive a huge allocation.
+         */
+        private int readLength(String what) {
+            long len = u64();
+            if (len < 0 || len > Integer.MAX_VALUE) {
+                throw new ProtocolException(what + " length out of range: " + len);
+            }
+            if (len > buf.remaining()) {
+                throw new ProtocolException(
+                        what + " length " + len + " exceeds " + buf.remaining() + " remaining bytes");
+            }
+            return (int) len;
+        }
+
+        private void require(int n) {
+            if (buf.remaining() < n) {
+                throw new ProtocolException(
+                        "truncated message: need " + n + " bytes, have " + buf.remaining());
+            }
+        }
+    }
+
+    /** Sequential writer producing a bincode-encoded buffer. */
+    static final class Writer {
+        private ByteBuffer buf = ByteBuffer.allocate(256).order(ByteOrder.LITTLE_ENDIAN);
+
+        Writer u8(int v) {
+            ensure(1);
+            buf.put((byte) v);
+            return this;
+        }
+
+        Writer u16(int v) {
+            ensure(2);
+            buf.putShort((short) v);
+            return this;
+        }
+
+        Writer u32(long v) {
+            ensure(4);
+            buf.putInt((int) v);
+            return this;
+        }
+
+        Writer u64(long v) {
+            ensure(8);
+            buf.putLong(v);
+            return this;
+        }
+
+        /** An enum variant tag. */
+        Writer variant(int tag) {
+            return u32(tag);
+        }
+
+        Writer string(String s) {
+            byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+            // The prefix counts bytes, not characters: a multi-byte key encodes
+            // its UTF-8 length.
+            u64(bytes.length);
+            ensure(bytes.length);
+            buf.put(bytes);
+            return this;
+        }
+
+        Writer seqLen(int n) {
+            return u64(n);
+        }
+
+        byte[] toBytes() {
+            byte[] out = new byte[buf.position()];
+            buf.duplicate().flip().get(out);
+            return out;
+        }
+
+        private void ensure(int n) {
+            if (buf.remaining() >= n) {
+                return;
+            }
+            ByteBuffer bigger =
+                    ByteBuffer.allocate(Math.max(buf.capacity() * 2, buf.position() + n))
+                            .order(ByteOrder.LITTLE_ENDIAN);
+            buf.flip();
+            bigger.put(buf);
+            buf = bigger;
+        }
+    }
+}

--- a/clients/java/src/main/java/io/milvus/talon/BlockId.java
+++ b/clients/java/src/main/java/io/milvus/talon/BlockId.java
@@ -1,0 +1,67 @@
+package io.milvus.talon;
+
+import java.util.Objects;
+
+/**
+ * A block's identity: an object, an offset, a block size, and a version.
+ *
+ * <p>Placement is computed per block, so the block size must match the workers'
+ * configuration — a mismatch addresses blocks that do not exist. The version is
+ * the object's source ETag, which is what makes an overwrite invalidate cached
+ * blocks rather than serving stale bytes.
+ */
+public final class BlockId {
+
+    private final ObjectId object;
+    private final long offset;
+    private final int blockSize;
+    private final String version;
+
+    public BlockId(ObjectId object, long offset, int blockSize, String version) {
+        this.object = Objects.requireNonNull(object, "object");
+        this.offset = offset;
+        this.blockSize = blockSize;
+        this.version = Objects.requireNonNull(version, "version");
+    }
+
+    public ObjectId object() {
+        return object;
+    }
+
+    public long offset() {
+        return offset;
+    }
+
+    public int blockSize() {
+        return blockSize;
+    }
+
+    public String version() {
+        return version;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BlockId)) {
+            return false;
+        }
+        BlockId other = (BlockId) o;
+        return offset == other.offset
+                && blockSize == other.blockSize
+                && object.equals(other.object)
+                && version.equals(other.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(object, offset, blockSize, version);
+    }
+
+    @Override
+    public String toString() {
+        return object + "@" + offset + "/" + blockSize + "#" + version;
+    }
+}

--- a/clients/java/src/main/java/io/milvus/talon/Frame.java
+++ b/clients/java/src/main/java/io/milvus/talon/Frame.java
@@ -1,0 +1,137 @@
+package io.milvus.talon;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * The 16-byte frame header that prefixes every message on both planes.
+ *
+ * <p><b>Big-endian</b>, unlike the bincode body that may follow it. Mixing the
+ * two up is the first thing to check when a decoder produces nonsense.
+ *
+ * <pre>
+ * offset  size  field
+ *      0     2  magic 0x544C ("TL")
+ *      2     1  protocol version
+ *      3     1  message type
+ *      4     2  flags
+ *      6     2  reserved (zero on send, ignored on receive)
+ *      8     4  request id
+ *     12     4  payload length
+ * </pre>
+ */
+public final class Frame {
+
+    /** Header size in bytes. */
+    public static final int HEADER_LEN = 16;
+    /** Magic prefix, ASCII "TL". */
+    public static final int MAGIC = 0x544C;
+    /** Protocol version this client speaks. */
+    public static final int PROTOCOL_VERSION = 1;
+
+    /** Set when the body is an error message rather than a payload. */
+    public static final int FLAG_ERROR = 0b10;
+    /** Set on the final frame of a multi-frame response. */
+    public static final int FLAG_END_OF_STREAM = 0b01;
+
+    /** Message types. Values are wire-visible and must not be renumbered. */
+    public enum MsgType {
+        CONTROL(0),
+        GET(1),
+        GET_RANGE(2),
+        PUT(3),
+        PING(4),
+        DELETE(5);
+
+        final int value;
+
+        MsgType(int value) {
+            this.value = value;
+        }
+
+        static MsgType from(int value) {
+            for (MsgType t : values()) {
+                if (t.value == value) {
+                    return t;
+                }
+            }
+            throw new ProtocolException("unknown message type: " + value);
+        }
+    }
+
+    private final MsgType type;
+    private final int flags;
+    private final int requestId;
+    private final int length;
+
+    public Frame(MsgType type, int flags, int requestId, int length) {
+        this.type = type;
+        this.flags = flags;
+        this.requestId = requestId;
+        this.length = length;
+    }
+
+    public MsgType type() {
+        return type;
+    }
+
+    public int requestId() {
+        return requestId;
+    }
+
+    /** Payload byte count. May legally be zero; that is not end-of-stream. */
+    public int length() {
+        return length;
+    }
+
+    public boolean isError() {
+        return (flags & FLAG_ERROR) != 0;
+    }
+
+    public byte[] encode() {
+        ByteBuffer b = ByteBuffer.allocate(HEADER_LEN).order(ByteOrder.BIG_ENDIAN);
+        b.putShort((short) MAGIC);
+        b.put((byte) PROTOCOL_VERSION);
+        b.put((byte) type.value);
+        b.putShort((short) flags);
+        b.putShort((short) 0); // reserved
+        b.putInt(requestId);
+        b.putInt(length);
+        return b.array();
+    }
+
+    /**
+     * Decode a header, validating magic and protocol version.
+     *
+     * <p>A wrong magic usually means the stream is desynchronised — for example
+     * after a truncated payload — rather than that the peer sent a bad header.
+     */
+    public static Frame decode(byte[] bytes) {
+        if (bytes.length < HEADER_LEN) {
+            throw new ProtocolException(
+                    "frame header truncated: need " + HEADER_LEN + " bytes, got " + bytes.length);
+        }
+        ByteBuffer b = ByteBuffer.wrap(bytes, 0, HEADER_LEN).order(ByteOrder.BIG_ENDIAN);
+        int magic = b.getShort() & 0xFFFF;
+        if (magic != MAGIC) {
+            throw new ProtocolException(
+                    String.format("bad frame magic 0x%04X (expected 0x%04X); stream desynchronised?",
+                            magic, MAGIC));
+        }
+        int version = b.get() & 0xFF;
+        if (version != PROTOCOL_VERSION) {
+            throw new ProtocolException(
+                    "unsupported protocol version " + version + "; this client speaks "
+                            + PROTOCOL_VERSION);
+        }
+        MsgType type = MsgType.from(b.get() & 0xFF);
+        int flags = b.getShort() & 0xFFFF;
+        b.getShort(); // reserved
+        int requestId = b.getInt();
+        int length = b.getInt();
+        if (length < 0) {
+            throw new ProtocolException("payload length exceeds 2^31: " + (length & 0xFFFFFFFFL));
+        }
+        return new Frame(type, flags, requestId, length);
+    }
+}

--- a/clients/java/src/main/java/io/milvus/talon/Messages.java
+++ b/clients/java/src/main/java/io/milvus/talon/Messages.java
@@ -1,0 +1,208 @@
+package io.milvus.talon;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Control-plane message encoding and decoding.
+ *
+ * <p>Only the read path is implemented. Variant tags are the Rust enum's
+ * declaration order and are wire-visible: inserting a variant renumbers
+ * everything after it, which is a breaking change requiring a schema bump.
+ * The values here are asserted against the conformance vectors, so a Rust-side
+ * reordering fails a test rather than silently misrouting messages.
+ */
+final class Messages {
+
+    /** Newest control schema this client understands. */
+    static final int CONTROL_SCHEMA_VERSION = 2;
+    /** Oldest schema the protocol defines. */
+    static final int MIN_CONTROL_SCHEMA_VERSION = 1;
+
+    // Variant tags, in Rust declaration order.
+    static final int TAG_PLACEMENT_LOOKUP = 2;
+    static final int TAG_PLACEMENT_RESPONSE = 3;
+    static final int TAG_MEMBERSHIP_QUERY = 6;
+    static final int TAG_MEMBERSHIP_LIST = 7;
+    static final int TAG_ACK = 8;
+    static final int TAG_STAT_OBJECT = 10;
+    static final int TAG_OBJECT_STAT = 11;
+    static final int TAG_LIST_OBJECTS = 12;
+    static final int TAG_OBJECT_LIST = 13;
+
+    // Backend enum tags.
+    static final int BACKEND_S3 = 0;
+    static final int BACKEND_GCS = 1;
+    static final int BACKEND_AZURE = 2;
+
+    // NodeRole enum tags.
+    static final int ROLE_COORDINATOR = 0;
+    static final int ROLE_WORKER = 1;
+
+    private Messages() {}
+
+    /**
+     * Write the {@code Envelope { schema, message }} prefix.
+     *
+     * <p>The schema field is the <b>minimum</b> version that can represent this
+     * message, not the newest the client speaks. Sending the newest would make a
+     * peer running an older schema reject requests it could actually have
+     * served — the field exists so a receiver can decide whether it understands
+     * the message, so it must describe the message rather than the sender.
+     */
+    private static Bincode.Writer envelope(int tag) {
+        return new Bincode.Writer().u16(minimumSchema(tag)).variant(tag);
+    }
+
+    /**
+     * The oldest schema that can represent a message.
+     *
+     * <p>{@code StatObject}, {@code ObjectStat}, {@code ListObjects}, and
+     * {@code ObjectList} were added in schema 2; everything else on the read
+     * path predates it.
+     */
+    static int minimumSchema(int tag) {
+        switch (tag) {
+            case TAG_STAT_OBJECT:
+            case TAG_OBJECT_STAT:
+            case TAG_LIST_OBJECTS:
+            case TAG_OBJECT_LIST:
+                return 2;
+            default:
+                return MIN_CONTROL_SCHEMA_VERSION;
+        }
+    }
+
+    /** Wrap a bincode body in a Control frame. */
+    private static byte[] framed(int requestId, byte[] body) {
+        byte[] header =
+                new Frame(Frame.MsgType.CONTROL, 0, requestId, body.length).encode();
+        byte[] out = new byte[header.length + body.length];
+        System.arraycopy(header, 0, out, 0, header.length);
+        System.arraycopy(body, 0, out, header.length, body.length);
+        return out;
+    }
+
+    static void writeObjectId(Bincode.Writer w, ObjectId object) {
+        w.variant(backendTag(object.backend()));
+        w.string(object.bucket());
+        w.string(object.key());
+    }
+
+    static int backendTag(ObjectId.Backend backend) {
+        switch (backend) {
+            case S3:
+                return BACKEND_S3;
+            case GCS:
+                return BACKEND_GCS;
+            case AZURE:
+                return BACKEND_AZURE;
+            default:
+                throw new ProtocolException("unhandled backend: " + backend);
+        }
+    }
+
+    static ObjectId.Backend backendFrom(int tag) {
+        switch (tag) {
+            case BACKEND_S3:
+                return ObjectId.Backend.S3;
+            case BACKEND_GCS:
+                return ObjectId.Backend.GCS;
+            case BACKEND_AZURE:
+                return ObjectId.Backend.AZURE;
+            default:
+                throw new ProtocolException("unknown backend tag: " + tag);
+        }
+    }
+
+    /** {@code PlacementLookup { block, k }} */
+    static byte[] placementLookup(int requestId, BlockId block, int k) {
+        Bincode.Writer w = envelope(TAG_PLACEMENT_LOOKUP);
+        writeObjectId(w, block.object());
+        w.u64(block.offset());
+        w.u32(block.blockSize());
+        w.string(block.version());
+        w.u8(k);
+        return framed(requestId, w.toBytes());
+    }
+
+    /** {@code MembershipQuery {}} — a unit variant: the tag and nothing else. */
+    static byte[] membershipQuery(int requestId) {
+        return framed(requestId, envelope(TAG_MEMBERSHIP_QUERY).toBytes());
+    }
+
+    /** {@code StatObject { object }} */
+    static byte[] statObject(int requestId, ObjectId object) {
+        Bincode.Writer w = envelope(TAG_STAT_OBJECT);
+        writeObjectId(w, object);
+        return framed(requestId, w.toBytes());
+    }
+
+    /** {@code ListObjects { prefix }} */
+    static byte[] listObjects(int requestId, String prefix) {
+        Bincode.Writer w = envelope(TAG_LIST_OBJECTS);
+        w.string(prefix);
+        return framed(requestId, w.toBytes());
+    }
+
+    /** A decoded control response. */
+    static final class Response {
+        final int tag;
+        final Bincode.Reader body;
+
+        Response(int tag, Bincode.Reader body) {
+            this.tag = tag;
+            this.body = body;
+        }
+    }
+
+    /**
+     * Decode a control response body, validating the schema before trusting it.
+     *
+     * <p>A schema the client cannot decode is rejected rather than
+     * misinterpreted — reading a newer layout with older rules yields plausible
+     * garbage, which is worse than a clear failure.
+     */
+    static Response decodeBody(byte[] payload) {
+        Bincode.Reader r = new Bincode.Reader(payload);
+        int schema = r.u16();
+        if (schema > CONTROL_SCHEMA_VERSION) {
+            throw new ProtocolException(
+                    "server speaks control schema " + schema + "; this client understands at most "
+                            + CONTROL_SCHEMA_VERSION + " — upgrade the client");
+        }
+        return new Response(r.variant(), r);
+    }
+
+    /** {@code PlacementResponse { owners, epoch }} */
+    static Placement readPlacementResponse(Bincode.Reader r) {
+        int n = r.seqLen();
+        List<String> owners = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            owners.add(r.string());
+        }
+        long epoch = r.u64();
+        return new Placement(owners, epoch);
+    }
+
+    /** {@code MembershipList { nodes }} */
+    static List<NodeInfo> readMembershipList(Bincode.Reader r) {
+        int n = r.seqLen();
+        List<NodeInfo> nodes = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) {
+            String id = r.string();
+            String address = r.string();
+            int role = r.variant();
+            nodes.add(new NodeInfo(id, address, role == ROLE_WORKER));
+        }
+        return nodes;
+    }
+
+    /** {@code Ack { ok, detail }} — {@code detail} is an {@code Option<String>}. */
+    static String readAckDetail(Bincode.Reader r) {
+        boolean ok = r.bool();
+        boolean hasDetail = r.bool();
+        String detail = hasDetail ? r.string() : null;
+        return ok ? null : (detail == null ? "request rejected" : detail);
+    }
+}

--- a/clients/java/src/main/java/io/milvus/talon/NodeInfo.java
+++ b/clients/java/src/main/java/io/milvus/talon/NodeInfo.java
@@ -1,0 +1,33 @@
+package io.milvus.talon;
+
+/** A cluster node: its id, its dialable address, and whether it is a worker. */
+public final class NodeInfo {
+
+    private final String id;
+    private final String address;
+    private final boolean worker;
+
+    public NodeInfo(String id, String address, boolean worker) {
+        this.id = id;
+        this.address = address;
+        this.worker = worker;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    /** {@code host:port} to dial for the data plane. */
+    public String address() {
+        return address;
+    }
+
+    public boolean isWorker() {
+        return worker;
+    }
+
+    @Override
+    public String toString() {
+        return id + "@" + address + (worker ? " (worker)" : " (coordinator)");
+    }
+}

--- a/clients/java/src/main/java/io/milvus/talon/ObjectEntry.java
+++ b/clients/java/src/main/java/io/milvus/talon/ObjectEntry.java
@@ -1,0 +1,26 @@
+package io.milvus.talon;
+
+/** One listing entry: a mount-relative path and its size. */
+public final class ObjectEntry {
+
+    private final String path;
+    private final long size;
+
+    public ObjectEntry(String path, long size) {
+        this.path = path;
+        this.size = size;
+    }
+
+    public String path() {
+        return path;
+    }
+
+    public long size() {
+        return size;
+    }
+
+    @Override
+    public String toString() {
+        return "ObjectEntry{path=\"" + path + "\", size=" + size + "}";
+    }
+}

--- a/clients/java/src/main/java/io/milvus/talon/ObjectId.java
+++ b/clients/java/src/main/java/io/milvus/talon/ObjectId.java
@@ -1,0 +1,107 @@
+package io.milvus.talon;
+
+import java.util.Objects;
+
+/** An object's address: which backend, which bucket, which key. */
+public final class ObjectId {
+
+    /** Backing stores, matching the namespaces the FUSE mount exposes. */
+    public enum Backend {
+        S3,
+        GCS,
+        AZURE
+    }
+
+    private final Backend backend;
+    private final String bucket;
+    private final String key;
+
+    public ObjectId(Backend backend, String bucket, String key) {
+        this.backend = Objects.requireNonNull(backend, "backend");
+        this.bucket = Objects.requireNonNull(bucket, "bucket");
+        this.key = Objects.requireNonNull(key, "key");
+    }
+
+    /**
+     * Parse a {@code scheme://bucket/key} URI.
+     *
+     * <p>Schemes match the FUSE mount's namespaces ({@code s3}, {@code gcs},
+     * {@code az}), so a path addresses the same object through either client.
+     */
+    public static ObjectId parse(String uri) {
+        int sep = uri.indexOf("://");
+        if (sep < 0) {
+            throw new IllegalArgumentException(
+                    "expected a scheme://bucket/key URI, got \"" + uri + "\" (schemes: s3, gcs, az)");
+        }
+        String scheme = uri.substring(0, sep);
+        String rest = uri.substring(sep + 3);
+        Backend backend;
+        switch (scheme) {
+            case "s3":
+                backend = Backend.S3;
+                break;
+            case "gcs":
+                backend = Backend.GCS;
+                break;
+            case "az":
+                backend = Backend.AZURE;
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "unknown backend scheme \"" + scheme + "\"; expected s3, gcs, or az");
+        }
+        int slash = rest.indexOf('/');
+        if (slash < 0) {
+            throw new IllegalArgumentException(
+                    "URI is missing an object key: \"" + uri + "\" (expected " + scheme
+                            + "://bucket/key)");
+        }
+        String bucket = rest.substring(0, slash);
+        String key = rest.substring(slash + 1);
+        if (bucket.isEmpty()) {
+            throw new IllegalArgumentException("URI has an empty bucket: \"" + uri + "\"");
+        }
+        if (key.isEmpty()) {
+            throw new IllegalArgumentException("URI has an empty object key: \"" + uri + "\"");
+        }
+        return new ObjectId(backend, bucket, key);
+    }
+
+    public Backend backend() {
+        return backend;
+    }
+
+    public String bucket() {
+        return bucket;
+    }
+
+    public String key() {
+        return key;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ObjectId)) {
+            return false;
+        }
+        ObjectId other = (ObjectId) o;
+        return backend == other.backend
+                && bucket.equals(other.bucket)
+                && key.equals(other.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(backend, bucket, key);
+    }
+
+    @Override
+    public String toString() {
+        String scheme = backend == Backend.S3 ? "s3" : backend == Backend.GCS ? "gcs" : "az";
+        return scheme + "://" + bucket + "/" + key;
+    }
+}

--- a/clients/java/src/main/java/io/milvus/talon/ObjectStat.java
+++ b/clients/java/src/main/java/io/milvus/talon/ObjectStat.java
@@ -1,0 +1,27 @@
+package io.milvus.talon;
+
+/** An object's size and source version. */
+public final class ObjectStat {
+
+    private final long size;
+    private final String version;
+
+    public ObjectStat(long size, String version) {
+        this.size = size;
+        this.version = version;
+    }
+
+    public long size() {
+        return size;
+    }
+
+    /** Source ETag; blocks are keyed by it. */
+    public String version() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return "ObjectStat{size=" + size + ", version=\"" + version + "\"}";
+    }
+}

--- a/clients/java/src/main/java/io/milvus/talon/Placement.java
+++ b/clients/java/src/main/java/io/milvus/talon/Placement.java
@@ -1,0 +1,32 @@
+package io.milvus.talon;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Where a block lives: owners in preference order, and the epoch they were
+ * computed at.
+ *
+ * <p>The epoch matters. Observing a different one means the cached placement may
+ * be stale, and continuing to use it is the quiet failure mode — reads keep
+ * succeeding, from the wrong worker, until something else forces a refresh.
+ */
+public final class Placement {
+
+    private final List<String> owners;
+    private final long epoch;
+
+    public Placement(List<String> owners, long epoch) {
+        this.owners = Collections.unmodifiableList(owners);
+        this.epoch = epoch;
+    }
+
+    /** Owner node ids, highest-weight first. Resolve to addresses via membership. */
+    public List<String> owners() {
+        return owners;
+    }
+
+    public long epoch() {
+        return epoch;
+    }
+}

--- a/clients/java/src/main/java/io/milvus/talon/ProtocolException.java
+++ b/clients/java/src/main/java/io/milvus/talon/ProtocolException.java
@@ -1,0 +1,21 @@
+package io.milvus.talon;
+
+/**
+ * A message could not be decoded, or violated the wire protocol.
+ *
+ * <p>Distinct from an I/O failure: this means the bytes on the wire were not
+ * what the protocol specifies, which usually indicates a version mismatch
+ * between this client and the cluster rather than a transient fault. Retrying
+ * will not help.
+ */
+public class ProtocolException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public ProtocolException(String message) {
+        super(message);
+    }
+
+    public ProtocolException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/clients/java/src/main/java/io/milvus/talon/TalonClient.java
+++ b/clients/java/src/main/java/io/milvus/talon/TalonClient.java
@@ -1,0 +1,398 @@
+package io.milvus.talon;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A client for reading objects through a Talon cache cluster.
+ *
+ * <p>Pure JVM: no native library, no JNI. The trade is that the wire protocol is
+ * implemented twice — here and in Rust — so this client is validated against the
+ * <a href="https://milvus-io.github.io/talon/reference/wire-protocol.html">
+ * conformance vectors</a>, which are generated from the Rust implementation. A
+ * change that alters the wire fails a test rather than silently breaking this.
+ *
+ * <p>Read-only in this release.
+ *
+ * <h2>Thread safety</h2>
+ *
+ * Instances are safe for concurrent use. Each call opens its own connection
+ * rather than sharing one, so a slow read cannot block an unrelated one; the
+ * placement cache is shared and synchronised.
+ *
+ * <h2>Example</h2>
+ *
+ * <pre>{@code
+ * try (TalonClient client = TalonClient.connect("coordinator:7000", 8 << 20)) {
+ *     byte[] data = client.read("az://container/dataset.parquet",
+ *                               "0x8DABCDEF", 0, 1 << 20);
+ * }
+ * }</pre>
+ */
+public final class TalonClient implements AutoCloseable {
+
+    /** Placement entries older than this are re-resolved. Matches the Rust default. */
+    private static final long PLACEMENT_TTL_MS = 30_000;
+    /** Replicas requested per lookup. RF=1 in v1. */
+    private static final int REPLICAS_K = 1;
+    private static final int CONNECT_TIMEOUT_MS = 10_000;
+    private static final int READ_TIMEOUT_MS = 30_000;
+
+    private final String coordinator;
+    private final int blockSize;
+    private final AtomicInteger requestIds = new AtomicInteger(1);
+    private final Map<BlockId, CachedPlacement> placementCache = new HashMap<>();
+
+    private TalonClient(String coordinator, int blockSize) {
+        this.coordinator = coordinator;
+        this.blockSize = blockSize;
+    }
+
+    /**
+     * Connect to a coordinator.
+     *
+     * @param blockSize must match the workers' configured block size; placement
+     *     is per block, so a mismatch addresses blocks that do not exist
+     */
+    public static TalonClient connect(String coordinator, int blockSize) {
+        if (blockSize <= 0) {
+            throw new IllegalArgumentException("blockSize must be positive, got " + blockSize);
+        }
+        return new TalonClient(coordinator, blockSize);
+    }
+
+    /** Connect using the worker default block size of 256 MiB. */
+    public static TalonClient connect(String coordinator) {
+        return connect(coordinator, 256 << 20);
+    }
+
+    public String coordinator() {
+        return coordinator;
+    }
+
+    /**
+     * Read {@code length} bytes of {@code uri} starting at {@code offset}.
+     *
+     * <p>Ranges spanning block boundaries are split into per-block fetches and
+     * reassembled in order, each benefiting independently from the placement
+     * cache.
+     *
+     * <p>{@code version} is the object's source ETag. It is required because no
+     * server implements {@code StatObject} yet (see issue #318), so the client
+     * cannot resolve it.
+     */
+    public byte[] read(String uri, String version, long offset, long length) throws IOException {
+        return read(ObjectId.parse(uri), version, offset, length);
+    }
+
+    /** As {@link #read(String, String, long, long)}, with a parsed object id. */
+    public byte[] read(ObjectId object, String version, long offset, long length)
+            throws IOException {
+        if (offset < 0 || length < 0) {
+            throw new IllegalArgumentException(
+                    "offset and length must be non-negative, got offset=" + offset
+                            + " length=" + length);
+        }
+        if (length == 0) {
+            return new byte[0];
+        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream((int) Math.min(length, 1 << 20));
+        for (Segment seg : planRead(object, version, offset, length)) {
+            out.write(readBlock(seg));
+        }
+        return out.toByteArray();
+    }
+
+    /**
+     * Return an object's size and version.
+     *
+     * <p><b>Not usable yet</b>: no server implements {@code StatObject}
+     * (issue #318). Kept because the client half is correct and starts working
+     * when the server side lands.
+     */
+    public ObjectStat stat(String uri) throws IOException {
+        ObjectId object = ObjectId.parse(uri);
+        int id = requestIds.getAndIncrement();
+        Messages.Response resp = controlRoundTrip(Messages.statObject(id, object));
+        if (resp.tag == Messages.TAG_OBJECT_STAT) {
+            long size = resp.body.u64();
+            return new ObjectStat(size, resp.body.string());
+        }
+        throw unexpected("StatObject", resp);
+    }
+
+    /**
+     * List objects beneath a mount-relative prefix.
+     *
+     * <p><b>Not usable yet</b> — see {@link #stat} and issue #318.
+     */
+    public List<ObjectEntry> list(String prefix) throws IOException {
+        int id = requestIds.getAndIncrement();
+        Messages.Response resp = controlRoundTrip(Messages.listObjects(id, prefix));
+        if (resp.tag == Messages.TAG_OBJECT_LIST) {
+            int n = resp.body.seqLen();
+            List<ObjectEntry> entries = new ArrayList<>(n);
+            for (int i = 0; i < n; i++) {
+                entries.add(new ObjectEntry(resp.body.string(), resp.body.u64()));
+            }
+            return entries;
+        }
+        throw unexpected("ListObjects", resp);
+    }
+
+    @Override
+    public void close() {
+        synchronized (placementCache) {
+            placementCache.clear();
+        }
+    }
+
+    // --- read planning -----------------------------------------------------
+
+    /** One block-aligned piece of a read. */
+    private static final class Segment {
+        final BlockId block;
+        final long offsetInBlock;
+        final int length;
+
+        Segment(BlockId block, long offsetInBlock, int length) {
+            this.block = block;
+            this.offsetInBlock = offsetInBlock;
+            this.length = length;
+        }
+    }
+
+    /**
+     * Split a byte range into per-block segments.
+     *
+     * <p>The boundary arithmetic is where a client quietly corrupts data: an
+     * off-by-one here produces a plausible-looking buffer with the wrong bytes
+     * in the middle, so it is covered directly by tests.
+     */
+    private List<Segment> planRead(ObjectId object, String version, long offset, long length) {
+        List<Segment> segments = new ArrayList<>();
+        long remaining = length;
+        long pos = offset;
+        while (remaining > 0) {
+            long blockStart = (pos / blockSize) * (long) blockSize;
+            long offsetInBlock = pos - blockStart;
+            long available = blockSize - offsetInBlock;
+            int take = (int) Math.min(available, remaining);
+            segments.add(
+                    new Segment(
+                            new BlockId(object, blockStart, blockSize, version),
+                            offsetInBlock,
+                            take));
+            pos += take;
+            remaining -= take;
+        }
+        return segments;
+    }
+
+    // --- placement ---------------------------------------------------------
+
+    private static final class CachedPlacement {
+        final List<String> addresses;
+        final long epoch;
+        final long expiresAtMs;
+
+        CachedPlacement(List<String> addresses, long epoch, long expiresAtMs) {
+            this.addresses = addresses;
+            this.epoch = epoch;
+            this.expiresAtMs = expiresAtMs;
+        }
+    }
+
+    /**
+     * Fetch one segment, walking replicas on failure.
+     *
+     * <p>If every cached replica fails the entry is invalidated and refreshed
+     * once before giving up, so a stale placement costs one retry rather than a
+     * permanent error.
+     */
+    private byte[] readBlock(Segment seg) throws IOException {
+        List<String> addresses = resolve(seg.block, false);
+        IOException last = null;
+        for (String address : addresses) {
+            try {
+                return fetchRange(address, seg);
+            } catch (IOException e) {
+                last = e;
+            }
+        }
+        // Every replica failed: the placement may be stale rather than the
+        // workers being down.
+        addresses = resolve(seg.block, true);
+        for (String address : addresses) {
+            try {
+                return fetchRange(address, seg);
+            } catch (IOException e) {
+                last = e;
+            }
+        }
+        throw new IOException(
+                "no replica served block " + seg.block + " after a placement refresh",
+                last);
+    }
+
+    private List<String> resolve(BlockId block, boolean forceRefresh) throws IOException {
+        long now = System.currentTimeMillis();
+        if (!forceRefresh) {
+            synchronized (placementCache) {
+                CachedPlacement cached = placementCache.get(block);
+                if (cached != null && cached.expiresAtMs > now) {
+                    return cached.addresses;
+                }
+            }
+        }
+
+        int id = requestIds.getAndIncrement();
+        Messages.Response resp =
+                controlRoundTrip(Messages.placementLookup(id, block, REPLICAS_K));
+        if (resp.tag != Messages.TAG_PLACEMENT_RESPONSE) {
+            throw unexpected("PlacementLookup", resp);
+        }
+        Placement placement = Messages.readPlacementResponse(resp.body);
+
+        // Owners are node ids; the data plane needs addresses.
+        Map<String, String> members = membershipByNodeId();
+        List<String> addresses = new ArrayList<>(placement.owners().size());
+        for (String owner : placement.owners()) {
+            String address = members.get(owner);
+            if (address != null) {
+                addresses.add(address);
+            }
+        }
+        if (addresses.isEmpty()) {
+            throw new IOException(
+                    "no owner of " + block + " resolved to a dialable address (owners="
+                            + placement.owners() + ")");
+        }
+
+        synchronized (placementCache) {
+            // A different epoch means every cached entry may be stale, not just
+            // this one, so drop the lot rather than serving from the wrong
+            // worker until each entry happens to expire.
+            CachedPlacement previous = placementCache.get(block);
+            if (previous != null && previous.epoch != placement.epoch()) {
+                placementCache.clear();
+            }
+            placementCache.put(
+                    block,
+                    new CachedPlacement(addresses, placement.epoch(), now + PLACEMENT_TTL_MS));
+        }
+        return addresses;
+    }
+
+    private Map<String, String> membershipByNodeId() throws IOException {
+        int id = requestIds.getAndIncrement();
+        Messages.Response resp = controlRoundTrip(Messages.membershipQuery(id));
+        if (resp.tag != Messages.TAG_MEMBERSHIP_LIST) {
+            throw unexpected("MembershipQuery", resp);
+        }
+        Map<String, String> byId = new HashMap<>();
+        for (NodeInfo node : Messages.readMembershipList(resp.body)) {
+            byId.put(node.id(), node.address());
+        }
+        return byId;
+    }
+
+    // --- transport ---------------------------------------------------------
+
+    private Messages.Response controlRoundTrip(byte[] request) throws IOException {
+        try (Socket socket = dial(coordinator)) {
+            OutputStream out = socket.getOutputStream();
+            out.write(request);
+            out.flush();
+
+            Frame header = readHeader(socket.getInputStream());
+            byte[] payload = readExactly(socket.getInputStream(), header.length());
+            if (header.isError()) {
+                throw new IOException(
+                        "coordinator returned an error: " + new String(payload, java.nio.charset.StandardCharsets.UTF_8));
+            }
+            return Messages.decodeBody(payload);
+        }
+    }
+
+    private byte[] fetchRange(String workerAddress, Segment seg) throws IOException {
+        int id = requestIds.getAndIncrement();
+        Bincode.Writer w = new Bincode.Writer();
+        Messages.writeObjectId(w, seg.block.object());
+        // The data-plane RangeRequest offset is absolute within the object.
+        w.u64(seg.block.offset() + seg.offsetInBlock);
+        w.u64(seg.length);
+        byte[] body = w.toBytes();
+        byte[] header = new Frame(Frame.MsgType.GET_RANGE, 0, id, body.length).encode();
+
+        try (Socket socket = dial(workerAddress)) {
+            OutputStream out = socket.getOutputStream();
+            out.write(header);
+            out.write(body);
+            out.flush();
+
+            InputStream in = socket.getInputStream();
+            Frame response = readHeader(in);
+            byte[] payload = readExactly(in, response.length());
+            if (response.isError()) {
+                throw new IOException(
+                        "worker " + workerAddress + " returned: "
+                                + new String(payload, java.nio.charset.StandardCharsets.UTF_8));
+            }
+            return payload;
+        }
+    }
+
+    private Socket dial(String hostPort) throws IOException {
+        int colon = hostPort.lastIndexOf(':');
+        if (colon < 0) {
+            throw new IOException("address is missing a port: " + hostPort);
+        }
+        String host = hostPort.substring(0, colon);
+        int port = Integer.parseInt(hostPort.substring(colon + 1));
+        Socket socket = new Socket();
+        socket.connect(new InetSocketAddress(host, port), CONNECT_TIMEOUT_MS);
+        socket.setSoTimeout(READ_TIMEOUT_MS);
+        socket.setTcpNoDelay(true);
+        return socket;
+    }
+
+    private static Frame readHeader(InputStream in) throws IOException {
+        return Frame.decode(readExactly(in, Frame.HEADER_LEN));
+    }
+
+    /**
+     * Read exactly {@code n} bytes.
+     *
+     * <p>A short read means the peer went away mid-frame. The connection is then
+     * desynchronised — a response header promising N bytes cannot be retracted —
+     * so this fails rather than attempting to resynchronise.
+     */
+    private static byte[] readExactly(InputStream in, int n) throws IOException {
+        byte[] buf = new byte[n];
+        if (n > 0) {
+            new DataInputStream(in).readFully(buf);
+        }
+        return buf;
+    }
+
+    private IOException unexpected(String request, Messages.Response resp) {
+        if (resp.tag == Messages.TAG_ACK) {
+            String detail = Messages.readAckDetail(resp.body);
+            if (detail != null) {
+                return new IOException(request + " rejected: " + detail);
+            }
+        }
+        return new IOException("unexpected reply to " + request + ": variant tag " + resp.tag);
+    }
+}

--- a/clients/java/src/test/java/io/milvus/talon/ConformanceTest.java
+++ b/clients/java/src/test/java/io/milvus/talon/ConformanceTest.java
@@ -1,0 +1,302 @@
+package io.milvus.talon;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Validates this client's codec against the conformance vectors.
+ *
+ * <p>This is the test that makes a pure-JVM implementation defensible. The wire
+ * protocol is implemented twice — here and in Rust — and the failure mode of
+ * drift is subtle: a client that occasionally reads a stale version rather than
+ * one that crashes. The vectors are generated from the Rust implementation, so
+ * asserting against them turns "these agree today" into "a Rust change that
+ * alters the wire fails a test".
+ *
+ * <p>Deliberately dependency-free: a hand-rolled JSON reader and assertions
+ * rather than JUnit and Jackson, so the client jar has no test-only transitive
+ * dependencies and the suite runs with nothing but a JDK.
+ */
+public final class ConformanceTest {
+
+    private static int passed = 0;
+    private static final List<String> failures = new ArrayList<>();
+
+    public static void main(String[] args) throws Exception {
+        Path vectors = locateVectors(args);
+        Map<String, byte[]> byName = parseVectors(Files.readString(vectors));
+        System.out.println("loaded " + byName.size() + " vectors from " + vectors);
+
+        frameHeaderDecodes(byName);
+        frameHeaderEncodesIdentically(byName);
+        zeroLengthPayloadIsNotEof(byName);
+        placementResponseDecodes(byName);
+        emptyOwnersDecodesAsEmptyList(byName);
+        membershipListDecodes(byName);
+        objectStatSurvivesValuesAbove2Pow32(byName);
+        objectListPreservesMultiByteUtf8(byName);
+        placementLookupEncodesIdentically(byName);
+        membershipQueryEncodesIdentically(byName);
+        statObjectEncodesIdentically(byName);
+        listObjectsEncodesEmptyPrefix(byName);
+        errorResponseIsFlaggedAndCarriesAMessage(byName);
+
+        System.out.println();
+        if (failures.isEmpty()) {
+            System.out.println("conformance: " + passed + " passed");
+            return;
+        }
+        System.out.println("conformance: " + passed + " passed, " + failures.size() + " FAILED");
+        failures.forEach(f -> System.out.println("  " + f));
+        System.exit(1);
+    }
+
+    // --- the checks --------------------------------------------------------
+
+    /** A header decodes to the fields the generator encoded. */
+    private static void frameHeaderDecodes(Map<String, byte[]> v) {
+        check("frame_header decodes", () -> {
+            Frame f = Frame.decode(v.get("frame_header.get_range"));
+            assertEquals(Frame.MsgType.GET_RANGE, f.type(), "type");
+            assertEquals(7, f.requestId(), "requestId");
+            assertEquals(42, f.length(), "length");
+            assertTrue(!f.isError(), "should not be flagged as an error");
+        });
+    }
+
+    /** Encoding reproduces the reference bytes exactly. */
+    private static void frameHeaderEncodesIdentically(Map<String, byte[]> v) {
+        check("frame_header round-trips byte-exactly", () -> {
+            byte[] expected = v.get("frame_header.get_range");
+            byte[] actual = new Frame(Frame.MsgType.GET_RANGE, 0, 7, 42).encode();
+            assertBytes(expected, actual);
+        });
+    }
+
+    /**
+     * A zero-length payload is legal. A decoder that treats it as EOF hangs or
+     * drops a valid frame.
+     */
+    private static void zeroLengthPayloadIsNotEof(Map<String, byte[]> v) {
+        check("zero-length payload is a valid frame", () -> {
+            Frame f = Frame.decode(v.get("frame_header.zero_length"));
+            assertEquals(0, f.length(), "length");
+            assertEquals(Frame.MsgType.PING, f.type(), "type");
+        });
+    }
+
+    private static void placementResponseDecodes(Map<String, byte[]> v) {
+        check("PlacementResponse decodes owners and epoch", () -> {
+            Messages.Response r = body(v.get("control.placement_response"));
+            assertEquals(Messages.TAG_PLACEMENT_RESPONSE, r.tag, "variant tag");
+            Placement p = Messages.readPlacementResponse(r.body);
+            assertEquals(Arrays.asList("worker-a", "worker-b"), p.owners(), "owners");
+            assertEquals(42L, p.epoch(), "epoch");
+        });
+    }
+
+    /** An empty Vec is a u64 zero, not an absent field. */
+    private static void emptyOwnersDecodesAsEmptyList(Map<String, byte[]> v) {
+        check("empty owners decodes as an empty list", () -> {
+            Messages.Response r = body(v.get("control.placement_response.empty_owners"));
+            Placement p = Messages.readPlacementResponse(r.body);
+            assertEquals(0, p.owners().size(), "owner count");
+            assertEquals(0L, p.epoch(), "epoch");
+        });
+    }
+
+    private static void membershipListDecodes(Map<String, byte[]> v) {
+        check("MembershipList decodes node id, address, and role", () -> {
+            Messages.Response r = body(v.get("control.membership_list"));
+            assertEquals(Messages.TAG_MEMBERSHIP_LIST, r.tag, "variant tag");
+            List<NodeInfo> nodes = Messages.readMembershipList(r.body);
+            assertEquals(1, nodes.size(), "node count");
+            assertEquals("worker-a", nodes.get(0).id(), "id");
+            assertEquals("10.0.0.1:7001", nodes.get(0).address(), "address");
+            assertTrue(nodes.get(0).isWorker(), "should be a worker");
+        });
+    }
+
+    /**
+     * The case a u32-reading decoder gets wrong silently: a size above 2^32
+     * truncates rather than failing.
+     */
+    private static void objectStatSurvivesValuesAbove2Pow32(Map<String, byte[]> v) {
+        check("ObjectStat size above 2^32 is not truncated", () -> {
+            Messages.Response r = body(v.get("control.object_stat.large_size"));
+            assertEquals(Messages.TAG_OBJECT_STAT, r.tag, "variant tag");
+            long size = r.body.u64();
+            assertEquals(5_000_000_000L, size, "size");
+            assertEquals("0x8DABCDEF", r.body.string(), "version");
+        });
+    }
+
+    /** Length prefixes count bytes; a char-counting decoder desynchronises here. */
+    private static void objectListPreservesMultiByteUtf8(Map<String, byte[]> v) {
+        check("ObjectList preserves multi-byte UTF-8 keys", () -> {
+            Messages.Response r = body(v.get("control.object_list.utf8"));
+            int n = r.body.seqLen();
+            assertEquals(2, n, "entry count");
+            String first = r.body.string();
+            long firstSize = r.body.u64();
+            assertEquals("az/container/数据/文件.parquet", first, "first path");
+            assertEquals(1024L, firstSize, "first size");
+            // Decoding the second entry proves the first consumed exactly the
+            // right number of bytes.
+            assertEquals("az/container/empty", r.body.string(), "second path");
+            assertEquals(0L, r.body.u64(), "second size");
+            assertEquals(0, r.body.remaining(), "trailing bytes");
+        });
+    }
+
+    private static void placementLookupEncodesIdentically(Map<String, byte[]> v) {
+        check("PlacementLookup encodes byte-exactly", () -> {
+            BlockId block =
+                    new BlockId(
+                            new ObjectId(ObjectId.Backend.AZURE, "container", "path/to/object"),
+                            268_435_456L,
+                            256 << 20,
+                            "v1");
+            assertBytes(v.get("control.placement_lookup"), Messages.placementLookup(1, block, 1));
+        });
+    }
+
+    /** A unit variant is the tag and nothing after it. */
+    private static void membershipQueryEncodesIdentically(Map<String, byte[]> v) {
+        check("MembershipQuery encodes byte-exactly", () ->
+                assertBytes(v.get("control.membership_query"), Messages.membershipQuery(2)));
+    }
+
+    private static void statObjectEncodesIdentically(Map<String, byte[]> v) {
+        check("StatObject encodes byte-exactly", () -> {
+            ObjectId object =
+                    new ObjectId(ObjectId.Backend.AZURE, "container", "path/to/object");
+            assertBytes(v.get("control.stat_object"), Messages.statObject(3, object));
+        });
+    }
+
+    /** An empty string is a u64 zero followed by nothing. */
+    private static void listObjectsEncodesEmptyPrefix(Map<String, byte[]> v) {
+        check("ListObjects encodes an empty prefix byte-exactly", () ->
+                assertBytes(v.get("control.list_objects.empty_prefix"), Messages.listObjects(4, "")));
+    }
+
+    private static void errorResponseIsFlaggedAndCarriesAMessage(Map<String, byte[]> v) {
+        check("error response sets the flag and carries UTF-8", () -> {
+            byte[] bytes = v.get("data.error_response");
+            Frame f = Frame.decode(bytes);
+            assertTrue(f.isError(), "ERROR flag should be set");
+            String message =
+                    new String(
+                            Arrays.copyOfRange(bytes, Frame.HEADER_LEN, bytes.length),
+                            StandardCharsets.UTF_8);
+            assertEquals("worker is not ready", message, "error message");
+        });
+    }
+
+    // --- harness -----------------------------------------------------------
+
+    private static Messages.Response body(byte[] framed) {
+        Frame header = Frame.decode(framed);
+        byte[] payload = Arrays.copyOfRange(framed, Frame.HEADER_LEN, framed.length);
+        assertEquals(header.length(), payload.length, "declared vs actual payload length");
+        return Messages.decodeBody(payload);
+    }
+
+    private interface Check {
+        void run();
+    }
+
+    private static void check(String name, Check c) {
+        try {
+            c.run();
+            passed++;
+            System.out.println("  ok   " + name);
+        } catch (Throwable t) {
+            failures.add(name + ": " + t.getMessage());
+            System.out.println("  FAIL " + name + ": " + t.getMessage());
+        }
+    }
+
+    private static void assertEquals(Object expected, Object actual, String what) {
+        if (!expected.equals(actual)) {
+            throw new AssertionError(what + " expected " + expected + " but was " + actual);
+        }
+    }
+
+    private static void assertTrue(boolean condition, String what) {
+        if (!condition) {
+            throw new AssertionError(what);
+        }
+    }
+
+    private static void assertBytes(byte[] expected, byte[] actual) {
+        if (!Arrays.equals(expected, actual)) {
+            throw new AssertionError(
+                    "bytes differ\n      expected: " + hex(expected) + "\n      actual:   " + hex(actual));
+        }
+    }
+
+    private static String hex(byte[] b) {
+        StringBuilder sb = new StringBuilder(b.length * 2);
+        for (byte x : b) {
+            sb.append(String.format("%02x", x));
+        }
+        return sb.toString();
+    }
+
+    private static Path locateVectors(String[] args) {
+        if (args.length > 0) {
+            return Paths.get(args[0]);
+        }
+        // clients/java -> repository root
+        return Paths.get("crates", "talon-transport", "tests", "conformance_vectors.json");
+    }
+
+    /**
+     * Minimal reader for the vector file's fixed shape, so the client jar needs
+     * no JSON dependency for its tests.
+     */
+    private static Map<String, byte[]> parseVectors(String json) throws IOException {
+        Map<String, byte[]> out = new LinkedHashMap<>();
+        int i = 0;
+        while ((i = json.indexOf("\"name\":", i)) >= 0) {
+            String name = quoted(json, json.indexOf('"', i + 7));
+            int hexAt = json.indexOf("\"hex\":", i);
+            if (hexAt < 0) {
+                throw new IOException("vector " + name + " has no hex field");
+            }
+            String hex = quoted(json, json.indexOf('"', hexAt + 6));
+            out.put(name, unhex(hex));
+            i = hexAt;
+        }
+        if (out.isEmpty()) {
+            throw new IOException("no vectors parsed; is the file the expected shape?");
+        }
+        return out;
+    }
+
+    private static String quoted(String s, int openQuote) {
+        int end = s.indexOf('"', openQuote + 1);
+        String raw = s.substring(openQuote + 1, end);
+        // The generator emits plain ASCII names and hex, so no unescaping is
+        // required beyond this.
+        return raw;
+    }
+
+    private static byte[] unhex(String hex) {
+        byte[] out = new byte[hex.length() / 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = (byte) Integer.parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+        }
+        return out;
+    }
+}

--- a/clients/java/src/test/java/io/milvus/talon/E2ETest.java
+++ b/clients/java/src/test/java/io/milvus/talon/E2ETest.java
@@ -1,0 +1,162 @@
+package io.milvus.talon;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * End-to-end tests against a live cluster.
+ *
+ * <p>Conformance vectors prove the codec matches Rust; these prove the client
+ * actually reads bytes. Both are needed — an encoder can be byte-perfect and
+ * still fail at block-boundary arithmetic or replica resolution.
+ *
+ * <p>Expects a coordinator address as {@code args[0]}, a block size as
+ * {@code args[1]}, and a version as {@code args[2]}. The harness in
+ * {@code scripts/java_client_e2e.sh} starts the cluster.
+ */
+public final class E2ETest {
+
+    private static int passed = 0;
+    private static final List<String> failures = new ArrayList<>();
+
+    public static void main(String[] args) throws Exception {
+        String coordinator = args.length > 0 ? args[0] : "127.0.0.1:17600";
+        int blockSize = args.length > 1 ? Integer.parseInt(args[1]) : (8 << 20);
+        String version = args.length > 2 ? args[2] : "0x8LOADTEST";
+        String uri = "az://container/bench";
+
+        try (TalonClient client = TalonClient.connect(coordinator, blockSize)) {
+            check("reads exact bytes at offset 0", () -> {
+                byte[] got = client.read(uri, version, 0, 4096);
+                assertBytes(ramp(0, 4096), got);
+            });
+
+            check("reads exact bytes at a non-zero offset", () -> {
+                byte[] got = client.read(uri, version, 1000, 8192);
+                assertBytes(ramp(1000, 8192), got);
+            });
+
+            // Wrong boundary arithmetic yields a plausible-looking buffer with
+            // the wrong bytes in the middle, so assert content and not length.
+            check("reassembles a range spanning block boundaries", () -> {
+                int length = blockSize + (4 << 20);
+                byte[] got = client.read(uri, version, 0, length);
+                assertBytes(ramp(0, length), got);
+            });
+
+            check("reads across exactly one block edge", () -> {
+                long offset = blockSize - 2048;
+                byte[] got = client.read(uri, version, offset, 4096);
+                assertBytes(ramp(offset, 4096), got);
+            });
+
+            check("zero-length read returns empty", () -> {
+                byte[] got = client.read(uri, version, 0, 0);
+                assertEquals(0, got.length, "length");
+            });
+
+            check("placement cache serves a repeated read", () -> {
+                byte[] first = client.read(uri, version, 0, 4096);
+                byte[] second = client.read(uri, version, 0, 4096);
+                assertBytes(first, second);
+            });
+
+            check("concurrent reads from threads are correct", () -> {
+                int n = 8;
+                byte[][] results = new byte[n][];
+                Throwable[] errors = new Throwable[n];
+                List<Thread> threads = new ArrayList<>();
+                for (int i = 0; i < n; i++) {
+                    final int idx = i;
+                    Thread t = new Thread(() -> {
+                        try {
+                            results[idx] = client.read(uri, version, idx * 65536L, 65536);
+                        } catch (Throwable e) {
+                            errors[idx] = e;
+                        }
+                    });
+                    threads.add(t);
+                    t.start();
+                }
+                for (Thread t : threads) {
+                    t.join();
+                }
+                for (int i = 0; i < n; i++) {
+                    if (errors[i] != null) {
+                        throw new AssertionError("thread " + i + " failed: " + errors[i]);
+                    }
+                    assertBytes(ramp(i * 65536L, 65536), results[i]);
+                }
+            });
+
+            check("malformed URIs are rejected before any I/O", () -> {
+                for (String bad : Arrays.asList(
+                        "no-scheme", "ftp://bucket/key", "az://bucket", "az:///key", "az://bucket/")) {
+                    try {
+                        client.read(bad, version, 0, 1);
+                        throw new AssertionError("should have rejected " + bad);
+                    } catch (IllegalArgumentException expected) {
+                        // The message must name the problem, not just fail.
+                        if (expected.getMessage() == null || expected.getMessage().isEmpty()) {
+                            throw new AssertionError("empty error message for " + bad);
+                        }
+                    }
+                }
+            });
+        }
+
+        System.out.println();
+        if (failures.isEmpty()) {
+            System.out.println("e2e: " + passed + " passed");
+            return;
+        }
+        System.out.println("e2e: " + passed + " passed, " + failures.size() + " FAILED");
+        failures.forEach(f -> System.out.println("  " + f));
+        System.exit(1);
+    }
+
+    /** The deterministic bytes the test origin serves. */
+    private static byte[] ramp(long start, int length) {
+        byte[] out = new byte[length];
+        for (int i = 0; i < length; i++) {
+            out[i] = (byte) ((start + i) % 251);
+        }
+        return out;
+    }
+
+    private interface Check {
+        void run() throws Exception;
+    }
+
+    private static void check(String name, Check c) {
+        try {
+            c.run();
+            passed++;
+            System.out.println("  ok   " + name);
+        } catch (Throwable t) {
+            failures.add(name + ": " + t.getMessage());
+            System.out.println("  FAIL " + name + ": " + t.getMessage());
+        }
+    }
+
+    private static void assertEquals(long expected, long actual, String what) {
+        if (expected != actual) {
+            throw new AssertionError(what + " expected " + expected + " but was " + actual);
+        }
+    }
+
+    private static void assertBytes(byte[] expected, byte[] actual) {
+        if (expected.length != actual.length) {
+            throw new AssertionError(
+                    "length expected " + expected.length + " but was " + actual.length);
+        }
+        for (int i = 0; i < expected.length; i++) {
+            if (expected[i] != actual[i]) {
+                throw new AssertionError(
+                        "bytes differ at index " + i + ": expected " + expected[i]
+                                + " but was " + actual[i]);
+            }
+        }
+    }
+}

--- a/scripts/java_client_e2e.sh
+++ b/scripts/java_client_e2e.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# End-to-end test for the Java client against a live cluster (#313).
+#
+# Starts a coordinator, a worker, and a local blob origin, then runs the Java
+# conformance and e2e suites against them. Requires a JDK on PATH or JAVA_HOME.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+JAVA="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+JAVAC="${JAVA_HOME:+$JAVA_HOME/bin/}javac"
+command -v "$JAVAC" >/dev/null 2>&1 || { echo "no JDK found; set JAVA_HOME"; exit 1; }
+
+COORD_PORT=17620
+WORKER_PORT=17621
+ADMIN_PORT=17671
+ORIGIN_PORT=17720
+BLOCK_SIZE=$((8 << 20))
+VERSION="0x8LOADTEST"
+
+CACHE="$(mktemp -d /tmp/talon-java-e2e.XXXXXX)"
+LOGS="$(mktemp -d /tmp/talon-java-e2e-logs.XXXXXX)"
+CLASSES="$(mktemp -d /tmp/talon-java-classes.XXXXXX)"
+
+cleanup() {
+  # Kill by recorded pid rather than by name: pkill -f would also match the
+  # shell running this script, and talon-coordinator exceeds pkill -x's
+  # 15-character comm limit.
+  for pid in "${ORIGIN_PID:-}" "${COORD_PID:-}" "${WORKER_PID:-}"; do
+    [ -n "$pid" ] && kill "$pid" 2>/dev/null
+  done
+  rm -rf "$CACHE" "$CLASSES"
+}
+trap cleanup EXIT
+
+echo "building..."
+cargo build --release -q -p talon-worker --bin talon-worker -p talon-coordinator --bin talon-coordinator
+"$JAVAC" -d "$CLASSES" \
+  clients/java/src/main/java/io/milvus/talon/*.java \
+  clients/java/src/test/java/io/milvus/talon/*.java
+
+export TALON_WORKER_CACHE_DIRS="$CACHE"
+export TALON_WORKER_AZURE_ACCOUNT=test TALON_WORKER_AZURE_SAS=test
+export TALON_WORKER_AZURE_ENDPOINT="http://127.0.0.1:$ORIGIN_PORT"
+export RUST_LOG="${RUST_LOG:-warn}"
+
+python3 scripts/loadtest_origin.py "$ORIGIN_PORT" >"$LOGS/origin.log" 2>&1 &
+ORIGIN_PID=$!
+sleep 1
+
+setsid target/release/talon-coordinator \
+  --listen "127.0.0.1:$COORD_PORT" --admin-listen "127.0.0.1:$((COORD_PORT + 50))" \
+  >"$LOGS/coordinator.log" 2>&1 </dev/null &
+COORD_PID=$!
+sleep 3
+
+setsid target/release/talon-worker \
+  --listen "127.0.0.1:$WORKER_PORT" --admin-listen "127.0.0.1:$ADMIN_PORT" \
+  --coordinator "127.0.0.1:$COORD_PORT" \
+  >"$LOGS/worker.log" 2>&1 </dev/null &
+WORKER_PID=$!
+
+# An unready worker error-frames every read, so wait rather than sleeping.
+for _ in $(seq 1 30); do
+  curl -fsS "http://127.0.0.1:$ADMIN_PORT/readyz" >/dev/null 2>&1 && break
+  sleep 1
+done
+
+echo
+echo "=== conformance vectors ==="
+"$JAVA" -cp "$CLASSES" io.milvus.talon.ConformanceTest || exit 1
+
+echo
+echo "=== end-to-end ==="
+"$JAVA" -cp "$CLASSES" io.milvus.talon.E2ETest \
+  "127.0.0.1:$COORD_PORT" "$BLOCK_SIZE" "$VERSION" || exit 1


### PR DESCRIPTION
Sub-task 3 of #310. A **plain jar with no native dependency** — no JNI, no FFM, no per-platform artifact, no `System.loadLibrary` failure mode, no minimum JDK beyond the declared 17.

```java
try (TalonClient client = TalonClient.connect("coordinator:7000", 8 << 20)) {
    byte[] data = client.read("az://container/dataset.parquet", "0x8DABCDEF", 0, 1 << 20);
}
```

## The conformance vectors earned their keep immediately

The cost of a native-free jar is that the wire protocol is implemented twice, and the failure mode of drift is subtle — a client that occasionally reads a *stale version*, not one that crashes. #311 exists to make that acceptable.

**The first conformance run failed two vectors:**

```
FAIL PlacementLookup encodes byte-exactly
  expected: 544c...48 01 00 02000000...
  actual:   544c...48 02 00 02000000...
                    ^^ schema field
```

I had sent the envelope schema as *the newest version this client speaks*. Rust sends *the minimum version that can represent the message* — `StatObject` and friends are schema 2, everything else on the read path is schema 1.

Nothing would have crashed. A coordinator running an older schema would simply have **rejected requests it could have served**, and the cause would have been invisible from either side. The vectors caught it before the code left my machine.

That is the single best argument for having built #311 first, and I would not have found this by testing against a current-version cluster.

## What is implemented

Frame codec, the bincode subset the control plane uses, and the read path: placement lookup with a client-side cache, resolving owner node ids to addresses via the membership snapshot, **ordered replica fallback with one placement refresh before giving up**, epoch-based invalidation, and multi-block range splitting.

**Prefetch and readahead are deliberately absent.** A first client should be correct before it is clever.

## Two hazards handled explicitly

**`u64` lengths indexing `int` arrays.** Validated against both `Integer.MAX_VALUE` and the remaining buffer rather than cast — which also bounds allocation from a malformed peer, the same discipline the server applies (#111).

**Epoch invalidation is cluster-wide, not per-entry.** A bumped epoch means *every* cached placement may be stale, so the cache is cleared rather than the one entry. Getting this wrong is the quiet bug the wire spec calls out: reads keep succeeding, from the wrong worker.

## Tests: 13 conformance + 8 end-to-end

Dependency-free by design — hand-rolled assertions and JSON reading rather than JUnit and Jackson — so nothing test-only reaches a consumer's classpath.

```
=== conformance vectors ===        === end-to-end ===
conformance: 13 passed             e2e: 8 passed
```

The end-to-end set runs against a live coordinator, worker, and blob origin, and covers **block-boundary reassembly** and a read **straddling exactly one block edge** — that arithmetic fails by producing plausible-looking data with the wrong bytes in the middle rather than by erroring, so the tests assert content, never length.

```sh
JAVA_HOME=/path/to/jdk scripts/java_client_e2e.sh
```

## Scope

Read-only. `stat` and `list` are implemented but documented as not-yet-usable pending #318, so `read` takes the object version explicitly.

## Verification

- 13 conformance vectors — byte equality against Rust-generated encodings
- 8 end-to-end checks against a live cluster
- `javac -Xlint:all --release 17` — clean, confirming the declared minimum JDK
- `cargo test/clippy/fmt --workspace` — unaffected

Refs #310, #313, #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)
