### PR TITLE
fix(fuse): honor POSIX open flags

### DIFF
--- a/crates/talon-fuse/Cargo.toml
+++ b/crates/talon-fuse/Cargo.toml
@@ -28,7 +28,7 @@ thiserror.workspace = true
 # path stays testable everywhere. `default-features = false` drops fuser's
 # libfuse C dependency (it talks to /dev/fuse directly), so `--features mount`
 # compiles without the libfuse headers installed.
-fuser = { version = "0.14", optional = true, default-features = false }
+fuser = { version = "0.14", optional = true, default-features = false, features = ["abi-7-9"] }
 libc = { version = "0.2", optional = true }
 
 [features]
@@ -45,4 +45,3 @@ harness = false
 [[bench]]
 name = "conn_pool_benches"
 harness = false
-

--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 use crate::block_reader::{BlockReader, FileView};
 use crate::lock::MutexExt;
 use crate::mapping::path_to_object;
-use crate::ops::{Attr, FileKind, FsError, ReadOnlyFs};
+use crate::ops::{Attr, FileKind, FsError, OpenOptions, ReadOnlyFs, ReadSource};
 use crate::prefetch::Prefetcher;
 use crate::readahead::ReadaheadConfig;
 use talon_core::ObjectId;
@@ -54,10 +54,32 @@ pub(crate) fn errno(err: FsError) -> i32 {
     match err {
         FsError::NotFound => libc::ENOENT,
         FsError::ReadOnly => libc::EROFS,
-        FsError::Unsupported => libc::ENOSYS,
+        FsError::Unsupported => libc::EOPNOTSUPP,
         FsError::BadHandle => libc::EBADF,
         FsError::TooLarge => libc::EFBIG,
+        FsError::IsDir => libc::EISDIR,
+        FsError::NotDir => libc::ENOTDIR,
+        FsError::Exists => libc::EEXIST,
+        FsError::Invalid => libc::EINVAL,
     }
+}
+
+fn open_options(flags: i32) -> Result<(OpenOptions, bool), FsError> {
+    let (read, write) = match flags & libc::O_ACCMODE {
+        libc::O_RDONLY => (true, false),
+        libc::O_WRONLY => (false, true),
+        libc::O_RDWR => (true, true),
+        _ => return Err(FsError::Invalid),
+    };
+    let truncate = flags & libc::O_TRUNC != 0;
+    Ok((
+        OpenOptions {
+            read,
+            write,
+            append: flags & libc::O_APPEND != 0,
+        },
+        truncate,
+    ))
 }
 
 /// A monotonic-ish millisecond timestamp for the placement cache TTL.
@@ -286,7 +308,11 @@ impl TalonFuse {
         })
     }
 
-    /// Read the committed object before opening a writable working copy.
+    /// Read the complete committed object before a non-truncating write open.
+    ///
+    /// Talon writes whole objects through to the blob backend. A writable handle
+    /// therefore needs the current bytes as its initial working copy unless
+    /// `O_TRUNC` explicitly starts from an empty object.
     fn read_committed_object(&self, path: &str, size: u64) -> Result<Vec<u8>, i32> {
         if size == 0 {
             return Ok(Vec::new());
@@ -306,6 +332,37 @@ impl TalonFuse {
                 reader.read(&view, 0, size, now_ms()).await
             })
             .map_err(|_| libc::EIO)
+    }
+
+    fn open_inode(&self, ino: u64, flags: i32) -> Result<(u64, u32), i32> {
+        if flags & libc::O_DIRECTORY != 0 {
+            return Err(libc::ENOTDIR);
+        }
+        let (options, truncate) = open_options(flags).map_err(errno)?;
+        let mutates = options.write || truncate;
+        let initial_contents = if mutates {
+            if !self.read_write {
+                return Err(libc::EROFS);
+            }
+            if truncate {
+                Some(Vec::new())
+            } else {
+                let (path, size) = self.fs.inode_file_meta(ino).map_err(errno)?;
+                Some(self.read_committed_object(&path, size)?)
+            }
+        } else {
+            None
+        };
+        let fh = self
+            .fs
+            .open_with_options(ino, options, initial_contents)
+            .map_err(errno)?;
+        let reply_flags = if mutates {
+            0
+        } else {
+            fuser::consts::FOPEN_KEEP_CACHE
+        };
+        Ok((fh, reply_flags))
     }
 
     /// The namespace tree backing metadata ops.
