### PR TITLE
fix(fuse): write through regular file rename

### DIFF
--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -839,6 +839,95 @@ impl fuser::Filesystem for TalonFuse {
         }
     }
 
+    /// Rename a regular file by replacing the destination blob, deleting the
+    /// source blob, and only then committing the namespace move.
+    fn rename(
+        &mut self,
+        _req: &fuser::Request<'_>,
+        parent: u64,
+        name: &std::ffi::OsStr,
+        newparent: u64,
+        newname: &std::ffi::OsStr,
+        flags: u32,
+        reply: fuser::ReplyEmpty,
+    ) {
+        if !self.read_write {
+            return reply.error(libc::EROFS);
+        }
+        if flags != 0 {
+            return reply.error(libc::EINVAL);
+        }
+        let (name, newname) = match (name.to_str(), newname.to_str()) {
+            (Some(name), Some(newname)) => (name, newname),
+            _ => return reply.error(libc::EINVAL),
+        };
+        let plan = match self.fs.file_rename_plan(parent, name, newparent, newname) {
+            Ok(plan) => plan,
+            Err(error) => return reply.error(errno(error)),
+        };
+        if plan.source_path == plan.target_path {
+            return reply.ok();
+        }
+        let source_bytes = match self.read_committed_object(&plan.source_path, plan.source_size) {
+            Ok(bytes) => bytes,
+            Err(error) => return reply.error(error),
+        };
+        let target_backup = match plan.target {
+            Some((_, size)) => match self.read_committed_object(&plan.target_path, size) {
+                Ok(bytes) => Some(bytes),
+                Err(error) => return reply.error(error),
+            },
+            None => None,
+        };
+        if let Err(error) = self.writeback_object(&plan.target_path, source_bytes.clone()) {
+            tracing::warn!(
+                source = %plan.source_path,
+                target = %plan.target_path,
+                %error,
+                "rename destination writeback failed"
+            );
+            return reply.error(libc::EIO);
+        }
+        if let Err(error) = self.delete_backend_object(&plan.source_path) {
+            let rollback = match target_backup {
+                Some(bytes) => self.writeback_object(&plan.target_path, bytes),
+                None => self.delete_backend_object(&plan.target_path),
+            };
+            if let Err(rollback_error) = rollback {
+                tracing::error!(
+                    target = %plan.target_path,
+                    %rollback_error,
+                    "rename destination rollback failed"
+                );
+            }
+            tracing::warn!(source = %plan.source_path, %error, "rename source delete failed");
+            return reply.error(libc::EIO);
+        }
+        if let Err(error) = self.fs.commit_file_rename(&plan) {
+            let restore_source = self.writeback_object(&plan.source_path, source_bytes);
+            let restore_target = match target_backup {
+                Some(bytes) => self.writeback_object(&plan.target_path, bytes),
+                None => self.delete_backend_object(&plan.target_path),
+            };
+            if let Err(rollback_error) = restore_source {
+                tracing::error!(
+                    source = %plan.source_path,
+                    %rollback_error,
+                    "rename source rollback failed"
+                );
+            }
+            if let Err(rollback_error) = restore_target {
+                tracing::error!(
+                    target = %plan.target_path,
+                    %rollback_error,
+                    "rename target rollback failed"
+                );
+            }
+            return reply.error(errno(error));
+        }
+        reply.ok();
+    }
+
     /// Remove a file: delete the backend object, then drop the namespace node.
     fn unlink(
         &mut self,

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -116,6 +116,20 @@ pub struct DirEntry {
     pub name: String,
 }
 
+/// Immutable backend and namespace facts for a regular-file rename.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileRenamePlan {
+    pub(crate) source_ino: u64,
+    pub(crate) source_parent: u64,
+    pub(crate) source_name: String,
+    pub(crate) source_path: String,
+    pub(crate) source_size: u64,
+    pub(crate) target_parent: u64,
+    pub(crate) target_name: String,
+    pub(crate) target_path: String,
+    pub(crate) target: Option<(u64, u64)>,
+}
+
 #[derive(Debug, Clone)]
 struct Node {
     ino: u64,
@@ -765,6 +779,113 @@ impl ReadOnlyFs {
         Some(node.path.clone())
     }
 
+    /// Validate and describe a regular-file rename without mutating namespace.
+    pub fn file_rename_plan(
+        &self,
+        source_parent: u64,
+        source_name: &str,
+        target_parent: u64,
+        target_name: &str,
+    ) -> Result<FileRenamePlan, FsError> {
+        Self::validate_component(source_name)?;
+        Self::validate_component(target_name)?;
+        let g = self.inner.lock_recover();
+        let source_parent_node = g.nodes.get(&source_parent).ok_or(FsError::NotFound)?;
+        let target_parent_node = g.nodes.get(&target_parent).ok_or(FsError::NotFound)?;
+        if source_parent_node.kind != FileKind::Directory
+            || target_parent_node.kind != FileKind::Directory
+        {
+            return Err(FsError::NotDir);
+        }
+        let source_ino = *g
+            .index
+            .get(&(source_parent, source_name.to_string()))
+            .ok_or(FsError::NotFound)?;
+        let source = g.nodes.get(&source_ino).ok_or(FsError::NotFound)?;
+        if source.kind != FileKind::File {
+            return Err(FsError::IsDir);
+        }
+        let target_path = Self::child_path(target_parent_node, target_name);
+        path_to_object(&target_path).map_err(|_| FsError::Invalid)?;
+        let target = match g.index.get(&(target_parent, target_name.to_string())) {
+            Some(&target_ino) if target_ino == source_ino => None,
+            Some(&target_ino) => {
+                let node = g.nodes.get(&target_ino).ok_or(FsError::NotFound)?;
+                if node.kind != FileKind::File {
+                    return Err(FsError::IsDir);
+                }
+                Some((target_ino, node.size))
+            }
+            None => None,
+        };
+        Ok(FileRenamePlan {
+            source_ino,
+            source_parent,
+            source_name: source_name.to_string(),
+            source_path: source.path.clone(),
+            source_size: source.size,
+            target_parent,
+            target_name: target_name.to_string(),
+            target_path,
+            target,
+        })
+    }
+
+    /// Commit a regular-file rename after backend copy/delete succeeds.
+    pub fn commit_file_rename(&self, plan: &FileRenamePlan) -> Result<(), FsError> {
+        if plan.source_path == plan.target_path {
+            return Ok(());
+        }
+        let mut g = self.inner.lock_recover();
+        let current_source = g
+            .index
+            .get(&(plan.source_parent, plan.source_name.clone()))
+            .copied();
+        if current_source != Some(plan.source_ino) {
+            return Err(FsError::NotFound);
+        }
+        if let Some((target_ino, _)) = plan.target {
+            let current_target = g
+                .index
+                .get(&(plan.target_parent, plan.target_name.clone()))
+                .copied();
+            if current_target != Some(target_ino) {
+                return Err(FsError::Exists);
+            }
+            g.index
+                .remove(&(plan.target_parent, plan.target_name.clone()));
+            if let Some(parent) = g.nodes.get_mut(&plan.target_parent) {
+                parent.children.retain(|child| *child != target_ino);
+            }
+            g.nodes.remove(&target_ino);
+        } else if g
+            .index
+            .contains_key(&(plan.target_parent, plan.target_name.clone()))
+        {
+            return Err(FsError::Exists);
+        }
+
+        g.index
+            .remove(&(plan.source_parent, plan.source_name.clone()));
+        if let Some(parent) = g.nodes.get_mut(&plan.source_parent) {
+            parent.children.retain(|child| *child != plan.source_ino);
+        }
+        let source = g.nodes.get_mut(&plan.source_ino).ok_or(FsError::NotFound)?;
+        source.parent = Some(plan.target_parent);
+        source.name.clone_from(&plan.target_name);
+        source.path.clone_from(&plan.target_path);
+        g.index.insert(
+            (plan.target_parent, plan.target_name.clone()),
+            plan.source_ino,
+        );
+        g.nodes
+            .get_mut(&plan.target_parent)
+            .ok_or(FsError::NotFound)?
+            .children
+            .push(plan.source_ino);
+        Ok(())
+    }
+
     /// Validate a new directory and return its trailing-slash marker path.
     pub fn new_directory_marker_path(
         &self,
@@ -1219,6 +1340,68 @@ mod tests {
         assert_eq!(
             fs.dirty_bytes(write_fh).unwrap(),
             vec![b'a', b'b', b'c', 0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn file_rename_preserves_inode_and_updates_open_handles() {
+        let fs = fs();
+        let parent = data_dir(&fs);
+        let source = fs.lookup(parent.ino, "a.bin").unwrap();
+        let fh = fs
+            .open_with_options(
+                source.ino,
+                OpenOptions {
+                    read: true,
+                    write: true,
+                    append: false,
+                },
+                Some(b"contents".to_vec()),
+            )
+            .unwrap();
+
+        let plan = fs
+            .file_rename_plan(parent.ino, "a.bin", parent.ino, "renamed.bin")
+            .unwrap();
+        assert_eq!(plan.source_path, "s3/bucket/data/a.bin");
+        assert_eq!(plan.target_path, "s3/bucket/data/renamed.bin");
+        assert_eq!(fs.lookup(parent.ino, "a.bin").unwrap().ino, source.ino);
+
+        fs.commit_file_rename(&plan).unwrap();
+        assert_eq!(fs.lookup(parent.ino, "a.bin"), Err(FsError::NotFound));
+        assert_eq!(
+            fs.lookup(parent.ino, "renamed.bin").unwrap().ino,
+            source.ino
+        );
+        assert_eq!(
+            fs.dirty_path(fh).as_deref(),
+            Some("s3/bucket/data/renamed.bin")
+        );
+    }
+
+    #[test]
+    fn file_rename_replaces_a_regular_file_and_rejects_directories() {
+        let fs = fs();
+        let parent = data_dir(&fs);
+        let source = fs.lookup(parent.ino, "a.bin").unwrap();
+        let replaced = fs.lookup(parent.ino, "b.bin").unwrap();
+
+        let plan = fs
+            .file_rename_plan(parent.ino, "a.bin", parent.ino, "b.bin")
+            .unwrap();
+        assert_eq!(plan.target, Some((replaced.ino, 500)));
+        fs.commit_file_rename(&plan).unwrap();
+        assert_eq!(fs.lookup(parent.ino, "b.bin").unwrap().ino, source.ino);
+        assert_eq!(fs.getattr(replaced.ino), Err(FsError::NotFound));
+
+        assert_eq!(
+            fs.file_rename_plan(
+                fs.lookup(ROOT_INO, "s3").unwrap().ino,
+                "bucket",
+                parent.ino,
+                "bucket"
+            ),
+            Err(FsError::IsDir)
         );
     }
 

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -717,6 +717,99 @@ async fn mount_truncate_and_ftruncate_are_written_through() {
     result.expect("exercise truncate and ftruncate through mount");
 }
 
+/// Rename regular files through backend PUT/DELETE and preserve open handles.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires /dev/fuse; run with --features mount -- --ignored"]
+async fn mount_regular_file_rename_is_written_through() {
+    use fuser::MountOption;
+
+    let block_size: u32 = 4 * 1024 * 1024;
+    let store: Store = Arc::new(Mutex::new(HashMap::from([
+        ("/s3/bucket/source.bin".to_string(), b"source".to_vec()),
+        ("/s3/bucket/target.bin".to_string(), b"old".to_vec()),
+    ])));
+    let worker = spawn_rw_worker(Arc::clone(&store)).await;
+    let coord = spawn_coordinator(worker).await;
+
+    let fs = Arc::new(ReadOnlyFs::new());
+    fs.insert_object("s3/bucket/source.bin", 6);
+    fs.insert_object("s3/bucket/target.bin", 3);
+
+    let cache = Arc::new(PlacementCache::new(10_000));
+    let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
+    let adapter = TalonFuse::new(
+        Arc::clone(&fs),
+        reader,
+        tokio::runtime::Handle::current(),
+        block_size,
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
+    )
+    .with_read_write(true);
+
+    let require_fuse = std::env::var_os("TALON_REQUIRE_FUSE").is_some();
+    let mountpoint =
+        std::env::temp_dir().join(format!("talon-mount-e2e-rename-{}", std::process::id()));
+    std::fs::create_dir_all(&mountpoint).unwrap();
+    let options = vec![MountOption::FSName("talon".into())];
+    let session = match fuser::spawn_mount2(adapter, &mountpoint, &options) {
+        Ok(session) => session,
+        Err(error) => {
+            std::fs::remove_dir_all(&mountpoint).ok();
+            if require_fuse {
+                panic!(
+                    "TALON_REQUIRE_FUSE is set but the FUSE mount failed: {error}. \
+                     The runner must provide an accessible /dev/fuse."
+                );
+            }
+            eprintln!("skipping: /dev/fuse unavailable: {error}");
+            return;
+        }
+    };
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let bucket = mountpoint.join("s3").join("bucket");
+    let operation_store = Arc::clone(&store);
+    let result = tokio::task::spawn_blocking(move || {
+        let source = bucket.join("source.bin");
+        let target = bucket.join("target.bin");
+        let mut open_source = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&source)?;
+
+        std::fs::rename(&source, &target)?;
+        assert!(!source.exists());
+        assert_eq!(std::fs::read(&target)?, b"source");
+        {
+            let committed = operation_store.lock().unwrap();
+            assert!(!committed.contains_key("/s3/bucket/source.bin"));
+            assert_eq!(
+                committed.get("/s3/bucket/target.bin"),
+                Some(&b"source".to_vec())
+            );
+        }
+
+        open_source.seek(SeekFrom::Start(0))?;
+        open_source.write_all(b"XY")?;
+        open_source.sync_all()?;
+        assert_eq!(
+            operation_store.lock().unwrap().get("/s3/bucket/target.bin"),
+            Some(&b"XYurce".to_vec()),
+            "the pre-rename handle must flush to the new object key"
+        );
+
+        std::fs::rename(&target, &target)?;
+        assert_eq!(std::fs::read(&target)?, b"XYurce");
+        Ok::<(), std::io::Error>(())
+    })
+    .await
+    .unwrap();
+
+    drop(session);
+    std::fs::remove_dir_all(&mountpoint).ok();
+    result.expect("exercise regular-file rename through mount");
+}
+
 /// Mount the read-write fixture and run the pinned pjdfstest suite against it.
 ///
 /// This is separately gated because the normal real-kernel smoke job runs all


### PR DESCRIPTION
## Summary

Implement regular-file rename for Talon FUSE using direct blob-store write-through. Rename preserves the source inode, replaces an existing regular-file target, and keeps pre-rename open handles pointed at the new object key.

This PR is stacked on #338. Its diff will shrink to the rename-specific commit after the prerequisite PRs merge.

## Related issues

- Progresses #325
- Part of #259 and #262

## Type of change

- [x] Bug fix
- [x] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [x] Docs / tests / tooling

## Design alignment

Object stores do not provide a portable atomic rename. Talon therefore performs a guarded whole-object PUT to the destination, DELETE of the source, and only then commits the namespace move. Failed source deletion restores the previous destination; a failed namespace commit restores both backend keys.

## Changes

- Add immutable namespace rename planning and post-backend commit APIs.
- Preserve the source inode across same-directory and cross-directory moves.
- Replace existing regular-file destinations with POSIX type checks.
- Update open-handle paths when the inode moves.
- Reject unsupported rename flags and file/directory type conflicts with stable errno values.
- Add destination backup and backend rollback for partial PUT/DELETE failures.
- Add unit tests for inode identity, replacement, type errors, and open handles.
- Add a real-kernel test for destination replacement, backend key movement, and writes through a pre-rename descriptor.

## Test plan

- [x] `cargo test -p talon-fuse --lib --features mount --locked`: 103 passed
- [x] `cargo test -p talon-fuse --features mount --test mount_e2e --no-run --locked`
- [x] `cargo clippy -p talon-fuse --features mount --all-targets --locked -- -D warnings`
- [x] Exact commit `a70338c13bd608fd64f081cc9890f164ec1eeb51` passed `mount_regular_file_rename_is_written_through` in a privileged `falcon-phx-ca` Job with host `/dev/fuse`
- [x] Full real-kernel `rename,unlink` pjdfstest: 1,947 passed, 3,350 failed out of 5,297, up from 1,775 passed and 3,522 failed

The remaining group failures are dominated by directory rename, permissions and ownership (#328), links (#323), special nodes (#327), timestamps (#324), and unlink-while-open lifetime.

## Performance impact

Regular-file rename reads the source object, optionally reads the destination for rollback, then performs one destination PUT and one source DELETE. This cost is limited to explicit rename operations.

- [x] Not performance-sensitive outside explicit rename operations

## Checklist

- [x] PR title follows Conventional Commits
- [x] Public behavior is covered by tests
- [x] No new dependencies
- [x] Based on the latest `main` through the stacked prerequisite branches
