### PR TITLE
fix(fuse): write through directory tree rename

### DIFF
--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -22,7 +22,10 @@ use std::time::Duration;
 use crate::block_reader::{BlockReader, FileView};
 use crate::lock::MutexExt;
 use crate::mapping::path_to_object;
-use crate::ops::{Attr, FileKind, FsError, OpenOptions, ReadOnlyFs, ReadSource};
+use crate::ops::{
+    Attr, DirectoryRenameEntry, DirectoryRenamePlan, FileKind, FsError, OpenOptions, ReadOnlyFs,
+    ReadSource,
+};
 use crate::prefetch::Prefetcher;
 use crate::readahead::ReadaheadConfig;
 use talon_core::ObjectId;
@@ -325,6 +328,123 @@ impl TalonFuse {
         let mut object = path_to_object(directory_path)?;
         object.object_path.push('/');
         Ok(object)
+    }
+
+    fn write_backend_path(&self, path: &str, marker: bool, bytes: Vec<u8>) -> anyhow::Result<()> {
+        if marker {
+            self.writeback_object_id(Self::directory_marker_object(path)?, bytes)
+        } else {
+            self.writeback_object(path, bytes)
+        }
+    }
+
+    fn delete_backend_path(&self, path: &str, marker: bool) -> anyhow::Result<()> {
+        if marker {
+            self.delete_backend_object_id(Self::directory_marker_object(path)?)
+        } else {
+            self.delete_backend_object(path)
+        }
+    }
+
+    fn read_directory_rename_entry(&self, entry: &DirectoryRenameEntry) -> Result<Vec<u8>, i32> {
+        if entry.marker {
+            Ok(Vec::new())
+        } else {
+            self.read_committed_object(&entry.source_path, entry.size)
+        }
+    }
+
+    fn rollback_directory_rename(
+        &self,
+        plan: &DirectoryRenamePlan,
+        source_objects: &[(DirectoryRenameEntry, Vec<u8>)],
+    ) {
+        for (entry, bytes) in source_objects {
+            if let Err(error) =
+                self.write_backend_path(&entry.source_path, entry.marker, bytes.clone())
+            {
+                tracing::error!(
+                    path = %entry.source_path,
+                    %error,
+                    "directory rename source rollback failed"
+                );
+            }
+        }
+        for (entry, _) in source_objects.iter().rev() {
+            if let Err(error) = self.delete_backend_path(&entry.target_path, entry.marker) {
+                tracing::error!(
+                    path = %entry.target_path,
+                    %error,
+                    "directory rename target rollback failed"
+                );
+            }
+        }
+        if matches!(plan.target, Some((_, true))) {
+            let marker_path = format!("{}/", plan.target_path);
+            if let Err(error) = self.write_backend_path(&marker_path, true, Vec::new()) {
+                tracing::error!(
+                    path = %marker_path,
+                    %error,
+                    "directory rename replaced-marker rollback failed"
+                );
+            }
+        }
+    }
+
+    fn rename_directory_backend(&self, plan: &DirectoryRenamePlan) -> Result<(), i32> {
+        if plan.source_path == plan.target_path {
+            return Ok(());
+        }
+        let mut source_objects = Vec::with_capacity(plan.entries.len());
+        for entry in &plan.entries {
+            source_objects.push((entry.clone(), self.read_directory_rename_entry(entry)?));
+        }
+        for (entry, bytes) in &source_objects {
+            if let Err(error) =
+                self.write_backend_path(&entry.target_path, entry.marker, bytes.clone())
+            {
+                tracing::warn!(
+                    source = %entry.source_path,
+                    target = %entry.target_path,
+                    %error,
+                    "directory rename target writeback failed"
+                );
+                self.rollback_directory_rename(plan, &source_objects);
+                return Err(libc::EIO);
+            }
+        }
+        let target_root_marker = format!("{}/", plan.target_path);
+        let source_replaces_target_marker = plan
+            .entries
+            .iter()
+            .any(|entry| entry.marker && entry.target_path == target_root_marker);
+        if matches!(plan.target, Some((_, true))) && !source_replaces_target_marker {
+            if let Err(error) = self.delete_backend_path(&target_root_marker, true) {
+                tracing::warn!(
+                    path = %target_root_marker,
+                    %error,
+                    "directory rename replaced-marker delete failed"
+                );
+                self.rollback_directory_rename(plan, &source_objects);
+                return Err(libc::EIO);
+            }
+        }
+        for (entry, _) in source_objects.iter().rev() {
+            if let Err(error) = self.delete_backend_path(&entry.source_path, entry.marker) {
+                tracing::warn!(
+                    path = %entry.source_path,
+                    %error,
+                    "directory rename source delete failed"
+                );
+                self.rollback_directory_rename(plan, &source_objects);
+                return Err(libc::EIO);
+            }
+        }
+        if let Err(error) = self.fs.commit_directory_rename(plan) {
+            self.rollback_directory_rename(plan, &source_objects);
+            return Err(errno(error));
+        }
+        Ok(())
     }
 
     /// Read the complete committed object before a non-truncating write open.
