### PR TITLE
fix(fuse): write through truncate operations

### DIFF
--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -721,9 +721,11 @@ impl fuser::Filesystem for TalonFuse {
         }
     }
 
-    /// Set attributes; only a size change (truncate) is meaningful for a write
-    /// handle. Other attribute sets are accepted as a no-op so `chmod`/`touch`
-    /// don't fail the write flow.
+    /// Set attributes. Size changes are written through as complete replacement
+    /// objects before the visible inode and handle state is committed.
+    ///
+    /// Other attribute sets are accepted as a no-op until the metadata model is
+    /// implemented, so `chmod`/`touch` do not fail unrelated write flows.
     #[allow(clippy::too_many_arguments)]
     fn setattr(
         &mut self,
@@ -747,11 +749,42 @@ impl fuser::Filesystem for TalonFuse {
             if !self.read_write {
                 return reply.error(libc::EROFS);
             }
-            if let Some(fh) = fh {
-                if let Err(e) = self.fs.truncate(fh, new_size) {
-                    return reply.error(errno(e));
-                }
+            if new_size > self.fs.max_object_bytes() {
+                return reply.error(libc::EFBIG);
             }
+            let (path, contents) = if let Some(fh) = fh {
+                match self.fs.truncate_handle_plan(fh, new_size) {
+                    Ok(plan) => plan,
+                    Err(e) => return reply.error(errno(e)),
+                }
+            } else {
+                let (path, current_size) = match self.fs.inode_file_meta(ino) {
+                    Ok(meta) => meta,
+                    Err(e) => return reply.error(errno(e)),
+                };
+                let retained_size = current_size.min(new_size);
+                let existing = match self.read_committed_object(&path, retained_size) {
+                    Ok(contents) => contents,
+                    Err(error) => return reply.error(error),
+                };
+                match self.fs.truncate_inode_plan(ino, new_size, existing) {
+                    Ok(plan) => plan,
+                    Err(e) => return reply.error(errno(e)),
+                }
+            };
+            if let Err(error) = self.writeback_object(&path, contents.clone()) {
+                tracing::warn!(%path, %error, "truncate writeback failed");
+                return reply.error(libc::EIO);
+            }
+            let attr = if let Some(fh) = fh {
+                self.fs.commit_handle_contents(fh, contents)
+            } else {
+                self.fs.commit_inode_contents(ino, contents)
+            };
+            return match attr {
+                Ok(attr) => reply.attr(&ATTR_TTL, &to_file_attr(attr, req.uid(), req.gid())),
+                Err(e) => reply.error(errno(e)),
+            };
         }
         // Reply with the current attributes.
         match self.fs.getattr(ino) {

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -1193,32 +1193,32 @@ mod tests {
                     write: true,
                     append: false,
                 },
-                Some(b"hello".to_vec()),
+                Some(b"abcde".to_vec()),
             )
             .unwrap();
 
         let (path, planned) = fs.truncate_handle_plan(write_fh, 3).unwrap();
         assert_eq!(path, "s3/bucket/data/a.bin");
-        assert_eq!(planned, b"hel");
+        assert_eq!(planned, b"abc");
         assert_eq!(fs.getattr(file.ino).unwrap().size, 5);
-        assert_eq!(fs.dirty_bytes(write_fh).unwrap(), b"hello");
+        assert_eq!(fs.dirty_bytes(write_fh).unwrap(), b"abcde");
 
         let committed = fs.commit_handle_contents(write_fh, planned).unwrap();
         assert_eq!(committed.size, 3);
-        assert_eq!(fs.dirty_bytes(write_fh).unwrap(), b"hel");
+        assert_eq!(fs.dirty_bytes(write_fh).unwrap(), b"abc");
 
         let (path, planned) = fs
-            .truncate_inode_plan(file.ino, 6, b"hel".to_vec())
+            .truncate_inode_plan(file.ino, 6, b"abc".to_vec())
             .unwrap();
         assert_eq!(path, "s3/bucket/data/a.bin");
-        assert_eq!(planned, vec![b'h', b'e', b'l', 0, 0, 0]);
+        assert_eq!(planned, vec![b'a', b'b', b'c', 0, 0, 0]);
         assert_eq!(fs.getattr(file.ino).unwrap().size, 3);
 
         fs.commit_inode_contents(file.ino, planned).unwrap();
         assert_eq!(fs.getattr(file.ino).unwrap().size, 6);
         assert_eq!(
             fs.dirty_bytes(write_fh).unwrap(),
-            vec![b'h', b'e', b'l', 0, 0, 0]
+            vec![b'a', b'b', b'c', 0, 0, 0]
         );
     }
 

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -627,9 +627,8 @@ impl ReadOnlyFs {
             return Err(FsError::BadHandle);
         }
         let append = handle.append;
-        let dirty = g.dirty.get_mut(&fh).ok_or(FsError::BadHandle)?;
         let start = if append {
-            dirty.buf.len() as u64
+            g.dirty.get(&fh).ok_or(FsError::BadHandle)?.buf.len() as u64
         } else {
             offset
         };
@@ -641,6 +640,7 @@ impl ReadOnlyFs {
         }
         let end: usize = end.try_into().map_err(|_| FsError::TooLarge)?;
         let start: usize = start.try_into().map_err(|_| FsError::TooLarge)?;
+        let dirty = g.dirty.get_mut(&fh).ok_or(FsError::BadHandle)?;
         if dirty.buf.len() < end {
             dirty.buf.resize(end, 0);
         }
@@ -653,13 +653,11 @@ impl ReadOnlyFs {
         Ok(data.len() as u32)
     }
 
-    /// `setattr(size)`: truncate/extend the write handle's buffer to `size`.
-    ///
-    /// Fails with [`FsError::TooLarge`] (`EFBIG`) if `size` exceeds
-    /// [`ReadOnlyFs::max_object_bytes`] — `ftruncate` takes an arbitrary
-    /// user-supplied length and the buffer is zero-filled eagerly.
-    pub fn truncate(&self, fh: u64, size: u64) -> Result<(), FsError> {
-        let mut g = self.inner.lock_recover();
+    /// Build a resized whole-object buffer for `ftruncate` without committing
+    /// the visible size. The caller can write the returned bytes through to the
+    /// backend before calling [`commit_handle_contents`](Self::commit_handle_contents).
+    pub fn truncate_handle_plan(&self, fh: u64, size: u64) -> Result<(String, Vec<u8>), FsError> {
+        let g = self.inner.lock_recover();
         let handle = g.handles.get(&fh).ok_or(FsError::BadHandle)?;
         if !handle.write {
             return Err(FsError::BadHandle);
@@ -668,13 +666,76 @@ impl ReadOnlyFs {
             return Err(FsError::TooLarge);
         }
         let new_len: usize = size.try_into().map_err(|_| FsError::TooLarge)?;
-        let dirty = g.dirty.get_mut(&fh).ok_or(FsError::BadHandle)?;
-        dirty.buf.resize(new_len, 0);
-        let ino = dirty.ino;
-        if let Some(node) = g.nodes.get_mut(&ino) {
-            node.size = size;
+        let dirty = g.dirty.get(&fh).ok_or(FsError::BadHandle)?;
+        let node = g.nodes.get(&dirty.ino).ok_or(FsError::NotFound)?;
+        let mut contents = dirty.buf.clone();
+        contents.resize(new_len, 0);
+        Ok((node.path.clone(), contents))
+    }
+
+    /// Build a resized whole-object buffer for path-based `truncate`.
+    ///
+    /// `contents` must contain the committed prefix that should survive the
+    /// resize. A shrink may pass only the retained prefix; an extension passes
+    /// the complete existing object.
+    pub fn truncate_inode_plan(
+        &self,
+        ino: u64,
+        size: u64,
+        mut contents: Vec<u8>,
+    ) -> Result<(String, Vec<u8>), FsError> {
+        let g = self.inner.lock_recover();
+        let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
+        if node.kind != FileKind::File {
+            return Err(FsError::IsDir);
         }
+        if size > self.max_object_bytes {
+            return Err(FsError::TooLarge);
+        }
+        let new_len: usize = size.try_into().map_err(|_| FsError::TooLarge)?;
+        contents.resize(new_len, 0);
+        Ok((node.path.clone(), contents))
+    }
+
+    /// Commit bytes after a successful handle-based truncate write-through.
+    pub fn commit_handle_contents(&self, fh: u64, contents: Vec<u8>) -> Result<Attr, FsError> {
+        let mut g = self.inner.lock_recover();
+        let handle = g.handles.get(&fh).ok_or(FsError::BadHandle)?;
+        if !handle.write {
+            return Err(FsError::BadHandle);
+        }
+        let ino = handle.ino;
+        Self::commit_inode_contents_locked(&mut g, ino, contents)
+    }
+
+    /// Commit bytes after a successful path-based truncate write-through.
+    pub fn commit_inode_contents(&self, ino: u64, contents: Vec<u8>) -> Result<Attr, FsError> {
+        let mut g = self.inner.lock_recover();
+        Self::commit_inode_contents_locked(&mut g, ino, contents)
+    }
+
+    /// Resize a handle in memory. The mount adapter uses the plan/commit methods
+    /// above so backend write-through happens before this state change.
+    pub fn truncate(&self, fh: u64, size: u64) -> Result<(), FsError> {
+        let (_, contents) = self.truncate_handle_plan(fh, size)?;
+        self.commit_handle_contents(fh, contents)?;
         Ok(())
+    }
+
+    fn commit_inode_contents_locked(
+        g: &mut Inner,
+        ino: u64,
+        contents: Vec<u8>,
+    ) -> Result<Attr, FsError> {
+        let node = g.nodes.get_mut(&ino).ok_or(FsError::NotFound)?;
+        if node.kind != FileKind::File {
+            return Err(FsError::IsDir);
+        }
+        node.size = contents.len() as u64;
+        for dirty in g.dirty.values_mut().filter(|dirty| dirty.ino == ino) {
+            dirty.buf.clone_from(&contents);
+        }
+        Ok(Self::attr_of(g.nodes.get(&ino).unwrap()))
     }
 
     /// Return the assembled object bytes for a write handle (for writeback at
@@ -1117,6 +1178,47 @@ mod tests {
         assert_eq!(
             fs.dirty_bytes(fh).unwrap(),
             vec![b'0', b'1', b'2', b'3', 0, 0]
+        );
+    }
+
+    #[test]
+    fn truncate_plans_do_not_change_visible_state_before_commit() {
+        let fs = fs();
+        let file = fs.lookup(data_dir(&fs).ino, "a.bin").unwrap();
+        let write_fh = fs
+            .open_with_options(
+                file.ino,
+                OpenOptions {
+                    read: true,
+                    write: true,
+                    append: false,
+                },
+                Some(b"hello".to_vec()),
+            )
+            .unwrap();
+
+        let (path, planned) = fs.truncate_handle_plan(write_fh, 3).unwrap();
+        assert_eq!(path, "s3/bucket/data/a.bin");
+        assert_eq!(planned, b"hel");
+        assert_eq!(fs.getattr(file.ino).unwrap().size, 5);
+        assert_eq!(fs.dirty_bytes(write_fh).unwrap(), b"hello");
+
+        let committed = fs.commit_handle_contents(write_fh, planned).unwrap();
+        assert_eq!(committed.size, 3);
+        assert_eq!(fs.dirty_bytes(write_fh).unwrap(), b"hel");
+
+        let (path, planned) = fs
+            .truncate_inode_plan(file.ino, 6, b"hel".to_vec())
+            .unwrap();
+        assert_eq!(path, "s3/bucket/data/a.bin");
+        assert_eq!(planned, vec![b'h', b'e', b'l', 0, 0, 0]);
+        assert_eq!(fs.getattr(file.ino).unwrap().size, 3);
+
+        fs.commit_inode_contents(file.ino, planned).unwrap();
+        assert_eq!(fs.getattr(file.ino).unwrap().size, 6);
+        assert_eq!(
+            fs.dirty_bytes(write_fh).unwrap(),
+            vec![b'h', b'e', b'l', 0, 0, 0]
         );
     }
 

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -617,6 +617,106 @@ async fn mount_directory_markers_are_written_through() {
     assert!(remounted.readdir(persisted.ino).unwrap().is_empty());
 }
 
+/// Write path and descriptor truncation through immediately to the blob store.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires /dev/fuse; run with --features mount -- --ignored"]
+async fn mount_truncate_and_ftruncate_are_written_through() {
+    use fuser::MountOption;
+
+    let block_size: u32 = 4 * 1024 * 1024;
+    let store: Store = Arc::new(Mutex::new(HashMap::from([(
+        "/s3/bucket/data.bin".to_string(),
+        b"abcdef".to_vec(),
+    )])));
+    let worker = spawn_rw_worker(Arc::clone(&store)).await;
+    let coord = spawn_coordinator(worker).await;
+
+    let fs = Arc::new(ReadOnlyFs::new());
+    fs.insert_object("s3/bucket/data.bin", 6);
+
+    let cache = Arc::new(PlacementCache::new(10_000));
+    let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
+    let adapter = TalonFuse::new(
+        Arc::clone(&fs),
+        reader,
+        tokio::runtime::Handle::current(),
+        block_size,
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
+    )
+    .with_read_write(true);
+
+    let require_fuse = std::env::var_os("TALON_REQUIRE_FUSE").is_some();
+    let mountpoint =
+        std::env::temp_dir().join(format!("talon-mount-e2e-truncate-{}", std::process::id()));
+    std::fs::create_dir_all(&mountpoint).unwrap();
+    let options = vec![MountOption::FSName("talon".into())];
+    let session = match fuser::spawn_mount2(adapter, &mountpoint, &options) {
+        Ok(session) => session,
+        Err(error) => {
+            std::fs::remove_dir_all(&mountpoint).ok();
+            if require_fuse {
+                panic!(
+                    "TALON_REQUIRE_FUSE is set but the FUSE mount failed: {error}. \
+                     The runner must provide an accessible /dev/fuse."
+                );
+            }
+            eprintln!("skipping: /dev/fuse unavailable: {error}");
+            return;
+        }
+    };
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let file_path = mountpoint.join("s3").join("bucket").join("data.bin");
+    let directory_path = mountpoint.join("s3").join("bucket");
+    let operation_store = Arc::clone(&store);
+    let result = tokio::task::spawn_blocking(move || {
+        let c_path = std::ffi::CString::new(file_path.to_str().unwrap()).unwrap();
+        let status = unsafe { libc::truncate(c_path.as_ptr(), 3) };
+        assert_eq!(
+            status,
+            0,
+            "path truncate failed: {}",
+            std::io::Error::last_os_error()
+        );
+        assert_eq!(
+            operation_store.lock().unwrap().get("/s3/bucket/data.bin"),
+            Some(&b"abc".to_vec()),
+            "truncate must replace the blob before returning"
+        );
+
+        let file = std::fs::OpenOptions::new().write(true).open(&file_path)?;
+        file.set_len(6)?;
+        assert_eq!(
+            operation_store.lock().unwrap().get("/s3/bucket/data.bin"),
+            Some(&vec![b'a', b'b', b'c', 0, 0, 0]),
+            "ftruncate must zero-extend and replace the blob before returning"
+        );
+
+        let read_only = std::fs::File::open(&file_path)?;
+        let bad_fd = read_only.set_len(2).unwrap_err();
+        assert_eq!(bad_fd.raw_os_error(), Some(libc::EINVAL));
+
+        let directory = std::ffi::CString::new(directory_path.to_str().unwrap()).unwrap();
+        let status = unsafe { libc::truncate(directory.as_ptr(), 0) };
+        assert_eq!(status, -1);
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::EISDIR)
+        );
+
+        let too_large = file.set_len((1 << 30) + 1).unwrap_err();
+        assert_eq!(too_large.raw_os_error(), Some(libc::EFBIG));
+        assert_eq!(std::fs::metadata(&file_path)?.len(), 6);
+        Ok::<(), std::io::Error>(())
+    })
+    .await
+    .unwrap();
+
+    drop(session);
+    std::fs::remove_dir_all(&mountpoint).ok();
+    result.expect("exercise truncate and ftruncate through mount");
+}
+
 /// Mount the read-write fixture and run the pinned pjdfstest suite against it.
 ///
 /// This is separately gated because the normal real-kernel smoke job runs all


### PR DESCRIPTION
## Summary

Complete path-based `truncate` and descriptor-based `ftruncate` for Talon FUSE using whole-object write-through. The resized object is PUT to the owning worker before inode and handle state changes become visible, and oversized writes/truncates are rejected before allocation.

This PR is stacked on #336, which is stacked on #334. Its diff will shrink to the truncate-specific commits as the prerequisite PRs merge.

## Related issues

- Progresses #329
- Part of #259 and #262

## Type of change

- [x] Bug fix
- [x] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [x] Docs / tests / tooling

## Design alignment

Talon continues to use a whole-object write model. Truncation builds the replacement bytes, writes them directly through the existing worker/backend path, and only then commits the new namespace size. No metadata or write-back cache is added.

## Changes

- Add a configurable 1 GiB default cap for per-object in-memory write buffers.
- Return `EFBIG` before allocating for oversized offsets, writes, and truncates.
- Use checked offset arithmetic so malformed large writes cannot panic or poison the namespace lock.
- Implement path-based `truncate` by reading only the retained prefix, zero-extending when needed, and replacing the backend object.
- Implement `ftruncate` as a two-phase plan/write-through/commit operation.
- Keep active handle buffers and visible inode size coherent after a successful truncate.
- Add unit coverage for allocation bounds, overflow, zero-fill, and commit ordering.
- Add a real-kernel test for path truncate, ftruncate, immediate backend bytes, `EINVAL`, `EISDIR`, and `EFBIG`.

## Test plan

- [x] `cargo test -p talon-fuse --lib --features mount --locked`: 101 passed
- [x] `cargo test -p talon-fuse --features mount --test mount_e2e --no-run --locked`
- [x] `cargo clippy -p talon-fuse --features mount --all-targets --locked -- -D warnings`
- [x] Exact commit `53d6d83c4f081cffbe66276642f31f5d66213807` passed `mount_truncate_and_ftruncate_are_written_through` in a privileged `falcon-phx-ca` Job with host `/dev/fuse`
- [x] Real-kernel `truncate,ftruncate` pjdfstest: 142 passed, 31 failed out of 173, up from 82 passed and 91 failed

The remaining grouped failures depend on permissions and ownership (#328), timestamps (#324), and symlinks (#323), rather than the core resize and persistence path.

## Performance impact

Path truncation reads the retained object prefix and performs one synchronous whole-object PUT. Descriptor truncation performs one synchronous whole-object PUT. This is the required write-through durability behavior and does not affect read-only operations.

- [x] Not performance-sensitive outside explicit truncate operations

## Checklist

- [x] PR title follows Conventional Commits
- [x] Public behavior is covered by tests
- [x] No new dependencies
- [x] Based on the latest `main` through the stacked prerequisite branches
