### PR TITLE
feat(fuse): add write-through hard links

### DIFF
--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -68,6 +68,8 @@ pub(crate) fn errno(err: FsError) -> i32 {
         FsError::NotEmpty => libc::ENOTEMPTY,
         FsError::NameTooLong => libc::ENAMETOOLONG,
         FsError::Loop => libc::ELOOP,
+        FsError::OperationNotPermitted => libc::EPERM,
+        FsError::CrossDevice => libc::EXDEV,
     }
 }
 
@@ -299,6 +301,22 @@ impl TalonFuse {
             client.put_object(&object, &bytes).await?;
             Ok::<(), anyhow::Error>(())
         })
+    }
+
+    fn writeback_object_paths(&self, paths: &[String], bytes: Vec<u8>) -> anyhow::Result<()> {
+        if paths.is_empty() {
+            anyhow::bail!("inode has no backend object paths");
+        }
+        let mut first_error = None;
+        for path in paths {
+            if let Err(error) = self.writeback_object(path, bytes.clone()) {
+                first_error.get_or_insert(error);
+            }
+        }
+        if let Some(error) = first_error {
+            return Err(error);
+        }
+        Ok(())
     }
 
     /// Delete the object at mount-relative `path` through its owning worker.
@@ -822,6 +840,60 @@ impl fuser::Filesystem for TalonFuse {
         }
     }
 