@@ -861,6 +981,23 @@ impl fuser::Filesystem for TalonFuse {
             (Some(name), Some(newname)) => (name, newname),
             _ => return reply.error(libc::EINVAL),
         };
+        let source = match self.fs.lookup(parent, name) {
+            Ok(source) => source,
+            Err(error) => return reply.error(errno(error)),
+        };
+        if source.kind == FileKind::Directory {
+            let plan = match self
+                .fs
+                .directory_rename_plan(parent, name, newparent, newname)
+            {
+                Ok(plan) => plan,
+                Err(error) => return reply.error(errno(error)),
+            };
+            return match self.rename_directory_backend(&plan) {
+                Ok(()) => reply.ok(),
+                Err(error) => reply.error(error),
+            };
+        }
         let plan = match self.fs.file_rename_plan(parent, name, newparent, newname) {
             Ok(plan) => plan,
             Err(error) => return reply.error(errno(error)),

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -130,6 +130,29 @@ pub struct FileRenamePlan {
     pub(crate) target: Option<(u64, u64)>,
 }
 
+/// One backend object moved as part of a directory-tree rename.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectoryRenameEntry {
+    pub(crate) source_path: String,
+    pub(crate) target_path: String,
+    pub(crate) size: u64,
+    pub(crate) marker: bool,
+}
+
+/// Immutable backend and namespace facts for a directory-tree rename.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectoryRenamePlan {
+    pub(crate) source_ino: u64,
+    pub(crate) source_parent: u64,
+    pub(crate) source_name: String,
+    pub(crate) source_path: String,
+    pub(crate) target_parent: u64,
+    pub(crate) target_name: String,
+    pub(crate) target_path: String,
+    pub(crate) target: Option<(u64, bool)>,
+    pub(crate) entries: Vec<DirectoryRenameEntry>,
+}
+
 #[derive(Debug, Clone)]
 struct Node {
     ino: u64,
@@ -886,6 +909,184 @@ impl ReadOnlyFs {
         Ok(())
     }
 
+    /// Validate and describe a directory-tree rename without mutating namespace.
+    pub fn directory_rename_plan(
+        &self,
+        source_parent: u64,
+        source_name: &str,
+        target_parent: u64,
+        target_name: &str,
+    ) -> Result<DirectoryRenamePlan, FsError> {
+        Self::validate_component(source_name)?;
+        Self::validate_component(target_name)?;
+        let g = self.inner.lock_recover();
+        let source_parent_node = g.nodes.get(&source_parent).ok_or(FsError::NotFound)?;
+        let target_parent_node = g.nodes.get(&target_parent).ok_or(FsError::NotFound)?;
+        if source_parent_node.kind != FileKind::Directory
+            || target_parent_node.kind != FileKind::Directory
+        {
+            return Err(FsError::NotDir);
+        }
+        let source_ino = *g
+            .index
+            .get(&(source_parent, source_name.to_string()))
+            .ok_or(FsError::NotFound)?;
+        let source = g.nodes.get(&source_ino).ok_or(FsError::NotFound)?;
+        if source.kind != FileKind::Directory {
+            return Err(FsError::NotDir);
+        }
+        let target_path = Self::child_path(target_parent_node, target_name);
+        if source.path == target_path {
+            return Ok(DirectoryRenamePlan {
+                source_ino,
+                source_parent,
+                source_name: source_name.to_string(),
+                source_path: source.path.clone(),
+                target_parent,
+                target_name: target_name.to_string(),
+                target_path,
+                target: None,
+                entries: Vec::new(),
+            });
+        }
+        let mut ancestor = Some(target_parent);
+        while let Some(ino) = ancestor {
+            if ino == source_ino {
+                return Err(FsError::Invalid);
+            }
+            ancestor = g.nodes.get(&ino).and_then(|node| node.parent);
+        }
+        path_to_object(&target_path).map_err(|_| FsError::Invalid)?;
+        let target = match g.index.get(&(target_parent, target_name.to_string())) {
+            Some(&target_ino) => {
+                let node = g.nodes.get(&target_ino).ok_or(FsError::NotFound)?;
+                if node.kind != FileKind::Directory {
+                    return Err(FsError::NotDir);
+                }
+                if !node.children.is_empty() {
+                    return Err(FsError::NotEmpty);
+                }
+                Some((target_ino, node.directory_marker))
+            }
+            None => None,
+        };
+
+        let mut stack = vec![source_ino];
+        let mut entries = Vec::new();
+        while let Some(ino) = stack.pop() {
+            let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
+            stack.extend(node.children.iter().copied());
+            let suffix = node
+                .path
+                .strip_prefix(&source.path)
+                .ok_or(FsError::Invalid)?;
+            let moved_path = format!("{target_path}{suffix}");
+            match node.kind {
+                FileKind::File => entries.push(DirectoryRenameEntry {
+                    source_path: node.path.clone(),
+                    target_path: moved_path,
+                    size: node.size,
+                    marker: false,
+                }),
+                FileKind::Directory if node.directory_marker => {
+                    entries.push(DirectoryRenameEntry {
+                        source_path: format!("{}/", node.path),
+                        target_path: format!("{moved_path}/"),
+                        size: 0,
+                        marker: true,
+                    });
+                }
+                FileKind::Directory => {}
+            }
+        }
+        entries.sort_by(|left, right| left.source_path.cmp(&right.source_path));
+        Ok(DirectoryRenamePlan {
+            source_ino,
+            source_parent,
+            source_name: source_name.to_string(),
+            source_path: source.path.clone(),
+            target_parent,
+            target_name: target_name.to_string(),
+            target_path,
+            target,
+            entries,
+        })
+    }
+
+    /// Commit a directory-tree rename after all backend moves succeed.
+    pub fn commit_directory_rename(&self, plan: &DirectoryRenamePlan) -> Result<(), FsError> {
+        if plan.source_path == plan.target_path {
+            return Ok(());
+        }
+        let mut g = self.inner.lock_recover();
+        if g.index
+            .get(&(plan.source_parent, plan.source_name.clone()))
+            .copied()
+            != Some(plan.source_ino)
+        {
+            return Err(FsError::NotFound);
+        }
+        if let Some((target_ino, _)) = plan.target {
+            if g.index
+                .get(&(plan.target_parent, plan.target_name.clone()))
+                .copied()
+                != Some(target_ino)
+            {
+                return Err(FsError::Exists);
+            }
+            let target = g.nodes.get(&target_ino).ok_or(FsError::NotFound)?;
+            if target.kind != FileKind::Directory || !target.children.is_empty() {
+                return Err(FsError::NotEmpty);
+            }
+            g.index
+                .remove(&(plan.target_parent, plan.target_name.clone()));
+            if let Some(parent) = g.nodes.get_mut(&plan.target_parent) {
+                parent.children.retain(|child| *child != target_ino);
+            }
+            g.nodes.remove(&target_ino);
+        } else if g
+            .index
+            .contains_key(&(plan.target_parent, plan.target_name.clone()))
+        {
+            return Err(FsError::Exists);
+        }
+
+        let mut stack = vec![plan.source_ino];
+        let mut subtree = Vec::new();
+        while let Some(ino) = stack.pop() {
+            let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
+            stack.extend(node.children.iter().copied());
+            subtree.push(ino);
+        }
+        g.index
+            .remove(&(plan.source_parent, plan.source_name.clone()));
+        if let Some(parent) = g.nodes.get_mut(&plan.source_parent) {
+            parent.children.retain(|child| *child != plan.source_ino);
+        }
+        for ino in subtree {
+            let node = g.nodes.get_mut(&ino).ok_or(FsError::NotFound)?;
+            let suffix = node
+                .path
+                .strip_prefix(&plan.source_path)
+                .ok_or(FsError::Invalid)?;
+            node.path = format!("{}{}", plan.target_path, suffix);
+            if ino == plan.source_ino {
+                node.parent = Some(plan.target_parent);
+                node.name.clone_from(&plan.target_name);
+            }
+        }
+        g.index.insert(
+            (plan.target_parent, plan.target_name.clone()),
+            plan.source_ino,
+        );
+        g.nodes
+            .get_mut(&plan.target_parent)
+            .ok_or(FsError::NotFound)?
+            .children
+            .push(plan.source_ino);
+        Ok(())
+    }
+
     /// Validate a new directory and return its trailing-slash marker path.
     pub fn new_directory_marker_path(
         &self,
@@ -1402,6 +1603,60 @@ mod tests {
                 "bucket"
             ),
             Err(FsError::IsDir)
+        );
+    }
+
+    #[test]
+    fn directory_rename_rewrites_subtree_paths_and_open_handles() {
+        let fs = fs();
+        let s3 = fs.lookup(ROOT_INO, "s3").unwrap();
+        let bucket = fs.lookup(s3.ino, "bucket").unwrap();
+        let source = fs.lookup(bucket.ino, "data").unwrap();
+        let file = fs.lookup(source.ino, "a.bin").unwrap();
+        let fh = fs
+            .open_with_options(
+                file.ino,
+                OpenOptions {
+                    read: true,
+                    write: true,
+                    append: false,
+                },
+                Some(b"abc".to_vec()),
+            )
+            .unwrap();
+
+        let plan = fs
+            .directory_rename_plan(bucket.ino, "data", bucket.ino, "moved")
+            .unwrap();
+        assert_eq!(plan.entries.len(), 2);
+        assert!(plan.entries.iter().any(|entry| {
+            entry.source_path == "s3/bucket/data/a.bin"
+                && entry.target_path == "s3/bucket/moved/a.bin"
+        }));
+        fs.commit_directory_rename(&plan).unwrap();
+
+        assert_eq!(fs.lookup(bucket.ino, "data"), Err(FsError::NotFound));
+        let moved = fs.lookup(bucket.ino, "moved").unwrap();
+        assert_eq!(moved.ino, source.ino);
+        assert_eq!(fs.lookup(moved.ino, "a.bin").unwrap().ino, file.ino);
+        assert_eq!(fs.dirty_path(fh).as_deref(), Some("s3/bucket/moved/a.bin"));
+    }
+
+    #[test]
+    fn directory_rename_rejects_cycles_and_nonempty_targets() {
+        let fs = fs();
+        let s3 = fs.lookup(ROOT_INO, "s3").unwrap();
+        let bucket = fs.lookup(s3.ino, "bucket").unwrap();
+        let source = fs.lookup(bucket.ino, "data").unwrap();
+        assert_eq!(
+            fs.directory_rename_plan(bucket.ino, "data", source.ino, "nested"),
+            Err(FsError::Invalid)
+        );
+
+        fs.insert_object("s3/bucket/target/file.bin", 1);
+        assert_eq!(
+            fs.directory_rename_plan(bucket.ino, "data", bucket.ino, "target"),
+            Err(FsError::NotEmpty)
         );
     }
 

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -810,6 +810,132 @@ async fn mount_regular_file_rename_is_written_through() {
     result.expect("exercise regular-file rename through mount");
 }
 
