### PR TITLE
feat(fuse): add mount-local special nodes

### DIFF
--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -108,6 +108,10 @@ pub(crate) fn to_file_attr(attr: Attr, uid: u32, gid: u32) -> fuser::FileAttr {
         FileKind::Directory => fuser::FileType::Directory,
         FileKind::File => fuser::FileType::RegularFile,
         FileKind::Symlink => fuser::FileType::Symlink,
+        FileKind::NamedPipe => fuser::FileType::NamedPipe,
+        FileKind::BlockDevice => fuser::FileType::BlockDevice,
+        FileKind::CharDevice => fuser::FileType::CharDevice,
+        FileKind::Socket => fuser::FileType::Socket,
     };
     fuser::FileAttr {
         ino: attr.ino,
@@ -122,7 +126,7 @@ pub(crate) fn to_file_attr(attr: Attr, uid: u32, gid: u32) -> fuser::FileAttr {
         nlink: attr.nlink,
         uid,
         gid,
-        rdev: 0,
+        rdev: attr.rdev,
         blksize: 512,
         flags: 0,
     }
@@ -643,6 +647,10 @@ impl fuser::Filesystem for TalonFuse {
                 FileKind::Directory => fuser::FileType::Directory,
                 FileKind::File => fuser::FileType::RegularFile,
                 FileKind::Symlink => fuser::FileType::Symlink,
+                FileKind::NamedPipe => fuser::FileType::NamedPipe,
+                FileKind::BlockDevice => fuser::FileType::BlockDevice,
+                FileKind::CharDevice => fuser::FileType::CharDevice,
+                FileKind::Socket => fuser::FileType::Socket,
             };
             (e.ino, kind, e.name)
         }));
@@ -858,6 +866,12 @@ impl fuser::Filesystem for TalonFuse {
             Ok(plan) => plan,
             Err(error) => return reply.error(errno(error)),
         };
