### PR TITLE
feat(fuse): add symbolic link support

### DIFF
--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -16,6 +16,7 @@
 //! [#100]: https://github.com/milvus-io/talon/issues/100
 
 use std::collections::HashMap;
+use std::os::unix::ffi::OsStrExt;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -66,6 +67,7 @@ pub(crate) fn errno(err: FsError) -> i32 {
         FsError::Invalid => libc::EINVAL,
         FsError::NotEmpty => libc::ENOTEMPTY,
         FsError::NameTooLong => libc::ENAMETOOLONG,
+        FsError::Loop => libc::ELOOP,
     }
 }
 
@@ -98,13 +100,13 @@ fn now_ms() -> u64 {
 /// Convert a synthesized [`Attr`] into a `fuser::FileAttr`.
 ///
 /// Times are fixed to the UNIX epoch (the namespace is synthetic and read-only,
-/// so there is no meaningful mtime); links are 1, ownership is left to the
-/// mounting user via `uid`/`gid`. `blocks` is a 512-byte-unit count as POSIX
-/// expects.
+/// so there is no meaningful mtime); ownership is left to the mounting user via
+/// `uid`/`gid`. `blocks` is a 512-byte-unit count as POSIX expects.
 pub(crate) fn to_file_attr(attr: Attr, uid: u32, gid: u32) -> fuser::FileAttr {
     let kind = match attr.kind {
         FileKind::Directory => fuser::FileType::Directory,
         FileKind::File => fuser::FileType::RegularFile,
+        FileKind::Symlink => fuser::FileType::Symlink,
     };
     let epoch = std::time::UNIX_EPOCH;
     fuser::FileAttr {
@@ -624,6 +626,7 @@ impl fuser::Filesystem for TalonFuse {
             let kind = match e.kind {
                 FileKind::Directory => fuser::FileType::Directory,
                 FileKind::File => fuser::FileType::RegularFile,
+                FileKind::Symlink => fuser::FileType::Symlink,
             };
             (e.ino, kind, e.name)
         }));
@@ -721,6 +724,14 @@ impl fuser::Filesystem for TalonFuse {
         }
     }
 
+    /// Return the raw target bytes for a symbolic-link inode.
+    fn readlink(&mut self, _req: &fuser::Request<'_>, ino: u64, reply: fuser::ReplyData) {
+        match self.fs.readlink(ino) {
+            Ok(target) => reply.data(&target),
+            Err(error) => reply.error(errno(error)),
+        }
+    }
+
     /// Create and open a new file for writing (`O_CREAT`).
     fn create(
         &mut self,
@@ -765,6 +776,49 @@ impl fuser::Filesystem for TalonFuse {
                 reply.created(&ATTR_TTL, &fa, 0, fh, 0);
             }
             Err(e) => reply.error(errno(e)),
+        }
+    }
+
+    /// Create a symbolic link and persist its raw target bytes.
+    fn symlink(
+        &mut self,
+        req: &fuser::Request<'_>,
+        parent: u64,
+        link_name: &std::ffi::OsStr,
+        target: &std::path::Path,
+        reply: fuser::ReplyEntry,
+    ) {
+        if !self.read_write {
+            return reply.error(libc::EROFS);
+        }
+        let link_name = match link_name.to_str() {
+            Some(name) => name,
+            None => return reply.error(libc::EINVAL),
+        };
+        let target = target.as_os_str().as_bytes().to_vec();
+        let path = match self.fs.new_symlink_path(parent, link_name, &target) {
+            Ok(path) => path,
+            Err(error) => return reply.error(errno(error)),
+        };
+        if let Err(error) = self.writeback_object(&path, target.clone()) {
+            tracing::warn!(%path, %error, "symlink target writeback failed");
+            return reply.error(libc::EIO);
+        }
+        match self.fs.symlink(parent, link_name, target) {
+            Ok(attr) => {
+                let file_attr = to_file_attr(attr, req.uid(), req.gid());
+                reply.entry(&ATTR_TTL, &file_attr, 0);
+            }
+            Err(error) => {
+                if let Err(rollback_error) = self.delete_backend_object(&path) {
+                    tracing::error!(
+                        %path,
+                        %rollback_error,
+                        "failed to roll back symlink object"
+                    );
+                }
+                reply.error(errno(error));
+            }
         }
     }
 