+/// Rename directory trees through a rollback-capable multi-object transaction.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires /dev/fuse; run with --features mount -- --ignored"]
+async fn mount_directory_tree_rename_is_written_through() {
+    use fuser::MountOption;
+
+    let block_size: u32 = 4 * 1024 * 1024;
+    let store: Store = Arc::new(Mutex::new(HashMap::from([
+        ("/s3/bucket/tree/".to_string(), Vec::new()),
+        ("/s3/bucket/tree/file.bin".to_string(), b"root".to_vec()),
+        ("/s3/bucket/tree/nested/".to_string(), Vec::new()),
+        (
+            "/s3/bucket/tree/nested/child.bin".to_string(),
+            b"child".to_vec(),
+        ),
+        ("/s3/bucket/target/".to_string(), Vec::new()),
+        (
+            "/s3/bucket/occupied/file.bin".to_string(),
+            b"occupied".to_vec(),
+        ),
+    ])));
+    let worker = spawn_rw_worker(Arc::clone(&store)).await;
+    let coord = spawn_coordinator(worker).await;
+
+    let fs = Arc::new(ReadOnlyFs::new());
+    fs.populate_from_listing([
+        ("s3/bucket/tree/", 0),
+        ("s3/bucket/tree/file.bin", 4),
+        ("s3/bucket/tree/nested/", 0),
+        ("s3/bucket/tree/nested/child.bin", 5),
+        ("s3/bucket/target/", 0),
+        ("s3/bucket/occupied/file.bin", 8),
+    ]);
+
+    let cache = Arc::new(PlacementCache::new(10_000));
+    let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
+    let adapter = TalonFuse::new(
+        Arc::clone(&fs),
+        reader,
+        tokio::runtime::Handle::current(),
+        block_size,
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
+    )
+    .with_read_write(true);
+
+    let require_fuse = std::env::var_os("TALON_REQUIRE_FUSE").is_some();
+    let mountpoint =
+        std::env::temp_dir().join(format!("talon-mount-e2e-dir-rename-{}", std::process::id()));
+    std::fs::create_dir_all(&mountpoint).unwrap();
+    let options = vec![MountOption::FSName("talon".into())];
+    let session = match fuser::spawn_mount2(adapter, &mountpoint, &options) {
+        Ok(session) => session,
+        Err(error) => {
+            std::fs::remove_dir_all(&mountpoint).ok();
+            if require_fuse {
+                panic!(
+                    "TALON_REQUIRE_FUSE is set but the FUSE mount failed: {error}. \
+                     The runner must provide an accessible /dev/fuse."
+                );
+            }
+            eprintln!("skipping: /dev/fuse unavailable: {error}");
+            return;
+        }
+    };
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let bucket = mountpoint.join("s3").join("bucket");
+    let operation_store = Arc::clone(&store);
+    let result = tokio::task::spawn_blocking(move || {
+        let source = bucket.join("tree");
+        let target = bucket.join("target");
+        let occupied = bucket.join("occupied");
+        let mut open_file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(source.join("file.bin"))?;
+
+        std::fs::rename(&source, &target)?;
+        assert!(!source.exists());
+        assert_eq!(std::fs::read(target.join("file.bin"))?, b"root");
+        assert_eq!(
+            std::fs::read(target.join("nested").join("child.bin"))?,
+            b"child"
+        );
+        {
+            let committed = operation_store.lock().unwrap();
+            assert!(!committed
+                .keys()
+                .any(|path| path.starts_with("/s3/bucket/tree/")));
+            assert_eq!(
+                committed.get("/s3/bucket/target/file.bin"),
+                Some(&b"root".to_vec())
+            );
+            assert_eq!(
+                committed.get("/s3/bucket/target/nested/child.bin"),
+                Some(&b"child".to_vec())
+            );
+            assert!(committed.contains_key("/s3/bucket/target/"));
+            assert!(committed.contains_key("/s3/bucket/target/nested/"));
+        }
+
+        open_file.seek(SeekFrom::Start(0))?;
+        open_file.write_all(b"MOVE")?;
+        open_file.sync_all()?;
+        assert_eq!(
+            operation_store
+                .lock()
+                .unwrap()
+                .get("/s3/bucket/target/file.bin"),
+            Some(&b"MOVE".to_vec())
+        );
+
+        let cycle = std::fs::rename(&target, target.join("nested").join("loop")).unwrap_err();
+        assert_eq!(cycle.raw_os_error(), Some(libc::EINVAL));
+        let nonempty = std::fs::rename(&target, &occupied).unwrap_err();
+        assert_eq!(nonempty.raw_os_error(), Some(libc::ENOTEMPTY));
+        Ok::<(), std::io::Error>(())
+    })
+    .await
+    .unwrap();
+
+    drop(session);
+    std::fs::remove_dir_all(&mountpoint).ok();
+    result.expect("exercise directory-tree rename through mount");
+}
+
 /// Mount the read-write fixture and run the pinned pjdfstest suite against it.
 ///
 /// This is separately gated because the normal real-kernel smoke job runs all


