### PR TITLE
test(fuse): exercise POSIX and kernel I/O paths

### DIFF
--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -540,7 +540,7 @@ async fn mount_kernel_io_benchmark() {
         store
             .lock()
             .unwrap()
-            .get("s3/bucket/bench-write.bin")
+            .get("/s3/bucket/bench-write.bin")
             .map(Vec::len),
         Some(write_size as usize),
         "benchmark write must reach the mock backend"

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -23,9 +23,12 @@
 #![cfg(feature = "mount")]
 
 use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::os::unix::fs::FileExt;
+use std::process::Command;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use talon_core::{NodeId, NodeInfo, NodeRole};
 use talon_fuse::mount::TalonFuse;
@@ -362,4 +365,214 @@ async fn mount_write_through_is_visible_in_backend() {
         !final_store.contains_key("s3/bucket/hello.bin"),
         "object should be gone from backend after unlink"
     );
+}
+
+/// Mount the read-write fixture and run the pinned pjdfstest suite against it.
+///
+/// This is separately gated because the normal real-kernel smoke job runs all
+/// ignored tests. Set `TALON_RUN_PJDFSTEST=1` to opt in. A comma-separated
+/// `TALON_PJDFSTEST_TESTS` value selects groups or files; omitting it runs the
+/// complete suite.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires /dev/fuse, root, and pjdfstest build dependencies"]
+async fn mount_pjdfstest_compatibility_suite() {
+    use fuser::MountOption;
+
+    if std::env::var_os("TALON_RUN_PJDFSTEST").is_none() {
+        eprintln!("skipping: set TALON_RUN_PJDFSTEST=1 to run pjdfstest");
+        return;
+    }
+
+    let block_size: u32 = 4 * 1024 * 1024;
+    let store: Store = Arc::new(Mutex::new(HashMap::new()));
+    let worker = spawn_rw_worker(store).await;
+    let coord = spawn_coordinator(worker).await;
+
+    let fs = Arc::new(ReadOnlyFs::new());
+    fs.insert_object("s3/bucket/placeholder", 0);
+
+    let cache = Arc::new(PlacementCache::new(10_000));
+    let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
+    let adapter = TalonFuse::new(
+        Arc::clone(&fs),
+        reader,
+        tokio::runtime::Handle::current(),
+        block_size,
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
+    )
+    .with_read_write(true);
+
+    let mountpoint = std::env::temp_dir().join(format!("talon-pjdfstest-{}", std::process::id()));
+    std::fs::create_dir_all(&mountpoint).unwrap();
+    let options = vec![MountOption::FSName("talon".into())];
+    let session = fuser::spawn_mount2(adapter, &mountpoint, &options)
+        .expect("TALON_RUN_PJDFSTEST requires a working /dev/fuse");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let test_dir = mountpoint.join("s3").join("bucket");
+    let runner =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/posix/pjdfstest/run.sh");
+    let selectors = std::env::var("TALON_PJDFSTEST_TESTS").unwrap_or_default();
+
+    let status = tokio::task::spawn_blocking(move || {
+        let mut command = Command::new(runner);
+        command.arg("--mountpoint").arg(test_dir);
+        for selector in selectors
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            command.arg(selector);
+        }
+        command.status()
+    })
+    .await
+    .unwrap()
+    .expect("start pjdfstest runner");
+
+    drop(session);
+    std::fs::remove_dir_all(&mountpoint).ok();
+
+    assert!(
+        status.success(),
+        "pjdfstest reported compatibility failures"
+    );
+}
+
+/// Measure I/O through a real kernel FUSE mount backed by local protocol mocks.
+///
+/// Set `TALON_RUN_FUSE_BENCH=1` to opt in. The benchmark reports FUSE/Talon
+/// userspace path performance, not object-store or cross-region performance.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires /dev/fuse; set TALON_RUN_FUSE_BENCH=1"]
+async fn mount_kernel_io_benchmark() {
+    use fuser::MountOption;
+
+    if std::env::var_os("TALON_RUN_FUSE_BENCH").is_none() {
+        eprintln!("skipping: set TALON_RUN_FUSE_BENCH=1 to run the benchmark");
+        return;
+    }
+
+    let read_mib = env_u64("TALON_FUSE_BENCH_READ_MIB", 128);
+    let write_mib = env_u64("TALON_FUSE_BENCH_WRITE_MIB", 64);
+    let random_ops = env_u64("TALON_FUSE_BENCH_RANDOM_OPS", 4096);
+    let read_size = read_mib * 1024 * 1024;
+    let write_size = write_mib * 1024 * 1024;
+
+    let block_size: u32 = 4 * 1024 * 1024;
+    let store: Store = Arc::new(Mutex::new(HashMap::new()));
+    let worker = spawn_rw_worker(Arc::clone(&store)).await;
+    let coord = spawn_coordinator(worker).await;
+
+    let fs = Arc::new(ReadOnlyFs::new());
+    fs.insert_object("s3/bucket/bench-read.bin", read_size);
+
+    let cache = Arc::new(PlacementCache::new(10_000));
+    let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
+    let adapter = TalonFuse::new(
+        Arc::clone(&fs),
+        reader,
+        tokio::runtime::Handle::current(),
+        block_size,
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
+    )
+    .with_read_write(true);
+
+    let mountpoint = std::env::temp_dir().join(format!("talon-fuse-bench-{}", std::process::id()));
+    std::fs::create_dir_all(&mountpoint).unwrap();
+    let options = vec![MountOption::FSName("talon".into())];
+    let session = fuser::spawn_mount2(adapter, &mountpoint, &options)
+        .expect("TALON_RUN_FUSE_BENCH requires a working /dev/fuse");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let read_path = mountpoint.join("s3").join("bucket").join("bench-read.bin");
+    let write_path = mountpoint.join("s3").join("bucket").join("bench-write.bin");
+
+    tokio::task::spawn_blocking(move || {
+        let file = std::fs::File::open(&read_path).expect("open benchmark read file");
+        let mut page = [0u8; 4096];
+        let max_page = (read_size / page.len() as u64).max(1);
+        let mut state = 0x4d595df4d0f33173u64;
+        let random_started = Instant::now();
+        for _ in 0..random_ops {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            let offset = (state % max_page) * page.len() as u64;
+            file.read_exact_at(&mut page, offset)
+                .expect("random benchmark read");
+            std::hint::black_box(&page);
+        }
+        let random_elapsed = random_started.elapsed();
+        report_rate(
+            "random_read_4k_iops",
+            random_ops as f64 / random_elapsed.as_secs_f64(),
+            "ops/s",
+        );
+
+        let cold_started = Instant::now();
+        let cold_bytes = stream_file(&read_path);
+        let cold_elapsed = cold_started.elapsed();
+        report_throughput("sequential_read_cold", cold_bytes, cold_elapsed);
+
+        let warm_started = Instant::now();
+        let warm_bytes = stream_file(&read_path);
+        let warm_elapsed = warm_started.elapsed();
+        report_throughput("sequential_read_warm", warm_bytes, warm_elapsed);
+
+        let payload = vec![0x5au8; write_size as usize];
+        let write_started = Instant::now();
+        {
+            let mut output =
+                std::fs::File::create(&write_path).expect("create benchmark write file");
+            output.write_all(&payload).expect("write benchmark payload");
+        }
+        let write_elapsed = write_started.elapsed();
+        report_throughput("write_through", write_size, write_elapsed);
+    })
+    .await
+    .unwrap();
+
+    drop(session);
+    std::fs::remove_dir_all(&mountpoint).ok();
+
+    assert_eq!(
+        store
+            .lock()
+            .unwrap()
+            .get("s3/bucket/bench-write.bin")
+            .map(Vec::len),
+        Some(write_size as usize),
+        "benchmark write must reach the mock backend"
+    );
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn stream_file(path: &std::path::Path) -> u64 {
+    let mut file = std::fs::File::open(path).expect("open sequential benchmark file");
+    let mut buffer = vec![0u8; 1024 * 1024];
+    let mut total = 0u64;
+    loop {
+        let read = file.read(&mut buffer).expect("sequential benchmark read");
+        if read == 0 {
+            return total;
+        }
+        total += read as u64;
+        std::hint::black_box(&buffer[..read]);
+    }
+}
+
+fn report_throughput(metric: &str, bytes: u64, elapsed: Duration) {
+    let mib_per_second = bytes as f64 / (1024.0 * 1024.0) / elapsed.as_secs_f64();
+    report_rate(metric, mib_per_second, "MiB/s");
+}
+
+fn report_rate(metric: &str, value: f64, unit: &str) {
+    println!("TALON_FUSE_BENCH metric={metric} value={value:.2} unit={unit}");
 }

--- a/crates/talon-fuse/tests/posix/README.md
+++ b/crates/talon-fuse/tests/posix/README.md
@@ -54,3 +54,44 @@ running destructive filesystem tests against the host filesystem.
 The complete suite is not expected to pass until Talon implements all covered
 operations. Add operation-specific invocations and expected-result tracking
 incrementally as support is added.
+
+## Run through the kernel-mount fixture
+
+The `mount_e2e` integration test can start mock coordinator and worker servers,
+mount Talon through the kernel, and invoke this runner inside the synthesized
+`s3/bucket` directory.
+
+Run the complete suite:
+
+```sh
+sudo TALON_REQUIRE_FUSE=1 TALON_RUN_PJDFSTEST=1 \
+  cargo test -p talon-fuse --features mount --test mount_e2e \
+  mount_pjdfstest_compatibility_suite -- --ignored --nocapture
+```
+
+Run selected groups or files:
+
+```sh
+sudo TALON_REQUIRE_FUSE=1 \
+  TALON_RUN_PJDFSTEST=1 \
+  TALON_PJDFSTEST_TESTS=open/00.t,unlink \
+  cargo test -p talon-fuse --features mount --test mount_e2e \
+  mount_pjdfstest_compatibility_suite -- --ignored --nocapture
+```
+
+## Run the kernel I/O benchmark
+
+The opt-in benchmark measures the Talon userspace and kernel FUSE path over
+local protocol mocks. It does not include object-store or cross-region latency.
+
+```sh
+sudo TALON_REQUIRE_FUSE=1 TALON_RUN_FUSE_BENCH=1 \
+  cargo test -p talon-fuse --features mount --test mount_e2e \
+  mount_kernel_io_benchmark -- --ignored --nocapture
+```
+
+The workload size can be adjusted with:
+
+- `TALON_FUSE_BENCH_READ_MIB`
+- `TALON_FUSE_BENCH_WRITE_MIB`
+- `TALON_FUSE_BENCH_RANDOM_OPS`


### PR DESCRIPTION
## Summary

Follow up on #319 by wiring the pinned pjdfstest runner into a real Talon kernel mount and adding an opt-in FUSE I/O benchmark. This makes the POSIX suite executable end to end against the mock coordinator and worker fixture while keeping it outside the default test matrix.

## Related issues

- Follow-up to #319

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no behavior change)
- [x] Performance
- [x] Docs / tests / tooling