@@ -1356,6 +1410,7 @@ mod tests {
         assert_eq!(errno(FsError::Invalid), libc::EINVAL);
         assert_eq!(errno(FsError::NotEmpty), libc::ENOTEMPTY);
         assert_eq!(errno(FsError::NameTooLong), libc::ENAMETOOLONG);
+        assert_eq!(errno(FsError::Loop), libc::ELOOP);
     }
 
     #[test]
@@ -1423,6 +1478,18 @@ mod tests {
         assert_eq!(fa.blocks, 2);
         assert_eq!(fa.blksize, 512);
         assert_eq!(fa.nlink, 0);
+
+        let symlink = Attr {
+            ino: 8,
+            kind: FileKind::Symlink,
+            size: 6,
+            perm: 0o777,
+            nlink: 1,
+        };
+        let fa = to_file_attr(symlink, 0, 0);
+        assert_eq!(fa.kind, fuser::FileType::Symlink);
+        assert_eq!(fa.size, 6);
+        assert_eq!(fa.perm, 0o777);
     }
 
     #[tokio::test]

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -30,6 +30,8 @@ pub enum FileKind {
     Directory,
     /// A regular file (a backend object).
     File,
+    /// A symbolic link whose target bytes are stored in a backend object.
+    Symlink,
 }
 
 /// Synthesized attributes for a node.
@@ -73,6 +75,8 @@ pub enum FsError {
     NotEmpty,
     /// A pathname component exceeds the filesystem name limit (`ENAMETOOLONG`).
     NameTooLong,
+    /// Too many symbolic links were encountered (`ELOOP`).
+    Loop,
 }
 
 /// Access and mutation behavior for an open file handle.
@@ -110,6 +114,7 @@ pub enum ReadSource {
 pub const DEFAULT_MAX_OBJECT_BYTES: u64 = 1 << 30;
 
 const INTERNAL_OBJECT_PREFIX: &str = ".__talon_internal";
+const MAX_SYMLINK_TARGET_BYTES: usize = 4095;
 
 /// A directory entry yielded by `readdir`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -183,6 +188,8 @@ struct Node {
     path: String,
     /// Whether this directory is persisted by a trailing-slash blob marker.
     directory_marker: bool,
+    /// Raw target bytes for symbolic links.
+    symlink_target: Option<Vec<u8>>,
     /// Whether the inode still has a visible namespace entry.
     linked: bool,
 }
@@ -256,6 +263,7 @@ impl ReadOnlyFs {
                 children: Vec::new(),
                 path: String::new(),
                 directory_marker: false,
+                symlink_target: None,
                 linked: true,
             },
         );
@@ -325,6 +333,7 @@ impl ReadOnlyFs {
                 children: Vec::new(),
                 path: current_path.clone(),
                 directory_marker: false,
+                symlink_target: None,
                 linked: true,
             };
             g.nodes.insert(ino, node);
@@ -404,6 +413,7 @@ impl ReadOnlyFs {
                 children: Vec::new(),
                 path: current_path.clone(),
                 directory_marker: index == comps.len() - 1,
+                symlink_target: None,
                 linked: true,
             };
             g.nodes.insert(ino, node);
