### PR TITLE
test(worker): cover LRU accounting by build mode

### DIFF
--- a/crates/talon-worker/src/eviction.rs
+++ b/crates/talon-worker/src/eviction.rs
@@ -291,10 +291,19 @@ mod tests {
         assert_eq!(lru.remove(&whole(1)), None);
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "LRU byte accounting underflow")]
     fn accounting_underflow_is_detected_in_debug_builds() {
         Lru::subtract_bytes(&mut 0, 1);
+    }
+
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn accounting_underflow_saturates_in_release_builds() {
+        let mut total = 0;
+        Lru::subtract_bytes(&mut total, 1);
+        assert_eq!(total, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- gate the `debug_assert!` panic test with `cfg(debug_assertions)`
- add release-mode coverage for saturating underflow behavior

Without the build-mode gate, `cargo test --release` fails because `debug_assert!` is compiled out while `#[should_panic]` remains active.

Follow-up to #308.

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p talon-worker --all-targets --all-features --locked -- -D warnings`
- `cargo test -p talon-worker --all-features --locked`
- `cargo test --release -p talon-worker eviction --locked`