## Design alignment

This extends FUSE validation without changing runtime filesystem behavior or the design described in `DESIGN.md`.

## Changes

- Add an opt-in real-kernel fixture that mounts Talon over mock coordinator and worker services and runs pjdfstest against `/s3/bucket`.
- Support comma-separated pjdfstest group and file selectors through `TALON_PJDFSTEST_TESTS`.
- Add an opt-in benchmark for 4 KiB random reads, cold and warm sequential reads, and write-through throughput.
- Verify benchmark writes reach the mock backend.
- Document the mount fixture, selectors, benchmark controls, and commands.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p talon-fuse --features mount --test mount_e2e --no-run --locked`
- [x] `git diff --check upstream/main...HEAD`
- [x] Existing real-kernel read and write-through tests in a privileged Kubernetes Job with host `/dev/fuse`: 2 passed, 0 failed
- [x] Complete pjdfstest run through a real Talon FUSE mount on `falcon-phx-ca`: 238 files, 8,798 assertions, 2,406 passed, 6,392 failed, 201 seconds
- [x] FUSE I/O benchmark through a real kernel mount on `falcon-phx-ca`: 1 passed, 0 failed

The pjdfstest run establishes a compatibility baseline rather than a passing gate. Current gaps are concentrated in ownership and mode semantics, directory operations, links, rename, timestamps, and detailed errno behavior. Individual operation groups can become required tests as support is implemented.

## Performance impact

The benchmark uses local protocol mocks, so it measures the kernel FUSE and Talon userspace path rather than remote object-store or cross-region performance. On `aks-system-42717909-vmss000002` with 4 CPU and 8 GiB limits:

- 4 KiB random read: 4,797.85 IOPS
- Cold sequential read: 47.14 MiB/s
- Warm sequential read: 6,119.28 MiB/s
- Write-through: 76.00 MiB/s

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`<type>(<scope>): <description>`) - it becomes the squash-merge commit subject and is checked by CI
- [x] Public items are documented; no broken intra-doc links
- [x] No new dependencies
- [x] Based on the latest `upstream/main`
