### PR TITLE
fix(fuse): preserve open files after unlink

### DIFF
--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -117,7 +117,7 @@ pub(crate) fn to_file_attr(attr: Attr, uid: u32, gid: u32) -> fuser::FileAttr {
         crtime: epoch,
         kind,
         perm: attr.perm,
-        nlink: 1,
+        nlink: attr.nlink,
         uid,
         gid,
         rdev: 0,
@@ -1065,7 +1065,12 @@ impl fuser::Filesystem for TalonFuse {
         reply.ok();
     }
 
-    /// Remove a file: delete the backend object, then drop the namespace node.
+    /// Remove a file from the visible namespace.
+    ///
+    /// An inode without open handles is deleted directly. An open inode is first
+    /// written to a mount-scoped internal blob, then the visible backend key is
+    /// deleted and the namespace entry is detached. Its handles continue to use
+    /// the orphan blob until final release deletes it.
     fn unlink(
         &mut self,
         _req: &fuser::Request<'_>,
@@ -1080,22 +1085,67 @@ impl fuser::Filesystem for TalonFuse {
             Some(s) => s,
             None => return reply.error(libc::EINVAL),
         };
-        // Look up the path first (without removing) so a backend delete failure
-        // leaves the namespace entry intact.
-        let path = match self.fs.lookup(parent, name) {
-            Ok(_) => match self.fs.file_path(parent, name) {
-                Some(p) => p,
-                None => return reply.error(libc::ENOENT),
-            },
-            Err(e) => return reply.error(errno(e)),
+        let plan = match self.fs.unlink_plan(parent, name) {
+            Ok(plan) => plan,
+            Err(error) => return reply.error(errno(error)),
         };
-        if let Err(error) = self.delete_backend_object(&path) {
-            tracing::warn!(%path, %error, "unlink backend delete failed");
+        if let Some(orphan_path) = &plan.orphan_path {
+            let contents = match &plan.buffered_contents {
+                Some(contents) => contents.clone(),
+                None => match self.read_committed_object(&plan.source_path, plan.source_size) {
+                    Ok(contents) => contents,
+                    Err(error) => return reply.error(error),
+                },
+            };
+            if let Err(error) = self.writeback_object(orphan_path, contents.clone()) {
+                tracing::warn!(
+                    source = %plan.source_path,
+                    orphan = %orphan_path,
+                    %error,
+                    "unlink orphan writeback failed"
+                );
+                return reply.error(libc::EIO);
+            }
+            if let Err(error) = self.delete_backend_object(&plan.source_path) {
+                if let Err(rollback_error) = self.delete_backend_object(orphan_path) {
+                    tracing::error!(
+                        orphan = %orphan_path,
+                        %rollback_error,
+                        "unlink orphan rollback failed"
+                    );
+                }
+                tracing::warn!(path = %plan.source_path, %error, "unlink backend delete failed");
+                return reply.error(libc::EIO);
+            }
+            if let Err(error) = self.fs.commit_unlink(&plan) {
+                if let Err(rollback_error) =
+                    self.writeback_object(&plan.source_path, contents.clone())
+                {
+                    tracing::error!(
+                        path = %plan.source_path,
+                        %rollback_error,
+                        "unlink source rollback failed"
+                    );
+                }
+                if let Err(rollback_error) = self.delete_backend_object(orphan_path) {
+                    tracing::error!(
+                        orphan = %orphan_path,
+                        %rollback_error,
+                        "unlink orphan cleanup failed"
+                    );
+                }
+                return reply.error(errno(error));
+            }
+            return reply.ok();
+        }
+
+        if let Err(error) = self.delete_backend_object(&plan.source_path) {
+            tracing::warn!(path = %plan.source_path, %error, "unlink backend delete failed");
             return reply.error(libc::EIO);
         }
-        match self.fs.unlink(parent, name) {
-            Ok(_) => reply.ok(),
-            Err(e) => reply.error(errno(e)),
+        match self.fs.commit_unlink(&plan) {
+            Ok(()) => reply.ok(),
+            Err(error) => reply.error(errno(error)),
         }
     }
 
@@ -1151,9 +1201,21 @@ impl fuser::Filesystem for TalonFuse {
         // Drop this handle's prefetch state (and its readahead cursor); any
         // in-flight speculative fetches finish on their own detached tasks.
         self.prefetchers.lock_recover().remove(&fh);
+        let cleanup_path = match self.fs.release_cleanup_path(fh) {
+            Ok(path) => path,
+            Err(error) => return reply.error(errno(error)),
+        };
+        let cleanup_error = cleanup_path.as_deref().and_then(|path| {
+            self.delete_backend_object(path)
+                .inspect_err(|error| {
+                    tracing::warn!(%path, %error, "final unlink orphan cleanup failed");
+                })
+                .err()
+        });
         match self.fs.release(fh) {
-            Ok(()) => reply.ok(),
-            Err(e) => reply.error(errno(e)),
+            Ok(()) if cleanup_error.is_none() => reply.ok(),
+            Ok(()) => reply.error(libc::EIO),
+            Err(error) => reply.error(errno(error)),
         }
     }
 }
@@ -1340,6 +1402,7 @@ mod tests {
             kind: FileKind::Directory,
             size: 0,
             perm: 0o555,
+            nlink: 1,
         };
         let fa = to_file_attr(dir, 1000, 1000);
         assert_eq!(fa.kind, fuser::FileType::Directory);
@@ -1352,12 +1415,14 @@ mod tests {
             kind: FileKind::File,
             size: 1000, // 1000 bytes → ceil(1000/512) = 2 blocks
             perm: 0o444,
+            nlink: 0,
         };
         let fa = to_file_attr(file, 0, 0);
         assert_eq!(fa.kind, fuser::FileType::RegularFile);
         assert_eq!(fa.size, 1000);
         assert_eq!(fa.blocks, 2);
         assert_eq!(fa.blksize, 512);
+        assert_eq!(fa.nlink, 0);
     }
 
     #[tokio::test]

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -16,7 +16,9 @@
 use crate::lock::MutexExt;
 use crate::mapping::path_to_object;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// The root inode number (fixed by FUSE convention).
 pub const ROOT_INO: u64 = 1;
@@ -41,6 +43,8 @@ pub struct Attr {
     pub size: u64,
     /// Read-only permission bits (dirs `0o555`, files `0o444`).
     pub perm: u16,
+    /// Number of namespace links. An open file retained after unlink has zero.
+    pub nlink: u32,
 }
 
 /// Errors returned by the read-only op layer (mapped to errno by the adapter).
@@ -105,6 +109,8 @@ pub enum ReadSource {
 /// [`ReadOnlyFs::with_max_object_bytes`] to tune.
 pub const DEFAULT_MAX_OBJECT_BYTES: u64 = 1 << 30;
 
+const INTERNAL_OBJECT_PREFIX: &str = ".__talon_internal";
+
 /// A directory entry yielded by `readdir`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DirEntry {
@@ -153,6 +159,18 @@ pub struct DirectoryRenamePlan {
     pub(crate) entries: Vec<DirectoryRenameEntry>,
 }
 
+/// Immutable backend and namespace facts for an unlink operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnlinkPlan {
+    pub(crate) ino: u64,
+    pub(crate) parent: u64,
+    pub(crate) name: String,
+    pub(crate) source_path: String,
+    pub(crate) source_size: u64,
+    pub(crate) orphan_path: Option<String>,
+    pub(crate) buffered_contents: Option<Vec<u8>>,
+}
+
 #[derive(Debug, Clone)]
 struct Node {
     ino: u64,
@@ -165,6 +183,8 @@ struct Node {
     path: String,
     /// Whether this directory is persisted by a trailing-slash blob marker.
     directory_marker: bool,
+    /// Whether the inode still has a visible namespace entry.
+    linked: bool,
 }
 
 /// A read-only view over the backend namespace, addressed by inode.
@@ -176,6 +196,8 @@ pub struct ReadOnlyFs {
     inner: Mutex<Inner>,
     /// Cap on the length of any single write handle's in-memory buffer.
     max_object_bytes: u64,
+    /// Mount-scoped backend namespace for open-but-unlinked objects.
+    orphan_namespace: String,
 }
 
 struct Inner {
@@ -211,6 +233,8 @@ struct DirtyFile {
     buf: Vec<u8>,
 }
 
+static NEXT_FS_INSTANCE: AtomicU64 = AtomicU64::new(1);
+
 impl Default for ReadOnlyFs {
     fn default() -> Self {
         Self::new()
@@ -232,8 +256,14 @@ impl ReadOnlyFs {
                 children: Vec::new(),
                 path: String::new(),
                 directory_marker: false,
+                linked: true,
             },
         );
+        let instance = NEXT_FS_INSTANCE.fetch_add(1, Ordering::Relaxed);
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
         Self {
             inner: Mutex::new(Inner {
                 nodes,
@@ -244,6 +274,7 @@ impl ReadOnlyFs {
                 dirty: HashMap::new(),
             }),
             max_object_bytes: DEFAULT_MAX_OBJECT_BYTES,
+            orphan_namespace: format!("{:x}-{timestamp:x}-{instance:x}", std::process::id()),
         }
     }
 
@@ -294,6 +325,7 @@ impl ReadOnlyFs {
                 children: Vec::new(),
                 path: current_path.clone(),
                 directory_marker: false,
+                linked: true,
             };
             g.nodes.insert(ino, node);
             g.index.insert(key, ino);
@@ -315,6 +347,9 @@ impl ReadOnlyFs {
     {
         let mut n = 0;
         for (path, size) in entries {
+            if Self::is_internal_object_path(path) {
+                continue;
+            }
             if path.ends_with('/') {
                 if self.insert_directory_marker(path).is_ok() {
                     n += 1;
@@ -333,7 +368,7 @@ impl ReadOnlyFs {
             .strip_suffix('/')
             .filter(|path| !path.is_empty())
             .ok_or(FsError::Invalid)?;
-        path_to_object(path).map_err(|_| FsError::Invalid)?;
+        Self::validate_visible_object_path(path)?;
         let comps: Vec<&str> = path
             .split('/')
             .filter(|component| !component.is_empty())
@@ -369,6 +404,7 @@ impl ReadOnlyFs {
                 children: Vec::new(),
                 path: current_path.clone(),
                 directory_marker: index == comps.len() - 1,
+                linked: true,
             };
             g.nodes.insert(ino, node);
             g.index.insert(key, ino);
@@ -388,6 +424,7 @@ impl ReadOnlyFs {
             kind: node.kind,
             size: node.size,
             perm,
+            nlink: u32::from(node.linked),
         }
     }
 
@@ -493,18 +530,45 @@ impl ReadOnlyFs {
         )
     }
 
+    /// Return the orphan backend path that the final release must delete.
+    pub fn release_cleanup_path(&self, fh: u64) -> Result<Option<String>, FsError> {
+        let g = self.inner.lock_recover();
+        let handle = g.handles.get(&fh).ok_or(FsError::BadHandle)?;
+        let is_last_handle = g
+            .handles
+            .values()
+            .filter(|candidate| candidate.ino == handle.ino)
+            .count()
+            == 1;
+        let Some(node) = g.nodes.get(&handle.ino) else {
+            return Ok(None);
+        };
+        Ok((is_last_handle && !node.linked).then(|| node.path.clone()))
+    }
+
     /// `release`: drop a previously opened handle (read or write), discarding any
     /// write buffer. The caller is expected to have already flushed a dirty write
-    /// handle's contents (writeback happens on flush, #232).
+    /// handle's contents and deleted a final orphan object when requested by
+    /// [`release_cleanup_path`](Self::release_cleanup_path).
     pub fn release(&self, fh: u64) -> Result<(), FsError> {
         let mut g = self.inner.lock_recover();
         let had_dirty = g.dirty.remove(&fh).is_some();
-        let had_handle = g.handles.remove(&fh).is_some();
-        if had_handle || had_dirty {
-            Ok(())
-        } else {
-            Err(FsError::BadHandle)
+        let handle = g.handles.remove(&fh);
+        let Some(handle) = handle else {
+            return if had_dirty {
+                Ok(())
+            } else {
+                Err(FsError::BadHandle)
+            };
+        };
+        let has_remaining_handles = g
+            .handles
+            .values()
+            .any(|candidate| candidate.ino == handle.ino);
+        if !has_remaining_handles && g.nodes.get(&handle.ino).is_some_and(|node| !node.linked) {
+            g.nodes.remove(&handle.ino);
         }
+        Ok(())
     }
 
     /// The mount-relative object path + size for an open file handle.
@@ -593,7 +657,7 @@ impl ReadOnlyFs {
             parts.push(name.to_string());
             parts.join("/")
         };
-        path_to_object(&path).map_err(|_| FsError::Invalid)?;
+        Self::validate_visible_object_path(&path)?;
         let ino = g.next_ino;
         g.next_ino += 1;
         let node = Node {
@@ -605,6 +669,7 @@ impl ReadOnlyFs {
             children: Vec::new(),
             path,
             directory_marker: false,
+            linked: true,
         };
         g.nodes.insert(ino, node);
         g.index.insert((parent_ino, name.to_string()), ino);
@@ -829,7 +894,7 @@ impl ReadOnlyFs {
             return Err(FsError::IsDir);
         }
         let target_path = Self::child_path(target_parent_node, target_name);
-        path_to_object(&target_path).map_err(|_| FsError::Invalid)?;
+        Self::validate_visible_object_path(&target_path)?;
         let target = match g.index.get(&(target_parent, target_name.to_string())) {
             Some(&target_ino) if target_ino == source_ino => None,
             Some(&target_ino) => {
@@ -956,7 +1021,7 @@ impl ReadOnlyFs {
             }
             ancestor = g.nodes.get(&ino).and_then(|node| node.parent);
         }
-        path_to_object(&target_path).map_err(|_| FsError::Invalid)?;
+        Self::validate_visible_object_path(&target_path)?;
         let target = match g.index.get(&(target_parent, target_name.to_string())) {
             Some(&target_ino) => {
                 let node = g.nodes.get(&target_ino).ok_or(FsError::NotFound)?;
@@ -1103,7 +1168,7 @@ impl ReadOnlyFs {
             return Err(FsError::Exists);
         }
         let path = Self::child_path(parent, name);
-        path_to_object(&path).map_err(|_| FsError::Invalid)?;
+        Self::validate_visible_object_path(&path)?;
         Ok(format!("{path}/"))
     }
 
@@ -1119,7 +1184,7 @@ impl ReadOnlyFs {
             return Err(FsError::Exists);
         }
         let path = Self::child_path(parent, name);
-        path_to_object(&path).map_err(|_| FsError::Invalid)?;
+        Self::validate_visible_object_path(&path)?;
         let ino = g.next_ino;
         g.next_ino += 1;
         let node = Node {
@@ -1131,6 +1196,7 @@ impl ReadOnlyFs {
             children: Vec::new(),
             path,
             directory_marker: true,
+            linked: true,
         };
         g.nodes.insert(ino, node);
         g.index.insert((parent_ino, name.to_string()), ino);
@@ -1183,11 +1249,18 @@ impl ReadOnlyFs {
         Ok(())
     }
 
-    /// `unlink`: remove file `name` under directory `parent_ino` from the
-    /// namespace. Returns the removed file's mount-relative path so the caller
-    /// can delete the backend object. Directories are not removed here.
-    pub fn unlink(&self, parent_ino: u64, name: &str) -> Result<String, FsError> {
-        let mut g = self.inner.lock_recover();
+    /// Validate and describe an unlink without mutating the namespace.
+    ///
+    /// Files with open handles move to a mount-scoped internal backend key so
+    /// descriptors can continue to read, write, and fsync after the visible name
+    /// is removed. The final release deletes that orphan object.
+    pub fn unlink_plan(&self, parent_ino: u64, name: &str) -> Result<UnlinkPlan, FsError> {
+        Self::validate_component(name)?;
+        let g = self.inner.lock_recover();
+        let parent = g.nodes.get(&parent_ino).ok_or(FsError::NotFound)?;
+        if parent.kind != FileKind::Directory {
+            return Err(FsError::NotDir);
+        }
         let ino = *g
             .index
             .get(&(parent_ino, name.to_string()))
@@ -1196,12 +1269,65 @@ impl ReadOnlyFs {
         if node.kind != FileKind::File {
             return Err(FsError::IsDir);
         }
-        let path = node.path.clone();
-        g.nodes.remove(&ino);
-        g.index.remove(&(parent_ino, name.to_string()));
-        if let Some(parent) = g.nodes.get_mut(&parent_ino) {
-            parent.children.retain(|c| *c != ino);
+        let has_open_handles = g.handles.values().any(|handle| handle.ino == ino);
+        let orphan_path = has_open_handles
+            .then(|| self.orphan_path(&node.path, ino))
+            .transpose()?;
+        let buffered_contents = g
+            .dirty
+            .iter()
+            .filter(|(_, dirty)| dirty.ino == ino)
+            .max_by_key(|(fh, _)| *fh)
+            .map(|(_, dirty)| dirty.buf.clone());
+        Ok(UnlinkPlan {
+            ino,
+            parent: parent_ino,
+            name: name.to_string(),
+            source_path: node.path.clone(),
+            source_size: node.size,
+            orphan_path,
+            buffered_contents,
+        })
+    }
+
+    /// Commit an unlink after the backend delete or orphan move succeeds.
+    pub fn commit_unlink(&self, plan: &UnlinkPlan) -> Result<(), FsError> {
+        let mut g = self.inner.lock_recover();
+        if g.index.get(&(plan.parent, plan.name.clone())).copied() != Some(plan.ino) {
+            return Err(FsError::NotFound);
         }
+        let node = g.nodes.get(&plan.ino).ok_or(FsError::NotFound)?;
+        if node.path != plan.source_path || node.kind != FileKind::File {
+            return Err(FsError::Invalid);
+        }
+        let has_open_handles = g.handles.values().any(|handle| handle.ino == plan.ino);
+        if has_open_handles != plan.orphan_path.is_some() {
+            return Err(FsError::Invalid);
+        }
+
+        g.index.remove(&(plan.parent, plan.name.clone()));
+        if let Some(parent) = g.nodes.get_mut(&plan.parent) {
+            parent.children.retain(|child| *child != plan.ino);
+        }
+        if let Some(orphan_path) = &plan.orphan_path {
+            let node = g.nodes.get_mut(&plan.ino).ok_or(FsError::NotFound)?;
+            node.parent = None;
+            node.path.clone_from(orphan_path);
+            node.linked = false;
+        } else {
+            g.nodes.remove(&plan.ino);
+        }
+        Ok(())
+    }
+
+    /// Remove a file from the in-memory namespace without backend I/O.
+    ///
+    /// The mount adapter uses [`unlink_plan`](Self::unlink_plan) and
+    /// [`commit_unlink`](Self::commit_unlink) around synchronous backend work.
+    pub fn unlink(&self, parent_ino: u64, name: &str) -> Result<String, FsError> {
+        let plan = self.unlink_plan(parent_ino, name)?;
+        let path = plan.source_path.clone();
+        self.commit_unlink(&plan)?;
         Ok(path)
     }
 
@@ -1248,6 +1374,30 @@ impl ReadOnlyFs {
         } else {
             format!("{}/{}", parent.path, name)
         }
+    }
+
+    fn orphan_path(&self, source_path: &str, ino: u64) -> Result<String, FsError> {
+        let object = path_to_object(source_path).map_err(|_| FsError::Invalid)?;
+        Ok(format!(
+            "{}/{}/{INTERNAL_OBJECT_PREFIX}/unlinked/{}/{ino}",
+            object.backend.prefix(),
+            object.bucket,
+            self.orphan_namespace
+        ))
+    }
+
+    fn validate_visible_object_path(path: &str) -> Result<(), FsError> {
+        let object = path_to_object(path).map_err(|_| FsError::Invalid)?;
+        if object.object_path.split('/').next() == Some(INTERNAL_OBJECT_PREFIX) {
+            return Err(FsError::Invalid);
+        }
+        Ok(())
+    }
+
+    fn is_internal_object_path(path: &str) -> bool {
+        path_to_object(path).is_ok_and(|object| {
+            object.object_path.split('/').next() == Some(INTERNAL_OBJECT_PREFIX)
+        })
     }
 }
 
@@ -1385,6 +1535,31 @@ mod tests {
         assert_eq!(
             fs.rmdir_marker_path(bucket.ino, "empty").unwrap(),
             Some("s3/bkt/empty/".to_string())
+        );
+    }
+
+    #[test]
+    fn internal_orphan_objects_are_hidden_and_reserved() {
+        let fs = ReadOnlyFs::new();
+        let count = fs.populate_from_listing([
+            ("s3/bkt/visible.bin", 1u64),
+            ("s3/bkt/.__talon_internal/unlinked/stale/7", 5u64),
+        ]);
+        assert_eq!(count, 1);
+
+        let s3 = fs.lookup(ROOT_INO, "s3").unwrap();
+        let bucket = fs.lookup(s3.ino, "bkt").unwrap();
+        assert_eq!(
+            fs.lookup(bucket.ino, INTERNAL_OBJECT_PREFIX),
+            Err(FsError::NotFound)
+        );
+        assert_eq!(
+            fs.create(bucket.ino, INTERNAL_OBJECT_PREFIX),
+            Err(FsError::Invalid)
+        );
+        assert_eq!(
+            fs.mkdir(bucket.ino, INTERNAL_OBJECT_PREFIX),
+            Err(FsError::Invalid)
         );
     }
 
@@ -1675,6 +1850,46 @@ mod tests {
         assert_eq!(fs.lookup(dir.ino, "a.bin"), Err(FsError::NotFound));
         // Unlinking a missing name errors.
         assert_eq!(fs.unlink(dir.ino, "a.bin"), Err(FsError::NotFound));
+    }
+
+    #[test]
+    fn unlink_retains_an_open_inode_under_an_orphan_path() {
+        let fs = fs();
+        let dir = data_dir(&fs);
+        let file = fs.lookup(dir.ino, "a.bin").unwrap();
+        let fh = fs
+            .open_with_options(
+                file.ino,
+                OpenOptions {
+                    read: true,
+                    write: true,
+                    append: false,
+                },
+                Some(b"contents".to_vec()),
+            )
+            .unwrap();
+
+        let plan = fs.unlink_plan(dir.ino, "a.bin").unwrap();
+        let orphan_path = plan.orphan_path.clone().unwrap();
+        assert!(orphan_path.contains("/.__talon_internal/unlinked/"));
+        assert_eq!(
+            plan.buffered_contents.as_deref(),
+            Some(b"contents".as_slice())
+        );
+
+        fs.commit_unlink(&plan).unwrap();
+        assert_eq!(fs.lookup(dir.ino, "a.bin"), Err(FsError::NotFound));
+        assert_eq!(fs.getattr(file.ino).unwrap().nlink, 0);
+        assert_eq!(fs.dirty_path(fh).as_deref(), Some(orphan_path.as_str()));
+
+        fs.write(fh, 8, b"-tail").unwrap();
+        assert_eq!(fs.dirty_bytes(fh).unwrap(), b"contents-tail");
+        assert_eq!(
+            fs.release_cleanup_path(fh).unwrap().as_deref(),
+            Some(orphan_path.as_str())
+        );
+        fs.release(fh).unwrap();
+        assert_eq!(fs.getattr(file.ino), Err(FsError::NotFound));
     }
 
     #[test]

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -24,7 +24,7 @@
 
 use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom, Write};
-use std::os::unix::fs::{FileExt, OpenOptionsExt};
+use std::os::unix::fs::{FileExt, MetadataExt, OpenOptionsExt};
 use std::process::Command;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
@@ -934,6 +934,125 @@ async fn mount_directory_tree_rename_is_written_through() {
     drop(session);
     std::fs::remove_dir_all(&mountpoint).ok();
     result.expect("exercise directory-tree rename through mount");
+}
+
+/// Keep an unlinked inode on an internal backend object until final release.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires /dev/fuse; run with --features mount -- --ignored"]
+async fn mount_unlink_preserves_open_descriptors_without_recreating_the_name() {
+    use fuser::MountOption;
+
+    let block_size: u32 = 4 * 1024 * 1024;
+    let store: Store = Arc::new(Mutex::new(HashMap::from([(
+        "/s3/bucket/live.bin".to_string(),
+        b"start".to_vec(),
+    )])));
+    let worker = spawn_rw_worker(Arc::clone(&store)).await;
+    let coord = spawn_coordinator(worker).await;
+
+    let fs = Arc::new(ReadOnlyFs::new());
+    fs.insert_object("s3/bucket/live.bin", 5);
+
+    let cache = Arc::new(PlacementCache::new(10_000));
+    let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
+    let adapter = TalonFuse::new(
+        Arc::clone(&fs),
+        reader,
+        tokio::runtime::Handle::current(),
+        block_size,
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
+    )
+    .with_read_write(true);
+
+    let require_fuse = std::env::var_os("TALON_REQUIRE_FUSE").is_some();
+    let mountpoint =
+        std::env::temp_dir().join(format!("talon-mount-e2e-unlink-{}", std::process::id()));
+    std::fs::create_dir_all(&mountpoint).unwrap();
+    let options = vec![MountOption::FSName("talon".into())];
+    let session = match fuser::spawn_mount2(adapter, &mountpoint, &options) {
+        Ok(session) => session,
+        Err(error) => {
+            std::fs::remove_dir_all(&mountpoint).ok();
+            if require_fuse {
+                panic!(
+                    "TALON_REQUIRE_FUSE is set but the FUSE mount failed: {error}. \
+                     The runner must provide an accessible /dev/fuse."
+                );
+            }
+            eprintln!("skipping: /dev/fuse unavailable: {error}");
+            return;
+        }
+    };
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let path = mountpoint.join("s3").join("bucket").join("live.bin");
+    let operation_store = Arc::clone(&store);
+    let result = tokio::task::spawn_blocking(move || {
+        let mut open_file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)?;
+
+        std::fs::remove_file(&path)?;
+        assert!(!path.exists());
+        assert_eq!(open_file.metadata()?.nlink(), 0);
+
+        let orphan_path = {
+            let committed = operation_store.lock().unwrap();
+            assert!(!committed.contains_key("/s3/bucket/live.bin"));
+            let (path, contents) = committed
+                .iter()
+                .find(|(path, _)| path.starts_with("/s3/bucket/.__talon_internal/unlinked/"))
+                .expect("unlink should create an internal orphan object");
+            assert_eq!(contents, b"start");
+            path.clone()
+        };
+
+        open_file.seek(SeekFrom::Start(0))?;
+        let mut initial = Vec::new();
+        open_file.read_to_end(&mut initial)?;
+        assert_eq!(initial, b"start");
+
+        open_file.seek(SeekFrom::Start(0))?;
+        open_file.write_all(b"after")?;
+        open_file.sync_all()?;
+        assert_eq!(
+            operation_store.lock().unwrap().get(&orphan_path),
+            Some(&b"after".to_vec())
+        );
+
+        std::fs::write(&path, b"replacement")?;
+        open_file.seek(SeekFrom::Start(0))?;
+        open_file.write_all(b"older")?;
+        open_file.sync_all()?;
+        assert_eq!(
+            operation_store.lock().unwrap().get("/s3/bucket/live.bin"),
+            Some(&b"replacement".to_vec())
+        );
+        assert_eq!(
+            operation_store.lock().unwrap().get(&orphan_path),
+            Some(&b"older".to_vec())
+        );
+
+        drop(open_file);
+        for _ in 0..100 {
+            if !operation_store.lock().unwrap().contains_key(&orphan_path) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            !operation_store.lock().unwrap().contains_key(&orphan_path),
+            "final release should delete the orphan object"
+        );
+        Ok::<(), std::io::Error>(())
+    })
+    .await
+    .unwrap();
+
+    drop(session);
+    std::fs::remove_dir_all(&mountpoint).ok();
+    result.expect("exercise unlink-while-open through mount");
 }
 
 /// Mount the read-write fixture and run the pinned pjdfstest suite against it.


### PR DESCRIPTION
## Summary

Implement POSIX unlink-while-open lifetime for Talon FUSE without introducing a write-back cache. A file with open descriptors is moved to a mount-scoped internal blob key before its visible object key is deleted. Existing descriptors continue to read, write, and fsync that orphan object, and the final release deletes it.

This PR is stacked on #340. Its diff will shrink to the unlink-lifetime commit after the prerequisite PRs merge.

## Related issues

- Progresses #325
- Part of #259 and #262
- Production listing and remount reconstruction still depend on #332

## Type of change

- [x] Bug fix
- [x] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [x] Docs / tests / tooling

## Design alignment

The write path remains backend write-through:

1. PUT the current bytes to `.__talon_internal/unlinked/<mount>/<inode>` in the same bucket.
2. DELETE the visible source object.
3. Detach the namespace entry and report `nlink = 0` for the retained inode.
4. Route later descriptor reads, writes, flushes, and fsyncs to the orphan object.
5. DELETE the orphan object on final release.

An unlink without open handles retains the existing single backend DELETE path. A failed orphan PUT leaves the source untouched. A failed source DELETE removes the orphan. A failed namespace commit restores the source and removes the orphan.

Internal orphan objects are filtered from listing-based namespace population, and the internal top-level key is reserved from user create, mkdir, and rename targets.

## Changes

- Add immutable unlink planning and post-backend namespace commit APIs.
- Retain open unlinked inodes with stable inode identity and zero link count.
- Keep dirty write buffers and read-only handles pointed at an internal backend object.
- Prevent an old unlinked descriptor from recreating or overwriting a new file at the original name.
- Delete the internal object when the final handle is released.
- Add rollback for partial orphan PUT, source DELETE, and namespace commit failures.
- Hide and reserve the internal orphan key namespace.
- Add unit coverage and a privileged real-kernel lifecycle test.

## Test plan

- [x] `cargo test -p talon-fuse --lib --features mount --locked`: 107 passed
- [x] `cargo test -p talon-fuse --features mount --test mount_e2e --no-run --locked`
- [x] `cargo clippy -p talon-fuse --features mount --all-targets --locked -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Exact commit `59d1c9afc265bb4575954988de5a395f5ac60c6c` passed `mount_unlink_preserves_open_descriptors_without_recreating_the_name` in a privileged `falcon-phx-ca` Job with host `/dev/fuse`
- [x] Full real-kernel `rename,unlink` pjdfstest: 1,955 passed, 3,342 failed out of 5,297, up from 1,953 passed and 3,344 failed after directory rename and 1,775 passed and 3,522 failed at baseline
- [x] Both assertions in pjdfstest `unlink/14.t` now pass: zero link count after unlink and I/O through an open deleted file

The remaining grouped failures are dominated by permissions and ownership (#328), links (#323), special nodes (#327), and timestamps (#324).

## Performance impact

Unlink without open handles remains one synchronous backend DELETE. Unlink with open handles adds one whole-object PUT before deleting the visible key, and final release adds one DELETE. Later fsync operations write through to the orphan object exactly as they previously wrote through to the visible object.

- [x] Limited to unlink operations on open files

## Checklist

- [x] PR title follows Conventional Commits
- [x] Public behavior is covered by tests
- [x] No new dependencies
- [x] Based on `main` through the stacked prerequisite branches