+        if !plan.backend_object {
+            return match self.fs.commit_hard_link(&plan) {
+                Ok(attr) => reply.entry(&ATTR_TTL, &to_file_attr(attr, req.uid(), req.gid()), 0),
+                Err(error) => reply.error(errno(error)),
+            };
+        }
         let contents = match &plan.buffered_contents {
             Some(contents) => contents.clone(),
             None => match self.read_committed_object(&plan.source_path, plan.source_size) {
@@ -886,6 +900,51 @@ impl fuser::Filesystem for TalonFuse {
                         %rollback_error,
                         "hard-link destination rollback failed"
                     );
+                }
+                reply.error(errno(error));
+            }
+        }
+    }
+
+    /// Create a regular file or mount-local POSIX special node.
+    fn mknod(
+        &mut self,
+        req: &fuser::Request<'_>,
+        parent: u64,
+        name: &std::ffi::OsStr,
+        mode: u32,
+        umask: u32,
+        rdev: u32,
+        reply: fuser::ReplyEntry,
+    ) {
+        if !self.read_write {
+            return reply.error(libc::EROFS);
+        }
+        let name = match name.to_str() {
+            Some(name) => name,
+            None => return reply.error(libc::EINVAL),
+        };
+        let plan = match self.fs.mknod_plan(parent, name, mode, umask, rdev) {
+            Ok(plan) => plan,
+            Err(error) => return reply.error(errno(error)),
+        };
+        if plan.kind.has_backend_object() {
+            if let Err(error) = self.writeback_object(&plan.path, Vec::new()) {
+                tracing::warn!(path = %plan.path, %error, "mknod writeback failed");
+                return reply.error(libc::EIO);
+            }
+        }
+        match self.fs.commit_mknod(&plan) {
+            Ok(attr) => reply.entry(&ATTR_TTL, &to_file_attr(attr, req.uid(), req.gid()), 0),
+            Err(error) => {
+                if plan.kind.has_backend_object() {
+                    if let Err(rollback_error) = self.delete_backend_object(&plan.path) {
+                        tracing::error!(
+                            path = %plan.path,
+                            %rollback_error,
+                            "mknod rollback failed"
+                        );
+                    }
                 }
                 reply.error(errno(error));
             }
@@ -1153,16 +1212,53 @@ impl fuser::Filesystem for TalonFuse {
         if plan.source_path == plan.target_path {
             return reply.ok();
         }
+        if !plan.source_backend_object {
+            let target_backup = if plan.target_backend_object {
+                let size = plan.target.map(|(_, size)| size).unwrap_or(0);
+                match self.read_committed_object(&plan.target_path, size) {
+                    Ok(bytes) => Some(bytes),
+                    Err(error) => return reply.error(error),
+                }
+            } else {
+                None
+            };
+            if plan.target_backend_object {
+                if let Err(error) = self.delete_backend_object(&plan.target_path) {
+                    tracing::warn!(
+                        target = %plan.target_path,
+                        %error,
+                        "special-node rename target delete failed"
+                    );
+                    return reply.error(libc::EIO);
+                }
+            }
+            return match self.fs.commit_file_rename(&plan) {
+                Ok(()) => reply.ok(),
+                Err(error) => {
+                    if let Some(bytes) = target_backup {
+                        if let Err(rollback_error) = self.writeback_object(&plan.target_path, bytes)
+                        {
+                            tracing::error!(
+                                target = %plan.target_path,
+                                %rollback_error,
+                                "special-node rename target rollback failed"
+                            );
+                        }
+                    }
+                    reply.error(errno(error));
+                }
+            };
+        }
         let source_bytes = match self.read_committed_object(&plan.source_path, plan.source_size) {
             Ok(bytes) => bytes,
             Err(error) => return reply.error(error),
         };
-        let target_backup = match plan.target {
-            Some((_, size)) => match self.read_committed_object(&plan.target_path, size) {
+        let target_backup = match (plan.target, plan.target_backend_object) {
+            (Some((_, size)), true) => match self.read_committed_object(&plan.target_path, size) {
                 Ok(bytes) => Some(bytes),
                 Err(error) => return reply.error(error),
             },
-            None => None,
+            _ => None,
         };
         if let Err(error) = self.writeback_object(&plan.target_path, source_bytes.clone()) {
             tracing::warn!(
@@ -1237,6 +1333,12 @@ impl fuser::Filesystem for TalonFuse {
             Ok(plan) => plan,
             Err(error) => return reply.error(errno(error)),
         };
+        if !plan.backend_object {
+            return match self.fs.commit_unlink(&plan) {
+                Ok(()) => reply.ok(),
+                Err(error) => reply.error(errno(error)),
+            };
+        }
         if let Some(orphan_path) = &plan.orphan_path {
             let contents = match &plan.buffered_contents {
                 Some(contents) => contents.clone(),
@@ -1558,6 +1660,7 @@ mod tests {
             atime: timestamp,
             mtime: timestamp,
             ctime: timestamp,
+            rdev: 0,
         };
         let fa = to_file_attr(dir, 1000, 1000);
         assert_eq!(fa.kind, fuser::FileType::Directory);
@@ -1577,6 +1680,7 @@ mod tests {
             atime: timestamp,
             mtime: timestamp,
             ctime: timestamp,
+            rdev: 0,
         };
         let fa = to_file_attr(file, 0, 0);
         assert_eq!(fa.kind, fuser::FileType::RegularFile);
@@ -1594,6 +1698,7 @@ mod tests {
             atime: timestamp,
             mtime: timestamp,
             ctime: timestamp,
+            rdev: 0,
         };
         let fa = to_file_attr(symlink, 0, 0);
         assert_eq!(fa.kind, fuser::FileType::Symlink);

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -32,6 +32,20 @@ pub enum FileKind {
     File,
     /// A symbolic link whose target bytes are stored in a backend object.
     Symlink,
+    /// A mount-local named pipe.
+    NamedPipe,
+    /// A mount-local block device node.
+    BlockDevice,
+    /// A mount-local character device node.
+    CharDevice,
+    /// A mount-local Unix socket node.
+    Socket,
+}
+
+impl FileKind {
+    pub(crate) fn has_backend_object(self) -> bool {
+        matches!(self, Self::File | Self::Symlink)
+    }
 }
 
 /// Synthesized attributes for a node.
@@ -53,6 +67,8 @@ pub struct Attr {
     pub mtime: SystemTime,
     /// Last inode metadata change time.
     pub ctime: SystemTime,
+    /// Device identifier for block and character devices.
+    pub rdev: u32,
 }
 
 /// Errors returned by the read-only op layer (mapped to errno by the adapter).
@@ -125,6 +141,14 @@ pub const DEFAULT_MAX_OBJECT_BYTES: u64 = 1 << 30;
 
 const INTERNAL_OBJECT_PREFIX: &str = ".__talon_internal";
 const MAX_SYMLINK_TARGET_BYTES: usize = 4095;
+const MODE_TYPE_MASK: u32 = 0o170000;
+const MODE_SOCKET: u32 = 0o140000;
+const MODE_SYMLINK: u32 = 0o120000;
+const MODE_REGULAR: u32 = 0o100000;
+const MODE_BLOCK_DEVICE: u32 = 0o060000;
+const MODE_DIRECTORY: u32 = 0o040000;
+const MODE_CHAR_DEVICE: u32 = 0o020000;
+const MODE_NAMED_PIPE: u32 = 0o010000;
 
 /// A directory entry yielded by `readdir`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -145,10 +169,12 @@ pub struct FileRenamePlan {
     pub(crate) source_name: String,
     pub(crate) source_path: String,
     pub(crate) source_size: u64,
+    pub(crate) source_backend_object: bool,
     pub(crate) target_parent: u64,
     pub(crate) target_name: String,
     pub(crate) target_path: String,
     pub(crate) target: Option<(u64, u64)>,
+    pub(crate) target_backend_object: bool,
 }
 
 /// One backend object moved as part of a directory-tree rename.
@@ -184,6 +210,7 @@ pub struct UnlinkPlan {
     pub(crate) source_size: u64,
     pub(crate) orphan_path: Option<String>,
     pub(crate) buffered_contents: Option<Vec<u8>>,
+    pub(crate) backend_object: bool,
 }
 
 /// Immutable backend and namespace facts for hard-link creation.
@@ -196,6 +223,18 @@ pub struct HardLinkPlan {
     pub(crate) target_parent: u64,
     pub(crate) target_name: String,
     pub(crate) target_path: String,
+    pub(crate) backend_object: bool,
+}
+
+/// Immutable namespace and backend facts for `mknod`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MknodPlan {
+    pub(crate) parent: u64,
+    pub(crate) name: String,
+    pub(crate) path: String,
+    pub(crate) kind: FileKind,
+    pub(crate) perm: u16,
+    pub(crate) rdev: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -214,6 +253,8 @@ struct Node {
     symlink_target: Option<Vec<u8>>,
     /// Whether the inode still has a visible namespace entry.
     linked: bool,
+    perm: u16,
+    rdev: u32,
     atime: SystemTime,
     mtime: SystemTime,
     ctime: SystemTime,
@@ -291,6 +332,8 @@ impl ReadOnlyFs {
                 directory_marker: false,
                 symlink_target: None,
                 linked: true,
+                perm: 0o555,
+                rdev: 0,
                 atime: now,
                 mtime: now,
                 ctime: now,
@@ -365,6 +408,8 @@ impl ReadOnlyFs {
                 directory_marker: false,
                 symlink_target: None,
                 linked: true,
+                perm: if is_leaf { 0o444 } else { 0o555 },
+                rdev: 0,
                 atime: now,
                 mtime: now,
                 ctime: now,
@@ -449,6 +494,8 @@ impl ReadOnlyFs {
                 directory_marker: index == comps.len() - 1,
                 symlink_target: None,
                 linked: true,
+                perm: 0o555,
+                rdev: 0,
                 atime: now,
                 mtime: now,
                 ctime: now,
@@ -462,11 +509,6 @@ impl ReadOnlyFs {
     }
 
     fn attr_of(g: &Inner, node: &Node) -> Attr {
-        let perm = match node.kind {
-            FileKind::Directory => 0o555,
-            FileKind::File => 0o444,
-            FileKind::Symlink => 0o777,
-        };
         let nlink = if node.kind == FileKind::Directory {
             1
         } else {
@@ -479,11 +521,12 @@ impl ReadOnlyFs {
             ino: node.ino,
             kind: node.kind,
             size: node.size,
-            perm,
+            perm: node.perm,
             nlink,
             atime: node.atime,
             mtime: node.mtime,
             ctime: node.ctime,
+            rdev: node.rdev,
         }
     }
 
@@ -588,6 +631,10 @@ impl ReadOnlyFs {
             FileKind::File => {}
             FileKind::Directory => return Err(FsError::IsDir),
             FileKind::Symlink => return Err(FsError::Loop),
+            FileKind::NamedPipe
+            | FileKind::BlockDevice
+            | FileKind::CharDevice
+            | FileKind::Socket => return Err(FsError::Unsupported),
         }
         if options.write && initial_contents.is_none() {
             return Err(FsError::Invalid);
@@ -771,6 +818,8 @@ impl ReadOnlyFs {
             directory_marker: false,
             symlink_target: None,
             linked: true,
+            perm: 0o444,
+            rdev: 0,
             atime: now,
             mtime: now,
             ctime: now,
@@ -814,6 +863,95 @@ impl ReadOnlyFs {
                 append: false,
             },
         )
+    }
+
+    /// Validate and describe a regular or mount-local special node creation.
+    pub fn mknod_plan(
+        &self,
+        parent_ino: u64,
+        name: &str,
+        mode: u32,
+        umask: u32,
+        rdev: u32,
+    ) -> Result<MknodPlan, FsError> {
+        Self::validate_component(name)?;
+        let kind = match mode & MODE_TYPE_MASK {
+            MODE_REGULAR => FileKind::File,
+            MODE_NAMED_PIPE => FileKind::NamedPipe,
+            MODE_BLOCK_DEVICE => FileKind::BlockDevice,
+            MODE_CHAR_DEVICE => FileKind::CharDevice,
+            MODE_SOCKET => FileKind::Socket,
+            MODE_DIRECTORY | MODE_SYMLINK => return Err(FsError::OperationNotPermitted),
+            _ => return Err(FsError::Invalid),
+        };
+        let g = self.inner.lock_recover();
+        let parent = g.nodes.get(&parent_ino).ok_or(FsError::NotFound)?;
+        if parent.kind != FileKind::Directory {
+            return Err(FsError::NotDir);
+        }
+        if g.index.contains_key(&(parent_ino, name.to_string())) {
+            return Err(FsError::Exists);
+        }
+        let path = Self::child_path(parent, name);
+        Self::validate_visible_object_path(&path)?;
+        Ok(MknodPlan {
+            parent: parent_ino,
+            name: name.to_string(),
+            path,
+            kind,
+            perm: ((mode & !umask) & 0o7777) as u16,
+            rdev: if matches!(kind, FileKind::BlockDevice | FileKind::CharDevice) {
+                rdev
+            } else {
+                0
+            },
+        })
+    }
+
+    /// Publish a node after any required regular-file backend PUT succeeds.
+    pub fn commit_mknod(&self, plan: &MknodPlan) -> Result<Attr, FsError> {
+        let mut g = self.inner.lock_recover();
+        if g.index.contains_key(&(plan.parent, plan.name.clone())) {
+            return Err(FsError::Exists);
+        }
+        let parent = g.nodes.get(&plan.parent).ok_or(FsError::NotFound)?;
+        if parent.kind != FileKind::Directory || Self::child_path(parent, &plan.name) != plan.path {
+            return Err(FsError::NotDir);
+        }
+        let ino = g.next_ino;
+        g.next_ino += 1;
+        let now = SystemTime::now();
+        g.nodes.insert(
+            ino,
+            Node {
+                ino,
+                parent: Some(plan.parent),
+                name: plan.name.clone(),
+                kind: plan.kind,
+                size: 0,
+                children: Vec::new(),
+                path: plan.path.clone(),
+                directory_marker: false,
+                symlink_target: None,
+                linked: true,
+                perm: plan.perm,
+                rdev: plan.rdev,
+                atime: now,
+                mtime: now,
+                ctime: now,
+            },
+        );
+        g.index.insert((plan.parent, plan.name.clone()), ino);
+        g.nodes
+            .get_mut(&plan.parent)
+            .ok_or(FsError::NotFound)?
+            .children
+            .push(ino);
+        Self::mark_directory_changed(&mut g, plan.parent, now);
+        Ok(Self::attr_of(
+            &g,
+            g.nodes.get(&ino).ok_or(FsError::NotFound)?,
+        ))
     }
 
     /// `write`: write `data` at `offset` into the write handle's buffer.
@@ -1035,6 +1173,7 @@ impl ReadOnlyFs {
             target_parent,
             target_name: target_name.to_string(),
             target_path,
+            backend_object: source.kind.has_backend_object(),
         })
     }
 
@@ -1120,16 +1259,21 @@ impl ReadOnlyFs {
             }
             None => None,
         };
+        let target_backend_object = target
+            .and_then(|(target_ino, _)| g.nodes.get(&target_ino))
+            .is_some_and(|node| node.kind.has_backend_object());
         Ok(FileRenamePlan {
             source_ino,
             source_parent,
             source_name: source_name.to_string(),
             source_path,
             source_size: source.size,
+            source_backend_object: source.kind.has_backend_object(),
             target_parent,
             target_name: target_name.to_string(),
             target_path,
             target,
+            target_backend_object,
         })
     }
 
@@ -1291,7 +1435,7 @@ impl ReadOnlyFs {
                 let child_target_path = format!("{current_target_path}/{name}");
                 if child.kind == FileKind::Directory {
                     stack.push((child_ino, child_source_path, child_target_path));
-                } else {
+                } else if child.kind.has_backend_object() {
                     entries.push(DirectoryRenameEntry {
                         source_path: child_source_path,
                         target_path: child_target_path,
@@ -1430,6 +1574,8 @@ impl ReadOnlyFs {
             directory_marker: false,
             symlink_target: Some(target),
             linked: true,
+            perm: 0o777,
+            rdev: 0,
             atime: now,
             mtime: now,
             ctime: now,
@@ -1498,6 +1644,8 @@ impl ReadOnlyFs {
             directory_marker: true,
             symlink_target: None,
             linked: true,
+            perm: 0o555,
+            rdev: 0,
             atime: now,
             mtime: now,
             ctime: now,
@@ -1599,6 +1747,7 @@ impl ReadOnlyFs {
             source_size: node.size,
             orphan_path,
             buffered_contents,
+            backend_object: node.kind.has_backend_object(),
         })
     }
 
@@ -2094,6 +2243,72 @@ mod tests {
             fs.hard_link_plan(source.ino, other.ino, "linked.bin"),
             Err(FsError::CrossDevice)
         );
+    }
+
+    #[test]
+    fn mknod_creates_regular_and_mount_local_special_nodes() {
+        let fs = fs();
+        let parent = data_dir(&fs);
+        let cases = [
+            (MODE_REGULAR, FileKind::File, 0),
+            (MODE_NAMED_PIPE, FileKind::NamedPipe, 0),
+            (MODE_BLOCK_DEVICE, FileKind::BlockDevice, 0x0102),
+            (MODE_CHAR_DEVICE, FileKind::CharDevice, 0x0304),
+            (MODE_SOCKET, FileKind::Socket, 0),
+        ];
+
+        for (index, (mode, kind, rdev)) in cases.into_iter().enumerate() {
+            let name = format!("node-{index}");
+            let plan = fs
+                .mknod_plan(parent.ino, &name, mode | 0o666, 0o022, rdev)
+                .unwrap();
+            assert_eq!(plan.kind, kind);
+            assert_eq!(plan.perm, 0o644);
+            assert_eq!(plan.kind.has_backend_object(), kind == FileKind::File);
+            let attr = fs.commit_mknod(&plan).unwrap();
+            assert_eq!(attr.kind, kind);
+            assert_eq!(attr.perm, 0o644);
+            assert_eq!(
+                attr.rdev,
+                if matches!(kind, FileKind::BlockDevice | FileKind::CharDevice) {
+                    rdev
+                } else {
+                    0
+                }
+            );
+            assert_eq!(fs.lookup(parent.ino, &name).unwrap(), attr);
+        }
+    }
+
+    #[test]
+    fn mount_local_special_nodes_link_rename_and_unlink_without_backend_paths() {
+        let fs = fs();
+        let parent = data_dir(&fs);
+        let plan = fs
+            .mknod_plan(parent.ino, "fifo", MODE_NAMED_PIPE | 0o600, 0, 0)
+            .unwrap();
+        let fifo = fs.commit_mknod(&plan).unwrap();
+
+        let link = fs
+            .hard_link_plan(fifo.ino, parent.ino, "fifo-link")
+            .unwrap();
+        assert!(!link.backend_object);
+        assert_eq!(fs.commit_hard_link(&link).unwrap().nlink, 2);
+
+        let rename = fs
+            .file_rename_plan(parent.ino, "fifo-link", parent.ino, "fifo-moved")
+            .unwrap();
+        fs.commit_file_rename(&rename).unwrap();
+        assert_eq!(
+            fs.lookup(parent.ino, "fifo-moved").unwrap().kind,
+            FileKind::NamedPipe
+        );
+
+        let unlink = fs.unlink_plan(parent.ino, "fifo").unwrap();
+        assert!(!unlink.backend_object);
+        fs.commit_unlink(&unlink).unwrap();
+        assert_eq!(fs.lookup(parent.ino, "fifo"), Err(FsError::NotFound));
+        assert_eq!(fs.lookup(parent.ino, "fifo-moved").unwrap().nlink, 1);
     }
 
     #[test]

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -26,7 +26,8 @@ use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::os::fd::AsRawFd;
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::fs::{FileExt, MetadataExt, OpenOptionsExt};
+use std::os::unix::fs::{FileExt, FileTypeExt, MetadataExt, OpenOptionsExt};
+use std::os::unix::net::UnixListener;
 use std::process::Command;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
@@ -1465,6 +1466,222 @@ async fn mount_timestamp_updates_follow_utimens_semantics() {
     drop(session);
     std::fs::remove_dir_all(&mountpoint).ok();
     result.expect("exercise timestamp updates through mount");
+}
+
+/// Create mount-local FIFOs and sockets without materializing blob objects.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires /dev/fuse; run with --features mount -- --ignored"]
+async fn mount_special_nodes_are_namespace_only() {
+    use fuser::MountOption;
+
+    let block_size: u32 = 4 * 1024 * 1024;
+    let store: Store = Arc::new(Mutex::new(HashMap::from([(
+        "/s3/bucket/placeholder".to_string(),
+        Vec::new(),
+    )])));
+    let worker = spawn_rw_worker(Arc::clone(&store)).await;
+    let coord = spawn_coordinator(worker).await;
+
+    let fs = Arc::new(ReadOnlyFs::new());
+    fs.insert_object("s3/bucket/placeholder", 0);
+
+    let cache = Arc::new(PlacementCache::new(10_000));
+    let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
+    let adapter = TalonFuse::new(
+        Arc::clone(&fs),
+        reader,
+        tokio::runtime::Handle::current(),
+        block_size,
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
+    )
+    .with_read_write(true);
+
+    let require_fuse = std::env::var_os("TALON_REQUIRE_FUSE").is_some();
+    let mountpoint =
+        std::env::temp_dir().join(format!("talon-mount-e2e-special-{}", std::process::id()));
+    std::fs::create_dir_all(&mountpoint).unwrap();
+    let options = vec![MountOption::FSName("talon".into())];
+    let session = match fuser::spawn_mount2(adapter, &mountpoint, &options) {
+        Ok(session) => session,
+        Err(error) => {
+            std::fs::remove_dir_all(&mountpoint).ok();
+            if require_fuse {
+                panic!(
+                    "TALON_REQUIRE_FUSE is set but the FUSE mount failed: {error}. \
+                     The runner must provide an accessible /dev/fuse."
+                );
+            }
+            eprintln!("skipping: /dev/fuse unavailable: {error}");
+            return;
+        }
+    };
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let bucket = mountpoint.join("s3").join("bucket");
+    let operation_store = Arc::clone(&store);
+    let result = tokio::task::spawn_blocking(move || {
+        let fifo = bucket.join("events.fifo");
+        let fifo_path = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        let result = unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o640) };
+        if result != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        assert!(std::fs::symlink_metadata(&fifo)?.file_type().is_fifo());
+        assert_eq!(std::fs::metadata(&fifo)?.mode() & 0o7777, 0o640);
+
+        let socket = bucket.join("service.sock");
+        let listener = UnixListener::bind(&socket)?;
+        assert!(std::fs::symlink_metadata(&socket)?.file_type().is_socket());
+
+        let regular = bucket.join("mknod.bin");
+        let regular_path = std::ffi::CString::new(regular.as_os_str().as_bytes()).unwrap();
+        let result = unsafe { libc::mknod(regular_path.as_ptr(), libc::S_IFREG | 0o600, 0) };
+        if result != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        assert!(std::fs::metadata(&regular)?.file_type().is_file());
+        assert_eq!(
+            operation_store.lock().unwrap().get("/s3/bucket/mknod.bin"),
+            Some(&Vec::new())
+        );
+        assert!(!operation_store
+            .lock()
+            .unwrap()
+            .contains_key("/s3/bucket/events.fifo"));
+        assert!(!operation_store
+            .lock()
+            .unwrap()
+            .contains_key("/s3/bucket/service.sock"));
+
+        let fifo_link = bucket.join("events-link.fifo");
+        std::fs::hard_link(&fifo, &fifo_link)?;
+        assert_eq!(std::fs::metadata(&fifo)?.nlink(), 2);
+        let fifo_moved = bucket.join("events-moved.fifo");
+        std::fs::rename(&fifo_link, &fifo_moved)?;
+        std::fs::remove_file(&fifo)?;
+        assert!(std::fs::symlink_metadata(&fifo_moved)?
+            .file_type()
+            .is_fifo());
+
+        let replacement = bucket.join("replacement");
+        std::fs::write(&replacement, b"old")?;
+        std::fs::rename(&fifo_moved, &replacement)?;
+        assert!(std::fs::symlink_metadata(&replacement)?
+            .file_type()
+            .is_fifo());
+        assert!(!operation_store
+            .lock()
+            .unwrap()
+            .contains_key("/s3/bucket/replacement"));
+
+        let source = bucket.join("source.bin");
+        std::fs::write(&source, b"new")?;
+        std::fs::rename(&source, &replacement)?;
+        assert!(std::fs::metadata(&replacement)?.file_type().is_file());
+        assert_eq!(std::fs::read(&replacement)?, b"new");
+        assert_eq!(
+            operation_store
+                .lock()
+                .unwrap()
+                .get("/s3/bucket/replacement"),
+            Some(&b"new".to_vec())
+        );
+
+        drop(listener);
+        std::fs::remove_file(&socket)?;
+        std::fs::remove_file(&replacement)?;
+        std::fs::remove_file(&regular)?;
+        Ok::<(), std::io::Error>(())
+    })
+    .await
+    .unwrap();
+
+    drop(session);
+    std::fs::remove_dir_all(&mountpoint).ok();
+    result.expect("exercise mount-local special nodes through mount");
+}
+
+/// Validate privileged block and character device creation through FUSE.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires privileged /dev/fuse and TALON_TEST_DEVICE_NODES=1"]
+async fn mount_device_nodes_preserve_rdev() {
+    use fuser::MountOption;
+
+    if std::env::var_os("TALON_TEST_DEVICE_NODES").is_none() {
+        return;
+    }
+    let block_size: u32 = 4 * 1024 * 1024;
+    let store: Store = Arc::new(Mutex::new(HashMap::from([(
+        "/s3/bucket/placeholder".to_string(),
+        Vec::new(),
+    )])));
+    let worker = spawn_rw_worker(Arc::clone(&store)).await;
+    let coord = spawn_coordinator(worker).await;
+
+    let fs = Arc::new(ReadOnlyFs::new());
+    fs.insert_object("s3/bucket/placeholder", 0);
+    let cache = Arc::new(PlacementCache::new(10_000));
+    let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
+    let adapter = TalonFuse::new(
+        Arc::clone(&fs),
+        reader,
+        tokio::runtime::Handle::current(),
+        block_size,
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
+    )
+    .with_read_write(true);
+
+    let mountpoint =
+        std::env::temp_dir().join(format!("talon-mount-e2e-devices-{}", std::process::id()));
+    std::fs::create_dir_all(&mountpoint).unwrap();
+    let options = vec![MountOption::FSName("talon".into())];
+    let session = fuser::spawn_mount2(adapter, &mountpoint, &options)
+        .expect("privileged device-node test requires a working FUSE mount");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let bucket = mountpoint.join("s3").join("bucket");
+    let operation_store = Arc::clone(&store);
+    let result = tokio::task::spawn_blocking(move || {
+        let block = bucket.join("block.dev");
+        let character = bucket.join("char.dev");
+        let block_path = std::ffi::CString::new(block.as_os_str().as_bytes()).unwrap();
+        let char_path = std::ffi::CString::new(character.as_os_str().as_bytes()).unwrap();
+        let block_rdev = libc::makedev(7, 1);
+        let char_rdev = libc::makedev(1, 3);
+        let result = unsafe { libc::mknod(block_path.as_ptr(), libc::S_IFBLK | 0o600, block_rdev) };
+        if result != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let result = unsafe { libc::mknod(char_path.as_ptr(), libc::S_IFCHR | 0o620, char_rdev) };
+        if result != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        let block_metadata = std::fs::symlink_metadata(&block)?;
+        assert!(block_metadata.file_type().is_block_device());
+        assert_eq!(block_metadata.rdev(), block_rdev);
+        let char_metadata = std::fs::symlink_metadata(&character)?;
+        assert!(char_metadata.file_type().is_char_device());
+        assert_eq!(char_metadata.rdev(), char_rdev);
+        assert!(!operation_store
+            .lock()
+            .unwrap()
+            .contains_key("/s3/bucket/block.dev"));
+        assert!(!operation_store
+            .lock()
+            .unwrap()
+            .contains_key("/s3/bucket/char.dev"));
+
+        std::fs::remove_file(&block)?;
+        std::fs::remove_file(&character)?;
+        Ok::<(), std::io::Error>(())
+    })
+    .await
+    .unwrap();
+
+    drop(session);
+    std::fs::remove_dir_all(&mountpoint).ok();
+    result.expect("exercise block and character device nodes through mount");
 }
 
 /// Mount the read-write fixture and run the pinned pjdfstest suite against it.


### PR DESCRIPTION
## Summary

Add POSIX `mknod` support for regular files, FIFOs, block devices, character devices, and Unix sockets. Regular-file nodes are written through as empty blob objects before namespace publication. Special nodes are deliberately mount-local inodes and never materialize fake blob objects.

This PR is stacked on #344. Its diff will shrink to the special-node-specific commit after the prerequisite PRs merge.

## Related issues

- Progresses #327
- Part of #259 and #262
- Multi-user ownership and permission enforcement remains in #328
- Special-node persistence across remount depends on #332

## Type of change

- [ ] Bug fix
- [x] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [x] Docs / tests / tooling

## Persistence policy

Regular `mknod` creates an ordinary zero-byte backend object using the same PUT-before-namespace-commit transaction as other regular-file creation paths.

FIFOs, block devices, character devices, and Unix sockets are mount-local. Their type, mode, device number, inode identity, links, timestamps, and namespace operations are maintained for the lifetime of the mount. They do not create hidden metadata objects or visible placeholder blobs. Reconstructing these nodes after remount requires the metadata contract tracked by #332.

## Changes

- Add named-pipe, block-device, character-device, and socket inode kinds.
- Add mode and `rdev` attributes for special nodes.
- Implement the FUSE `mknod` callback for regular and special node types.
- Apply umask to the created node mode.
- PUT zero-byte regular nodes before publishing their namespace entry.
- Keep special nodes namespace-only with no backend I/O.
- Support lookup, getattr, readdir, timestamps, hard links, rename, and unlink for special nodes.
- Handle replacement rename transactions between backend regular files and mount-local special nodes without creating stale or fake blobs.
- Exclude mount-local nodes from directory-tree backend copy/delete transactions while still moving their namespace paths.
- Add focused namespace, unprivileged kernel, and privileged device-node tests.

## Test plan

- [x] `cargo test -p talon-fuse --lib`: 105 passed
- [x] `cargo test -p talon-fuse --features mount --test mount_e2e --no-run`
- [x] `cargo clippy -p talon-fuse --all-targets --features mount -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Exact commit `e06dbe2de869ce5794c35ad8c4fee32a45305374` passed the complete privileged real-kernel mount suite in `falcon-phx-ca` with host `/dev/fuse`
- [x] The PHX suite created FIFOs and Unix sockets, verified namespace-only backend behavior, exercised mixed regular/special rename replacement, and created block/character devices with exact `rdev` values
- [x] Real-kernel `mkfifo,mknod` pjdfstest on runner commit `df72d46eee4f08b9055e2f8a69ff5e6961fe6842` improved from 34 passed / 272 failed to 272 passed / 34 failed out of 306 assertions

All 34 remaining assertions are multi-user ownership or parent-directory permission cases tracked by #328.

## Performance impact

Regular `mknod` performs one synchronous empty-object PUT. Mount-local special-node creation and namespace operations do not perform backend I/O.

- [x] No backend I/O for special nodes

## Checklist

- [x] PR title follows Conventional Commits
- [x] Public behavior is covered by tests
- [x] No new dependencies
- [x] Based on `main` through the stacked prerequisite branches