@@ -337,6 +394,13 @@ impl fuser::Filesystem for TalonFuse {
         _req: &fuser::Request<'_>,
         config: &mut fuser::KernelConfig,
     ) -> Result<(), libc::c_int> {
+        match config.add_capabilities(fuser::consts::FUSE_ATOMIC_O_TRUNC) {
+            Ok(()) => tracing::info!("negotiated atomic O_TRUNC handling"),
+            Err(missing) => tracing::warn!(
+                missing_capabilities = missing,
+                "kernel does not support atomic O_TRUNC handling"
+            ),
+        }
         match config.set_max_write(TARGET_MAX_IO) {
             Ok(granted) => tracing::info!(max_write = granted, "negotiated FUSE max_write"),
             Err(cap) => {
@@ -433,47 +497,18 @@ impl fuser::Filesystem for TalonFuse {
 
     /// Open a file inode, returning a handle for subsequent reads.
     ///
-    /// Directories are rejected with `EISDIR`-equivalent `ENOSYS` semantics via
-    /// the op layer (`FsError::Unsupported`). The handle indexes into the
-    /// namespace so the `read` callback can recover the object.
+    /// Directories are rejected with `EISDIR`. Writable opens preserve the
+    /// committed object unless `O_TRUNC` is present; append mode is recorded on
+    /// the handle and enforced by the write op.
     ///
     /// Replies with `FOPEN_KEEP_CACHE` so the kernel retains this file's page
     /// cache across opens: the namespace is read-only and immutable for a mount
     /// session, so repeated reads and `mmap` can serve from RAM without a FUSE
     /// round-trip (issue #180).
     fn open(&mut self, _req: &fuser::Request<'_>, ino: u64, flags: i32, reply: fuser::ReplyOpen) {
-        // A write/read-write open needs the committed bytes as its initial
-        // whole-object working copy. Linux may handle O_TRUNC through setattr
-        // before open, so rejecting an open that lacks the flag breaks normal
-        // std::fs::write and does not reliably identify truncation.
-        let accmode = flags & libc::O_ACCMODE;
-        let wants_write = accmode == libc::O_WRONLY || accmode == libc::O_RDWR;
-        if wants_write {
-            if !self.read_write {
-                return reply.error(libc::EROFS);
-            }
-            let initial_contents = if flags & libc::O_TRUNC != 0 {
-                Vec::new()
-            } else {
-                let (path, size) = match self.fs.inode_file_meta(ino) {
-                    Ok(meta) => meta,
-                    Err(error) => return reply.error(errno(error)),
-                };
-                match self.read_committed_object(&path, size) {
-                    Ok(contents) => contents,
-                    Err(error) => return reply.error(error),
-                }
-            };
-            match self.fs.open_write(ino, initial_contents) {
-                // No FOPEN_KEEP_CACHE for a write handle: contents are changing.
-                Ok(fh) => reply.opened(fh, 0),
-                Err(e) => reply.error(errno(e)),
-            }
-        } else {
-            match self.fs.open(ino) {
-                Ok(fh) => reply.opened(fh, fuser::consts::FOPEN_KEEP_CACHE),
-                Err(e) => reply.error(errno(e)),
-            }
+        match self.open_inode(ino, flags) {
+            Ok((fh, reply_flags)) => reply.opened(fh, reply_flags),
+            Err(error) => reply.error(error),
         }
     }
 
@@ -496,8 +531,9 @@ impl fuser::Filesystem for TalonFuse {
         _lock: Option<u64>,
         reply: fuser::ReplyData,
     ) {
-        let (path, file_size) = match self.fs.file_meta(fh) {
-            Ok(m) => m,
+        let (path, file_size) = match self.fs.read_source(fh, offset.max(0) as u64, size) {
+            Ok(ReadSource::Buffered(bytes)) => return reply.data(&bytes),
+            Ok(ReadSource::Backend { path, size }) => (path, size),
             Err(e) => return reply.error(errno(e)),
         };
         let object = match path_to_object(&path) {
@@ -551,7 +587,7 @@ impl fuser::Filesystem for TalonFuse {
         name: &std::ffi::OsStr,
         _mode: u32,
         _umask: u32,
-        _flags: i32,
+        flags: i32,
         reply: fuser::ReplyCreate,
     ) {
         if !self.read_write {
@@ -561,7 +597,27 @@ impl fuser::Filesystem for TalonFuse {
             Some(s) => s,
             None => return reply.error(libc::EINVAL),
         };
-        match self.fs.create(parent, name) {
+        let (options, _) = match open_options(flags) {
+            Ok(parsed) => parsed,
+            Err(e) => return reply.error(errno(e)),
+        };
+        match self.fs.lookup(parent, name) {
+            Ok(attr) => {
+                if flags & libc::O_EXCL != 0 {
+                    return reply.error(libc::EEXIST);
+                }
+                return match self.open_inode(attr.ino, flags) {
+                    Ok((fh, reply_flags)) => {
+                        let fa = to_file_attr(attr, req.uid(), req.gid());
+                        reply.created(&ATTR_TTL, &fa, 0, fh, reply_flags);
+                    }
+                    Err(error) => reply.error(error),
+                };
+            }
+            Err(FsError::NotFound) => {}
+            Err(e) => return reply.error(errno(e)),
+        }
+        match self.fs.create_with_options(parent, name, options) {
             Ok((attr, fh)) => {
                 let fa = to_file_attr(attr, req.uid(), req.gid());
                 reply.created(&ATTR_TTL, &fa, 0, fh, 0);
@@ -860,9 +916,50 @@ mod tests {
     fn errno_maps_each_fs_error() {
         assert_eq!(errno(FsError::NotFound), libc::ENOENT);
         assert_eq!(errno(FsError::ReadOnly), libc::EROFS);
-        assert_eq!(errno(FsError::Unsupported), libc::ENOSYS);
+        assert_eq!(errno(FsError::Unsupported), libc::EOPNOTSUPP);
         assert_eq!(errno(FsError::BadHandle), libc::EBADF);
         assert_eq!(errno(FsError::TooLarge), libc::EFBIG);
+        assert_eq!(errno(FsError::IsDir), libc::EISDIR);
+        assert_eq!(errno(FsError::NotDir), libc::ENOTDIR);
+        assert_eq!(errno(FsError::Exists), libc::EEXIST);
+        assert_eq!(errno(FsError::Invalid), libc::EINVAL);
+    }
+
+    #[test]
+    fn open_options_parse_access_append_and_truncate() {
+        let (read_only, truncate) = open_options(libc::O_RDONLY).unwrap();
+        assert_eq!(
+            read_only,
+            OpenOptions {
+                read: true,
+                write: false,
+                append: false,
+            }
+        );
+        assert!(!truncate);
+
+        let (read_write, truncate) =
+            open_options(libc::O_RDWR | libc::O_APPEND | libc::O_TRUNC).unwrap();
+        assert_eq!(
+            read_write,
+            OpenOptions {
+                read: true,
+                write: true,
+                append: true,
+            }
+        );
+        assert!(truncate);
+
+        let (read_truncate, truncate) = open_options(libc::O_RDONLY | libc::O_TRUNC).unwrap();
+        assert_eq!(
+            read_truncate,
+            OpenOptions {
+                read: true,
+                write: false,
+                append: false,
+            }
+        );
+        assert!(truncate);
     }
 
     #[test]

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -14,6 +14,7 @@
 //! object is written through to the backend at flush.
 
 use crate::lock::MutexExt;
+use crate::mapping::path_to_object;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
@@ -56,6 +57,39 @@ pub enum FsError {
     /// The write would grow a buffered object past the allowed maximum, or the
     /// requested offset is not representable (`EFBIG`).
     TooLarge,
+    /// A file-only operation targeted a directory (`EISDIR`).
+    IsDir,
+    /// A directory was required but another node type was found (`ENOTDIR`).
+    NotDir,
+    /// The target name already exists (`EEXIST`).
+    Exists,
+    /// An invalid flag, name, path, or argument was supplied (`EINVAL`).
+    Invalid,
+}
+
+/// Access and mutation behavior for an open file handle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OpenOptions {
+    /// Permit reads through the handle.
+    pub read: bool,
+    /// Permit writes through the handle.
+    pub write: bool,
+    /// Force each write to the current end of the file.
+    pub append: bool,
+}
+
+/// Data source for a read through an open handle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReadSource {
+    /// Read from an in-progress whole-object write buffer.
+    Buffered(Vec<u8>),
+    /// Read the committed object from the backend.
+    Backend {
+        /// Mount-relative object path.
+        path: String,
+        /// Current object size.
+        size: u64,
+    },
 }
 
 /// Default cap on a single in-memory write buffer (1 GiB).
@@ -106,8 +140,8 @@ struct Inner {
     // (parent_ino, name) -> child_ino for O(1) lookup.
     index: HashMap<(u64, String), u64>,
     next_ino: u64,
-    // Open file handles -> the inode they reference.
-    handles: HashMap<u64, u64>,
+    // Open file handles -> inode and access mode.
+    handles: HashMap<u64, Handle>,
     next_fh: u64,
     // Write handles -> their in-progress whole-object buffer. A handle opened for
     // write accumulates bytes here (random-offset writes land by position); the
@@ -115,6 +149,14 @@ struct Inner {
     // backend (#226/#231). v1 buffers in memory (objects are single-block/small);
     // a temp-file-backed buffer for large objects is future work.
     dirty: HashMap<u64, DirtyFile>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Handle {
+    ino: u64,
+    read: bool,
+    write: bool,
+    append: bool,
 }
 
 /// A per-write-handle whole-object buffer.
@@ -281,17 +323,58 @@ impl ReadOnlyFs {
         Ok(entries)
     }
 
-    /// `open`: obtain a read handle for a file inode. Directories are rejected.
-    pub fn open(&self, ino: u64) -> Result<u64, FsError> {
+    /// Open an existing file with the requested access mode.
+    ///
+    /// Writable handles use `initial_contents` as their whole-object working
+    /// copy. A truncating open passes an empty vector; a non-truncating open
+    /// passes bytes read from the committed backend object.
+    pub fn open_with_options(
+        &self,
+        ino: u64,
+        options: OpenOptions,
+        initial_contents: Option<Vec<u8>>,
+    ) -> Result<u64, FsError> {
+        if !options.read && !options.write {
+            return Err(FsError::Invalid);
+        }
         let mut g = self.inner.lock_recover();
         let kind = g.nodes.get(&ino).ok_or(FsError::NotFound)?.kind;
         if kind != FileKind::File {
-            return Err(FsError::Unsupported);
+            return Err(FsError::IsDir);
+        }
+        if options.write && initial_contents.is_none() {
+            return Err(FsError::Invalid);
         }
         let fh = g.next_fh;
         g.next_fh += 1;
-        g.handles.insert(fh, ino);
+        g.handles.insert(
+            fh,
+            Handle {
+                ino,
+                read: options.read,
+                write: options.write,
+                append: options.append,
+            },
+        );
+        if let Some(buf) = initial_contents {
+            g.dirty.insert(fh, DirtyFile { ino, buf });
+            let size = g.dirty.get(&fh).unwrap().buf.len() as u64;
+            g.nodes.get_mut(&ino).unwrap().size = size;
+        }
         Ok(fh)
+    }
+
+    /// Open an existing file read-only.
+    pub fn open(&self, ino: u64) -> Result<u64, FsError> {
+        self.open_with_options(
+            ino,
+            OpenOptions {
+                read: true,
+                write: false,
+                append: false,
+            },
+            None,
+        )
     }
 
     /// `release`: drop a previously opened handle (read or write), discarding any
@@ -316,20 +399,45 @@ impl ReadOnlyFs {
     /// [`FsError::Unsupported`] if the handle somehow references a directory.
     pub fn file_meta(&self, fh: u64) -> Result<(String, u64), FsError> {
         let g = self.inner.lock_recover();
-        let ino = *g.handles.get(&fh).ok_or(FsError::BadHandle)?;
-        let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
+        let handle = g.handles.get(&fh).ok_or(FsError::BadHandle)?;
+        if !handle.read {
+            return Err(FsError::BadHandle);
+        }
+        let node = g.nodes.get(&handle.ino).ok_or(FsError::NotFound)?;
         if node.kind != FileKind::File {
-            return Err(FsError::Unsupported);
+            return Err(FsError::IsDir);
         }
         Ok((node.path.clone(), node.size))
     }
 
-    /// Return the committed object path and size before opening a writable copy.
+    /// Return a handle's read source, preferring its uncommitted write buffer.
+    pub fn read_source(&self, fh: u64, offset: u64, size: u32) -> Result<ReadSource, FsError> {
+        let g = self.inner.lock_recover();
+        let handle = g.handles.get(&fh).ok_or(FsError::BadHandle)?;
+        if !handle.read {
+            return Err(FsError::BadHandle);
+        }
+        let node = g.nodes.get(&handle.ino).ok_or(FsError::NotFound)?;
+        if let Some(dirty) = g.dirty.get(&fh) {
+            let start = usize::try_from(offset).map_err(|_| FsError::Invalid)?;
+            if start >= dirty.buf.len() {
+                return Ok(ReadSource::Buffered(Vec::new()));
+            }
+            let end = start.saturating_add(size as usize).min(dirty.buf.len());
+            return Ok(ReadSource::Buffered(dirty.buf[start..end].to_vec()));
+        }
+        Ok(ReadSource::Backend {
+            path: node.path.clone(),
+            size: node.size,
+        })
+    }
+
+    /// Return the committed object path and size for an inode before opening it.
     pub fn inode_file_meta(&self, ino: u64) -> Result<(String, u64), FsError> {
         let g = self.inner.lock_recover();
         let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
         if node.kind != FileKind::File {
-            return Err(FsError::Unsupported);
+            return Err(FsError::IsDir);
         }
         Ok((node.path.clone(), node.size))
     }
@@ -341,18 +449,27 @@ impl ReadOnlyFs {
     ///
     /// Inserts a `File` node (size 0) into the namespace and returns
     /// `(attr, fh)` where `fh` is a write handle backed by an empty dirty buffer.
-    /// Fails with [`FsError::NotFound`] if `parent_ino` is not a directory, or
-    /// [`FsError::ReadOnly`] if the name already exists (v1 uses O_TRUNC-style
-    /// whole-object creation; opening an existing file for write is
-    /// [`open_write`](Self::open_write)).
-    pub fn create(&self, parent_ino: u64, name: &str) -> Result<(Attr, u64), FsError> {
+    /// Fails with [`FsError::NotDir`] if `parent_ino` is not a directory or
+    /// [`FsError::Exists`] if the name already exists.
+    pub fn create_with_options(
+        &self,
+        parent_ino: u64,
+        name: &str,
+        options: OpenOptions,
+    ) -> Result<(Attr, u64), FsError> {
+        if !options.read && !options.write {
+            return Err(FsError::Invalid);
+        }
+        if name.is_empty() || name == "." || name == ".." || name.contains('/') {
+            return Err(FsError::Invalid);
+        }
         let mut g = self.inner.lock_recover();
         let parent = g.nodes.get(&parent_ino).ok_or(FsError::NotFound)?;
         if parent.kind != FileKind::Directory {
-            return Err(FsError::NotFound);
+            return Err(FsError::NotDir);
         }
         if g.index.contains_key(&(parent_ino, name.to_string())) {
-            return Err(FsError::ReadOnly);
+            return Err(FsError::Exists);
         }
         // Build the child's mount-relative path from its ancestors.
         let path = {
@@ -360,6 +477,7 @@ impl ReadOnlyFs {
             parts.push(name.to_string());
             parts.join("/")
         };
+        path_to_object(&path).map_err(|_| FsError::Invalid)?;
         let ino = g.next_ino;
         g.next_ino += 1;
         let node = Node {
@@ -375,7 +493,17 @@ impl ReadOnlyFs {
         g.nodes.get_mut(&parent_ino).unwrap().children.push(ino);
         let fh = g.next_fh;
         g.next_fh += 1;
-        g.handles.insert(fh, ino);
+        g.handles.insert(
+            fh,
+            Handle {
+                ino,
+                read: options.read,
+                write: options.write,
+                append: options.append,
+            },
+        );
+        // A newly created object must be written through even when opened
+        // read-only and never explicitly written.
         g.dirty.insert(
             fh,
             DirtyFile {
@@ -387,28 +515,17 @@ impl ReadOnlyFs {
         Ok((attr, fh))
     }
 
-    /// Open an existing file `ino` for writing from a whole-object working copy.
-    pub fn open_write(&self, ino: u64, initial_contents: Vec<u8>) -> Result<u64, FsError> {
-        let mut g = self.inner.lock_recover();
-        let kind = g.nodes.get(&ino).ok_or(FsError::NotFound)?.kind;
-        if kind != FileKind::File {
-            return Err(FsError::Unsupported);
-        }
-        let fh = g.next_fh;
-        g.next_fh += 1;
-        g.handles.insert(fh, ino);
-        let size = initial_contents.len() as u64;
-        g.dirty.insert(
-            fh,
-            DirtyFile {
-                ino,
-                buf: initial_contents,
+    /// Create a new file opened write-only with an empty whole-object buffer.
+    pub fn create(&self, parent_ino: u64, name: &str) -> Result<(Attr, u64), FsError> {
+        self.create_with_options(
+            parent_ino,
+            name,
+            OpenOptions {
+                read: false,
+                write: true,
+                append: false,
             },
-        );
-        if let Some(node) = g.nodes.get_mut(&ino) {
-            node.size = size;
-        }
-        Ok(fh)
+        )
     }
 
     /// `write`: write `data` at `offset` into the write handle's buffer.
@@ -424,21 +541,25 @@ impl ReadOnlyFs {
     /// debug panic under the global lock, a wrap in release).
     pub fn write(&self, fh: u64, offset: u64, data: &[u8]) -> Result<u32, FsError> {
         let mut g = self.inner.lock_recover();
-        // EBADF outranks EFBIG, so validate the handle before the size checks.
-        if !g.dirty.contains_key(&fh) {
+        let handle = g.handles.get(&fh).ok_or(FsError::BadHandle)?;
+        if !handle.write {
             return Err(FsError::BadHandle);
         }
-        let end = offset
+        let append = handle.append;
+        let dirty = g.dirty.get_mut(&fh).ok_or(FsError::BadHandle)?;
+        let start = if append {
+            dirty.buf.len() as u64
+        } else {
+            offset
+        };
+        let end = start
             .checked_add(data.len() as u64)
             .ok_or(FsError::TooLarge)?;
         if end > self.max_object_bytes {
             return Err(FsError::TooLarge);
         }
-        // Past the cap check, `end` fits in u64 and is bounded; on a 32-bit host
-        // it may still exceed usize, which is a legitimate EFBIG.
         let end: usize = end.try_into().map_err(|_| FsError::TooLarge)?;
-        let start: usize = offset.try_into().map_err(|_| FsError::TooLarge)?;
-        let dirty = g.dirty.get_mut(&fh).ok_or(FsError::BadHandle)?;
+        let start: usize = start.try_into().map_err(|_| FsError::TooLarge)?;
         if dirty.buf.len() < end {
             dirty.buf.resize(end, 0);
         }
@@ -458,7 +579,8 @@ impl ReadOnlyFs {
     /// user-supplied length and the buffer is zero-filled eagerly.
     pub fn truncate(&self, fh: u64, size: u64) -> Result<(), FsError> {
         let mut g = self.inner.lock_recover();
-        if !g.dirty.contains_key(&fh) {
+        let handle = g.handles.get(&fh).ok_or(FsError::BadHandle)?;
+        if !handle.write {
             return Err(FsError::BadHandle);
         }
         if size > self.max_object_bytes {
@@ -564,6 +686,12 @@ mod tests {
         fs
     }
 
+    fn data_dir(fs: &ReadOnlyFs) -> Attr {
+        let s3 = fs.lookup(ROOT_INO, "s3").unwrap();
+        let bucket = fs.lookup(s3.ino, "bucket").unwrap();
+        fs.lookup(bucket.ino, "data").unwrap()
+    }
+
     #[test]
     fn lookup_and_getattr_walk_the_tree() {
         let fs = fs();
@@ -605,7 +733,7 @@ mod tests {
         let a = fs.lookup(data.ino, "a.bin").unwrap();
 
         // Cannot open a directory.
-        assert_eq!(fs.open(data.ino), Err(FsError::Unsupported));
+        assert_eq!(fs.open(data.ino), Err(FsError::IsDir));
 
         let fh = fs.open(a.ino).unwrap();
         // file_meta yields the object path + size for the open handle.
@@ -703,8 +831,8 @@ mod tests {
 
     #[test]
     fn write_past_end_extends_with_zeros() {
-        let fs = ReadOnlyFs::new();
-        let (_, fh) = fs.create(ROOT_INO, "sparse.bin").unwrap();
+        let fs = fs();
+        let (_, fh) = fs.create(data_dir(&fs).ino, "sparse.bin").unwrap();
         // Write at offset 5 with nothing before → bytes 0..5 are zero-filled.
         fs.write(fh, 5, b"XY").unwrap();
         assert_eq!(fs.dirty_bytes(fh).unwrap(), vec![0, 0, 0, 0, 0, b'X', b'Y']);
@@ -712,8 +840,8 @@ mod tests {
 
     #[test]
     fn truncate_resizes_buffer_and_size() {
-        let fs = ReadOnlyFs::new();
-        let (attr, fh) = fs.create(ROOT_INO, "t.bin").unwrap();
+        let fs = fs();
+        let (attr, fh) = fs.create(data_dir(&fs).ino, "t.bin").unwrap();
         fs.write(fh, 0, b"0123456789").unwrap();
         fs.truncate(fh, 4).unwrap();
         assert_eq!(fs.dirty_bytes(fh).unwrap(), b"0123");
@@ -745,8 +873,8 @@ mod tests {
 
     #[test]
     fn write_and_release_handle_lifecycle() {
-        let fs = ReadOnlyFs::new();
-        let (_, fh) = fs.create(ROOT_INO, "x.bin").unwrap();
+        let fs = fs();
+        let (_, fh) = fs.create(data_dir(&fs).ino, "x.bin").unwrap();
         assert!(fs.dirty_bytes(fh).is_some());
         fs.release(fh).unwrap();
         // After release the write buffer is gone.
@@ -761,7 +889,82 @@ mod tests {
             .lookup(fs.lookup(ROOT_INO, "s3").unwrap().ino, "bucket")
             .unwrap();
         let dir = fs.lookup(bucket.ino, "data").unwrap();
-        assert_eq!(fs.create(dir.ino, "a.bin"), Err(FsError::ReadOnly));
+        assert_eq!(fs.create(dir.ino, "a.bin"), Err(FsError::Exists));
+    }
+
+    #[test]
+    fn non_truncating_write_open_preserves_existing_contents() {
+        let fs = fs();
+        let file = fs.lookup(data_dir(&fs).ino, "a.bin").unwrap();
+        let fh = fs
+            .open_with_options(
+                file.ino,
+                OpenOptions {
+                    read: true,
+                    write: true,
+                    append: false,
+                },
+                Some(b"existing".to_vec()),
+            )
+            .unwrap();
+
+        fs.write(fh, 3, b"XYZ").unwrap();
+        assert_eq!(fs.dirty_bytes(fh).unwrap(), b"exiXYZng");
+        assert_eq!(
+            fs.read_source(fh, 0, 8).unwrap(),
+            ReadSource::Buffered(b"exiXYZng".to_vec())
+        );
+    }
+
+    #[test]
+    fn append_handle_ignores_the_supplied_offset() {
+        let fs = fs();
+        let file = fs.lookup(data_dir(&fs).ino, "a.bin").unwrap();
+        let fh = fs
+            .open_with_options(
+                file.ino,
+                OpenOptions {
+                    read: false,
+                    write: true,
+                    append: true,
+                },
+                Some(b"base".to_vec()),
+            )
+            .unwrap();
+
+        fs.write(fh, 0, b"-tail").unwrap();
+        assert_eq!(fs.dirty_bytes(fh).unwrap(), b"base-tail");
+        assert_eq!(fs.read_source(fh, 0, 32), Err(FsError::BadHandle));
+    }
+
+    #[test]
+    fn read_only_truncating_open_mutates_but_does_not_allow_write() {
+        let fs = fs();
+        let file = fs.lookup(data_dir(&fs).ino, "a.bin").unwrap();
+        let fh = fs
+            .open_with_options(
+                file.ino,
+                OpenOptions {
+                    read: true,
+                    write: false,
+                    append: false,
+                },
+                Some(Vec::new()),
+            )
+            .unwrap();
+
+        assert_eq!(
+            fs.read_source(fh, 0, 32).unwrap(),
+            ReadSource::Buffered(Vec::new())
+        );
+        assert_eq!(fs.write(fh, 0, b"x"), Err(FsError::BadHandle));
+        assert_eq!(fs.dirty_bytes(fh).unwrap(), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn create_rejects_paths_without_backend_and_bucket() {
+        let fs = ReadOnlyFs::new();
+        assert_eq!(fs.create(ROOT_INO, "orphan.bin"), Err(FsError::Invalid));
     }
 
     /// The namespace lives behind a single Mutex, so with `lock().unwrap()` one
@@ -814,8 +1017,8 @@ mod tests {
     /// of the whole mount. It is now bounded by `max_object_bytes`.
     #[test]
     fn write_past_the_cap_is_efbig_and_allocates_nothing() {
-        let fs = ReadOnlyFs::new().with_max_object_bytes(1024);
-        let (attr, fh) = fs.create(ROOT_INO, "big.bin").unwrap();
+        let fs = fs().with_max_object_bytes(1024);
+        let (attr, fh) = fs.create(data_dir(&fs).ino, "big.bin").unwrap();
 
         // 1 TiB offset: would have been a 1 TiB resize.
         assert_eq!(fs.write(fh, 1 << 40, b"x"), Err(FsError::TooLarge));
@@ -838,8 +1041,8 @@ mod tests {
     /// release. It is now a checked add.
     #[test]
     fn write_offset_overflow_is_efbig_not_a_panic() {
-        let fs = ReadOnlyFs::new();
-        let (_, fh) = fs.create(ROOT_INO, "ovf.bin").unwrap();
+        let fs = fs();
+        let (_, fh) = fs.create(data_dir(&fs).ino, "ovf.bin").unwrap();
         assert_eq!(fs.write(fh, u64::MAX, b"xyz"), Err(FsError::TooLarge));
         assert_eq!(fs.write(fh, u64::MAX - 1, b"xyz"), Err(FsError::TooLarge));
         // The filesystem is still usable afterwards (no poisoned lock).
@@ -850,8 +1053,8 @@ mod tests {
     /// `truncate -s 1P file` reached `buf.resize(size)` directly.
     #[test]
     fn truncate_past_the_cap_is_efbig() {
-        let fs = ReadOnlyFs::new().with_max_object_bytes(1024);
-        let (attr, fh) = fs.create(ROOT_INO, "t.bin").unwrap();
+        let fs = fs().with_max_object_bytes(1024);
+        let (attr, fh) = fs.create(data_dir(&fs).ino, "t.bin").unwrap();
         fs.write(fh, 0, b"seed").unwrap();
 
         assert_eq!(fs.truncate(fh, 1 << 50), Err(FsError::TooLarge));
@@ -898,7 +1101,17 @@ mod tests {
             .unwrap();
         let dir = fs.lookup(bucket.ino, "data").unwrap();
         let file = fs.lookup(dir.ino, "a.bin").unwrap();
-        let fh = fs.open_write(file.ino, b"existing".to_vec()).unwrap();
+        let fh = fs
+            .open_with_options(
+                file.ino,
+                OpenOptions {
+                    read: true,
+                    write: true,
+                    append: false,
+                },
+                Some(b"existing".to_vec()),
+            )
+            .unwrap();
         assert_eq!(fs.dirty_bytes(fh).unwrap(), b"existing");
         assert_eq!(fs.getattr(file.ino).unwrap().size, 8);
         fs.write(fh, 0, b"new").unwrap();
@@ -914,7 +1127,17 @@ mod tests {
         let dir = fs.lookup(bucket.ino, "data").unwrap();
         let file = fs.lookup(dir.ino, "a.bin").unwrap();
 
-        let fh = fs.open_write(file.ino, Vec::new()).unwrap();
+        let fh = fs
+            .open_with_options(
+                file.ino,
+                OpenOptions {
+                    read: false,
+                    write: true,
+                    append: false,
+                },
+                Some(Vec::new()),
+            )
+            .unwrap();
         assert_eq!(fs.dirty_bytes(fh).unwrap(), Vec::<u8>::new());
         assert_eq!(fs.getattr(file.ino).unwrap().size, 0);
         fs.write(fh, 0, b"new contents").unwrap();
@@ -922,9 +1145,20 @@ mod tests {
     }
 
     #[test]
-    fn open_write_on_a_directory_is_unsupported() {
+    fn open_write_on_a_directory_is_isdir() {
         let fs = fs();
         let s3 = fs.lookup(ROOT_INO, "s3").unwrap();
-        assert_eq!(fs.open_write(s3.ino, Vec::new()), Err(FsError::Unsupported));
+        assert_eq!(
+            fs.open_with_options(
+                s3.ino,
+                OpenOptions {
+                    read: false,
+                    write: true,
+                    append: false,
+                },
+                Some(Vec::new()),
+            ),
+            Err(FsError::IsDir)
+        );
     }
 }

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -23,8 +23,8 @@
 #![cfg(feature = "mount")]
 
 use std::collections::HashMap;
-use std::io::{Read, Write};
-use std::os::unix::fs::FileExt;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::os::unix::fs::{FileExt, OpenOptionsExt};
 use std::process::Command;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
@@ -389,6 +389,121 @@ async fn mount_write_through_is_visible_in_backend() {
     assert!(
         !final_store.contains_key("/s3/bucket/hello.bin"),
         "object should be gone from backend after unlink"
+    );
+}
+
+/// Exercise open flags through the kernel and verify their blob-store effects.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires /dev/fuse; run with --features mount -- --ignored"]
+async fn mount_open_flags_preserve_and_replace_blob_contents() {
+    use fuser::MountOption;
+
+    let block_size: u32 = 4 * 1024 * 1024;
+    let store: Store = Arc::new(Mutex::new(HashMap::from([(
+        "/s3/bucket/existing.bin".to_string(),
+        b"abcdef".to_vec(),
+    )])));
+    let worker = spawn_rw_worker(Arc::clone(&store)).await;
+    let coord = spawn_coordinator(worker).await;
+
+    let fs = Arc::new(ReadOnlyFs::new());
+    fs.insert_object("s3/bucket/existing.bin", 6);
+
+    let cache = Arc::new(PlacementCache::new(10_000));
+    let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
+    let adapter = TalonFuse::new(
+        Arc::clone(&fs),
+        reader,
+        tokio::runtime::Handle::current(),
+        block_size,
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
+    )
+    .with_read_write(true);
+
+    let require_fuse = std::env::var_os("TALON_REQUIRE_FUSE").is_some();
+    let mountpoint =
+        std::env::temp_dir().join(format!("talon-mount-e2e-open-{}", std::process::id()));
+    std::fs::create_dir_all(&mountpoint).unwrap();
+    let options = vec![MountOption::FSName("talon".into())];
+    let session = match fuser::spawn_mount2(adapter, &mountpoint, &options) {
+        Ok(s) => s,
+        Err(e) => {
+            std::fs::remove_dir_all(&mountpoint).ok();
+            if require_fuse {
+                panic!(
+                    "TALON_REQUIRE_FUSE is set but the FUSE mount failed: {e}. \
+                     The runner must provide an accessible /dev/fuse."
+                );
+            }
+            eprintln!("skipping: /dev/fuse unavailable: {e}");
+            return;
+        }
+    };
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let path = mountpoint.join("s3").join("bucket").join("existing.bin");
+    let dir = mountpoint.join("s3").join("bucket");
+    let result = tokio::task::spawn_blocking(move || {
+        {
+            let mut file = std::fs::OpenOptions::new().write(true).open(&path)?;
+            file.write_all(b"XY")?;
+        }
+
+        {
+            let mut file = std::fs::OpenOptions::new().append(true).open(&path)?;
+            file.write_all(b"-tail")?;
+        }
+
+        {
+            let mut file = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .truncate(true)
+                .open(&path)?;
+            file.write_all(b"working-copy")?;
+            file.seek(SeekFrom::Start(0))?;
+            let mut bytes = Vec::new();
+            file.read_to_end(&mut bytes)?;
+            assert_eq!(bytes, b"working-copy");
+        }
+
+        let exists = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .unwrap_err();
+        assert_eq!(exists.raw_os_error(), Some(libc::EEXIST));
+
+        let not_dir = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY)
+            .open(&path)
+            .unwrap_err();
+        assert_eq!(not_dir.raw_os_error(), Some(libc::ENOTDIR));
+
+        let is_dir = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&dir)
+            .unwrap_err();
+        assert_eq!(is_dir.raw_os_error(), Some(libc::EISDIR));
+
+        Ok::<(), std::io::Error>(())
+    })
+    .await
+    .unwrap();
+
+    drop(session);
+    std::fs::remove_dir_all(&mountpoint).ok();
+    result.expect("exercise open flags through mount");
+
+    assert_eq!(
+        store
+            .lock()
+            .unwrap()
+            .get("/s3/bucket/existing.bin")
+            .map(Vec::as_slice),
+        Some(b"working-copy".as_slice()),
+        "final write-through must replace the committed blob"
     );
 }
 


### PR DESCRIPTION
## Summary

Implement the first open/create correctness increment from #326 while preserving Talon's direct write-through blob-store model.

## Related issues

- Progress on #326
- POSIX umbrella: #259

## Type of change

- [x] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [x] Docs / tests / tooling

## Changes

- Track read, write, and append access per open file handle.
- Preserve committed blob contents for writable opens without `O_TRUNC` by reading the current whole object before creating the write working copy.
- Keep truncating read-only descriptors read-only while still writing the empty object through on flush.
- Apply `O_APPEND` at the operation layer instead of trusting the caller-provided offset.
- Serve reads from the current writable working copy for `O_RDWR` handles.
- Negotiate `FUSE_ATOMIC_O_TRUNC` so the kernel passes the truncate intent to the filesystem.
- Make `O_CREAT|O_EXCL` return `EEXIST` and reject `O_DIRECTORY` on regular files with `ENOTDIR`.
- Add precise `EISDIR`, `ENOTDIR`, `EEXIST`, and `EINVAL` error variants; map unsupported operations to `EOPNOTSUPP` instead of `ENOSYS`.
- Reject newly created paths that cannot map to a backend, bucket, and object key.
- Add unit coverage and a real-kernel mount test that verifies final blob bytes.

## Write-through semantics

This does not add a persistent write-back cache. Existing objects are read into the per-open whole-object working copy only because blob stores replace whole objects. `flush` and `fsync` continue to PUT the complete object through the Talon worker to the blob backend, and unlink continues to issue backend DELETE before removing the namespace entry.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p talon-fuse --lib --features mount --locked` (92 passed)
- [x] `cargo test -p talon-fuse --features mount --test mount_e2e --no-run --locked`
- [x] `cargo clippy -p talon-fuse --features mount --all-targets --locked -- -D warnings`
- [x] Real-kernel privileged Kubernetes Job on `falcon-phx-ca`, commit `28f4df4716e1ebe706ad9b4b93ba1c68e7a8c603`: `mount_open_flags_preserve_and_replace_blob_contents` passed
- [x] Isolated real-kernel `TALON_PJDFSTEST_TESTS=open`: 139 passed, 198 failed out of 337, matching the pre-change baseline with no regression

The remaining open-group failures are primarily blocked by directory operations (#330), permission and ownership metadata (#328), and link/symlink support (#323). This PR intentionally does not close #326.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Public items are documented
- [x] No runtime dependencies added
- [x] Based on the latest `upstream/main`