### PR DESCRIPTION
## Summary

Implement directory-tree rename for Talon FUSE using direct blob-store write-through. The operation preserves inode identity across the moved subtree, rewrites paths for open handles, and supports replacement of an empty target directory.

This PR is stacked on #339. Its diff will shrink to the directory-specific commit after the prerequisite PRs merge.

## Related issues

- Progresses #325
- Part of #259 and #262

## Type of change

- [x] Bug fix
- [x] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [x] Docs / tests / tooling

## Design alignment

Object stores do not provide a portable atomic directory rename. Talon plans the complete subtree, reads source objects, writes every destination object and directory marker, deletes the source objects, and commits the in-memory namespace last. A failure restores source objects, removes newly written destination objects, and restores a replaced target marker.

No directory write-back cache is introduced. Every regular object and explicit trailing-slash directory marker is moved through the existing worker/backend path before success is returned.

## Changes

- Add immutable directory-tree rename planning and post-backend namespace commit APIs.
- Recursively move regular-file objects and explicit trailing-slash directory markers.
- Preserve directory and child inode identity across same-directory and cross-directory moves.
- Rewrite open-handle paths for files inside a moved subtree.
- Replace empty target directories and reject non-empty targets with `ENOTEMPTY`.
- Reject directory cycles with `EINVAL` and file targets with `ENOTDIR`.
- Add backend rollback for partial destination PUT, target marker DELETE, source DELETE, and namespace commit failures.
- Add focused namespace tests and a privileged real-kernel mount test.

