### PR TITLE
feat(fuse): implement POSIX timestamps

### DIFF
--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -101,24 +101,22 @@ fn now_ms() -> u64 {
 
 /// Convert a synthesized [`Attr`] into a `fuser::FileAttr`.
 ///
-/// Times are fixed to the UNIX epoch (the namespace is synthetic and read-only,
-/// so there is no meaningful mtime); ownership is left to the mounting user via
-/// `uid`/`gid`. `blocks` is a 512-byte-unit count as POSIX expects.
+/// Ownership is left to the mounting user via `uid`/`gid`. `blocks` is a
+/// 512-byte-unit count as POSIX expects.
 pub(crate) fn to_file_attr(attr: Attr, uid: u32, gid: u32) -> fuser::FileAttr {
     let kind = match attr.kind {
         FileKind::Directory => fuser::FileType::Directory,
         FileKind::File => fuser::FileType::RegularFile,
         FileKind::Symlink => fuser::FileType::Symlink,
     };
-    let epoch = std::time::UNIX_EPOCH;
     fuser::FileAttr {
         ino: attr.ino,
         size: attr.size,
         blocks: attr.size.div_ceil(512),
-        atime: epoch,
-        mtime: epoch,
-        ctime: epoch,
-        crtime: epoch,
+        atime: attr.atime,
+        mtime: attr.mtime,
+        ctime: attr.ctime,
+        crtime: attr.ctime,
         kind,
         perm: attr.perm,
         nlink: attr.nlink,
@@ -981,8 +979,8 @@ impl fuser::Filesystem for TalonFuse {
         _uid: Option<u32>,
         _gid: Option<u32>,
         size: Option<u64>,
-        _atime: Option<fuser::TimeOrNow>,
-        _mtime: Option<fuser::TimeOrNow>,
+        atime: Option<fuser::TimeOrNow>,
+        mtime: Option<fuser::TimeOrNow>,
         _ctime: Option<std::time::SystemTime>,
         fh: Option<u64>,
         _crtime: Option<std::time::SystemTime>,
@@ -1042,8 +1040,15 @@ impl fuser::Filesystem for TalonFuse {
                 Err(e) => reply.error(errno(e)),
             };
         }
-        // Reply with the current attributes.
-        match self.fs.getattr(ino) {
+        let now = std::time::SystemTime::now();
+        let resolve_time = |time: fuser::TimeOrNow| match time {
+            fuser::TimeOrNow::SpecificTime(time) => time,
+            fuser::TimeOrNow::Now => now,
+        };
+        match self
+            .fs
+            .set_times(ino, atime.map(resolve_time), mtime.map(resolve_time))
+        {
             Ok(attr) => reply.attr(&ATTR_TTL, &to_file_attr(attr, req.uid(), req.gid())),
             Err(e) => reply.error(errno(e)),
         }
@@ -1543,18 +1548,25 @@ mod tests {
 
     #[test]
     fn to_file_attr_maps_kind_size_and_perm() {
+        let timestamp = std::time::UNIX_EPOCH + Duration::from_secs(123);
         let dir = Attr {
             ino: 1,
             kind: FileKind::Directory,
             size: 0,
             perm: 0o555,
             nlink: 1,
+            atime: timestamp,
+            mtime: timestamp,
+            ctime: timestamp,
         };
         let fa = to_file_attr(dir, 1000, 1000);
         assert_eq!(fa.kind, fuser::FileType::Directory);
         assert_eq!(fa.perm, 0o555);
         assert_eq!(fa.uid, 1000);
         assert_eq!(fa.nlink, 1);
+        assert_eq!(fa.atime, timestamp);
+        assert_eq!(fa.mtime, timestamp);
+        assert_eq!(fa.ctime, timestamp);
 
         let file = Attr {
             ino: 7,
@@ -1562,6 +1574,9 @@ mod tests {
             size: 1000, // 1000 bytes → ceil(1000/512) = 2 blocks
             perm: 0o444,
             nlink: 0,
+            atime: timestamp,
+            mtime: timestamp,
+            ctime: timestamp,
         };
         let fa = to_file_attr(file, 0, 0);
         assert_eq!(fa.kind, fuser::FileType::RegularFile);
@@ -1576,6 +1591,9 @@ mod tests {
             size: 6,
             perm: 0o777,
             nlink: 1,
+            atime: timestamp,
+            mtime: timestamp,
+            ctime: timestamp,
         };
         let fa = to_file_attr(symlink, 0, 0);
         assert_eq!(fa.kind, fuser::FileType::Symlink);

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -47,6 +47,12 @@ pub struct Attr {
     pub perm: u16,
     /// Number of namespace links. An open file retained after unlink has zero.
     pub nlink: u32,
+    /// Last access time.
+    pub atime: SystemTime,
+    /// Last content modification time.
+    pub mtime: SystemTime,
+    /// Last inode metadata change time.
+    pub ctime: SystemTime,
 }
 
 /// Errors returned by the read-only op layer (mapped to errno by the adapter).
@@ -208,6 +214,9 @@ struct Node {
     symlink_target: Option<Vec<u8>>,
     /// Whether the inode still has a visible namespace entry.
     linked: bool,
+    atime: SystemTime,
+    mtime: SystemTime,
+    ctime: SystemTime,
 }
 
 /// A read-only view over the backend namespace, addressed by inode.
@@ -268,6 +277,7 @@ impl ReadOnlyFs {
     /// Create a filesystem with just the root directory.
     pub fn new() -> Self {
         let mut nodes = HashMap::new();
+        let now = SystemTime::now();
         nodes.insert(
             ROOT_INO,
             Node {
@@ -281,6 +291,9 @@ impl ReadOnlyFs {
                 directory_marker: false,
                 symlink_target: None,
                 linked: true,
+                atime: now,
+                mtime: now,
+                ctime: now,
             },
         );
         let instance = NEXT_FS_INSTANCE.fetch_add(1, Ordering::Relaxed);
@@ -322,6 +335,7 @@ impl ReadOnlyFs {
         let mut g = self.inner.lock_recover();
         let mut parent = ROOT_INO;
         let mut current_path = String::new();
+        let now = SystemTime::now();
         for (i, comp) in comps.iter().enumerate() {
             let is_leaf = i == comps.len() - 1;
             if !current_path.is_empty() {
@@ -351,6 +365,9 @@ impl ReadOnlyFs {
                 directory_marker: false,
                 symlink_target: None,
                 linked: true,
+                atime: now,
+                mtime: now,
+                ctime: now,
             };
             g.nodes.insert(ino, node);
             g.index.insert(key, ino);
@@ -401,6 +418,7 @@ impl ReadOnlyFs {
         let mut g = self.inner.lock_recover();
         let mut parent = ROOT_INO;
         let mut current_path = String::new();
+        let now = SystemTime::now();
         for (index, component) in comps.iter().enumerate() {
             if !current_path.is_empty() {
                 current_path.push('/');
@@ -431,6 +449,9 @@ impl ReadOnlyFs {
                 directory_marker: index == comps.len() - 1,
                 symlink_target: None,
                 linked: true,
+                atime: now,
+                mtime: now,
+                ctime: now,
             };
             g.nodes.insert(ino, node);
             g.index.insert(key, ino);
@@ -460,6 +481,9 @@ impl ReadOnlyFs {
             size: node.size,
             perm,
             nlink,
+            atime: node.atime,
+            mtime: node.mtime,
+            ctime: node.ctime,
         }
     }
 
@@ -480,6 +504,31 @@ impl ReadOnlyFs {
     /// `getattr`: attributes for an inode.
     pub fn getattr(&self, ino: u64) -> Result<Attr, FsError> {
         let g = self.inner.lock_recover();
+        Ok(Self::attr_of(
+            &g,
+            g.nodes.get(&ino).ok_or(FsError::NotFound)?,
+        ))
+    }
+
+    /// Apply explicit atime/mtime updates and advance ctime when either changes.
+    pub fn set_times(
+        &self,
+        ino: u64,
+        atime: Option<SystemTime>,
+        mtime: Option<SystemTime>,
+    ) -> Result<Attr, FsError> {
+        let mut g = self.inner.lock_recover();
+        let node = g.nodes.get_mut(&ino).ok_or(FsError::NotFound)?;
+        let changed = atime.is_some() || mtime.is_some();
+        if let Some(atime) = atime {
+            node.atime = atime;
+        }
+        if let Some(mtime) = mtime {
+            node.mtime = mtime;
+        }
+        if changed {
+            node.ctime = SystemTime::now();
+        }
         Ok(Self::attr_of(
             &g,
             g.nodes.get(&ino).ok_or(FsError::NotFound)?,
@@ -637,24 +686,29 @@ impl ReadOnlyFs {
 
     /// Return a handle's read source, preferring its uncommitted write buffer.
     pub fn read_source(&self, fh: u64, offset: u64, size: u32) -> Result<ReadSource, FsError> {
-        let g = self.inner.lock_recover();
+        let mut g = self.inner.lock_recover();
         let handle = g.handles.get(&fh).ok_or(FsError::BadHandle)?;
         if !handle.read {
             return Err(FsError::BadHandle);
         }
-        let node = g.nodes.get(&handle.ino).ok_or(FsError::NotFound)?;
-        if let Some(dirty) = g.dirty.get(&fh) {
+        let ino = handle.ino;
+        let source = if let Some(dirty) = g.dirty.get(&fh) {
             let start = usize::try_from(offset).map_err(|_| FsError::Invalid)?;
             if start >= dirty.buf.len() {
-                return Ok(ReadSource::Buffered(Vec::new()));
+                ReadSource::Buffered(Vec::new())
+            } else {
+                let end = start.saturating_add(size as usize).min(dirty.buf.len());
+                ReadSource::Buffered(dirty.buf[start..end].to_vec())
             }
-            let end = start.saturating_add(size as usize).min(dirty.buf.len());
-            return Ok(ReadSource::Buffered(dirty.buf[start..end].to_vec()));
-        }
-        Ok(ReadSource::Backend {
-            path: node.path.clone(),
-            size: node.size,
-        })
+        } else {
+            let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
+            ReadSource::Backend {
+                path: node.path.clone(),
+                size: node.size,
+            }
+        };
+        g.nodes.get_mut(&ino).ok_or(FsError::NotFound)?.atime = SystemTime::now();
+        Ok(source)
     }
 
     /// Return the committed object path and size for an inode before opening it.
@@ -705,6 +759,7 @@ impl ReadOnlyFs {
         Self::validate_visible_object_path(&path)?;
         let ino = g.next_ino;
         g.next_ino += 1;
+        let now = SystemTime::now();
         let node = Node {
             ino,
             parent: Some(parent_ino),
@@ -716,10 +771,14 @@ impl ReadOnlyFs {
             directory_marker: false,
             symlink_target: None,
             linked: true,
+            atime: now,
+            mtime: now,
+            ctime: now,
         };
         g.nodes.insert(ino, node);
         g.index.insert((parent_ino, name.to_string()), ino);
         g.nodes.get_mut(&parent_ino).unwrap().children.push(ino);
+        Self::mark_directory_changed(&mut g, parent_ino, now);
         let fh = g.next_fh;
         g.next_fh += 1;
         g.handles.insert(
@@ -797,6 +856,9 @@ impl ReadOnlyFs {
         let new_size = dirty.buf.len() as u64;
         if let Some(node) = g.nodes.get_mut(&ino) {
             node.size = node.size.max(new_size);
+            let now = SystemTime::now();
+            node.mtime = now;
+            node.ctime = now;
         }
         Ok(data.len() as u32)
     }
@@ -880,6 +942,9 @@ impl ReadOnlyFs {
             return Err(FsError::IsDir);
         }
         node.size = contents.len() as u64;
+        let now = SystemTime::now();
+        node.mtime = now;
+        node.ctime = now;
         for dirty in g.dirty.values_mut().filter(|dirty| dirty.ino == ino) {
             dirty.buf.clone_from(&contents);
         }
@@ -1000,6 +1065,12 @@ impl ReadOnlyFs {
             .ok_or(FsError::NotFound)?
             .children
             .push(plan.source_ino);
+        let now = SystemTime::now();
+        Self::mark_directory_changed(&mut g, plan.target_parent, now);
+        g.nodes
+            .get_mut(&plan.source_ino)
+            .ok_or(FsError::NotFound)?
+            .ctime = now;
         Ok(Self::attr_of(
             &g,
             g.nodes.get(&plan.source_ino).ok_or(FsError::NotFound)?,
@@ -1122,6 +1193,10 @@ impl ReadOnlyFs {
             source.name.clone_from(&plan.target_name);
             source.path.clone_from(&plan.target_path);
         }
+        let now = SystemTime::now();
+        source.ctime = now;
+        Self::mark_directory_changed(&mut g, plan.source_parent, now);
+        Self::mark_directory_changed(&mut g, plan.target_parent, now);
         Ok(())
     }
 
@@ -1294,6 +1369,8 @@ impl ReadOnlyFs {
         let source = g.nodes.get_mut(&plan.source_ino).ok_or(FsError::NotFound)?;
         source.parent = Some(plan.target_parent);
         source.name.clone_from(&plan.target_name);
+        let now = SystemTime::now();
+        source.ctime = now;
         g.index.insert(
             (plan.target_parent, plan.target_name.clone()),
             plan.source_ino,
@@ -1303,6 +1380,8 @@ impl ReadOnlyFs {
             .ok_or(FsError::NotFound)?
             .children
             .push(plan.source_ino);
+        Self::mark_directory_changed(&mut g, plan.source_parent, now);
+        Self::mark_directory_changed(&mut g, plan.target_parent, now);
         Ok(())
     }
 
@@ -1339,6 +1418,7 @@ impl ReadOnlyFs {
         }
         let ino = g.next_ino;
         g.next_ino += 1;
+        let now = SystemTime::now();
         let node = Node {
             ino,
             parent: Some(parent_ino),
@@ -1350,10 +1430,14 @@ impl ReadOnlyFs {
             directory_marker: false,
             symlink_target: Some(target),
             linked: true,
+            atime: now,
+            mtime: now,
+            ctime: now,
         };
         g.nodes.insert(ino, node);
         g.index.insert((parent_ino, name.to_string()), ino);
         g.nodes.get_mut(&parent_ino).unwrap().children.push(ino);
+        Self::mark_directory_changed(&mut g, parent_ino, now);
         Ok(Self::attr_of(&g, g.nodes.get(&ino).unwrap()))
     }
 
@@ -1402,6 +1486,7 @@ impl ReadOnlyFs {
         Self::validate_visible_object_path(&path)?;
         let ino = g.next_ino;
         g.next_ino += 1;
+        let now = SystemTime::now();
         let node = Node {
             ino,
             parent: Some(parent_ino),
@@ -1413,10 +1498,14 @@ impl ReadOnlyFs {
             directory_marker: true,
             symlink_target: None,
             linked: true,
+            atime: now,
+            mtime: now,
+            ctime: now,
         };
         g.nodes.insert(ino, node);
         g.index.insert((parent_ino, name.to_string()), ino);
         g.nodes.get_mut(&parent_ino).unwrap().children.push(ino);
+        Self::mark_directory_changed(&mut g, parent_ino, now);
         Ok(Self::attr_of(&g, g.nodes.get(&ino).unwrap()))
     }
 
@@ -1462,6 +1551,7 @@ impl ReadOnlyFs {
         if let Some(parent) = g.nodes.get_mut(&parent_ino) {
             parent.children.retain(|child| *child != ino);
         }
+        Self::mark_directory_changed(&mut g, parent_ino, SystemTime::now());
         Ok(())
     }
 
@@ -1538,6 +1628,8 @@ impl ReadOnlyFs {
 
         g.index.remove(&(plan.parent, plan.name.clone()));
         Self::remove_child_once(&mut g, plan.parent, plan.ino);
+        let now = SystemTime::now();
+        Self::mark_directory_changed(&mut g, plan.parent, now);
         let remaining = Self::inode_dentries_locked(&g, plan.ino);
         if let Some((parent, name, path)) = remaining.first() {
             let node = g.nodes.get_mut(&plan.ino).ok_or(FsError::NotFound)?;
@@ -1547,11 +1639,13 @@ impl ReadOnlyFs {
                 node.path.clone_from(path);
             }
             node.linked = true;
+            node.ctime = now;
         } else if let Some(orphan_path) = &plan.orphan_path {
             let node = g.nodes.get_mut(&plan.ino).ok_or(FsError::NotFound)?;
             node.parent = None;
             node.path.clone_from(orphan_path);
             node.linked = false;
+            node.ctime = now;
         } else {
             g.nodes.remove(&plan.ino);
         }
@@ -1658,6 +1752,13 @@ impl ReadOnlyFs {
         }
     }
 
+    fn mark_directory_changed(g: &mut Inner, ino: u64, now: SystemTime) {
+        if let Some(node) = g.nodes.get_mut(&ino) {
+            node.mtime = now;
+            node.ctime = now;
+        }
+    }
+
     fn orphan_path(&self, source_path: &str, ino: u64) -> Result<String, FsError> {
         let object = path_to_object(source_path).map_err(|_| FsError::Invalid)?;
         Ok(format!(
@@ -1716,6 +1817,29 @@ mod tests {
         assert_eq!(fs.getattr(a.ino).unwrap(), a);
 
         assert_eq!(fs.lookup(ROOT_INO, "nope"), Err(FsError::NotFound));
+    }
+
+    #[test]
+    fn explicit_timestamp_updates_preserve_omitted_fields_and_advance_ctime() {
+        let fs = fs();
+        let file = fs.lookup(data_dir(&fs).ino, "a.bin").unwrap();
+        let original = fs.getattr(file.ino).unwrap();
+        let atime = UNIX_EPOCH + std::time::Duration::new(123, 456);
+        let mtime = UNIX_EPOCH + std::time::Duration::new(789, 123);
+
+        let updated = fs.set_times(file.ino, Some(atime), Some(mtime)).unwrap();
+        assert_eq!(updated.atime, atime);
+        assert_eq!(updated.mtime, mtime);
+        assert!(updated.ctime >= original.ctime);
+
+        let later_mtime = UNIX_EPOCH + std::time::Duration::new(999, 321);
+        let omitted = fs.set_times(file.ino, None, Some(later_mtime)).unwrap();
+        assert_eq!(omitted.atime, atime);
+        assert_eq!(omitted.mtime, later_mtime);
+        assert!(omitted.ctime >= updated.ctime);
+
+        let unchanged = fs.set_times(file.ino, None, None).unwrap();
+        assert_eq!(unchanged, omitted);
     }
 
     #[test]

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -24,6 +24,8 @@
 
 use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{FileExt, MetadataExt, OpenOptionsExt};
 use std::process::Command;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -1343,6 +1345,126 @@ async fn mount_hard_links_share_inode_and_backend_contents() {
     drop(session);
     std::fs::remove_dir_all(&mountpoint).ok();
     result.expect("exercise hard links through mount");
+}
+
+/// Apply explicit, omitted, and current timestamps through kernel setattr.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires /dev/fuse; run with --features mount -- --ignored"]
+async fn mount_timestamp_updates_follow_utimens_semantics() {
+    use fuser::MountOption;
+
+    let block_size: u32 = 4 * 1024 * 1024;
+    let store: Store = Arc::new(Mutex::new(HashMap::from([(
+        "/s3/bucket/placeholder".to_string(),
+        Vec::new(),
+    )])));
+    let worker = spawn_rw_worker(Arc::clone(&store)).await;
+    let coord = spawn_coordinator(worker).await;
+
+    let fs = Arc::new(ReadOnlyFs::new());
+    fs.insert_object("s3/bucket/placeholder", 0);
+
+    let cache = Arc::new(PlacementCache::new(10_000));
+    let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
+    let adapter = TalonFuse::new(
+        Arc::clone(&fs),
+        reader,
+        tokio::runtime::Handle::current(),
+        block_size,
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
+    )
+    .with_read_write(true);
+
+    let require_fuse = std::env::var_os("TALON_REQUIRE_FUSE").is_some();
+    let mountpoint =
+        std::env::temp_dir().join(format!("talon-mount-e2e-timestamps-{}", std::process::id()));
+    std::fs::create_dir_all(&mountpoint).unwrap();
+    let options = vec![MountOption::FSName("talon".into())];
+    let session = match fuser::spawn_mount2(adapter, &mountpoint, &options) {
+        Ok(session) => session,
+        Err(error) => {
+            std::fs::remove_dir_all(&mountpoint).ok();
+            if require_fuse {
+                panic!(
+                    "TALON_REQUIRE_FUSE is set but the FUSE mount failed: {error}. \
+                     The runner must provide an accessible /dev/fuse."
+                );
+            }
+            eprintln!("skipping: /dev/fuse unavailable: {error}");
+            return;
+        }
+    };
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let path = mountpoint.join("s3").join("bucket").join("file.bin");
+    let result = tokio::task::spawn_blocking(move || {
+        std::fs::write(&path, b"seed")?;
+        let file = std::fs::File::options()
+            .read(true)
+            .write(true)
+            .open(&path)?;
+        let explicit_atime = std::time::UNIX_EPOCH + Duration::new(123, 456);
+        let explicit_mtime = std::time::UNIX_EPOCH + Duration::new(789, 123);
+        file.set_times(
+            std::fs::FileTimes::new()
+                .set_accessed(explicit_atime)
+                .set_modified(explicit_mtime),
+        )?;
+        let explicit = file.metadata()?;
+        assert_eq!(explicit.atime(), 123);
+        assert_eq!(explicit.atime_nsec(), 456);
+        assert_eq!(explicit.mtime(), 789);
+        assert_eq!(explicit.mtime_nsec(), 123);
+
+        let later_mtime = libc::timespec {
+            tv_sec: 999,
+            tv_nsec: 321,
+        };
+        let omit_atime = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: libc::UTIME_OMIT,
+        };
+        let times = [omit_atime, later_mtime];
+        let path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        let result = unsafe { libc::utimensat(libc::AT_FDCWD, path.as_ptr(), times.as_ptr(), 0) };
+        if result != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let omitted = file.metadata()?;
+        assert_eq!(omitted.atime(), 123);
+        assert_eq!(omitted.atime_nsec(), 456);
+        assert_eq!(omitted.mtime(), 999);
+        assert_eq!(omitted.mtime_nsec(), 321);
+
+        let now_times = [
+            libc::timespec {
+                tv_sec: 0,
+                tv_nsec: libc::UTIME_NOW,
+            },
+            libc::timespec {
+                tv_sec: 0,
+                tv_nsec: libc::UTIME_NOW,
+            },
+        ];
+        let before = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let result = unsafe { libc::futimens(file.as_raw_fd(), now_times.as_ptr()) };
+        if result != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let current = file.metadata()?;
+        assert!(current.atime() >= before);
+        assert!(current.mtime() >= before);
+        Ok::<(), std::io::Error>(())
+    })
+    .await
+    .unwrap();
+
+    drop(session);
+    std::fs::remove_dir_all(&mountpoint).ok();
+    result.expect("exercise timestamp updates through mount");
 }
 
 /// Mount the read-write fixture and run the pinned pjdfstest suite against it.


### PR DESCRIPTION
## Summary

Add mount-session POSIX `atime`, `mtime`, and `ctime` state to Talon FUSE. Explicit `utimensat` and `futimens` updates support exact nanosecond timestamps, `UTIME_NOW`, and `UTIME_OMIT`; normal file and namespace operations advance the corresponding timestamps.

This PR is stacked on #343. Its diff will shrink to the timestamp-specific commit after the prerequisite PRs merge.

## Related issues

- Progresses #324
- Part of #259 and #262
- Timestamp ownership checks depend on #328
- Production metadata persistence and remount reconstruction depend on #332

## Type of change

- [ ] Bug fix
- [x] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [x] Docs / tests / tooling

## Timestamp model

Each in-memory inode stores nanosecond-resolution `atime`, `mtime`, and `ctime` values using `SystemTime`. Initial listing entries receive the mount-session insertion time because the current object listing contract does not expose POSIX metadata.

`setattr` resolves one shared current-time sample for all `UTIME_NOW` fields, preserves omitted fields, and advances `ctime` when either user-visible timestamp changes. Reads advance `atime`; writes and truncate advance `mtime` and `ctime`; create, link, unlink, rename, mkdir, rmdir, and symlink update the affected inode and parent-directory timestamps.

This PR does not add hidden metadata objects or a metadata write cache. Timestamp persistence across refresh and remount remains part of the metadata contract work in #332.

## Changes

- Store and report per-inode access, modification, and change timestamps.
- Return inode timestamps through FUSE `FileAttr` instead of the Unix epoch.
- Implement exact, current, and omitted timestamp updates through `setattr`.
- Preserve the same `UTIME_NOW` sample across atime and mtime in one request.
- Advance atime on reads.
- Advance mtime and ctime on writes and truncate.
- Advance parent-directory timestamps for namespace mutations.
- Advance inode ctime for hard-link, unlink, and rename changes.
- Add focused namespace and privileged real-kernel tests.

## Test plan

- [x] `cargo test -p talon-fuse --lib`: 103 passed
- [x] `cargo test -p talon-fuse --features mount --test mount_e2e --no-run`
- [x] `cargo clippy -p talon-fuse --all-targets --features mount -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Exact commit `e1d7a51597dd7590e49402943b5bb52d09f526aa` passed `mount_timestamp_updates_follow_utimens_semantics` in a privileged `falcon-phx-ca` Job with host `/dev/fuse`
- [x] Real-kernel `utimensat` pjdfstest on runner commit `50407fcd1a00d1119835b2aa46b40b752cc25915` improved from 44 passed / 78 failed to 93 passed / 29 failed out of 122 assertions

All 29 remaining assertions are attributable to other tracked prerequisites: 20 require FIFO, block device, character device, or Unix socket creation (#327), and 9 require ownership, mode, and permission enforcement (#328).

## Performance impact

Timestamp reads and updates are in-memory inode operations. Reads add one timestamp assignment under the existing namespace lock. No additional blob-store operation is introduced by this PR.

- [x] No additional backend I/O

## Checklist

- [x] PR title follows Conventional Commits
- [x] Public behavior is covered by tests
- [x] No new dependencies
- [x] Based on `main` through the stacked prerequisite branches