### PR TITLE
doc: add client SDK guides for Python and Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Start with the section that matches what you're doing:
 - **Deciding if Talon fits** — [Use cases](docs/use-cases/overview.md): model
   training, checkpointing, notebooks and data sharing, cross-cloud reads, and
   analytics — including where it does *not* help.
+- **Reading from Talon in code** — [Client SDKs](docs/clients/overview.md):
+  a [Python](docs/clients/python.md) wheel and a native-free
+  [Java](docs/clients/java.md) jar, for when a FUSE mount is not the right fit.
 - **Using Talon** — the [Getting started tutorial](docs/tutorials/getting-started.md)
   builds the workspace, runs a cluster, and opens the management console;
   [DESIGN.md](DESIGN.md) explains what each component does, and

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -29,6 +29,12 @@
 - [Security hardening](./operations/security.md)
 - [Latency lab](./testing/latency-lab.md)
 
+# Client SDKs
+
+- [Overview](./clients/overview.md)
+- [Python client](./clients/python.md)
+- [Java client](./clients/java.md)
+
 # Reference
 
 - [Configuration reference](./reference/configuration.md)

--- a/docs/book/src/clients/java.md
+++ b/docs/book/src/clients/java.md
@@ -1,0 +1,1 @@
+{{#include ../../../clients/java.md}}

--- a/docs/book/src/clients/overview.md
+++ b/docs/book/src/clients/overview.md
@@ -1,0 +1,1 @@
+{{#include ../../../clients/overview.md}}

--- a/docs/book/src/clients/python.md
+++ b/docs/book/src/clients/python.md
@@ -1,0 +1,1 @@
+{{#include ../../../clients/python.md}}

--- a/docs/clients/java.md
+++ b/docs/clients/java.md
@@ -1,0 +1,99 @@
+# Java client
+
+A pure-JVM client: a plain jar with **no native dependency**. No JNI, no FFM, no
+per-platform artifact, no `System.loadLibrary` failure mode.
+
+Requires Java 17 or newer.
+
+## Build
+
+```sh
+cd clients/java
+mvn package
+```
+
+The jar has no runtime dependencies, so it drops into any classpath without
+pulling anything else in. There is also no build-tool dependency — the sources
+compile with `javac` alone, which is what CI does:
+
+```sh
+javac -d classes clients/java/src/main/java/io/milvus/talon/*.java
+```
+
+## Reading
+
+```java
+import io.milvus.talon.ObjectStat;
+import io.milvus.talon.TalonClient;
+
+try (TalonClient client = TalonClient.connect("coordinator-host:7000", 8 << 20)) {
+    ObjectStat info = client.stat("az://container/datasets/train.parquet");
+    System.out.println(info.size() + " " + info.version());
+
+    byte[] chunk = client.read("az://container/datasets/train.parquet", 0, 1 << 20);
+}
+```
+
+The second argument to `connect` **must match the workers' configured block
+size**. Placement is computed per block, so a mismatch addresses blocks that do
+not exist.
+
+URIs use the same namespaces as the FUSE mount — `s3://`, `gcs://`, `az://`.
+
+## Reading many ranges of one object
+
+`read(uri, offset, length)` resolves the version with a `stat` first. When
+reading many ranges of the same object, resolve it once and use the overload
+that takes it:
+
+```java
+ObjectStat info = client.stat(uri);
+for (long offset = 0; offset < info.size(); offset += chunkSize) {
+    byte[] part = client.read(uri, info.version(), offset, chunkSize);
+}
+```
+
+## Threads
+
+Instances are safe for concurrent use. Each call opens its own connection, so a
+slow read cannot block an unrelated one; the placement cache is shared and
+synchronised.
+
+```java
+try (ExecutorService pool = Executors.newFixedThreadPool(8)) {
+    for (long offset : offsets) {
+        pool.submit(() -> client.read(uri, info.version(), offset, chunkSize));
+    }
+}
+```
+
+## Errors
+
+`IOException` for transport and worker failures, with the worker's message
+preserved. `ProtocolException` when bytes on the wire are not what the protocol
+specifies — usually a version mismatch between client and cluster rather than a
+transient fault, so **retrying will not help**. `IllegalArgumentException` for a
+malformed URI, raised before any I/O.
+
+## How this client stays correct
+
+The wire protocol is implemented twice: here and in Rust. The failure mode of
+drift is subtle — a client that occasionally reads a stale version rather than
+one that crashes — so this client is validated against **conformance vectors**
+generated from the Rust implementation:
+
+```sh
+scripts/java_client_e2e.sh
+```
+
+That runs both suites: byte-equality against the vectors, and an end-to-end read
+against a live cluster. Both run in CI on every pull request.
+
+See the [wire protocol reference](../reference/wire-protocol.md) for the format
+this implements.
+
+## Not yet available
+
+`list` is implemented but returns an error until the backends gain a listing
+capability ([#332](https://github.com/milvus-io/talon/issues/332)). Writes go
+through the FUSE mount or the Rust client.

--- a/docs/clients/overview.md
+++ b/docs/clients/overview.md
@@ -1,0 +1,63 @@
+# Client SDKs
+
+Talon can be reached three ways, and which one fits depends less on language
+than on how much control the workload needs.
+
+| | best for | needs |
+|---|---|---|
+| **FUSE mount** | unmodified applications, POSIX tooling | a privileged mount and `/dev/fuse` |
+| **Python client** | training loaders, notebooks, data pipelines | a wheel |
+| **Java client** | JVM query engines and data tooling | a jar |
+
+## Why a native client rather than the mount
+
+The FUSE mount is the least invasive option — existing code opens paths and
+keeps working. It also carries constraints a native client avoids:
+
+- **It needs a privileged mount** and access to `/dev/fuse`, which many
+  container platforms restrict.
+- **It imposes POSIX semantics** on what is really a ranged-read API. A read
+  becomes a file offset, an object becomes an inode, and errors become errnos.
+- **It cannot express cache-aware behaviour.** A client that wants to know
+  which worker holds a block, or to read many ranges of one object without
+  re-resolving its version, has nowhere to say so.
+
+If the application already speaks in terms of objects and byte ranges, a client
+is a closer fit.
+
+## Two different architectures, deliberately
+
+**Python binds the Rust core.** Block splitting, placement caching, replica
+fallback, and connection pooling already exist and are exercised by the FUSE
+client; reimplementing them in Python would reimplement their bugs. `abi3`
+wheels give one artifact per platform across CPython versions, which the
+ecosystem already expects.
+
+**Java is a pure jar.** No JNI, no FFM, no native artifact — it drops into any
+JVM build with no per-platform matrix, no `System.loadLibrary` failure mode, and
+no JNI crash surface. The cost is that the wire protocol is implemented twice.
+
+That duplication is why the [wire protocol reference](../reference/wire-protocol.md)
+exists as a specification with **conformance vectors** rather than as prose. The
+vectors are generated from the Rust implementation and asserted by the Java
+client, so a change that alters the wire fails a test rather than silently
+breaking a deployment.
+
+It has already earned that: the Java client's first conformance run failed
+because it sent the envelope schema as the newest version it understood, where
+Rust sends the minimum version that can represent the message. Nothing would
+have crashed — an older coordinator would simply have rejected requests it could
+have served, invisibly from both ends.
+
+## Current scope
+
+Both clients are **read-only**: `read` and `stat`.
+
+`list` is implemented in both but not yet usable, because listing needs a
+capability the storage backends do not have yet
+([#332](https://github.com/milvus-io/talon/issues/332)). Write-through
+(`put`/`delete`) is deliberately deferred — its error and version semantics
+deserve a design pass rather than being rushed into a first release.
+
+- [Python client](./python.md)
+- [Java client](./java.md)

--- a/docs/clients/python.md
+++ b/docs/clients/python.md
@@ -1,0 +1,95 @@
+# Python client
+
+A binding over Talon's Rust client core. Reads objects through the cache
+instead of from the origin, so repeated reads across a fleet are served from
+local NVMe.
+
+## Install
+
+```sh
+pip install talon-client
+```
+
+Wheels are `abi3`, so one artifact per platform covers CPython 3.8 and newer.
+
+To build from a checkout:
+
+```sh
+pip install maturin
+maturin build --release --manifest-path clients/python/Cargo.toml --out dist
+pip install dist/*.whl
+```
+
+## Reading
+
+```python
+import talon
+
+with talon.Client("coordinator-host:7000", block_size=8 << 20) as client:
+    info = client.stat("az://container/datasets/train.parquet")
+    print(info.size, info.version)
+
+    chunk = client.read("az://container/datasets/train.parquet",
+                        offset=0, length=1 << 20)
+```
+
+`block_size` **must match the workers' configured block size**. Placement is
+computed per block, so a mismatch addresses blocks that do not exist.
+
+URIs use the same namespaces as the FUSE mount — `s3://`, `gcs://`, `az://` —
+so a path addresses the same object through either.
+
+## Reading many ranges of one object
+
+`read` resolves the object's version with a `stat` when one is not supplied.
+That is one extra round trip per call, which is wasted work when reading many
+ranges of the same object: a version is stable for an object generation.
+
+```python
+info = client.stat(uri)
+for offset in range(0, info.size, chunk_size):
+    part = client.read(uri, version=info.version, size=info.size,
+                       offset=offset, length=chunk_size)
+```
+
+Passing `size` as well lets the client clamp at end-of-file without another
+lookup.
+
+## Threads
+
+Blocking calls release the GIL, so a threaded loader is limited by the network
+rather than serialised on the interpreter:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+with ThreadPoolExecutor(max_workers=8) as pool:
+    parts = list(pool.map(
+        lambda off: client.read(uri, version=info.version, size=info.size,
+                                offset=off, length=chunk_size),
+        offsets))
+```
+
+## Short reads
+
+A read at or past end-of-file returns an empty buffer, and a read overlapping
+the end is truncated to what exists — POSIX short-read semantics. **Check the
+returned length** rather than assuming the requested count:
+
+```python
+data = client.read(uri, offset=offset, length=length)
+if len(data) < length:
+    ...  # reached the end of the object
+```
+
+## Errors
+
+Failures raise `OSError` with the worker's own message preserved, so "object
+does not exist" stays distinguishable from "every replica is down". Malformed
+URIs raise `ValueError` before any I/O happens.
+
+## Not yet available
+
+`list` is implemented but returns an error until the backends gain a listing
+capability ([#332](https://github.com/milvus-io/talon/issues/332)). Writes go
+through the FUSE mount or the Rust client.

--- a/docs/use-cases/analytics.md
+++ b/docs/use-cases/analytics.md
@@ -25,6 +25,10 @@ fetch rather than one per reader.
 **Caches by object version.** Blocks are keyed by the origin's ETag, so
 republishing a partition at the same key does not serve stale data to a query.
 
+**Reachable from a JVM engine without a mount.** The
+[Java client](../clients/java.md) is a native-free jar, so a query engine can
+read ranges directly rather than through a privileged FUSE mount.
+
 ## Shuffle: read the caveat
 
 Shuffle intermediates are a **partial fit**, and it is worth being direct about

--- a/docs/use-cases/notebooks.md
+++ b/docs/use-cases/notebooks.md
@@ -16,6 +16,10 @@ Interactive analysis has a different profile from batch compute:
 
 ## What Talon does
 
+**Or skips the filesystem entirely.** The [Python client](../clients/python.md)
+reads objects and byte ranges directly, which suits a notebook that already
+thinks in those terms and avoids needing a privileged mount.
+
 **Presents object storage as a POSIX filesystem.** The FUSE mount maps backend
 namespaces to paths — `/s3/<bucket>/<key>`, `/gcs/...`, `/az/...` — so
 `open()`, `read()`, and `ls` work against object storage with no client library

--- a/docs/use-cases/training.md
+++ b/docs/use-cases/training.md
@@ -36,7 +36,9 @@ and prefetches subsequent blocks, so a scan is not serialised on per-block
 misses.
 
 **Requires no application change.** Training code opens files under the FUSE
-mount; the framework's existing data loader works unmodified.
+mount; the framework's existing data loader works unmodified. A loader that
+would rather speak in objects and byte ranges can use the
+[Python client](../clients/python.md) instead of a mount.
 
 **Runs on the training node without competing for it.** A worker can sit on the
 same host as the job: one CPU and ~7 MB of RSS serves ~49k range reads per


### PR DESCRIPTION
Both clients shipped without documentation beyond their READMEs, so the only way to learn the API was to read the source or the PR.

Three pages under a new **Client SDKs** section: an overview, and one page each for Python and Java.

## Every example was run before being written down

That caught one immediately: the Python snippet failed with

```
TypeError: Client.read() missing 1 required keyword argument: 'version'
```

— because the wheel I had installed predated the API simplification in #333. **An example that has only been read is not an example.** Both are now verified against a live cluster:

```
=== Python example (exactly as documented) ===
size=67108864 version=0x8LOADTEST
read 1048576 bytes
ranged reads ok

=== Java example (exactly as documented) ===
size=67108864 version=0x8LOADTEST
read 1048576 bytes
ranged reads ok
```

`mvn package` is documented but was **not** verifiable here (no Maven on this machine), so the `javac` invocation CI actually uses is given alongside it — and that one was verified.

## The overview leads with when *not* to use a client

A FUSE mount is less invasive and keeps existing code working. The reasons to prefer a client are specific rather than "it's faster": no privileged mount or `/dev/fuse`, no POSIX semantics imposed on a ranged-read API, and the ability to express cache-aware behaviour like reusing a resolved version across many reads.

It also explains **why the two clients have different architectures**, so that does not read as arbitrary — and states the cost of the Java choice (protocol implemented twice) along with the conformance vectors that make it maintainable, including the schema-version bug they caught on the Java client's first run.

## What the READMEs omitted

- **Short-read semantics** — a read past EOF returns empty, one overlapping the end truncates. Check the returned length.
- **Error types and which are worth retrying** — `ProtocolException` means a version mismatch, so retrying will not help.
- **`block_size` must match the workers' configuration**, because placement is computed per block and a mismatch addresses blocks that do not exist.
- **Skipping the per-read `stat`** when reading many ranges of one object.

## Cross-linked

From the README, and from the three use-case pages where a reader would want a client — training, notebooks, and analytics.

## Verification

- `mdbook build` — clean, all three pages render
- `lychee --offline` — 141 links, **0 errors**
- `typos` — clean
- Every documented API signature checked against the source (Python keyword args, both Java `read` overloads, JDK 17, CPython 3.8)

Refs #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)