@@ -418,6 +428,7 @@ impl ReadOnlyFs {
         let perm = match node.kind {
             FileKind::Directory => 0o555,
             FileKind::File => 0o444,
+            FileKind::Symlink => 0o777,
         };
         Attr {
             ino: node.ino,
@@ -492,8 +503,10 @@ impl ReadOnlyFs {
         }
         let mut g = self.inner.lock_recover();
         let kind = g.nodes.get(&ino).ok_or(FsError::NotFound)?.kind;
-        if kind != FileKind::File {
-            return Err(FsError::IsDir);
+        match kind {
+            FileKind::File => {}
+            FileKind::Directory => return Err(FsError::IsDir),
+            FileKind::Symlink => return Err(FsError::Loop),
         }
         if options.write && initial_contents.is_none() {
             return Err(FsError::Invalid);
@@ -669,6 +682,7 @@ impl ReadOnlyFs {
             children: Vec::new(),
             path,
             directory_marker: false,
+            symlink_target: None,
             linked: true,
         };
         g.nodes.insert(ino, node);
@@ -861,7 +875,7 @@ impl ReadOnlyFs {
         let g = self.inner.lock_recover();
         let ino = *g.index.get(&(parent_ino, name.to_string()))?;
         let node = g.nodes.get(&ino)?;
-        if node.kind != FileKind::File {
+        if node.kind == FileKind::Directory {
             return None;
         }
         Some(node.path.clone())
@@ -890,7 +904,7 @@ impl ReadOnlyFs {
             .get(&(source_parent, source_name.to_string()))
             .ok_or(FsError::NotFound)?;
         let source = g.nodes.get(&source_ino).ok_or(FsError::NotFound)?;
-        if source.kind != FileKind::File {
+        if source.kind == FileKind::Directory {
             return Err(FsError::IsDir);
         }
         let target_path = Self::child_path(target_parent_node, target_name);
@@ -899,7 +913,7 @@ impl ReadOnlyFs {
             Some(&target_ino) if target_ino == source_ino => None,
             Some(&target_ino) => {
                 let node = g.nodes.get(&target_ino).ok_or(FsError::NotFound)?;
-                if node.kind != FileKind::File {
+                if node.kind == FileKind::Directory {
                     return Err(FsError::IsDir);
                 }
                 Some((target_ino, node.size))
@@ -1047,7 +1061,7 @@ impl ReadOnlyFs {
                 .ok_or(FsError::Invalid)?;
             let moved_path = format!("{target_path}{suffix}");
             match node.kind {
-                FileKind::File => entries.push(DirectoryRenameEntry {
+                FileKind::File | FileKind::Symlink => entries.push(DirectoryRenameEntry {
                     source_path: node.path.clone(),
                     target_path: moved_path,
                     size: node.size,
@@ -1152,6 +1166,67 @@ impl ReadOnlyFs {
         Ok(())
     }
 
+    /// Validate a new symbolic link and return its backend object path.
+    pub fn new_symlink_path(
+        &self,
+        parent_ino: u64,
+        name: &str,
+        target: &[u8],
+    ) -> Result<String, FsError> {
+        Self::validate_component(name)?;
+        if target.len() > MAX_SYMLINK_TARGET_BYTES {
+            return Err(FsError::NameTooLong);
+        }
+        let g = self.inner.lock_recover();
+        let parent = g.nodes.get(&parent_ino).ok_or(FsError::NotFound)?;
+        if parent.kind != FileKind::Directory {
+            return Err(FsError::NotDir);
+        }
+        if g.index.contains_key(&(parent_ino, name.to_string())) {
+            return Err(FsError::Exists);
+        }
+        let path = Self::child_path(parent, name);
+        Self::validate_visible_object_path(&path)?;
+        Ok(path)
+    }
+
+    /// Insert a symbolic-link inode after its target bytes are written through.
+    pub fn symlink(&self, parent_ino: u64, name: &str, target: Vec<u8>) -> Result<Attr, FsError> {
+        let path = self.new_symlink_path(parent_ino, name, &target)?;
+        let mut g = self.inner.lock_recover();
+        if g.index.contains_key(&(parent_ino, name.to_string())) {
+            return Err(FsError::Exists);
+        }
+        let ino = g.next_ino;
+        g.next_ino += 1;
+        let node = Node {
+            ino,
+            parent: Some(parent_ino),
+            name: name.to_string(),
+            kind: FileKind::Symlink,
+            size: target.len() as u64,
+            children: Vec::new(),
+            path,
+            directory_marker: false,
+            symlink_target: Some(target),
+            linked: true,
+        };
+        g.nodes.insert(ino, node);
+        g.index.insert((parent_ino, name.to_string()), ino);
+        g.nodes.get_mut(&parent_ino).unwrap().children.push(ino);
+        Ok(Self::attr_of(g.nodes.get(&ino).unwrap()))
+    }
+
+    /// Return the raw target bytes for a symbolic-link inode.
+    pub fn readlink(&self, ino: u64) -> Result<Vec<u8>, FsError> {
+        let g = self.inner.lock_recover();
+        let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
+        match &node.symlink_target {
+            Some(target) if node.kind == FileKind::Symlink => Ok(target.clone()),
+            _ => Err(FsError::Invalid),
+        }
+    }
+
     /// Validate a new directory and return its trailing-slash marker path.
     pub fn new_directory_marker_path(
         &self,
@@ -1196,6 +1271,7 @@ impl ReadOnlyFs {
             children: Vec::new(),
             path,
             directory_marker: true,
+            symlink_target: None,
             linked: true,
         };
         g.nodes.insert(ino, node);
@@ -1266,7 +1342,7 @@ impl ReadOnlyFs {
             .get(&(parent_ino, name.to_string()))
             .ok_or(FsError::NotFound)?;
         let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
-        if node.kind != FileKind::File {
+        if node.kind == FileKind::Directory {
             return Err(FsError::IsDir);
         }
         let has_open_handles = g.handles.values().any(|handle| handle.ino == ino);
@@ -1297,7 +1373,7 @@ impl ReadOnlyFs {
             return Err(FsError::NotFound);
         }
         let node = g.nodes.get(&plan.ino).ok_or(FsError::NotFound)?;
-        if node.path != plan.source_path || node.kind != FileKind::File {
+        if node.path != plan.source_path || node.kind == FileKind::Directory {
             return Err(FsError::Invalid);
         }
         let has_open_handles = g.handles.values().any(|handle| handle.ino == plan.ino);
@@ -1560,6 +1636,52 @@ mod tests {
         assert_eq!(
             fs.mkdir(bucket.ino, INTERNAL_OBJECT_PREFIX),
             Err(FsError::Invalid)
+        );
+    }
+
+    #[test]
+    fn symlink_tracks_target_bytes_and_moves_as_a_nondirectory_object() {
+        let fs = fs();
+        let parent = data_dir(&fs);
+        let target = b"a.bin".to_vec();
+        assert_eq!(
+            fs.new_symlink_path(parent.ino, "alias", &target).unwrap(),
+            "s3/bucket/data/alias"
+        );
+
+        let link = fs.symlink(parent.ino, "alias", target.clone()).unwrap();
+        assert_eq!(link.kind, FileKind::Symlink);
+        assert_eq!(link.size, target.len() as u64);
+        assert_eq!(link.perm, 0o777);
+        assert_eq!(fs.readlink(link.ino).unwrap(), target);
+        assert_eq!(
+            fs.symlink(parent.ino, "alias", b"other".to_vec()),
+            Err(FsError::Exists)
+        );
+
+        let plan = fs
+            .file_rename_plan(parent.ino, "alias", parent.ino, "moved")
+            .unwrap();
+        fs.commit_file_rename(&plan).unwrap();
+        assert_eq!(fs.lookup(parent.ino, "alias"), Err(FsError::NotFound));
+        assert_eq!(fs.lookup(parent.ino, "moved").unwrap().ino, link.ino);
+        assert_eq!(fs.readlink(link.ino).unwrap(), b"a.bin");
+
+        fs.unlink(parent.ino, "moved").unwrap();
+        assert_eq!(fs.getattr(link.ino), Err(FsError::NotFound));
+    }
+
+    #[test]
+    fn symlink_rejects_long_targets_and_names() {
+        let fs = fs();
+        let parent = data_dir(&fs);
+        assert_eq!(
+            fs.new_symlink_path(parent.ino, "alias", &vec![b'x'; 4096]),
+            Err(FsError::NameTooLong)
+        );
+        assert_eq!(
+            fs.new_symlink_path(parent.ino, &"x".repeat(256), b"target"),
+            Err(FsError::NameTooLong)
         );
     }
 

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -1055,6 +1055,123 @@ async fn mount_unlink_preserves_open_descriptors_without_recreating_the_name() {
     result.expect("exercise unlink-while-open through mount");
 }
 
+/// Create, resolve, move, and delete symbolic links through the kernel.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires /dev/fuse; run with --features mount -- --ignored"]
+async fn mount_symbolic_links_are_written_through() {
+    use fuser::MountOption;
+
+    let block_size: u32 = 4 * 1024 * 1024;
+    let store: Store = Arc::new(Mutex::new(HashMap::from([(
+        "/s3/bucket/target.bin".to_string(),
+        b"payload".to_vec(),
+    )])));
+    let worker = spawn_rw_worker(Arc::clone(&store)).await;
+    let coord = spawn_coordinator(worker).await;
+
+    let fs = Arc::new(ReadOnlyFs::new());
+    fs.insert_object("s3/bucket/target.bin", 7);
+
+    let cache = Arc::new(PlacementCache::new(10_000));
+    let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
+    let adapter = TalonFuse::new(
+        Arc::clone(&fs),
+        reader,
+        tokio::runtime::Handle::current(),
+        block_size,
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
+    )
+    .with_read_write(true);
+
+    let require_fuse = std::env::var_os("TALON_REQUIRE_FUSE").is_some();
+    let mountpoint =
+        std::env::temp_dir().join(format!("talon-mount-e2e-symlink-{}", std::process::id()));
+    std::fs::create_dir_all(&mountpoint).unwrap();
+    let options = vec![MountOption::FSName("talon".into())];
+    let session = match fuser::spawn_mount2(adapter, &mountpoint, &options) {
+        Ok(session) => session,
+        Err(error) => {
+            std::fs::remove_dir_all(&mountpoint).ok();
+            if require_fuse {
+                panic!(
+                    "TALON_REQUIRE_FUSE is set but the FUSE mount failed: {error}. \
+                     The runner must provide an accessible /dev/fuse."
+                );
+            }
+            eprintln!("skipping: /dev/fuse unavailable: {error}");
+            return;
+        }
+    };
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let bucket = mountpoint.join("s3").join("bucket");
+    let operation_store = Arc::clone(&store);
+    let result = tokio::task::spawn_blocking(move || {
+        let link = bucket.join("link.bin");
+        std::os::unix::fs::symlink("target.bin", &link)?;
+        assert!(std::fs::symlink_metadata(&link)?.file_type().is_symlink());
+        assert_eq!(
+            std::fs::read_link(&link)?,
+            std::path::Path::new("target.bin")
+        );
+        assert_eq!(std::fs::read(&link)?, b"payload");
+        assert_eq!(
+            operation_store.lock().unwrap().get("/s3/bucket/link.bin"),
+            Some(&b"target.bin".to_vec())
+        );
+
+        let moved = bucket.join("moved.bin");
+        std::fs::rename(&link, &moved)?;
+        assert_eq!(
+            std::fs::read_link(&moved)?,
+            std::path::Path::new("target.bin")
+        );
+        assert_eq!(std::fs::read(&moved)?, b"payload");
+        {
+            let committed = operation_store.lock().unwrap();
+            assert!(!committed.contains_key("/s3/bucket/link.bin"));
+            assert_eq!(
+                committed.get("/s3/bucket/moved.bin"),
+                Some(&b"target.bin".to_vec())
+            );
+        }
+
+        let dangling = bucket.join("dangling");
+        std::os::unix::fs::symlink("missing", &dangling)?;
+        assert_eq!(
+            std::fs::read_link(&dangling)?,
+            std::path::Path::new("missing")
+        );
+        assert_eq!(
+            std::fs::read(&dangling).unwrap_err().raw_os_error(),
+            Some(libc::ENOENT)
+        );
+
+        let loop_a = bucket.join("loop-a");
+        let loop_b = bucket.join("loop-b");
+        std::os::unix::fs::symlink("loop-b", &loop_a)?;
+        std::os::unix::fs::symlink("loop-a", &loop_b)?;
+        assert_eq!(
+            std::fs::read(&loop_a).unwrap_err().raw_os_error(),
+            Some(libc::ELOOP)
+        );
+
+        std::fs::remove_file(&moved)?;
+        assert_eq!(std::fs::read(bucket.join("target.bin"))?, b"payload");
+        assert!(!operation_store
+            .lock()
+            .unwrap()
+            .contains_key("/s3/bucket/moved.bin"));
+        Ok::<(), std::io::Error>(())
+    })
+    .await
+    .unwrap();
+
+    drop(session);
+    std::fs::remove_dir_all(&mountpoint).ok();
+    result.expect("exercise symbolic links through mount");
+}
+
 /// Mount the read-write fixture and run the pinned pjdfstest suite against it.
 ///
 /// This is separately gated because the normal real-kernel smoke job runs all


### PR DESCRIPTION
## Summary

Add write-through symbolic-link creation, lookup, resolution, rename, and unlink behavior to Talon FUSE. Symlink target bytes are stored in the visible backend object and the in-memory namespace tracks a distinct symlink inode kind for kernel `readlink` resolution.

This PR is stacked on #341. Its diff will shrink to the symlink-specific commit after the prerequisite PRs merge.

## Related issues

- Progresses #323
- Part of #259 and #262
- Production symlink type reconstruction on remount still depends on #332

## Type of change

- [ ] Bug fix
- [x] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [x] Docs / tests / tooling

## Backend representation

A symlink is represented by one ordinary object at the visible link path. The object body is the raw symlink target byte sequence. Creation performs a synchronous PUT before namespace insertion; namespace failure DELETEs the object. Rename uses the existing destination PUT, source DELETE, and namespace commit transaction. Unlink DELETEs the link object without touching the target object.

This keeps all mutation write-through and avoids a metadata cache. The current listing API exposes only path and size, so production remount reconstruction cannot distinguish a symlink object from a regular object yet; that type metadata/reconstruction work remains coupled to #332.

## Changes

- Add a distinct symbolic-link inode kind with `0777` attributes and target length.
- Implement FUSE `symlink` and `readlink` callbacks with raw Unix target bytes.
- Persist symlink target bytes through the owning worker before returning success.
- Resolve relative, dangling, and looping links through normal kernel path traversal.
- Support symlink rename and unlink as non-directory backend objects.
- Include symlinks in directory-tree rename transactions.
- Return `ENAMETOOLONG`, `EEXIST`, `ENOTDIR`, `EROFS`, and `ELOOP` through the appropriate kernel paths.
- Add focused namespace tests and a privileged real-kernel mount test.

## Test plan

- [x] `cargo test -p talon-fuse --lib --features mount --locked`: 109 passed
- [x] `cargo test -p talon-fuse --features mount --test mount_e2e --no-run --locked`
- [x] `cargo clippy -p talon-fuse --features mount --all-targets --locked -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Exact commit `106e5cd831ad240c3f488a535ff6368d56aa3c51` passed `mount_symbolic_links_are_written_through` in a privileged `falcon-phx-ca` Job with host `/dev/fuse`
- [x] Real-kernel `symlink` pjdfstest improved from 47 passed / 48 failed to 75 passed / 20 failed out of 95 assertions

The remaining symlink-group failures require mode, ownership, and timestamp support (#328 and #324), or depend on FIFO/device/socket creation (#327). Hard links remain the next #323 slice.

## Performance impact

Symlink creation performs one synchronous PUT. Rename and unlink use the same whole-object write-through operations as regular non-directory objects. Link resolution is served from the in-memory inode target and does not read the backend object during the mount session.

- [x] Limited to explicit symlink mutation

## Checklist

- [x] PR title follows Conventional Commits
- [x] Public behavior is covered by tests
- [x] No new dependencies
- [x] Based on `main` through the stacked prerequisite branches
