### PR TITLE
fix(fuse): persist POSIX directories

### DIFF
--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -62,6 +62,7 @@ pub(crate) fn errno(err: FsError) -> i32 {
         FsError::Exists => libc::EEXIST,
         FsError::Invalid => libc::EINVAL,
         FsError::NotEmpty => libc::ENOTEMPTY,
+        FsError::NameTooLong => libc::ENAMETOOLONG,
     }
 }
 
@@ -1033,6 +1034,7 @@ mod tests {
         assert_eq!(errno(FsError::Exists), libc::EEXIST);
         assert_eq!(errno(FsError::Invalid), libc::EINVAL);
         assert_eq!(errno(FsError::NotEmpty), libc::ENOTEMPTY);
+        assert_eq!(errno(FsError::NameTooLong), libc::ENAMETOOLONG);
     }
 
     #[test]

--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -61,6 +61,7 @@ pub(crate) fn errno(err: FsError) -> i32 {
         FsError::NotDir => libc::ENOTDIR,
         FsError::Exists => libc::EEXIST,
         FsError::Invalid => libc::EINVAL,
+        FsError::NotEmpty => libc::ENOTEMPTY,
     }
 }
 
@@ -275,6 +276,10 @@ impl TalonFuse {
     /// `close(2)`/`fsync(2)` (#232).
     fn writeback_object(&self, path: &str, bytes: Vec<u8>) -> anyhow::Result<()> {
         let object = path_to_object(path)?;
+        self.writeback_object_id(object, bytes)
+    }
+
+    fn writeback_object_id(&self, object: ObjectId, bytes: Vec<u8>) -> anyhow::Result<()> {
         let reader = self.reader.clone();
         let pool = Arc::clone(&self.write_pool);
         let block_size = self.block_size;
@@ -293,6 +298,10 @@ impl TalonFuse {
     /// Delete the object at mount-relative `path` through its owning worker.
     fn delete_backend_object(&self, path: &str) -> anyhow::Result<()> {
         let object = path_to_object(path)?;
+        self.delete_backend_object_id(object)
+    }
+
+    fn delete_backend_object_id(&self, object: ObjectId) -> anyhow::Result<()> {
         let reader = self.reader.clone();
         let pool = Arc::clone(&self.write_pool);
         let block_size = self.block_size;
@@ -306,6 +315,15 @@ impl TalonFuse {
             client.delete_object(&object).await?;
             Ok::<(), anyhow::Error>(())
         })
+    }
+
+    fn directory_marker_object(marker_path: &str) -> anyhow::Result<ObjectId> {
+        let directory_path = marker_path
+            .strip_suffix('/')
+            .ok_or_else(|| anyhow::anyhow!("directory marker must end in '/'"))?;
+        let mut object = path_to_object(directory_path)?;
+        object.object_path.push('/');
+        Ok(object)
     }
 
     /// Read the complete committed object before a non-truncating write open.
@@ -472,11 +490,14 @@ impl fuser::Filesystem for TalonFuse {
             Ok(c) => c,
             Err(e) => return reply.error(errno(e)),
         };
-        // Prepend `.` and `..` so tools like `ls -a` behave; both point at `ino`
-        // (parent tracking is unnecessary for a read-only synthetic namespace).
+        let parent_ino = match self.fs.parent_ino(ino) {
+            Ok(parent) => parent,
+            Err(e) => return reply.error(errno(e)),
+        };
+        // Prepend `.` and `..` so tools like `ls -a` behave.
         let mut all: Vec<(u64, fuser::FileType, String)> = vec![
             (ino, fuser::FileType::Directory, ".".to_string()),
-            (ino, fuser::FileType::Directory, "..".to_string()),
+            (parent_ino, fuser::FileType::Directory, "..".to_string()),
         ];
         all.extend(children.into_iter().map(|e| {
             let kind = match e.kind {
@@ -626,6 +647,56 @@ impl fuser::Filesystem for TalonFuse {
         }
     }
 
+    /// Create a directory and persist it as a trailing-slash blob marker.
+    fn mkdir(
+        &mut self,
+        req: &fuser::Request<'_>,
+        parent: u64,
+        name: &std::ffi::OsStr,
+        _mode: u32,
+        _umask: u32,
+        reply: fuser::ReplyEntry,
+    ) {
+        if !self.read_write {
+            return reply.error(libc::EROFS);
+        }
+        let name = match name.to_str() {
+            Some(name) => name,
+            None => return reply.error(libc::EINVAL),
+        };
+        let marker_path = match self.fs.new_directory_marker_path(parent, name) {
+            Ok(path) => path,
+            Err(e) => return reply.error(errno(e)),
+        };
+        let marker = match Self::directory_marker_object(&marker_path) {
+            Ok(marker) => marker,
+            Err(error) => {
+                tracing::warn!(%marker_path, %error, "invalid directory marker path");
+                return reply.error(libc::EINVAL);
+            }
+        };
+        if let Err(error) = self.writeback_object_id(marker.clone(), Vec::new()) {
+            tracing::warn!(path = %marker.to_path(), %error, "mkdir marker writeback failed");
+            return reply.error(libc::EIO);
+        }
+        match self.fs.mkdir(parent, name) {
+            Ok(attr) => {
+                let file_attr = to_file_attr(attr, req.uid(), req.gid());
+                reply.entry(&ATTR_TTL, &file_attr, 0);
+            }
+            Err(e) => {
+                if let Err(error) = self.delete_backend_object_id(marker.clone()) {
+                    tracing::warn!(
+                        path = %marker.to_path(),
+                        %error,
+                        "failed to roll back mkdir marker"
+                    );
+                }
+                reply.error(errno(e));
+            }
+        }
+    }
+
     /// Write `data` at `offset` into an open write handle's dirty buffer.
     #[allow(clippy::too_many_arguments)]
     fn write(
@@ -764,6 +835,44 @@ impl fuser::Filesystem for TalonFuse {
         }
         match self.fs.unlink(parent, name) {
             Ok(_) => reply.ok(),
+            Err(e) => reply.error(errno(e)),
+        }
+    }
+
+    /// Remove an empty directory and its trailing-slash blob marker.
+    fn rmdir(
+        &mut self,
+        _req: &fuser::Request<'_>,
+        parent: u64,
+        name: &std::ffi::OsStr,
+        reply: fuser::ReplyEmpty,
+    ) {
+        if !self.read_write {
+            return reply.error(libc::EROFS);
+        }
+        let name = match name.to_str() {
+            Some(name) => name,
+            None => return reply.error(libc::EINVAL),
+        };
+        let marker_path = match self.fs.rmdir_marker_path(parent, name) {
+            Ok(path) => path,
+            Err(e) => return reply.error(errno(e)),
+        };
+        if let Some(marker_path) = marker_path {
+            let marker = match Self::directory_marker_object(&marker_path) {
+                Ok(marker) => marker,
+                Err(error) => {
+                    tracing::warn!(%marker_path, %error, "invalid directory marker path");
+                    return reply.error(libc::EINVAL);
+                }
+            };
+            if let Err(error) = self.delete_backend_object_id(marker.clone()) {
+                tracing::warn!(path = %marker.to_path(), %error, "rmdir marker delete failed");
+                return reply.error(libc::EIO);
+            }
+        }
+        match self.fs.rmdir(parent, name) {
+            Ok(()) => reply.ok(),
             Err(e) => reply.error(errno(e)),
         }
     }
@@ -923,6 +1032,7 @@ mod tests {
         assert_eq!(errno(FsError::NotDir), libc::ENOTDIR);
         assert_eq!(errno(FsError::Exists), libc::EEXIST);
         assert_eq!(errno(FsError::Invalid), libc::EINVAL);
+        assert_eq!(errno(FsError::NotEmpty), libc::ENOTEMPTY);
     }
 
     #[test]

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -65,6 +65,8 @@ pub enum FsError {
     Exists,
     /// An invalid flag, name, path, or argument was supplied (`EINVAL`).
     Invalid,
+    /// A directory is not empty (`ENOTEMPTY`).
+    NotEmpty,
 }
 
 /// Access and mutation behavior for an open file handle.
@@ -115,13 +117,15 @@ pub struct DirEntry {
 #[derive(Debug, Clone)]
 struct Node {
     ino: u64,
+    parent: Option<u64>,
     name: String,
     kind: FileKind,
     size: u64,
     children: Vec<u64>,
-    /// Full mount-relative path for a file leaf (e.g. `s3/bkt/o.bin`); empty for
-    /// directories. Lets a data callback recover the object from an inode.
+    /// Full mount-relative path, e.g. `s3/bkt/dir` or `s3/bkt/o.bin`.
     path: String,
+    /// Whether this directory is persisted by a trailing-slash blob marker.
+    directory_marker: bool,
 }
 
 /// A read-only view over the backend namespace, addressed by inode.
@@ -182,11 +186,13 @@ impl ReadOnlyFs {
             ROOT_INO,
             Node {
                 ino: ROOT_INO,
+                parent: None,
                 name: "/".to_string(),
                 kind: FileKind::Directory,
                 size: 0,
                 children: Vec::new(),
                 path: String::new(),
+                directory_marker: false,
             },
         );
         Self {
@@ -221,8 +227,13 @@ impl ReadOnlyFs {
         let comps: Vec<&str> = path.split('/').filter(|c| !c.is_empty()).collect();
         let mut g = self.inner.lock_recover();
         let mut parent = ROOT_INO;
+        let mut current_path = String::new();
         for (i, comp) in comps.iter().enumerate() {
             let is_leaf = i == comps.len() - 1;
+            if !current_path.is_empty() {
+                current_path.push('/');
+            }
+            current_path.push_str(comp);
             let key = (parent, comp.to_string());
             if let Some(&existing) = g.index.get(&key) {
                 parent = existing;
@@ -237,15 +248,13 @@ impl ReadOnlyFs {
             };
             let node = Node {
                 ino,
+                parent: Some(parent),
                 name: comp.to_string(),
                 kind,
                 size: if is_leaf { size } else { 0 },
                 children: Vec::new(),
-                path: if is_leaf {
-                    path.trim_start_matches('/').to_string()
-                } else {
-                    String::new()
-                },
+                path: current_path.clone(),
+                directory_marker: false,
             };
             g.nodes.insert(ino, node);
             g.index.insert(key, ino);
@@ -267,10 +276,67 @@ impl ReadOnlyFs {
     {
         let mut n = 0;
         for (path, size) in entries {
-            self.insert_object(path, size);
-            n += 1;
+            if path.ends_with('/') {
+                if self.insert_directory_marker(path).is_ok() {
+                    n += 1;
+                }
+            } else {
+                self.insert_object(path, size);
+                n += 1;
+            }
         }
         n
+    }
+
+    /// Register a directory represented by a trailing-slash blob marker.
+    pub fn insert_directory_marker(&self, marker_path: &str) -> Result<u64, FsError> {
+        let path = marker_path
+            .strip_suffix('/')
+            .filter(|path| !path.is_empty())
+            .ok_or(FsError::Invalid)?;
+        path_to_object(path).map_err(|_| FsError::Invalid)?;
+        let comps: Vec<&str> = path
+            .split('/')
+            .filter(|component| !component.is_empty())
+            .collect();
+        let mut g = self.inner.lock_recover();
+        let mut parent = ROOT_INO;
+        let mut current_path = String::new();
+        for (index, component) in comps.iter().enumerate() {
+            if !current_path.is_empty() {
+                current_path.push('/');
+            }
+            current_path.push_str(component);
+            let key = (parent, component.to_string());
+            if let Some(&existing) = g.index.get(&key) {
+                let node = g.nodes.get_mut(&existing).ok_or(FsError::NotFound)?;
+                if node.kind != FileKind::Directory {
+                    return Err(FsError::NotDir);
+                }
+                if index == comps.len() - 1 {
+                    node.directory_marker = true;
+                }
+                parent = existing;
+                continue;
+            }
+            let ino = g.next_ino;
+            g.next_ino += 1;
+            let node = Node {
+                ino,
+                parent: Some(parent),
+                name: component.to_string(),
+                kind: FileKind::Directory,
+                size: 0,
+                children: Vec::new(),
+                path: current_path.clone(),
+                directory_marker: index == comps.len() - 1,
+            };
+            g.nodes.insert(ino, node);
+            g.index.insert(key, ino);
+            g.nodes.get_mut(&parent).unwrap().children.push(ino);
+            parent = ino;
+        }
+        Ok(parent)
     }
 
     fn attr_of(node: &Node) -> Attr {
@@ -307,7 +373,7 @@ impl ReadOnlyFs {
         let g = self.inner.lock_recover();
         let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
         if node.kind != FileKind::Directory {
-            return Err(FsError::NotFound);
+            return Err(FsError::NotDir);
         }
         let mut entries: Vec<DirEntry> = node
             .children
@@ -321,6 +387,16 @@ impl ReadOnlyFs {
             .collect();
         entries.sort_by(|a, b| a.name.cmp(&b.name));
         Ok(entries)
+    }
+
+    /// Return a directory inode's parent, with root parented to itself.
+    pub fn parent_ino(&self, ino: u64) -> Result<u64, FsError> {
+        let g = self.inner.lock_recover();
+        let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
+        if node.kind != FileKind::Directory {
+            return Err(FsError::NotDir);
+        }
+        Ok(node.parent.unwrap_or(ROOT_INO))
     }
 
     /// Open an existing file with the requested access mode.
@@ -482,11 +558,13 @@ impl ReadOnlyFs {
         g.next_ino += 1;
         let node = Node {
             ino,
+            parent: Some(parent_ino),
             name: name.to_string(),
             kind: FileKind::File,
             size: 0,
             children: Vec::new(),
             path,
+            directory_marker: false,
         };
         g.nodes.insert(ino, node);
         g.index.insert((parent_ino, name.to_string()), ino);
@@ -623,6 +701,102 @@ impl ReadOnlyFs {
         Some(node.path.clone())
     }
 
+    /// Validate a new directory and return its trailing-slash marker path.
+    pub fn new_directory_marker_path(
+        &self,
+        parent_ino: u64,
+        name: &str,
+    ) -> Result<String, FsError> {
+        Self::validate_component(name)?;
+        let g = self.inner.lock_recover();
+        let parent = g.nodes.get(&parent_ino).ok_or(FsError::NotFound)?;
+        if parent.kind != FileKind::Directory {
+            return Err(FsError::NotDir);
+        }
+        if g.index.contains_key(&(parent_ino, name.to_string())) {
+            return Err(FsError::Exists);
+        }
+        let path = Self::child_path(parent, name);
+        path_to_object(&path).map_err(|_| FsError::Invalid)?;
+        Ok(format!("{path}/"))
+    }
+
+    /// Insert a new explicit directory after its marker has been committed.
+    pub fn mkdir(&self, parent_ino: u64, name: &str) -> Result<Attr, FsError> {
+        Self::validate_component(name)?;
+        let mut g = self.inner.lock_recover();
+        let parent = g.nodes.get(&parent_ino).ok_or(FsError::NotFound)?;
+        if parent.kind != FileKind::Directory {
+            return Err(FsError::NotDir);
+        }
+        if g.index.contains_key(&(parent_ino, name.to_string())) {
+            return Err(FsError::Exists);
+        }
+        let path = Self::child_path(parent, name);
+        path_to_object(&path).map_err(|_| FsError::Invalid)?;
+        let ino = g.next_ino;
+        g.next_ino += 1;
+        let node = Node {
+            ino,
+            parent: Some(parent_ino),
+            name: name.to_string(),
+            kind: FileKind::Directory,
+            size: 0,
+            children: Vec::new(),
+            path,
+            directory_marker: true,
+        };
+        g.nodes.insert(ino, node);
+        g.index.insert((parent_ino, name.to_string()), ino);
+        g.nodes.get_mut(&parent_ino).unwrap().children.push(ino);
+        Ok(Self::attr_of(g.nodes.get(&ino).unwrap()))
+    }
+
+    /// Return the marker to delete before removing an empty directory.
+    pub fn rmdir_marker_path(
+        &self,
+        parent_ino: u64,
+        name: &str,
+    ) -> Result<Option<String>, FsError> {
+        Self::validate_component(name)?;
+        let g = self.inner.lock_recover();
+        let ino = *g
+            .index
+            .get(&(parent_ino, name.to_string()))
+            .ok_or(FsError::NotFound)?;
+        let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
+        if node.kind != FileKind::Directory {
+            return Err(FsError::NotDir);
+        }
+        if !node.children.is_empty() {
+            return Err(FsError::NotEmpty);
+        }
+        Ok(node.directory_marker.then(|| format!("{}/", node.path)))
+    }
+
+    /// Remove an empty directory from the namespace.
+    pub fn rmdir(&self, parent_ino: u64, name: &str) -> Result<(), FsError> {
+        Self::validate_component(name)?;
+        let mut g = self.inner.lock_recover();
+        let ino = *g
+            .index
+            .get(&(parent_ino, name.to_string()))
+            .ok_or(FsError::NotFound)?;
+        let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
+        if node.kind != FileKind::Directory {
+            return Err(FsError::NotDir);
+        }
+        if !node.children.is_empty() {
+            return Err(FsError::NotEmpty);
+        }
+        g.nodes.remove(&ino);
+        g.index.remove(&(parent_ino, name.to_string()));
+        if let Some(parent) = g.nodes.get_mut(&parent_ino) {
+            parent.children.retain(|child| *child != ino);
+        }
+        Ok(())
+    }
+
     /// `unlink`: remove file `name` under directory `parent_ino` from the
     /// namespace. Returns the removed file's mount-relative path so the caller
     /// can delete the backend object. Directories are not removed here.
@@ -634,7 +808,7 @@ impl ReadOnlyFs {
             .ok_or(FsError::NotFound)?;
         let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
         if node.kind != FileKind::File {
-            return Err(FsError::Unsupported);
+            return Err(FsError::IsDir);
         }
         let path = node.path.clone();
         g.nodes.remove(&ino);
@@ -648,8 +822,6 @@ impl ReadOnlyFs {
     /// Build the ancestry name chain (root-excluded) of `ino`, e.g.
     /// `["s3", "bucket", "data"]`, so a child path can be formed on `create`.
     fn ancestry(g: &Inner, ino: u64) -> Vec<String> {
-        // Walk children from root is O(n); instead find each node's parent by
-        // scanning the index. For the shallow synthetic tree this is fine.
         let mut names = Vec::new();
         let mut cur = ino;
         while cur != ROOT_INO {
@@ -658,19 +830,29 @@ impl ReadOnlyFs {
                 None => break,
             };
             names.push(node.name.clone());
-            // Find the parent whose children contain `cur`.
-            let parent = g
-                .nodes
-                .iter()
-                .find(|(_, n)| n.children.contains(&cur))
-                .map(|(p, _)| *p);
-            match parent {
+            match node.parent {
                 Some(p) => cur = p,
                 None => break,
             }
         }
         names.reverse();
         names
+    }
+
+    fn validate_component(name: &str) -> Result<(), FsError> {
+        if name.is_empty() || name == "." || name == ".." || name.contains('/') {
+            Err(FsError::Invalid)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn child_path(parent: &Node, name: &str) -> String {
+        if parent.path.is_empty() {
+            name.to_string()
+        } else {
+            format!("{}/{}", parent.path, name)
+        }
     }
 }
 
@@ -786,6 +968,59 @@ mod tests {
         let a_ino = a.ino;
         fs.populate_from_listing([("s3/bkt/dir/a.bin", 10u64)]);
         assert_eq!(fs.lookup(dir.ino, "a.bin").unwrap().ino, a_ino);
+    }
+
+    #[test]
+    fn directory_markers_populate_hidden_empty_directories() {
+        let fs = ReadOnlyFs::new();
+        let count =
+            fs.populate_from_listing([("s3/bkt/empty/", 0u64), ("s3/bkt/nonempty/file.bin", 5u64)]);
+        assert_eq!(count, 2);
+
+        let s3 = fs.lookup(ROOT_INO, "s3").unwrap();
+        let bucket = fs.lookup(s3.ino, "bkt").unwrap();
+        let entries = fs.readdir(bucket.ino).unwrap();
+        let names: Vec<&str> = entries.iter().map(|entry| entry.name.as_str()).collect();
+        assert_eq!(names, vec!["empty", "nonempty"]);
+
+        let empty = fs.lookup(bucket.ino, "empty").unwrap();
+        assert_eq!(empty.kind, FileKind::Directory);
+        assert!(fs.readdir(empty.ino).unwrap().is_empty());
+        assert_eq!(fs.parent_ino(empty.ino).unwrap(), bucket.ino);
+        assert_eq!(
+            fs.rmdir_marker_path(bucket.ino, "empty").unwrap(),
+            Some("s3/bkt/empty/".to_string())
+        );
+    }
+
+    #[test]
+    fn mkdir_and_rmdir_enforce_empty_directory_invariants() {
+        let fs = fs();
+        let parent = data_dir(&fs);
+        assert_eq!(
+            fs.new_directory_marker_path(parent.ino, "new").unwrap(),
+            "s3/bucket/data/new/"
+        );
+        let directory = fs.mkdir(parent.ino, "new").unwrap();
+        assert_eq!(directory.kind, FileKind::Directory);
+        assert_eq!(fs.parent_ino(directory.ino).unwrap(), parent.ino);
+        assert_eq!(fs.mkdir(parent.ino, "new"), Err(FsError::Exists));
+
+        let (_, fh) = fs.create(directory.ino, "child.bin").unwrap();
+        fs.release(fh).unwrap();
+        assert_eq!(
+            fs.rmdir_marker_path(parent.ino, "new"),
+            Err(FsError::NotEmpty)
+        );
+        assert_eq!(fs.rmdir(parent.ino, "new"), Err(FsError::NotEmpty));
+
+        fs.unlink(directory.ino, "child.bin").unwrap();
+        assert_eq!(
+            fs.rmdir_marker_path(parent.ino, "new").unwrap(),
+            Some("s3/bucket/data/new/".to_string())
+        );
+        fs.rmdir(parent.ino, "new").unwrap();
+        assert_eq!(fs.lookup(parent.ino, "new"), Err(FsError::NotFound));
     }
 
     #[test]

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -356,6 +356,7 @@ impl ReadOnlyFs {
 
     /// `lookup`: resolve a child `name` under directory `parent_ino`.
     pub fn lookup(&self, parent_ino: u64, name: &str) -> Result<Attr, FsError> {
+        Self::validate_name_length(name)?;
         let g = self.inner.lock_recover();
         let ino = *g
             .index
@@ -842,10 +843,17 @@ impl ReadOnlyFs {
     }
 
     fn validate_component(name: &str) -> Result<(), FsError> {
+        Self::validate_name_length(name)?;
+        if name.is_empty() || name == "." || name == ".." || name.contains('/') {
+            Err(FsError::Invalid)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn validate_name_length(name: &str) -> Result<(), FsError> {
         if name.len() > 255 {
             Err(FsError::NameTooLong)
-        } else if name.is_empty() || name == "." || name == ".." || name.contains('/') {
-            Err(FsError::Invalid)
         } else {
             Ok(())
         }
@@ -1037,6 +1045,7 @@ mod tests {
             fs.new_directory_marker_path(parent.ino, &name),
             Err(FsError::NameTooLong)
         );
+        assert_eq!(fs.lookup(parent.ino, &name), Err(FsError::NameTooLong));
         assert_eq!(fs.mkdir(parent.ino, &name), Err(FsError::NameTooLong));
         assert_eq!(
             fs.rmdir_marker_path(parent.ino, &name),

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -67,6 +67,8 @@ pub enum FsError {
     Invalid,
     /// A directory is not empty (`ENOTEMPTY`).
     NotEmpty,
+    /// A pathname component exceeds the filesystem name limit (`ENAMETOOLONG`).
+    NameTooLong,
 }
 
 /// Access and mutation behavior for an open file handle.
@@ -840,7 +842,9 @@ impl ReadOnlyFs {
     }
 
     fn validate_component(name: &str) -> Result<(), FsError> {
-        if name.is_empty() || name == "." || name == ".." || name.contains('/') {
+        if name.len() > 255 {
+            Err(FsError::NameTooLong)
+        } else if name.is_empty() || name == "." || name == ".." || name.contains('/') {
             Err(FsError::Invalid)
         } else {
             Ok(())
@@ -1021,6 +1025,24 @@ mod tests {
         );
         fs.rmdir(parent.ino, "new").unwrap();
         assert_eq!(fs.lookup(parent.ino, "new"), Err(FsError::NotFound));
+    }
+
+    #[test]
+    fn directory_operations_reject_names_over_name_max() {
+        let fs = fs();
+        let parent = data_dir(&fs);
+        let name = "x".repeat(256);
+
+        assert_eq!(
+            fs.new_directory_marker_path(parent.ino, &name),
+            Err(FsError::NameTooLong)
+        );
+        assert_eq!(fs.mkdir(parent.ino, &name), Err(FsError::NameTooLong));
+        assert_eq!(
+            fs.rmdir_marker_path(parent.ino, &name),
+            Err(FsError::NameTooLong)
+        );
+        assert_eq!(fs.rmdir(parent.ino, &name), Err(FsError::NameTooLong));
     }
 
     #[test]

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -507,6 +507,116 @@ async fn mount_open_flags_preserve_and_replace_blob_contents() {
     );
 }
 
+/// Persist empty directories as trailing-slash blobs and rebuild them on listing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires /dev/fuse; run with --features mount -- --ignored"]
+async fn mount_directory_markers_are_written_through() {
+    use fuser::MountOption;
+
+    let block_size: u32 = 4 * 1024 * 1024;
+    let store: Store = Arc::new(Mutex::new(HashMap::new()));
+    let worker = spawn_rw_worker(Arc::clone(&store)).await;
+    let coord = spawn_coordinator(worker).await;
+
+    let fs = Arc::new(ReadOnlyFs::new());
+    fs.insert_object("s3/bucket/placeholder", 0);
+
+    let cache = Arc::new(PlacementCache::new(10_000));
+    let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
+    let adapter = TalonFuse::new(
+        Arc::clone(&fs),
+        reader,
+        tokio::runtime::Handle::current(),
+        block_size,
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
+    )
+    .with_read_write(true);
+
+    let require_fuse = std::env::var_os("TALON_REQUIRE_FUSE").is_some();
+    let mountpoint =
+        std::env::temp_dir().join(format!("talon-mount-e2e-dir-{}", std::process::id()));
+    std::fs::create_dir_all(&mountpoint).unwrap();
+    let options = vec![MountOption::FSName("talon".into())];
+    let session = match fuser::spawn_mount2(adapter, &mountpoint, &options) {
+        Ok(session) => session,
+        Err(error) => {
+            std::fs::remove_dir_all(&mountpoint).ok();
+            if require_fuse {
+                panic!(
+                    "TALON_REQUIRE_FUSE is set but the FUSE mount failed: {error}. \
+                     The runner must provide an accessible /dev/fuse."
+                );
+            }
+            eprintln!("skipping: /dev/fuse unavailable: {error}");
+            return;
+        }
+    };
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let bucket = mountpoint.join("s3").join("bucket");
+    let operation_store = Arc::clone(&store);
+    let result = tokio::task::spawn_blocking(move || {
+        let empty = bucket.join("empty");
+        let nested = empty.join("nested");
+        std::fs::create_dir(&empty)?;
+        assert!(operation_store
+            .lock()
+            .unwrap()
+            .contains_key("/s3/bucket/empty/"));
+
+        std::fs::create_dir(&nested)?;
+        assert!(operation_store
+            .lock()
+            .unwrap()
+            .contains_key("/s3/bucket/empty/nested/"));
+
+        let not_empty = std::fs::remove_dir(&empty).unwrap_err();
+        assert_eq!(not_empty.raw_os_error(), Some(libc::ENOTEMPTY));
+
+        std::fs::remove_dir(&nested)?;
+        assert!(!operation_store
+            .lock()
+            .unwrap()
+            .contains_key("/s3/bucket/empty/nested/"));
+        std::fs::remove_dir(&empty)?;
+
+        let persisted = bucket.join("persisted");
+        std::fs::create_dir(&persisted)?;
+        let names: Vec<String> = std::fs::read_dir(&bucket)?
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert!(names.iter().any(|name| name == "persisted"));
+        assert!(!names.iter().any(|name| name.ends_with('/')));
+        Ok::<(), std::io::Error>(())
+    })
+    .await
+    .unwrap();
+
+    drop(session);
+    std::fs::remove_dir_all(&mountpoint).ok();
+    result.expect("exercise directory markers through mount");
+
+    let listing: Vec<(String, u64)> = store
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|(path, bytes)| (path.trim_start_matches('/').to_string(), bytes.len() as u64))
+        .collect();
+    assert_eq!(
+        listing,
+        vec![("s3/bucket/persisted/".to_string(), 0)],
+        "only the retained directory marker should remain"
+    );
+
+    let remounted = ReadOnlyFs::new();
+    remounted.populate_from_listing(listing.iter().map(|(path, size)| (path.as_str(), *size)));
+    let s3 = remounted.lookup(talon_fuse::ops::ROOT_INO, "s3").unwrap();
+    let bucket = remounted.lookup(s3.ino, "bucket").unwrap();
+    let persisted = remounted.lookup(bucket.ino, "persisted").unwrap();
+    assert_eq!(persisted.kind, talon_fuse::FileKind::Directory);
+    assert!(remounted.readdir(persisted.ino).unwrap().is_empty());
+}
+
 /// Mount the read-write fixture and run the pinned pjdfstest suite against it.
 ///
 /// This is separately gated because the normal real-kernel smoke job runs all


### PR DESCRIPTION
## Summary

Implement writable POSIX directory creation and removal for Talon FUSE. Empty directories are persisted as zero-byte trailing-slash blob markers, and every `mkdir`/`rmdir` operation writes through to the owning worker before the in-memory namespace is updated; no directory write cache is introduced.

This PR is stacked on #334. Its diff will shrink to the directory-specific commits after #334 merges.

## Related issues

- Progresses #330
- Depends on #332 for production namespace reconstruction from backend listings
- Part of #259 and #262

## Type of change

- [x] Bug fix
- [x] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [x] Docs / tests / tooling

## Design alignment

This keeps the existing whole-object, write-through FUSE model. Directory markers use ordinary backend objects with keys ending in `/`, so directory durability follows the same worker placement and blob-store path as file writes and deletes.

## Changes

- Track parent inodes and full paths for namespace nodes.
- Recognize trailing-slash listing entries as hidden directory markers.
- Implement FUSE `mkdir` with synchronous zero-byte marker PUT and rollback on namespace failure.
- Implement FUSE `rmdir` with `ENOTEMPTY`, type validation, and synchronous marker DELETE.
- Return the actual parent inode for `..` directory entries.
- Return `ENAMETOOLONG` for names exceeding 255 bytes, including lookup-before-rmdir paths.
- Add focused namespace tests and a real-kernel marker persistence test.

## Test plan

- [x] `cargo test -p talon-fuse --lib --features mount --locked`: 95 passed
- [x] `cargo clippy -p talon-fuse --features mount --all-targets --locked -- -D warnings`
- [x] `cargo test -p talon-fuse --features mount --test mount_e2e --no-run --locked`
- [x] Exact commit `94eeef13049948fc8a706f7f0508afa562f7037e` passed `mount_directory_markers_are_written_through` in a privileged `falcon-phx-ca` Job with host `/dev/fuse`
- [x] Real-kernel `mkdir,rmdir` pjdfstest: 152 passed, 111 failed out of 263, up from 39 passed and 224 failed

The remaining grouped failures depend on metadata/mode/ownership (#328), timestamps (#324), links (#323), and special nodes (#327), rather than the core directory namespace callbacks.

## Performance impact

Directory mutation now performs one synchronous backend operation before acknowledging success. This is intentional write-through durability and does not affect file read or write hot paths.

- [x] Not performance-sensitive

## Checklist

- [x] PR title follows Conventional Commits
- [x] Public behavior is covered by tests
- [x] No new dependencies
- [x] Rebased on the latest `main`