## Test plan

- [x] `cargo test -p talon-fuse --lib --features mount --locked`: 105 passed
- [x] `cargo test -p talon-fuse --features mount --test mount_e2e --no-run --locked`
- [x] `cargo clippy -p talon-fuse --features mount --all-targets --locked -- -D warnings`
- [x] `git diff --check`
- [x] Exact commit `2b3c249a8267933401da2d43ac7cafd3868ec135` passed `mount_directory_tree_rename_is_written_through` in a privileged `falcon-phx-ca` Job with host `/dev/fuse`
- [x] Full real-kernel `rename,unlink` pjdfstest: 1,953 passed, 3,344 failed out of 5,297, up from 1,947 passed and 3,350 failed after regular-file rename and 1,775 passed and 3,522 failed at baseline

The remaining grouped failures are dominated by permissions and ownership (#328), links (#323), special nodes (#327), timestamps (#324), and unlink-while-open lifetime.

## Performance impact

Directory rename reads each source object, writes each destination object, and deletes each source object synchronously. This is the required write-through durability model and is limited to explicit directory rename operations.

- [x] Not performance-sensitive outside explicit rename operations

## Checklist

- [x] PR title follows Conventional Commits
- [x] Public behavior is covered by tests
- [x] No new dependencies
- [x] Based on `main` through the stacked prerequisite branches
