### PR TITLE
feat(worker): serve StatObject with coordinator proxy

### DIFF
--- a/clients/java/src/main/java/io/milvus/talon/TalonClient.java
+++ b/clients/java/src/main/java/io/milvus/talon/TalonClient.java
@@ -87,9 +87,22 @@ public final class TalonClient implements AutoCloseable {
      * reassembled in order, each benefiting independently from the placement
      * cache.
      *
-     * <p>{@code version} is the object's source ETag. It is required because no
-     * server implements {@code StatObject} yet (see issue #318), so the client
-     * cannot resolve it.
+     * <p>Resolves the object's version with a {@code stat} first. Use
+     * {@link #read(String, String, long, long)} to supply a known version and
+     * skip that round trip.
+     */
+    public byte[] read(String uri, long offset, long length) throws IOException {
+        ObjectId object = ObjectId.parse(uri);
+        ObjectStat stat = stat(object);
+        return read(object, stat.version(), offset, Math.min(length, Math.max(0, stat.size() - offset)));
+    }
+
+    /**
+     * Read with a known version, skipping the {@code stat} round trip.
+     *
+     * <p>Worth using when reading many ranges of one object: the version is
+     * stable for an object generation, so re-resolving it per read is wasted
+     * work.
      */
     public byte[] read(String uri, String version, long offset, long length) throws IOException {
         return read(ObjectId.parse(uri), version, offset, length);
@@ -113,15 +126,13 @@ public final class TalonClient implements AutoCloseable {
         return out.toByteArray();
     }
 
-    /**
-     * Return an object's size and version.
-     *
-     * <p><b>Not usable yet</b>: no server implements {@code StatObject}
-     * (issue #318). Kept because the client half is correct and starts working
-     * when the server side lands.
-     */
+    /** Return an object's size and version. */
     public ObjectStat stat(String uri) throws IOException {
-        ObjectId object = ObjectId.parse(uri);
+        return stat(ObjectId.parse(uri));
+    }
+
+    /** As {@link #stat(String)}, with a parsed object id. */
+    public ObjectStat stat(ObjectId object) throws IOException {
         int id = requestIds.getAndIncrement();
         Messages.Response resp = controlRoundTrip(Messages.statObject(id, object));
         if (resp.tag == Messages.TAG_OBJECT_STAT) {
@@ -134,7 +145,9 @@ public final class TalonClient implements AutoCloseable {
     /**
      * List objects beneath a mount-relative prefix.
      *
-     * <p><b>Not usable yet</b> — see {@link #stat} and issue #318.
+     * <p><b>Not usable yet</b>: {@code ListObjects} needs a listing capability
+     * on the backends, which they do not yet have (issue #332). {@code stat}
+     * and {@code read} are unaffected.
      */
     public List<ObjectEntry> list(String prefix) throws IOException {
         int id = requestIds.getAndIncrement();

--- a/clients/java/src/test/java/io/milvus/talon/E2ETest.java
+++ b/clients/java/src/test/java/io/milvus/talon/E2ETest.java
@@ -27,6 +27,20 @@ public final class E2ETest {
         String uri = "az://container/bench";
 
         try (TalonClient client = TalonClient.connect(coordinator, blockSize)) {
+            check("stat returns size and version", () -> {
+                ObjectStat s = client.stat(uri);
+                assertEquals(version.length(), s.version().length(), "version length");
+                if (s.size() <= 0) {
+                    throw new AssertionError("size should be positive, was " + s.size());
+                }
+            });
+
+            // The common case after #318: no version supplied, resolved via stat.
+            check("read resolves the version automatically", () -> {
+                byte[] got = client.read(uri, 0, 4096);
+                assertBytes(ramp(0, 4096), got);
+            });
+
             check("reads exact bytes at offset 0", () -> {
                 byte[] got = client.read(uri, version, 0, 4096);
                 assertBytes(ramp(0, 4096), got);

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -162,37 +162,46 @@ impl Client {
     /// Ranges spanning block boundaries are split and fetched per block, each
     /// benefiting independently from the placement cache.
     ///
-    /// `version` is the object's source ETag, which blocks are keyed by. It is
-    /// required because no server implements `StatObject` yet (#318), so the
-    /// client cannot resolve it. Once that lands this becomes optional and is
-    /// resolved automatically. `size` bounds the read at EOF; when omitted the
-    /// read is not clamped and a past-EOF request fails at the worker rather
-    /// than returning short.
-    #[pyo3(signature = (uri, *, version, offset = 0, length = None, size = None))]
+    /// `version` and `size` are resolved with a `stat` when omitted. Pass them
+    /// to skip that round trip when they are already known — for example when
+    /// reading many ranges of the same object.
+    #[pyo3(signature = (uri, *, offset = 0, length = None, version = None, size = None))]
     fn read<'py>(
         &self,
         py: Python<'py>,
         uri: &str,
-        version: &str,
         offset: u64,
         length: Option<u64>,
+        version: Option<&str>,
         size: Option<u64>,
     ) -> PyResult<Bound<'py, PyBytes>> {
         let object = parse_uri_inner(uri).map_err(PyValueError::new_err)?;
-        let version = Version::new(version);
+        let known_version = version.map(Version::new);
         let runtime = Arc::clone(&self.runtime);
         let reader = self.reader.clone();
+        let coordinator = self.coordinator.clone();
         let block_size = self.block_size;
-        let file_size = size.unwrap_or(u64::MAX);
-        let len = match length {
-            Some(n) => n,
-            None => file_size.saturating_sub(offset),
-        };
 
         // Release the GIL: this is network I/O, and holding it would serialise
         // every reader thread in the process on one request.
         let bytes = py.allow_threads(move || {
             runtime.block_on(async move {
+                // One stat covers both, so only issue it when something is
+                // actually missing.
+                let (version, file_size) = match (known_version, size) {
+                    (Some(v), Some(s)) => (v, s),
+                    (known, known_size) => {
+                        let stat = coordinator
+                            .stat_object(&object)
+                            .await
+                            .map_err(|e| e.to_string())?;
+                        (
+                            known.unwrap_or_else(|| Version::new(stat.version.as_str())),
+                            known_size.unwrap_or(stat.size),
+                        )
+                    }
+                };
+                let len = length.unwrap_or_else(|| file_size.saturating_sub(offset));
                 let file = FileView {
                     object: &object,
                     block_size,
@@ -210,11 +219,6 @@ impl Client {
     }
 
     /// Return an object's size and version.
-    ///
-    /// **Not usable yet**: no server implements `StatObject` (#318), so this
-    /// currently fails with the coordinator's rejection. It is kept because the
-    /// protocol defines it and the client half is correct; it starts working
-    /// when the server side lands.
     fn stat(&self, py: Python<'_>, uri: &str) -> PyResult<ObjectStat> {
         let object = parse_uri_inner(uri).map_err(PyValueError::new_err)?;
         let runtime = Arc::clone(&self.runtime);
@@ -236,8 +240,9 @@ impl Client {
 
     /// List objects under a mount-relative prefix, e.g. `az/container/dir`.
     ///
-    /// **Not usable yet** for the same reason as [`stat`](Self::stat) — see
-    /// #318.
+    /// **Not usable yet**: `ListObjects` needs a listing capability on
+    /// `BackendStore`, which the S3, GCS, and Azure backends do not yet have
+    /// (#332). `stat` and `read` are unaffected.
     fn list(&self, py: Python<'_>, prefix: &str) -> PyResult<Vec<ObjectEntry>> {
         let runtime = Arc::clone(&self.runtime);
         let coordinator = self.coordinator.clone();

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -101,6 +101,17 @@ def client(cluster):
         yield c
 
 
+def test_read_resolves_version_automatically(client):
+    """The common case: no version supplied, resolved via stat (#318)."""
+    assert client.read(URI, offset=0, length=4096) == ramp(0, 4096)
+
+
+def test_stat_returns_size_and_version(client):
+    info = client.stat(URI)
+    assert info.version == VERSION
+    assert info.size > 0
+
+
 def test_read_returns_exact_bytes(client):
     assert client.read(URI, version=VERSION, offset=0, length=4096) == ramp(0, 4096)
 

--- a/crates/talon-coordinator/src/main.rs
+++ b/crates/talon-coordinator/src/main.rs
@@ -20,6 +20,10 @@ use tokio::net::{TcpListener, TcpStream};
 /// this, new peers wait for an in-flight connection to finish.
 const MAX_CONTROL_CONNECTIONS: usize = 1024;
 
+/// Bound on a proxied worker round trip (#318). Short: a client is blocked on
+/// this, and trying the next worker beats waiting on an unresponsive one.
+const PROXY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 #[derive(Debug, Parser)]
 #[command(name = "talon-coordinator", version, about)]
 struct Args {
@@ -99,6 +103,73 @@ impl Coordinator {
             observability,
             lease_ttl,
         })
+    }
+
+    /// Forward a message to any healthy worker and return its reply (#318).
+    ///
+    /// `StatObject` needs backend credentials, which only workers hold. Giving
+    /// the coordinator its own credentials would duplicate secret distribution
+    /// for one read-only call, so it proxies instead.
+    ///
+    /// Any worker will do: a stat is independent of where the object's blocks
+    /// live. That is what breaks the circularity a client would otherwise hit —
+    /// it needs a version to compute placement, but placement to pick a worker.
+    ///
+    /// Workers are tried in membership order until one answers, so a single
+    /// unreachable worker does not fail the request.
+    async fn proxy_to_worker(&self, message: ControlMessage) -> ControlMessage {
+        let workers: Vec<_> = self
+            .service
+            .membership()
+            .snapshot()
+            .into_iter()
+            .filter(|node| node.role == NodeRole::Worker)
+            .collect();
+        if workers.is_empty() {
+            return ControlMessage::Ack {
+                ok: false,
+                detail: Some("no worker available to serve the request".into()),
+            };
+        }
+
+        let mut last_error = None;
+        for worker in &workers {
+            match Self::round_trip_worker(&worker.address, &message).await {
+                Ok(reply) => return reply,
+                Err(e) => last_error = Some(format!("{}: {e}", worker.address)),
+            }
+        }
+        ControlMessage::Ack {
+            ok: false,
+            detail: Some(format!(
+                "no worker served the request ({} tried); last error: {}",
+                workers.len(),
+                last_error.unwrap_or_else(|| "unknown".into())
+            )),
+        }
+    }
+
+    /// One request/response against a worker's data-plane port.
+    async fn round_trip_worker(
+        address: &str,
+        message: &ControlMessage,
+    ) -> anyhow::Result<ControlMessage> {
+        let mut stream = tokio::time::timeout(PROXY_TIMEOUT, TcpStream::connect(address)).await??;
+        let buf = codec::encode(0, message)?;
+        stream.write_all(&buf).await?;
+        stream.flush().await?;
+
+        let (header, payload) = tokio::time::timeout(
+            PROXY_TIMEOUT,
+            talon_transport::read_frame(&mut stream, PROXY_TIMEOUT),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
+        full.extend_from_slice(&header.encode());
+        full.extend_from_slice(&payload);
+        let (_, reply) = codec::decode(&full)?;
+        Ok(reply)
     }
 
     async fn dispatch(&self, message: ControlMessage) -> ControlMessage {
@@ -197,6 +268,15 @@ impl Coordinator {
                 ControlMessage::MembershipList {
                     nodes: self.service.membership().snapshot(),
                 }
+            }
+            stat @ ControlMessage::StatObject { .. } => {
+                if !self.observability.is_ready() {
+                    return ControlMessage::Ack {
+                        ok: false,
+                        detail: Some("coordinator not ready: shared state unavailable".into()),
+                    };
+                }
+                self.proxy_to_worker(stat).await
             }
             other => ControlMessage::Ack {
                 ok: false,

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -598,12 +598,31 @@ async fn handle_conn(
             continue;
         }
 
+        // A Control frame on the data plane carries StatObject (#318). Clients
+        // already hold a data-plane connection, and only a worker has backend
+        // credentials, so answering here avoids a second connection and avoids
+        // giving the coordinator backend access.
+        if header.msg_type == MsgType::Control {
+            handle_control_frame(
+                &mut stream,
+                &header,
+                &payload,
+                &worker,
+                &observability,
+                request_started,
+            )
+            .await?;
+            continue;
+        }
+
         // Type check BEFORE any per-request work; a data listener only serves
-        // GetRange (plus the Put/Delete handled above); other frames are capped
-        // tightly by read_frame.
+        // GetRange (plus the Put/Delete/Control handled above); other frames are
+        // capped tightly by read_frame.
         if header.msg_type != MsgType::GetRange {
-            let err =
-                data::encode_error(header.request_id, "worker only serves GetRange/Put/Delete");
+            let err = data::encode_error(
+                header.request_id,
+                "worker only serves GetRange/Put/Delete/StatObject",
+            );
             stream.write_all(&err).await?;
             stream.flush().await?;
             observability
@@ -684,6 +703,87 @@ async fn handle_conn(
             }
         }
     }
+}
+
+/// Handle a `Control` frame on the data plane.
+///
+/// Only `StatObject` is served here (#318): a client must know an object's
+/// version before it can address any block, and only a worker holds the backend
+/// credentials needed to resolve it. Anything else gets an `Ack` naming what
+/// was rejected, so a client sees the reason rather than a closed connection.
+async fn handle_control_frame(
+    stream: &mut TcpStream,
+    header: &FrameHeader,
+    payload: &[u8],
+    worker: &Arc<WorkerRuntime>,
+    observability: &Arc<WorkerObservability>,
+    request_started: Instant,
+) -> anyhow::Result<()> {
+    let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
+    full.extend_from_slice(&header.encode());
+    full.extend_from_slice(payload);
+
+    let (h, message) = match codec::decode(&full) {
+        Ok(v) => v,
+        Err(e) => {
+            let reply = codec::encode(
+                header.request_id,
+                &ControlMessage::Ack {
+                    ok: false,
+                    detail: Some(format!("bad control message: {e}")),
+                },
+            )?;
+            stream.write_all(&reply).await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+            return Ok(());
+        }
+    };
+
+    let reply = match message {
+        ControlMessage::StatObject { object } => {
+            if !observability.is_ready() {
+                ControlMessage::Ack {
+                    ok: false,
+                    detail: Some("worker is not ready".into()),
+                }
+            } else {
+                match worker.stat_object(&object).await {
+                    Ok(stat) => ControlMessage::ObjectStat {
+                        size: stat.len,
+                        version: stat.version.as_str().to_string(),
+                    },
+                    Err(error) => ControlMessage::Ack {
+                        ok: false,
+                        detail: Some(error.to_string()),
+                    },
+                }
+            }
+        }
+        other => ControlMessage::Ack {
+            ok: false,
+            detail: Some(format!(
+                "worker serves only StatObject on the data plane, got {other:?}"
+            )),
+        },
+    };
+
+    let is_error = matches!(reply, ControlMessage::Ack { ok: false, .. });
+    let buf = codec::encode(h.request_id, &reply)?;
+    stream.write_all(&buf).await?;
+    stream.flush().await?;
+    if is_error {
+        observability
+            .metrics()
+            .record_request_error(request_started.elapsed());
+    } else {
+        observability
+            .metrics()
+            .record_request_success(0, request_started.elapsed());
+    }
+    Ok(())
 }
 
 /// Handle a `Put` frame: read the whole object body, write it through to the

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -295,6 +295,33 @@ impl WorkerRuntime {
         Ok(out.freeze())
     }
 
+    /// Return an object's size and current version (#318).
+    ///
+    /// Backs the `StatObject` control message. A client needs the version
+    /// before it can address any block, since blocks are keyed by it, so this
+    /// is a prerequisite for reading rather than a convenience.
+    ///
+    /// The result is not cached beyond the version cache the read path already
+    /// maintains: a size can change under an overwrite, and serving a stale one
+    /// would make a client read past the end of the new object.
+    pub async fn stat_object(&self, object: &ObjectId) -> anyhow::Result<talon_core::ObjectStat> {
+        let stat = self
+            .backend
+            .head(object)
+            .await
+            .map_err(|error| anyhow::anyhow!("stat object (HEAD): {error}"))?;
+        if stat.version.0.trim().is_empty() {
+            anyhow::bail!(
+                "backend returned no version/etag for {object}; a client cannot address blocks \
+                 without one"
+            );
+        }
+        // Reuse the read path's cache so a stat immediately followed by a read
+        // does not pay a second HEAD.
+        self.store_version(object, &stat.version);
+        Ok(stat)
+    }
+
     /// Resolve the object's current version, refusing an empty/missing version
     /// rather than caching under a placeholder (#119).
     ///

--- a/crates/talon-worker/src/uring_conn.rs
+++ b/crates/talon-worker/src/uring_conn.rs
@@ -110,12 +110,29 @@ pub async fn handle_conn(
                 .await?;
                 continue;
             }
+            // A Control frame on the data plane carries StatObject (#318):
+            // clients already hold this connection, and only a worker has the
+            // backend credentials to resolve a version.
+            MsgType::Control => {
+                handle_control_frame(
+                    &mut stream,
+                    &header,
+                    &payload,
+                    &worker,
+                    &observability,
+                    request_started,
+                )
+                .await?;
+                continue;
+            }
             MsgType::GetRange => {}
             // A data listener serves only GetRange/Put/Delete; anything else is
             // rejected before any per-request work.
             _ => {
-                let err =
-                    data::encode_error(header.request_id, "worker only serves GetRange/Put/Delete");
+                let err = data::encode_error(
+                    header.request_id,
+                    "worker only serves GetRange/Put/Delete/StatObject",
+                );
                 write_all(&mut stream, err).await?;
                 observability
                     .metrics()
@@ -234,6 +251,83 @@ impl AsRawFd for FdRef {
     fn as_raw_fd(&self) -> std::os::fd::RawFd {
         self.0
     }
+}
+
+/// Handle a `Control` frame on the data plane.
+///
+/// Only `StatObject` is served (#318). Mirrors the Tokio path's semantics
+/// exactly — the two data planes must not diverge in what they answer, only in
+/// how they move bytes.
+async fn handle_control_frame(
+    stream: &mut TcpStream,
+    header: &FrameHeader,
+    payload: &[u8],
+    worker: &Arc<WorkerRuntime>,
+    observability: &Arc<WorkerObservability>,
+    request_started: Instant,
+) -> anyhow::Result<()> {
+    let (h, message) = match talon_transport::codec::decode(&rejoin(header, payload)) {
+        Ok(v) => v,
+        Err(e) => {
+            let reply = talon_transport::codec::encode(
+                header.request_id,
+                &talon_transport::ControlMessage::Ack {
+                    ok: false,
+                    detail: Some(format!("bad control message: {e}")),
+                },
+            )?;
+            write_all(stream, reply).await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+            return Ok(());
+        }
+    };
+
+    let reply = match message {
+        talon_transport::ControlMessage::StatObject { object } => {
+            if !observability.is_ready() {
+                talon_transport::ControlMessage::Ack {
+                    ok: false,
+                    detail: Some("worker is not ready".into()),
+                }
+            } else {
+                match worker.stat_object(&object).await {
+                    Ok(stat) => talon_transport::ControlMessage::ObjectStat {
+                        size: stat.len,
+                        version: stat.version.as_str().to_string(),
+                    },
+                    Err(error) => talon_transport::ControlMessage::Ack {
+                        ok: false,
+                        detail: Some(error.to_string()),
+                    },
+                }
+            }
+        }
+        other => talon_transport::ControlMessage::Ack {
+            ok: false,
+            detail: Some(format!(
+                "worker serves only StatObject on the data plane, got {other:?}"
+            )),
+        },
+    };
+
+    let is_error = matches!(
+        reply,
+        talon_transport::ControlMessage::Ack { ok: false, .. }
+    );
+    let buf = talon_transport::codec::encode(h.request_id, &reply)?;
+    write_all(stream, buf).await?;
+    if is_error {
+        observability
+            .metrics()
+            .record_request_error(request_started.elapsed());
+    } else {
+        observability
+            .metrics()
+            .record_request_success(0, request_started.elapsed());
+    }
+    Ok(())
 }
 
 /// Handle a `Put`: read the object body off the wire, write through to the


### PR DESCRIPTION
`StatObject` was defined in the protocol, called by `talon-fuse` and both client SDKs, and **implemented by no server**. Clients worked around it by requiring the caller to supply an object version — which is not something a caller generally knows.

## Breaking the circularity

The awkward part: a client needs a **version** to compute placement, and **placement** to pick a worker.

It breaks because **a stat does not depend on where an object's blocks live**. Any worker can answer it. So:

- the **worker** serves `StatObject` on the data plane — clients already hold that connection, and only a worker has backend credentials;
- the **coordinator proxies** to any healthy worker, trying them in membership order so one unreachable worker does not fail the request.

Giving the coordinator its own backend credentials would have duplicated secret distribution for one read-only call. Proxying avoids that.

`WorkerRuntime::stat_object` reuses the read path's version cache, so a stat immediately followed by a read does not pay a second `HEAD`. It refuses an empty version rather than returning one a client cannot address blocks with (#119).

## A cost of the io_uring migration, now visible

My first attempt only changed the Tokio data plane. The io_uring path — **the default since #299** — kept rejecting the frame, and direct-to-worker stat failed while I was still assuming the proxy was at fault.

Two implementations of the same dispatch is a standing cost of that migration. This is the first time it bit, and it is worth recording: any future data-plane message type has to be added in both places, and only an end-to-end test against the default path catches a miss.

## Client APIs simplified

```python
# before                                    # after
client.read(uri, version="0x8D...", ...)    client.read(uri, offset=0, length=4096)
```

```java
// before                                   // after
client.read(uri, "0x8D...", 0, 4096);       client.read(uri, 0, 4096);
```

The explicit form is kept as an overload — worth using when reading many ranges of one object, since the version is stable for an object generation and re-resolving it per read is wasted work.

## ListObjects deliberately excluded

It maps onto **no existing `BackendStore` method**. S3 (`ListObjectsV2`), GCS, and Azure (`List Blobs`) each need a different paginated implementation, and the trait method has to express pagination or a large prefix listing holds the whole result set in memory.

Split out as #332. Both clients now point there rather than at this issue.

## Verification

| suite | result |
|---|---|
| Java conformance vectors | 13 passed |
| Java end-to-end | **10 passed** (was 8; adds stat and auto-version) |
| Python end-to-end | **10 passed** (was 8; same additions) |
| `cargo test --workspace --all-features --locked` | pass |
| `cargo clippy -- -D warnings` | clean |
| `just gen-conformance-vectors` | **no diff** — this adds a handler, not a protocol change |

Both proxy and direct-to-worker paths verified against a live cluster:

```
stat via coordinator proxy: size=67108864 version=0x8LOADTEST
direct-to-worker stat:      ObjectStat{size=67108864, version="0x8LOADTEST"}
```

Closes #318
Refs #310, #312, #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)