+    /// Create a hard link by materializing the shared inode bytes at a new key.
+    fn link(
+        &mut self,
+        req: &fuser::Request<'_>,
+        ino: u64,
+        newparent: u64,
+        newname: &std::ffi::OsStr,
+        reply: fuser::ReplyEntry,
+    ) {
+        if !self.read_write {
+            return reply.error(libc::EROFS);
+        }
+        let newname = match newname.to_str() {
+            Some(name) => name,
+            None => return reply.error(libc::EINVAL),
+        };
+        let plan = match self.fs.hard_link_plan(ino, newparent, newname) {
+            Ok(plan) => plan,
+            Err(error) => return reply.error(errno(error)),
+        };
+        let contents = match &plan.buffered_contents {
+            Some(contents) => contents.clone(),
+            None => match self.read_committed_object(&plan.source_path, plan.source_size) {
+                Ok(contents) => contents,
+                Err(error) => return reply.error(error),
+            },
+        };
+        if let Err(error) = self.writeback_object(&plan.target_path, contents) {
+            tracing::warn!(
+                source = %plan.source_path,
+                target = %plan.target_path,
+                %error,
+                "hard-link destination writeback failed"
+            );
+            return reply.error(libc::EIO);
+        }
+        match self.fs.commit_hard_link(&plan) {
+            Ok(attr) => {
+                let file_attr = to_file_attr(attr, req.uid(), req.gid());
+                reply.entry(&ATTR_TTL, &file_attr, 0);
+            }
+            Err(error) => {
+                if let Err(rollback_error) = self.delete_backend_object(&plan.target_path) {
+                    tracing::error!(
+                        target = %plan.target_path,
+                        %rollback_error,
+                        "hard-link destination rollback failed"
+                    );
+                }
+                reply.error(errno(error));
+            }
+        }
+    }
+
     /// Create a directory and persist it as a trailing-slash blob marker.
     fn mkdir(
         &mut self,
@@ -926,11 +998,16 @@ impl fuser::Filesystem for TalonFuse {
             if new_size > self.fs.max_object_bytes() {
                 return reply.error(libc::EFBIG);
             }
-            let (path, contents) = if let Some(fh) = fh {
-                match self.fs.truncate_handle_plan(fh, new_size) {
+            let (paths, contents) = if let Some(fh) = fh {
+                let (_, contents) = match self.fs.truncate_handle_plan(fh, new_size) {
                     Ok(plan) => plan,
                     Err(e) => return reply.error(errno(e)),
-                }
+                };
+                let paths = match self.fs.dirty_paths(fh) {
+                    Ok(paths) => paths,
+                    Err(e) => return reply.error(errno(e)),
+                };
+                (paths, contents)
             } else {
                 let (path, current_size) = match self.fs.inode_file_meta(ino) {
                     Ok(meta) => meta,
@@ -941,13 +1018,18 @@ impl fuser::Filesystem for TalonFuse {
                     Ok(contents) => contents,
                     Err(error) => return reply.error(error),
                 };
-                match self.fs.truncate_inode_plan(ino, new_size, existing) {
+                let (_, contents) = match self.fs.truncate_inode_plan(ino, new_size, existing) {
                     Ok(plan) => plan,
                     Err(e) => return reply.error(errno(e)),
-                }
+                };
+                let paths = match self.fs.inode_paths(ino) {
+                    Ok(paths) => paths,
+                    Err(e) => return reply.error(errno(e)),
+                };
+                (paths, contents)
             };
-            if let Err(error) = self.writeback_object(&path, contents.clone()) {
-                tracing::warn!(%path, %error, "truncate writeback failed");
+            if let Err(error) = self.writeback_object_paths(&paths, contents.clone()) {
+                tracing::warn!(?paths, %error, "truncate writeback failed");
                 return reply.error(libc::EIO);
             }
             let attr = if let Some(fh) = fh {
@@ -980,15 +1062,18 @@ impl fuser::Filesystem for TalonFuse {
         _lock_owner: u64,
         reply: fuser::ReplyEmpty,
     ) {
-        let (path, bytes) = match (self.fs.dirty_path(fh), self.fs.dirty_bytes(fh)) {
-            (Some(p), Some(b)) => (p, b),
-            // Not a write handle → nothing to flush.
-            _ => return reply.ok(),
+        let bytes = match self.fs.dirty_bytes(fh) {
+            Some(bytes) => bytes,
+            None => return reply.ok(),
         };
-        match self.writeback_object(&path, bytes) {
+        let paths = match self.fs.dirty_paths(fh) {
+            Ok(paths) => paths,
+            Err(error) => return reply.error(errno(error)),
+        };
+        match self.writeback_object_paths(&paths, bytes) {
             Ok(()) => reply.ok(),
             Err(error) => {
-                tracing::warn!(%path, %error, "flush writeback failed");
+                tracing::warn!(?paths, %error, "flush writeback failed");
                 reply.error(libc::EIO);
             }
         }
@@ -1003,11 +1088,15 @@ impl fuser::Filesystem for TalonFuse {
         _datasync: bool,
         reply: fuser::ReplyEmpty,
     ) {
-        let (path, bytes) = match (self.fs.dirty_path(fh), self.fs.dirty_bytes(fh)) {
-            (Some(p), Some(b)) => (p, b),
-            _ => return reply.ok(),
+        let bytes = match self.fs.dirty_bytes(fh) {
+            Some(bytes) => bytes,
+            None => return reply.ok(),
         };
-        match self.writeback_object(&path, bytes) {
+        let paths = match self.fs.dirty_paths(fh) {
+            Ok(paths) => paths,
+            Err(error) => return reply.error(errno(error)),
+        };
+        match self.writeback_object_paths(&paths, bytes) {
             Ok(()) => reply.ok(),
             Err(_) => reply.error(libc::EIO),
         }
@@ -1411,6 +1500,8 @@ mod tests {
         assert_eq!(errno(FsError::NotEmpty), libc::ENOTEMPTY);
         assert_eq!(errno(FsError::NameTooLong), libc::ENAMETOOLONG);
         assert_eq!(errno(FsError::Loop), libc::ELOOP);
+        assert_eq!(errno(FsError::OperationNotPermitted), libc::EPERM);
+        assert_eq!(errno(FsError::CrossDevice), libc::EXDEV);
     }
 
     #[test]

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -77,6 +77,10 @@ pub enum FsError {
     NameTooLong,
     /// Too many symbolic links were encountered (`ELOOP`).
     Loop,
+    /// The operation is not permitted for this inode type (`EPERM`).
+    OperationNotPermitted,
+    /// Source and destination are on different backend filesystems (`EXDEV`).
+    CrossDevice,
 }
 
 /// Access and mutation behavior for an open file handle.
@@ -174,6 +178,18 @@ pub struct UnlinkPlan {
     pub(crate) source_size: u64,
     pub(crate) orphan_path: Option<String>,
     pub(crate) buffered_contents: Option<Vec<u8>>,
+}
+
+/// Immutable backend and namespace facts for hard-link creation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HardLinkPlan {
+    pub(crate) source_ino: u64,
+    pub(crate) source_path: String,
+    pub(crate) source_size: u64,
+    pub(crate) buffered_contents: Option<Vec<u8>>,
+    pub(crate) target_parent: u64,
+    pub(crate) target_name: String,
+    pub(crate) target_path: String,
 }
 
 #[derive(Debug, Clone)]
@@ -424,18 +440,26 @@ impl ReadOnlyFs {
         Ok(parent)
     }
 
-    fn attr_of(node: &Node) -> Attr {
+    fn attr_of(g: &Inner, node: &Node) -> Attr {
         let perm = match node.kind {
             FileKind::Directory => 0o555,
             FileKind::File => 0o444,
             FileKind::Symlink => 0o777,
+        };
+        let nlink = if node.kind == FileKind::Directory {
+            1
+        } else {
+            g.index
+                .values()
+                .filter(|candidate| **candidate == node.ino)
+                .count() as u32
         };
         Attr {
             ino: node.ino,
             kind: node.kind,
             size: node.size,
             perm,
-            nlink: u32::from(node.linked),
+            nlink,
         }
     }
 
@@ -447,13 +471,19 @@ impl ReadOnlyFs {
             .index
             .get(&(parent_ino, name.to_string()))
             .ok_or(FsError::NotFound)?;
-        Ok(Self::attr_of(g.nodes.get(&ino).ok_or(FsError::NotFound)?))
+        Ok(Self::attr_of(
+            &g,
+            g.nodes.get(&ino).ok_or(FsError::NotFound)?,
+        ))
     }
 
     /// `getattr`: attributes for an inode.
     pub fn getattr(&self, ino: u64) -> Result<Attr, FsError> {
         let g = self.inner.lock_recover();
-        Ok(Self::attr_of(g.nodes.get(&ino).ok_or(FsError::NotFound)?))
+        Ok(Self::attr_of(
+            &g,
+            g.nodes.get(&ino).ok_or(FsError::NotFound)?,
+        ))
     }
 
     /// `readdir`: list children of a directory inode (excluding `.`/`..`).
@@ -463,14 +493,16 @@ impl ReadOnlyFs {
         if node.kind != FileKind::Directory {
             return Err(FsError::NotDir);
         }
-        let mut entries: Vec<DirEntry> = node
-            .children
+        let mut entries: Vec<DirEntry> = g
+            .index
             .iter()
-            .filter_map(|c| g.nodes.get(c))
-            .map(|c| DirEntry {
-                ino: c.ino,
-                kind: c.kind,
-                name: c.name.clone(),
+            .filter(|((parent, _), _)| *parent == ino)
+            .filter_map(|((_, name), child_ino)| {
+                g.nodes.get(child_ino).map(|child| DirEntry {
+                    ino: child.ino,
+                    kind: child.kind,
+                    name: name.clone(),
+                })
             })
             .collect();
         entries.sort_by(|a, b| a.name.cmp(&b.name));
@@ -708,7 +740,7 @@ impl ReadOnlyFs {
                 buf: Vec::new(),
             },
         );
-        let attr = Self::attr_of(g.nodes.get(&ino).unwrap());
+        let attr = Self::attr_of(&g, g.nodes.get(&ino).unwrap());
         Ok((attr, fh))
     }
 
@@ -851,7 +883,7 @@ impl ReadOnlyFs {
         for dirty in g.dirty.values_mut().filter(|dirty| dirty.ino == ino) {
             dirty.buf.clone_from(&contents);
         }
-        Ok(Self::attr_of(g.nodes.get(&ino).unwrap()))
+        Ok(Self::attr_of(g, g.nodes.get(&ino).unwrap()))
     }
 
     /// Return the assembled object bytes for a write handle (for writeback at
@@ -869,6 +901,19 @@ impl ReadOnlyFs {
         g.nodes.get(&ino).map(|n| n.path.clone())
     }
 
+    /// All backend object paths linked to a write handle's inode.
+    pub fn dirty_paths(&self, fh: u64) -> Result<Vec<String>, FsError> {
+        let g = self.inner.lock_recover();
+        let ino = g.dirty.get(&fh).ok_or(FsError::BadHandle)?.ino;
+        Self::inode_paths_locked(&g, ino)
+    }
+
+    /// All visible backend object paths linked to an inode.
+    pub fn inode_paths(&self, ino: u64) -> Result<Vec<String>, FsError> {
+        let g = self.inner.lock_recover();
+        Self::inode_paths_locked(&g, ino)
+    }
+
     /// The mount-relative object path of file `name` under `parent_ino`, without
     /// removing it. `None` if the name doesn't resolve to a file.
     pub fn file_path(&self, parent_ino: u64, name: &str) -> Option<String> {
@@ -879,6 +924,86 @@ impl ReadOnlyFs {
             return None;
         }
         Some(node.path.clone())
+    }
+
+    /// Validate and describe hard-link creation without mutating namespace.
+    pub fn hard_link_plan(
+        &self,
+        source_ino: u64,
+        target_parent: u64,
+        target_name: &str,
+    ) -> Result<HardLinkPlan, FsError> {
+        Self::validate_component(target_name)?;
+        let g = self.inner.lock_recover();
+        let source = g.nodes.get(&source_ino).ok_or(FsError::NotFound)?;
+        if source.kind == FileKind::Directory {
+            return Err(FsError::OperationNotPermitted);
+        }
+        let target_parent_node = g.nodes.get(&target_parent).ok_or(FsError::NotFound)?;
+        if target_parent_node.kind != FileKind::Directory {
+            return Err(FsError::NotDir);
+        }
+        if g.index
+            .contains_key(&(target_parent, target_name.to_string()))
+        {
+            return Err(FsError::Exists);
+        }
+        let target_path = Self::child_path(target_parent_node, target_name);
+        Self::validate_visible_object_path(&target_path)?;
+        let source_object = path_to_object(&source.path).map_err(|_| FsError::Invalid)?;
+        let target_object = path_to_object(&target_path).map_err(|_| FsError::Invalid)?;
+        if source_object.backend != target_object.backend
+            || source_object.bucket != target_object.bucket
+        {
+            return Err(FsError::CrossDevice);
+        }
+        Ok(HardLinkPlan {
+            source_ino,
+            source_path: source.path.clone(),
+            source_size: source.size,
+            buffered_contents: g
+                .dirty
+                .iter()
+                .filter(|(_, dirty)| dirty.ino == source_ino)
+                .max_by_key(|(fh, _)| *fh)
+                .map(|(_, dirty)| dirty.buf.clone()),
+            target_parent,
+            target_name: target_name.to_string(),
+            target_path,
+        })
+    }
+
+    /// Add a hard-link dentry after the destination object is written through.
+    pub fn commit_hard_link(&self, plan: &HardLinkPlan) -> Result<Attr, FsError> {
+        let mut g = self.inner.lock_recover();
+        let source = g.nodes.get(&plan.source_ino).ok_or(FsError::NotFound)?;
+        if source.kind == FileKind::Directory || source.path != plan.source_path {
+            return Err(FsError::Invalid);
+        }
+        if g.index
+            .contains_key(&(plan.target_parent, plan.target_name.clone()))
+        {
+            return Err(FsError::Exists);
+        }
+        let target_parent = g.nodes.get(&plan.target_parent).ok_or(FsError::NotFound)?;
+        if target_parent.kind != FileKind::Directory
+            || Self::child_path(target_parent, &plan.target_name) != plan.target_path
+        {
+            return Err(FsError::NotDir);
+        }
+        g.index.insert(
+            (plan.target_parent, plan.target_name.clone()),
+            plan.source_ino,
+        );
+        g.nodes
+            .get_mut(&plan.target_parent)
+            .ok_or(FsError::NotFound)?
+            .children
+            .push(plan.source_ino);
+        Ok(Self::attr_of(
+            &g,
+            g.nodes.get(&plan.source_ino).ok_or(FsError::NotFound)?,
+        ))
     }
 
     /// Validate and describe a regular-file rename without mutating namespace.
@@ -907,10 +1032,14 @@ impl ReadOnlyFs {
         if source.kind == FileKind::Directory {
             return Err(FsError::IsDir);
         }
-        let target_path = Self::child_path(target_parent_node, target_name);
+        let source_path = Self::child_path(source_parent_node, source_name);
+        let mut target_path = Self::child_path(target_parent_node, target_name);
         Self::validate_visible_object_path(&target_path)?;
         let target = match g.index.get(&(target_parent, target_name.to_string())) {
-            Some(&target_ino) if target_ino == source_ino => None,
+            Some(&target_ino) if target_ino == source_ino => {
+                target_path.clone_from(&source_path);
+                None
+            }
             Some(&target_ino) => {
                 let node = g.nodes.get(&target_ino).ok_or(FsError::NotFound)?;
                 if node.kind == FileKind::Directory {
@@ -924,7 +1053,7 @@ impl ReadOnlyFs {
             source_ino,
             source_parent,
             source_name: source_name.to_string(),
-            source_path: source.path.clone(),
+            source_path,
             source_size: source.size,
             target_parent,
             target_name: target_name.to_string(),
@@ -956,10 +1085,18 @@ impl ReadOnlyFs {
             }
             g.index
                 .remove(&(plan.target_parent, plan.target_name.clone()));
-            if let Some(parent) = g.nodes.get_mut(&plan.target_parent) {
-                parent.children.retain(|child| *child != target_ino);
+            Self::remove_child_once(&mut g, plan.target_parent, target_ino);
+            let remaining_target = Self::inode_dentries_locked(&g, target_ino);
+            if let Some((parent, name, path)) = remaining_target.first() {
+                let target = g.nodes.get_mut(&target_ino).ok_or(FsError::NotFound)?;
+                if target.path == plan.target_path {
+                    target.parent = Some(*parent);
+                    target.name.clone_from(name);
+                    target.path.clone_from(path);
+                }
+            } else {
+                g.nodes.remove(&target_ino);
             }
-            g.nodes.remove(&target_ino);
         } else if g
             .index
             .contains_key(&(plan.target_parent, plan.target_name.clone()))
@@ -969,13 +1106,7 @@ impl ReadOnlyFs {
 
         g.index
             .remove(&(plan.source_parent, plan.source_name.clone()));
-        if let Some(parent) = g.nodes.get_mut(&plan.source_parent) {
-            parent.children.retain(|child| *child != plan.source_ino);
-        }
-        let source = g.nodes.get_mut(&plan.source_ino).ok_or(FsError::NotFound)?;
-        source.parent = Some(plan.target_parent);
-        source.name.clone_from(&plan.target_name);
-        source.path.clone_from(&plan.target_path);
+        Self::remove_child_once(&mut g, plan.source_parent, plan.source_ino);
         g.index.insert(
             (plan.target_parent, plan.target_name.clone()),
             plan.source_ino,
@@ -985,6 +1116,12 @@ impl ReadOnlyFs {
             .ok_or(FsError::NotFound)?
             .children
             .push(plan.source_ino);
+        let source = g.nodes.get_mut(&plan.source_ino).ok_or(FsError::NotFound)?;
+        if source.path == plan.source_path {
+            source.parent = Some(plan.target_parent);
+            source.name.clone_from(&plan.target_name);
+            source.path.clone_from(&plan.target_path);
+        }
         Ok(())
     }
 
@@ -1050,32 +1187,43 @@ impl ReadOnlyFs {
             None => None,
         };
 
-        let mut stack = vec![source_ino];
+        let source_path = Self::child_path(source_parent_node, source_name);
+        let mut stack = vec![(source_ino, source_path.clone(), target_path.clone())];
         let mut entries = Vec::new();
-        while let Some(ino) = stack.pop() {
+        while let Some((ino, current_source_path, current_target_path)) = stack.pop() {
             let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
-            stack.extend(node.children.iter().copied());
-            let suffix = node
-                .path
-                .strip_prefix(&source.path)
-                .ok_or(FsError::Invalid)?;
-            let moved_path = format!("{target_path}{suffix}");
-            match node.kind {
-                FileKind::File | FileKind::Symlink => entries.push(DirectoryRenameEntry {
-                    source_path: node.path.clone(),
-                    target_path: moved_path,
-                    size: node.size,
-                    marker: false,
-                }),
-                FileKind::Directory if node.directory_marker => {
+            if node.kind != FileKind::Directory {
+                return Err(FsError::Invalid);
+            }
+            if node.directory_marker {
+                entries.push(DirectoryRenameEntry {
+                    source_path: format!("{current_source_path}/"),
+                    target_path: format!("{current_target_path}/"),
+                    size: 0,
+                    marker: true,
+                });
+            }
+            let mut children: Vec<(String, u64)> = g
+                .index
+                .iter()
+                .filter(|((parent, _), _)| *parent == ino)
+                .map(|((_, name), child_ino)| (name.clone(), *child_ino))
+                .collect();
+            children.sort_by(|left, right| left.0.cmp(&right.0));
+            for (name, child_ino) in children.into_iter().rev() {
+                let child = g.nodes.get(&child_ino).ok_or(FsError::NotFound)?;
+                let child_source_path = format!("{current_source_path}/{name}");
+                let child_target_path = format!("{current_target_path}/{name}");
+                if child.kind == FileKind::Directory {
+                    stack.push((child_ino, child_source_path, child_target_path));
+                } else {
                     entries.push(DirectoryRenameEntry {
-                        source_path: format!("{}/", node.path),
-                        target_path: format!("{moved_path}/"),
-                        size: 0,
-                        marker: true,
+                        source_path: child_source_path,
+                        target_path: child_target_path,
+                        size: child.size,
+                        marker: false,
                     });
                 }
-                FileKind::Directory => {}
             }
         }
         entries.sort_by(|left, right| left.source_path.cmp(&right.source_path));
@@ -1130,30 +1278,22 @@ impl ReadOnlyFs {
             return Err(FsError::Exists);
         }
 
-        let mut stack = vec![plan.source_ino];
-        let mut subtree = Vec::new();
-        while let Some(ino) = stack.pop() {
-            let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
-            stack.extend(node.children.iter().copied());
-            subtree.push(ino);
-        }
         g.index
             .remove(&(plan.source_parent, plan.source_name.clone()));
         if let Some(parent) = g.nodes.get_mut(&plan.source_parent) {
             parent.children.retain(|child| *child != plan.source_ino);
         }
-        for ino in subtree {
-            let node = g.nodes.get_mut(&ino).ok_or(FsError::NotFound)?;
-            let suffix = node
-                .path
-                .strip_prefix(&plan.source_path)
-                .ok_or(FsError::Invalid)?;
-            node.path = format!("{}{}", plan.target_path, suffix);
-            if ino == plan.source_ino {
-                node.parent = Some(plan.target_parent);
-                node.name.clone_from(&plan.target_name);
+        let source_prefix = format!("{}/", plan.source_path);
+        for node in g.nodes.values_mut() {
+            if node.path == plan.source_path {
+                node.path.clone_from(&plan.target_path);
+            } else if let Some(suffix) = node.path.strip_prefix(&source_prefix) {
+                node.path = format!("{}/{suffix}", plan.target_path);
             }
         }
+        let source = g.nodes.get_mut(&plan.source_ino).ok_or(FsError::NotFound)?;
+        source.parent = Some(plan.target_parent);
+        source.name.clone_from(&plan.target_name);
         g.index.insert(
             (plan.target_parent, plan.target_name.clone()),
             plan.source_ino,
@@ -1214,7 +1354,7 @@ impl ReadOnlyFs {
         g.nodes.insert(ino, node);
         g.index.insert((parent_ino, name.to_string()), ino);
         g.nodes.get_mut(&parent_ino).unwrap().children.push(ino);
-        Ok(Self::attr_of(g.nodes.get(&ino).unwrap()))
+        Ok(Self::attr_of(&g, g.nodes.get(&ino).unwrap()))
     }
 
     /// Return the raw target bytes for a symbolic-link inode.
@@ -1277,7 +1417,7 @@ impl ReadOnlyFs {
         g.nodes.insert(ino, node);
         g.index.insert((parent_ino, name.to_string()), ino);
         g.nodes.get_mut(&parent_ino).unwrap().children.push(ino);
-        Ok(Self::attr_of(g.nodes.get(&ino).unwrap()))
+        Ok(Self::attr_of(&g, g.nodes.get(&ino).unwrap()))
     }
 
     /// Return the marker to delete before removing an empty directory.
@@ -1345,9 +1485,15 @@ impl ReadOnlyFs {
         if node.kind == FileKind::Directory {
             return Err(FsError::IsDir);
         }
+        let source_path = Self::child_path(parent, name);
+        let link_count = g
+            .index
+            .values()
+            .filter(|candidate| **candidate == ino)
+            .count();
         let has_open_handles = g.handles.values().any(|handle| handle.ino == ino);
-        let orphan_path = has_open_handles
-            .then(|| self.orphan_path(&node.path, ino))
+        let orphan_path = (link_count == 1 && has_open_handles)
+            .then(|| self.orphan_path(&source_path, ino))
             .transpose()?;
         let buffered_contents = g
             .dirty
@@ -1359,7 +1505,7 @@ impl ReadOnlyFs {
             ino,
             parent: parent_ino,
             name: name.to_string(),
-            source_path: node.path.clone(),
+            source_path,
             source_size: node.size,
             orphan_path,
             buffered_contents,
@@ -1373,19 +1519,35 @@ impl ReadOnlyFs {
             return Err(FsError::NotFound);
         }
         let node = g.nodes.get(&plan.ino).ok_or(FsError::NotFound)?;
-        if node.path != plan.source_path || node.kind == FileKind::Directory {
+        if node.kind == FileKind::Directory {
             return Err(FsError::Invalid);
         }
+        let parent = g.nodes.get(&plan.parent).ok_or(FsError::NotFound)?;
+        if Self::child_path(parent, &plan.name) != plan.source_path {
+            return Err(FsError::Invalid);
+        }
+        let link_count = g
+            .index
+            .values()
+            .filter(|candidate| **candidate == plan.ino)
+            .count();
         let has_open_handles = g.handles.values().any(|handle| handle.ino == plan.ino);
-        if has_open_handles != plan.orphan_path.is_some() {
+        if (link_count == 1 && has_open_handles) != plan.orphan_path.is_some() {
             return Err(FsError::Invalid);
         }
 
         g.index.remove(&(plan.parent, plan.name.clone()));
-        if let Some(parent) = g.nodes.get_mut(&plan.parent) {
-            parent.children.retain(|child| *child != plan.ino);
-        }
-        if let Some(orphan_path) = &plan.orphan_path {
+        Self::remove_child_once(&mut g, plan.parent, plan.ino);
+        let remaining = Self::inode_dentries_locked(&g, plan.ino);
+        if let Some((parent, name, path)) = remaining.first() {
+            let node = g.nodes.get_mut(&plan.ino).ok_or(FsError::NotFound)?;
+            if node.path == plan.source_path {
+                node.parent = Some(*parent);
+                node.name.clone_from(name);
+                node.path.clone_from(path);
+            }
+            node.linked = true;
+        } else if let Some(orphan_path) = &plan.orphan_path {
             let node = g.nodes.get_mut(&plan.ino).ok_or(FsError::NotFound)?;
             node.parent = None;
             node.path.clone_from(orphan_path);
@@ -1449,6 +1611,50 @@ impl ReadOnlyFs {
             name.to_string()
         } else {
             format!("{}/{}", parent.path, name)
+        }
+    }
+
+    fn inode_paths_locked(g: &Inner, ino: u64) -> Result<Vec<String>, FsError> {
+        let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
+        if node.kind == FileKind::Directory {
+            return Err(FsError::IsDir);
+        }
+        let mut paths: Vec<String> = Self::inode_dentries_locked(g, ino)
+            .into_iter()
+            .map(|(_, _, path)| path)
+            .collect();
+        paths.sort();
+        paths.dedup();
+        if paths.is_empty() && !node.linked {
+            paths.push(node.path.clone());
+        }
+        Ok(paths)
+    }
+
+    fn inode_dentries_locked(g: &Inner, ino: u64) -> Vec<(u64, String, String)> {
+        let mut entries: Vec<(u64, String, String)> = g
+            .index
+            .iter()
+            .filter(|(_, child_ino)| **child_ino == ino)
+            .filter_map(|((parent_ino, name), _)| {
+                g.nodes
+                    .get(parent_ino)
+                    .map(|parent| (*parent_ino, name.clone(), Self::child_path(parent, name)))
+            })
+            .collect();
+        entries.sort_by(|left, right| left.2.cmp(&right.2));
+        entries
+    }
+
+    fn remove_child_once(g: &mut Inner, parent_ino: u64, child_ino: u64) {
+        if let Some(parent) = g.nodes.get_mut(&parent_ino) {
+            if let Some(position) = parent
+                .children
+                .iter()
+                .position(|candidate| *candidate == child_ino)
+            {
+                parent.children.remove(position);
+            }
         }
     }
 
@@ -1682,6 +1888,87 @@ mod tests {
         assert_eq!(
             fs.new_symlink_path(parent.ino, &"x".repeat(256), b"target"),
             Err(FsError::NameTooLong)
+        );
+    }
+
+    #[test]
+    fn hard_links_share_inode_link_count_and_backend_paths() {
+        let fs = fs();
+        let parent = data_dir(&fs);
+        let source = fs.lookup(parent.ino, "a.bin").unwrap();
+        let plan = fs
+            .hard_link_plan(source.ino, parent.ino, "linked.bin")
+            .unwrap();
+        assert_eq!(plan.source_path, "s3/bucket/data/a.bin");
+        assert_eq!(plan.target_path, "s3/bucket/data/linked.bin");
+
+        let linked = fs.commit_hard_link(&plan).unwrap();
+        assert_eq!(linked.ino, source.ino);
+        assert_eq!(linked.nlink, 2);
+        assert_eq!(fs.lookup(parent.ino, "linked.bin").unwrap().ino, source.ino);
+        assert_eq!(
+            fs.inode_paths(source.ino).unwrap(),
+            vec![
+                "s3/bucket/data/a.bin".to_string(),
+                "s3/bucket/data/linked.bin".to_string(),
+            ]
+        );
+        let names: Vec<String> = fs
+            .readdir(parent.ino)
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.name)
+            .collect();
+        assert!(names.contains(&"a.bin".to_string()));
+        assert!(names.contains(&"linked.bin".to_string()));
+
+        let same_inode = fs
+            .file_rename_plan(parent.ino, "a.bin", parent.ino, "linked.bin")
+            .unwrap();
+        assert_eq!(same_inode.source_path, same_inode.target_path);
+        fs.commit_file_rename(&same_inode).unwrap();
+        assert_eq!(fs.getattr(source.ino).unwrap().nlink, 2);
+
+        let move_link = fs
+            .file_rename_plan(parent.ino, "linked.bin", parent.ino, "moved.bin")
+            .unwrap();
+        fs.commit_file_rename(&move_link).unwrap();
+        assert_eq!(
+            fs.inode_paths(source.ino).unwrap(),
+            vec![
+                "s3/bucket/data/a.bin".to_string(),
+                "s3/bucket/data/moved.bin".to_string(),
+            ]
+        );
+
+        fs.unlink(parent.ino, "a.bin").unwrap();
+        assert_eq!(fs.lookup(parent.ino, "a.bin"), Err(FsError::NotFound));
+        assert_eq!(fs.lookup(parent.ino, "moved.bin").unwrap().nlink, 1);
+        assert_eq!(
+            fs.inode_paths(source.ino).unwrap(),
+            vec!["s3/bucket/data/moved.bin".to_string()]
+        );
+    }
+
+    #[test]
+    fn hard_links_reject_directories_conflicts_and_cross_bucket_targets() {
+        let fs = fs();
+        let source_parent = data_dir(&fs);
+        let source = fs.lookup(source_parent.ino, "a.bin").unwrap();
+        assert_eq!(
+            fs.hard_link_plan(source.ino, source_parent.ino, "b.bin"),
+            Err(FsError::Exists)
+        );
+        assert_eq!(
+            fs.hard_link_plan(source_parent.ino, source_parent.ino, "dir-link"),
+            Err(FsError::OperationNotPermitted)
+        );
+
+        let gcs = fs.lookup(ROOT_INO, "gcs").unwrap();
+        let other = fs.lookup(gcs.ino, "other").unwrap();
+        assert_eq!(
+            fs.hard_link_plan(source.ino, other.ino, "linked.bin"),
+            Err(FsError::CrossDevice)
         );
     }
 
@@ -1937,6 +2224,43 @@ mod tests {
         assert_eq!(moved.ino, source.ino);
         assert_eq!(fs.lookup(moved.ino, "a.bin").unwrap().ino, file.ino);
         assert_eq!(fs.dirty_path(fh).as_deref(), Some("s3/bucket/moved/a.bin"));
+    }
+
+    #[test]
+    fn directory_rename_moves_only_hard_link_dentries_inside_the_subtree() {
+        let fs = fs();
+        let s3 = fs.lookup(ROOT_INO, "s3").unwrap();
+        let bucket = fs.lookup(s3.ino, "bucket").unwrap();
+        let source = fs.lookup(bucket.ino, "data").unwrap();
+        let file = fs.lookup(source.ino, "a.bin").unwrap();
+        let external = fs
+            .hard_link_plan(file.ino, bucket.ino, "external.bin")
+            .unwrap();
+        fs.commit_hard_link(&external).unwrap();
+
+        let plan = fs
+            .directory_rename_plan(bucket.ino, "data", bucket.ino, "moved")
+            .unwrap();
+        assert!(plan.entries.iter().any(|entry| {
+            entry.source_path == "s3/bucket/data/a.bin"
+                && entry.target_path == "s3/bucket/moved/a.bin"
+        }));
+        assert!(!plan
+            .entries
+            .iter()
+            .any(|entry| entry.source_path == "s3/bucket/external.bin"));
+        fs.commit_directory_rename(&plan).unwrap();
+
+        let moved = fs.lookup(bucket.ino, "moved").unwrap();
+        assert_eq!(fs.lookup(moved.ino, "a.bin").unwrap().ino, file.ino);
+        assert_eq!(fs.lookup(bucket.ino, "external.bin").unwrap().ino, file.ino);
+        assert_eq!(
+            fs.inode_paths(file.ino).unwrap(),
+            vec![
+                "s3/bucket/external.bin".to_string(),
+                "s3/bucket/moved/a.bin".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -1172,6 +1172,179 @@ async fn mount_symbolic_links_are_written_through() {
     result.expect("exercise symbolic links through mount");
 }
 
+/// Keep hard-link dentries on one inode while writing every linked blob key.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires /dev/fuse; run with --features mount -- --ignored"]
+async fn mount_hard_links_share_inode_and_backend_contents() {
+    use fuser::MountOption;
+
+    let block_size: u32 = 4 * 1024 * 1024;
+    let store: Store = Arc::new(Mutex::new(HashMap::from([
+        ("/s3/bucket/source.bin".to_string(), b"seed".to_vec()),
+        ("/gcs/other/placeholder".to_string(), Vec::new()),
+    ])));
+    let worker = spawn_rw_worker(Arc::clone(&store)).await;
+    let coord = spawn_coordinator(worker).await;
+
+    let fs = Arc::new(ReadOnlyFs::new());
+    fs.insert_object("s3/bucket/source.bin", 4);
+    fs.insert_object("gcs/other/placeholder", 0);
+
+    let cache = Arc::new(PlacementCache::new(10_000));
+    let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
+    let adapter = TalonFuse::new(
+        Arc::clone(&fs),
+        reader,
+        tokio::runtime::Handle::current(),
+        block_size,
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
+    )
+    .with_read_write(true);
+
+    let require_fuse = std::env::var_os("TALON_REQUIRE_FUSE").is_some();
+    let mountpoint =
+        std::env::temp_dir().join(format!("talon-mount-e2e-hard-link-{}", std::process::id()));
+    std::fs::create_dir_all(&mountpoint).unwrap();
+    let options = vec![MountOption::FSName("talon".into())];
+    let session = match fuser::spawn_mount2(adapter, &mountpoint, &options) {
+        Ok(session) => session,
+        Err(error) => {
+            std::fs::remove_dir_all(&mountpoint).ok();
+            if require_fuse {
+                panic!(
+                    "TALON_REQUIRE_FUSE is set but the FUSE mount failed: {error}. \
+                     The runner must provide an accessible /dev/fuse."
+                );
+            }
+            eprintln!("skipping: /dev/fuse unavailable: {error}");
+            return;
+        }
+    };
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let bucket = mountpoint.join("s3").join("bucket");
+    let source = bucket.join("source.bin");
+    let linked = bucket.join("linked.bin");
+    let moved = bucket.join("moved.bin");
+    let cross_bucket = mountpoint.join("gcs").join("other").join("linked.bin");
+    let operation_store = Arc::clone(&store);
+    let result = tokio::task::spawn_blocking(move || {
+        std::fs::hard_link(&source, &linked)?;
+        let source_metadata = std::fs::metadata(&source)?;
+        let linked_metadata = std::fs::metadata(&linked)?;
+        assert_eq!(source_metadata.ino(), linked_metadata.ino());
+        assert_eq!(source_metadata.nlink(), 2);
+        assert_eq!(linked_metadata.nlink(), 2);
+        {
+            let committed = operation_store.lock().unwrap();
+            assert_eq!(
+                committed.get("/s3/bucket/source.bin"),
+                Some(&b"seed".to_vec())
+            );
+            assert_eq!(
+                committed.get("/s3/bucket/linked.bin"),
+                Some(&b"seed".to_vec())
+            );
+        }
+
+        let mut writer = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&linked)?;
+        writer.seek(SeekFrom::Start(0))?;
+        writer.write_all(b"next")?;
+        writer.sync_all()?;
+        {
+            let committed = operation_store.lock().unwrap();
+            assert_eq!(
+                committed.get("/s3/bucket/source.bin"),
+                Some(&b"next".to_vec())
+            );
+            assert_eq!(
+                committed.get("/s3/bucket/linked.bin"),
+                Some(&b"next".to_vec())
+            );
+        }
+
+        writer.set_len(2)?;
+        writer.sync_all()?;
+        assert_eq!(std::fs::read(&source)?, b"ne");
+        {
+            let committed = operation_store.lock().unwrap();
+            assert_eq!(
+                committed.get("/s3/bucket/source.bin"),
+                Some(&b"ne".to_vec())
+            );
+            assert_eq!(
+                committed.get("/s3/bucket/linked.bin"),
+                Some(&b"ne".to_vec())
+            );
+        }
+        drop(writer);
+
+        assert_eq!(
+            std::fs::hard_link(&source, &cross_bucket)
+                .unwrap_err()
+                .raw_os_error(),
+            Some(libc::EXDEV)
+        );
+
+        std::fs::rename(&linked, &moved)?;
+        assert_eq!(std::fs::metadata(&source)?.nlink(), 2);
+        assert_eq!(std::fs::metadata(&moved)?.nlink(), 2);
+        {
+            let committed = operation_store.lock().unwrap();
+            assert!(!committed.contains_key("/s3/bucket/linked.bin"));
+            assert_eq!(committed.get("/s3/bucket/moved.bin"), Some(&b"ne".to_vec()));
+        }
+
+        std::fs::rename(&source, &moved)?;
+        assert!(source.exists());
+        assert!(moved.exists());
+        assert_eq!(std::fs::metadata(&source)?.nlink(), 2);
+
+        std::fs::remove_file(&source)?;
+        assert!(!source.exists());
+        assert_eq!(std::fs::metadata(&moved)?.nlink(), 1);
+        assert_eq!(std::fs::read(&moved)?, b"ne");
+
+        let mut final_handle = std::fs::File::open(&moved)?;
+        std::fs::remove_file(&moved)?;
+        assert_eq!(final_handle.metadata()?.nlink(), 0);
+        let mut retained = Vec::new();
+        final_handle.read_to_end(&mut retained)?;
+        assert_eq!(retained, b"ne");
+        drop(final_handle);
+
+        for _ in 0..100 {
+            let has_orphan = operation_store
+                .lock()
+                .unwrap()
+                .keys()
+                .any(|path| path.starts_with("/s3/bucket/.__talon_internal/unlinked/"));
+            if !has_orphan {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            !operation_store
+                .lock()
+                .unwrap()
+                .keys()
+                .any(|path| path.starts_with("/s3/bucket/.__talon_internal/unlinked/")),
+            "final release should delete the last-link orphan"
+        );
+        Ok::<(), std::io::Error>(())
+    })
+    .await
+    .unwrap();
+
+    drop(session);
+    std::fs::remove_dir_all(&mountpoint).ok();
+    result.expect("exercise hard links through mount");
+}
+
 /// Mount the read-write fixture and run the pinned pjdfstest suite against it.
 ///
 /// This is separately gated because the normal real-kernel smoke job runs all


### PR DESCRIPTION
## Summary

Add POSIX hard-link inode and dentry semantics to Talon FUSE while preserving direct write-through behavior. Creating a hard link materializes the current inode bytes at the destination blob key before publishing the dentry, and subsequent flush, fsync, and truncate operations replace every linked blob key.

This PR is stacked on #342. Its diff will shrink to the hard-link-specific commit after the prerequisite PRs merge.

## Related issues

- Progresses #323
- Part of #259 and #262
- Production hard-link identity reconstruction on remount still depends on #332

## Type of change

- [ ] Bug fix
- [x] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [x] Docs / tests / tooling

## Backend representation

Each hard-link dentry is represented by an ordinary visible object key containing the shared inode bytes. The mount-session namespace maps multiple `(parent, name)` dentries to one inode and derives `st_nlink` from that dentry set.

Link creation performs a synchronous PUT before namespace insertion and deletes the destination key if namespace commit fails. Writes, fsync, flush, and truncate synchronously PUT the replacement bytes to every visible key for the inode. All keys are attempted even when one PUT fails, and the operation returns `EIO` on any failure. Object stores do not provide a cross-key transaction, so a partial backend failure can temporarily leave linked keys divergent until a retry succeeds.

The current listing API exposes only independent paths and sizes. Reconstructing shared inode identity after remount requires the metadata work tracked by #332.

## Changes

- Add the FUSE `link` callback with `EPERM`, `EEXIST`, and `EXDEV` handling.
- Decouple dentry names from inode identity so multiple names can resolve to one inode.
- Derive regular-file and symlink link counts from visible dentries.
- Emit `readdir` names from the dentry index rather than a single inode name.
- Write the destination blob before committing a new hard-link dentry.
- Write flush, fsync, and truncate contents through to every linked blob key.
- Remove only one dentry on unlink and retain the inode until its final link and open handles are gone.
- Treat rename between two names for the same inode as a no-op.
- Preserve links outside a renamed directory tree while moving only dentries inside that tree.
- Add focused namespace and privileged real-kernel tests.

## Test plan

- [x] `cargo test -p talon-fuse --lib`: 102 passed
- [x] `cargo test -p talon-fuse --features mount --test mount_e2e --no-run`
- [x] `cargo clippy -p talon-fuse --all-targets --features mount -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Exact commit `996114128059cf770319ac8513703a92c2f41c6b` passed `mount_hard_links_share_inode_and_backend_contents` in a privileged `falcon-phx-ca` Job with host `/dev/fuse`
- [x] The same exact commit passed `mount_directory_tree_rename_is_written_through`, including one inode linked both inside and outside the renamed subtree
- [x] Real-kernel `link` pjdfstest on runner commit `9f5ec347b6b84422330e256bce0087d75ed7e28e` produced 183 passed / 176 failed out of 359 assertions, versus 150 passed / 209 failed at the issue baseline

The remaining link-group failures primarily require mode, ownership, and permission semantics (#328), or FIFO/device/socket prerequisites (#327).

## Performance impact

Hard-link creation adds one full-object PUT. Each writeback or truncate performs one full-object PUT per visible hard-link key. This is linear in `st_nlink` and intentionally favors immediate blob-store consistency over a metadata-only write cache.

- [x] Limited to inodes with multiple hard-link keys

## Checklist

- [x] PR title follows Conventional Commits
- [x] Public behavior is covered by tests
- [x] No new dependencies
- [x] Based on `main` through the stacked prerequisite branches