### PR TITLE
feat(fuse): enforce POSIX metadata permissions

### DIFF
--- a/crates/talon-fuse/src/main.rs
+++ b/crates/talon-fuse/src/main.rs
@@ -80,7 +80,8 @@ async fn main() -> anyhow::Result<()> {
 
     // Populate the namespace from a coordinator listing (best-effort: a listing
     // failure logs and yields an empty tree rather than aborting the mount).
-    let fs = Arc::new(ReadOnlyFs::new());
+    let (mount_uid, mount_gid) = mount_owner();
+    let fs = Arc::new(ReadOnlyFs::new_with_owner(mount_uid, mount_gid));
     match coordinator.list_objects("").await {
         Ok(entries) => {
             let n = fs.populate_from_listing(entries.iter().map(|e| (e.path.as_str(), e.size)));
@@ -92,6 +93,17 @@ async fn main() -> anyhow::Result<()> {
     }
 
     run_mount(cfg, fs, reader).await
+}
+
+#[cfg(feature = "mount")]
+fn mount_owner() -> (u32, u32) {
+    // SAFETY: geteuid/getegid have no preconditions and do not mutate memory.
+    unsafe { (libc::geteuid(), libc::getegid()) }
+}
+
+#[cfg(not(feature = "mount"))]
+fn mount_owner() -> (u32, u32) {
+    (0, 0)
 }
 
 /// Mount and serve until SIGINT (built with `--features mount`).

--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -70,6 +70,7 @@ pub(crate) fn errno(err: FsError) -> i32 {
         FsError::Loop => libc::ELOOP,
         FsError::OperationNotPermitted => libc::EPERM,
         FsError::CrossDevice => libc::EXDEV,
+        FsError::PermissionDenied => libc::EACCES,
     }
 }
 
@@ -91,6 +92,23 @@ fn open_options(flags: i32) -> Result<(OpenOptions, bool), FsError> {
     ))
 }
 
+fn request_groups(req: &fuser::Request<'_>) -> Vec<u32> {
+    let mut groups = vec![req.gid()];
+    let path = format!("/proc/{}/status", req.pid());
+    if let Ok(status) = std::fs::read_to_string(path) {
+        if let Some(line) = status.lines().find(|line| line.starts_with("Groups:")) {
+            groups.extend(
+                line.split_ascii_whitespace()
+                    .skip(1)
+                    .filter_map(|group| group.parse::<u32>().ok()),
+            );
+        }
+    }
+    groups.sort_unstable();
+    groups.dedup();
+    groups
+}
+
 /// A monotonic-ish millisecond timestamp for the placement cache TTL.
 fn now_ms() -> u64 {
     std::time::SystemTime::now()
@@ -103,7 +121,7 @@ fn now_ms() -> u64 {
 ///
 /// Ownership is left to the mounting user via `uid`/`gid`. `blocks` is a
 /// 512-byte-unit count as POSIX expects.
-pub(crate) fn to_file_attr(attr: Attr, uid: u32, gid: u32) -> fuser::FileAttr {
+pub(crate) fn to_file_attr(attr: Attr, _request_uid: u32, _request_gid: u32) -> fuser::FileAttr {
     let kind = match attr.kind {
         FileKind::Directory => fuser::FileType::Directory,
         FileKind::File => fuser::FileType::RegularFile,
@@ -124,8 +142,8 @@ pub(crate) fn to_file_attr(attr: Attr, uid: u32, gid: u32) -> fuser::FileAttr {
         kind,
         perm: attr.perm,
         nlink: attr.nlink,
-        uid,
-        gid,
+        uid: attr.uid,
+        gid: attr.gid,
         rdev: attr.rdev,
         blksize: 512,
         flags: 0,
@@ -516,7 +534,7 @@ impl TalonFuse {
         };
         let fh = self
             .fs
-            .open_with_options(ino, options, initial_contents)
+            .open_with_options_and_truncate(ino, options, initial_contents, truncate)
             .map_err(errno)?;
         let reply_flags = if mutates {
             0
@@ -762,8 +780,8 @@ impl fuser::Filesystem for TalonFuse {
         req: &fuser::Request<'_>,
         parent: u64,
         name: &std::ffi::OsStr,
-        _mode: u32,
-        _umask: u32,
+        mode: u32,
+        umask: u32,
         flags: i32,
         reply: fuser::ReplyCreate,
     ) {
@@ -794,7 +812,10 @@ impl fuser::Filesystem for TalonFuse {
             Err(FsError::NotFound) => {}
             Err(e) => return reply.error(errno(e)),
         }
-        match self.fs.create_with_options(parent, name, options) {
+        match self
+            .fs
+            .create_with_metadata(parent, name, options, mode, umask, req.uid(), req.gid())
+        {
             Ok((attr, fh)) => {
                 let fa = to_file_attr(attr, req.uid(), req.gid());
                 reply.created(&ATTR_TTL, &fa, 0, fh, 0);
@@ -828,7 +849,10 @@ impl fuser::Filesystem for TalonFuse {
             tracing::warn!(%path, %error, "symlink target writeback failed");
             return reply.error(libc::EIO);
         }
-        match self.fs.symlink(parent, link_name, target) {
+        match self
+            .fs
+            .symlink_with_owner(parent, link_name, target, req.uid(), req.gid())
+        {
             Ok(attr) => {
                 let file_attr = to_file_attr(attr, req.uid(), req.gid());
                 reply.entry(&ATTR_TTL, &file_attr, 0);
@@ -924,7 +948,10 @@ impl fuser::Filesystem for TalonFuse {
             Some(name) => name,
             None => return reply.error(libc::EINVAL),
         };
-        let plan = match self.fs.mknod_plan(parent, name, mode, umask, rdev) {
+        let plan = match self
+            .fs
+            .mknod_plan(parent, name, mode, umask, rdev, req.uid(), req.gid())
+        {
             Ok(plan) => plan,
             Err(error) => return reply.error(errno(error)),
         };
@@ -957,8 +984,8 @@ impl fuser::Filesystem for TalonFuse {
         req: &fuser::Request<'_>,
         parent: u64,
         name: &std::ffi::OsStr,
-        _mode: u32,
-        _umask: u32,
+        mode: u32,
+        umask: u32,
         reply: fuser::ReplyEntry,
     ) {
         if !self.read_write {
@@ -983,7 +1010,10 @@ impl fuser::Filesystem for TalonFuse {
             tracing::warn!(path = %marker.to_path(), %error, "mkdir marker writeback failed");
             return reply.error(libc::EIO);
         }
-        match self.fs.mkdir(parent, name) {
+        match self
+            .fs
+            .mkdir_with_metadata(parent, name, mode, umask, req.uid(), req.gid())
+        {
             Ok(attr) => {
                 let file_attr = to_file_attr(attr, req.uid(), req.gid());
                 reply.entry(&ATTR_TTL, &file_attr, 0);
@@ -1034,12 +1064,12 @@ impl fuser::Filesystem for TalonFuse {
         &mut self,
         req: &fuser::Request<'_>,
         ino: u64,
-        _mode: Option<u32>,
-        _uid: Option<u32>,
-        _gid: Option<u32>,
+        mode: Option<u32>,
+        uid: Option<u32>,
+        gid: Option<u32>,
         size: Option<u64>,
-        atime: Option<fuser::TimeOrNow>,
-        mtime: Option<fuser::TimeOrNow>,
+        atime_request: Option<fuser::TimeOrNow>,
+        mtime_request: Option<fuser::TimeOrNow>,
         _ctime: Option<std::time::SystemTime>,
         fh: Option<u64>,
         _crtime: Option<std::time::SystemTime>,
@@ -1048,10 +1078,17 @@ impl fuser::Filesystem for TalonFuse {
         _flags: Option<u32>,
         reply: fuser::ReplyAttr,
     ) {
+        if !self.read_write
+            && (size.is_some()
+                || mode.is_some()
+                || uid.is_some()
+                || gid.is_some()
+                || atime_request.is_some()
+                || mtime_request.is_some())
+        {
+            return reply.error(libc::EROFS);
+        }
         if let Some(new_size) = size {
-            if !self.read_write {
-                return reply.error(libc::EROFS);
-            }
             if new_size > self.fs.max_object_bytes() {
                 return reply.error(libc::EFBIG);
             }
@@ -1094,22 +1131,42 @@ impl fuser::Filesystem for TalonFuse {
             } else {
                 self.fs.commit_inode_contents(ino, contents)
             };
-            return match attr {
-                Ok(attr) => reply.attr(&ATTR_TTL, &to_file_attr(attr, req.uid(), req.gid())),
-                Err(e) => reply.error(errno(e)),
-            };
+            if let Err(error) = attr {
+                return reply.error(errno(error));
+            }
         }
         let now = std::time::SystemTime::now();
         let resolve_time = |time: fuser::TimeOrNow| match time {
             fuser::TimeOrNow::SpecificTime(time) => time,
             fuser::TimeOrNow::Now => now,
         };
-        match self
-            .fs
-            .set_times(ino, atime.map(resolve_time), mtime.map(resolve_time))
-        {
+        let times_are_now = [atime_request, mtime_request]
+            .into_iter()
+            .flatten()
+            .all(|time| matches!(time, fuser::TimeOrNow::Now));
+        let caller_groups = request_groups(req);
+        match self.fs.set_metadata(
+            ino,
+            req.uid(),
+            req.gid(),
+            &caller_groups,
+            mode,
+            uid,
+            gid,
+            atime_request.map(resolve_time),
+            mtime_request.map(resolve_time),
+            times_are_now,
+        ) {
             Ok(attr) => reply.attr(&ATTR_TTL, &to_file_attr(attr, req.uid(), req.gid())),
             Err(e) => reply.error(errno(e)),
+        }
+    }
+
+    /// Check access explicitly for mounts without `default_permissions`.
+    fn access(&mut self, req: &fuser::Request<'_>, ino: u64, mask: i32, reply: fuser::ReplyEmpty) {
+        match self.fs.check_access(ino, req.uid(), req.gid(), mask) {
+            Ok(()) => reply.ok(),
+            Err(error) => reply.error(errno(error)),
         }
     }
 
@@ -1609,6 +1666,7 @@ mod tests {
         assert_eq!(errno(FsError::Loop), libc::ELOOP);
         assert_eq!(errno(FsError::OperationNotPermitted), libc::EPERM);
         assert_eq!(errno(FsError::CrossDevice), libc::EXDEV);
+        assert_eq!(errno(FsError::PermissionDenied), libc::EACCES);
     }
 
     #[test]
@@ -1661,11 +1719,14 @@ mod tests {
             mtime: timestamp,
             ctime: timestamp,
             rdev: 0,
+            uid: 42,
+            gid: 43,
         };
         let fa = to_file_attr(dir, 1000, 1000);
         assert_eq!(fa.kind, fuser::FileType::Directory);
         assert_eq!(fa.perm, 0o555);
-        assert_eq!(fa.uid, 1000);
+        assert_eq!(fa.uid, 42);
+        assert_eq!(fa.gid, 43);
         assert_eq!(fa.nlink, 1);
         assert_eq!(fa.atime, timestamp);
         assert_eq!(fa.mtime, timestamp);
@@ -1681,6 +1742,8 @@ mod tests {
             mtime: timestamp,
             ctime: timestamp,
             rdev: 0,
+            uid: 0,
+            gid: 0,
         };
         let fa = to_file_attr(file, 0, 0);
         assert_eq!(fa.kind, fuser::FileType::RegularFile);
@@ -1699,6 +1762,8 @@ mod tests {
             mtime: timestamp,
             ctime: timestamp,
             rdev: 0,
+            uid: 0,
+            gid: 0,
         };
         let fa = to_file_attr(symlink, 0, 0);
         assert_eq!(fa.kind, fuser::FileType::Symlink);

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -69,6 +69,10 @@ pub struct Attr {
     pub ctime: SystemTime,
     /// Device identifier for block and character devices.
     pub rdev: u32,
+    /// Owning user.
+    pub uid: u32,
+    /// Owning group.
+    pub gid: u32,
 }
 
 /// Errors returned by the read-only op layer (mapped to errno by the adapter).
@@ -103,6 +107,8 @@ pub enum FsError {
     OperationNotPermitted,
     /// Source and destination are on different backend filesystems (`EXDEV`).
     CrossDevice,
+    /// Access is denied by inode mode bits (`EACCES`).
+    PermissionDenied,
 }
 
 /// Access and mutation behavior for an open file handle.
@@ -235,6 +241,8 @@ pub struct MknodPlan {
     pub(crate) kind: FileKind,
     pub(crate) perm: u16,
     pub(crate) rdev: u32,
+    pub(crate) uid: u32,
+    pub(crate) gid: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -255,6 +263,8 @@ struct Node {
     linked: bool,
     perm: u16,
     rdev: u32,
+    uid: u32,
+    gid: u32,
     atime: SystemTime,
     mtime: SystemTime,
     ctime: SystemTime,
@@ -267,6 +277,10 @@ struct Node {
 /// directories is created on demand.
 pub struct ReadOnlyFs {
     inner: Mutex<Inner>,
+    /// Owner assigned to nodes synthesized from backend listings.
+    listing_uid: u32,
+    /// Group assigned to nodes synthesized from backend listings.
+    listing_gid: u32,
     /// Cap on the length of any single write handle's in-memory buffer.
     max_object_bytes: u64,
     /// Mount-scoped backend namespace for open-but-unlinked objects.
@@ -315,8 +329,13 @@ impl Default for ReadOnlyFs {
 }
 
 impl ReadOnlyFs {
-    /// Create a filesystem with just the root directory.
+    /// Create a root-owned filesystem with just the root directory.
     pub fn new() -> Self {
+        Self::new_with_owner(0, 0)
+    }
+
+    /// Create a filesystem whose listed objects belong to `uid` and `gid`.
+    pub fn new_with_owner(uid: u32, gid: u32) -> Self {
         let mut nodes = HashMap::new();
         let now = SystemTime::now();
         nodes.insert(
@@ -334,6 +353,8 @@ impl ReadOnlyFs {
                 linked: true,
                 perm: 0o555,
                 rdev: 0,
+                uid,
+                gid,
                 atime: now,
                 mtime: now,
                 ctime: now,
@@ -353,6 +374,8 @@ impl ReadOnlyFs {
                 next_fh: 1,
                 dirty: HashMap::new(),
             }),
+            listing_uid: uid,
+            listing_gid: gid,
             max_object_bytes: DEFAULT_MAX_OBJECT_BYTES,
             orphan_namespace: format!("{:x}-{timestamp:x}-{instance:x}", std::process::id()),
         }
@@ -408,8 +431,10 @@ impl ReadOnlyFs {
                 directory_marker: false,
                 symlink_target: None,
                 linked: true,
-                perm: if is_leaf { 0o444 } else { 0o555 },
+                perm: if is_leaf { 0o644 } else { 0o755 },
                 rdev: 0,
+                uid: self.listing_uid,
+                gid: self.listing_gid,
                 atime: now,
                 mtime: now,
                 ctime: now,
@@ -494,8 +519,10 @@ impl ReadOnlyFs {
                 directory_marker: index == comps.len() - 1,
                 symlink_target: None,
                 linked: true,
-                perm: 0o555,
+                perm: 0o755,
                 rdev: 0,
+                uid: self.listing_uid,
+                gid: self.listing_gid,
                 atime: now,
                 mtime: now,
                 ctime: now,
@@ -510,7 +537,16 @@ impl ReadOnlyFs {
 
     fn attr_of(g: &Inner, node: &Node) -> Attr {
         let nlink = if node.kind == FileKind::Directory {
-            1
+            2 + g
+                .index
+                .iter()
+                .filter(|((parent, _), child_ino)| {
+                    *parent == node.ino
+                        && g.nodes
+                            .get(child_ino)
+                            .is_some_and(|child| child.kind == FileKind::Directory)
+                })
+                .count() as u32
         } else {
             g.index
                 .values()
@@ -527,6 +563,8 @@ impl ReadOnlyFs {
             mtime: node.mtime,
             ctime: node.ctime,
             rdev: node.rdev,
+            uid: node.uid,
+            gid: node.gid,
         }
     }
 
@@ -578,6 +616,115 @@ impl ReadOnlyFs {
         ))
     }
 
+    /// Apply chmod, chown, and timestamp changes with POSIX ownership checks.
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_metadata(
+        &self,
+        ino: u64,
+        caller_uid: u32,
+        caller_gid: u32,
+        caller_groups: &[u32],
+        mode: Option<u32>,
+        uid: Option<u32>,
+        gid: Option<u32>,
+        atime: Option<SystemTime>,
+        mtime: Option<SystemTime>,
+        times_are_now: bool,
+    ) -> Result<Attr, FsError> {
+        let mut g = self.inner.lock_recover();
+        let node = g.nodes.get_mut(&ino).ok_or(FsError::NotFound)?;
+        let is_root = caller_uid == 0;
+        let is_owner = caller_uid == node.uid;
+
+        if let Some(mode) = mode {
+            let requested = (mode & 0o7777) as u16;
+            let automatic_write_clear = requested == node.perm & !0o6000
+                && Self::access_allowed_with_groups(
+                    node,
+                    caller_uid,
+                    caller_gid,
+                    caller_groups,
+                    0o2,
+                );
+            if !is_root && !is_owner && !automatic_write_clear {
+                return Err(FsError::OperationNotPermitted);
+            }
+        }
+        if (uid.is_some() || gid.is_some()) && !is_root && !is_owner {
+            return Err(FsError::OperationNotPermitted);
+        }
+        if let Some(new_uid) = uid {
+            if !is_root && new_uid != node.uid {
+                return Err(FsError::OperationNotPermitted);
+            }
+        }
+        if let Some(new_gid) = gid {
+            if !is_root
+                && new_gid != node.gid
+                && new_gid != caller_gid
+                && !caller_groups.contains(&new_gid)
+            {
+                return Err(FsError::OperationNotPermitted);
+            }
+        }
+        if atime.is_some() || mtime.is_some() {
+            let can_write =
+                Self::access_allowed_with_groups(node, caller_uid, caller_gid, caller_groups, 0o2);
+            if !(is_root || is_owner || times_are_now && can_write) {
+                return Err(FsError::OperationNotPermitted);
+            }
+        }
+
+        let mut changed = false;
+        if let Some(mode) = mode {
+            let mut perm = (mode & 0o7777) as u16;
+            if !is_root && caller_gid != node.gid && !caller_groups.contains(&node.gid) {
+                perm &= !0o2000;
+            }
+            node.perm = perm;
+            changed = true;
+        }
+        let ownership_changed = uid.is_some_and(|new_uid| new_uid != node.uid)
+            || gid.is_some_and(|new_gid| new_gid != node.gid);
+        if let Some(uid) = uid {
+            node.uid = uid;
+            changed = true;
+        }
+        if let Some(gid) = gid {
+            node.gid = gid;
+            changed = true;
+        }
+        if ownership_changed && node.kind == FileKind::File {
+            node.perm &= !0o6000;
+        }
+        if let Some(atime) = atime {
+            node.atime = atime;
+            changed = true;
+        }
+        if let Some(mtime) = mtime {
+            node.mtime = mtime;
+            changed = true;
+        }
+        if changed {
+            node.ctime = SystemTime::now();
+        }
+        Ok(Self::attr_of(
+            &g,
+            g.nodes.get(&ino).ok_or(FsError::NotFound)?,
+        ))
+    }
+
+    /// Check read, write, and execute access for one primary uid/gid.
+    pub fn check_access(&self, ino: u64, uid: u32, gid: u32, mask: i32) -> Result<(), FsError> {
+        let g = self.inner.lock_recover();
+        let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
+        if Self::access_allowed(node, uid, gid, mask as u16) {
+            Ok(())
+        } else {
+            Err(FsError::PermissionDenied)
+        }
+    }
+
     /// `readdir`: list children of a directory inode (excluding `.`/`..`).
     pub fn readdir(&self, ino: u64) -> Result<Vec<DirEntry>, FsError> {
         let g = self.inner.lock_recover();
@@ -622,6 +769,17 @@ impl ReadOnlyFs {
         options: OpenOptions,
         initial_contents: Option<Vec<u8>>,
     ) -> Result<u64, FsError> {
+        self.open_with_options_and_truncate(ino, options, initial_contents, false)
+    }
+
+    /// Open an existing file and record whether `O_TRUNC` was requested.
+    pub fn open_with_options_and_truncate(
+        &self,
+        ino: u64,
+        options: OpenOptions,
+        initial_contents: Option<Vec<u8>>,
+        truncate: bool,
+    ) -> Result<u64, FsError> {
         if !options.read && !options.write {
             return Err(FsError::Invalid);
         }
@@ -653,7 +811,13 @@ impl ReadOnlyFs {
         if let Some(buf) = initial_contents {
             g.dirty.insert(fh, DirtyFile { ino, buf });
             let size = g.dirty.get(&fh).unwrap().buf.len() as u64;
-            g.nodes.get_mut(&ino).unwrap().size = size;
+            let node = g.nodes.get_mut(&ino).unwrap();
+            node.size = size;
+            if truncate {
+                let now = SystemTime::now();
+                node.mtime = now;
+                node.ctime = now;
+            }
         }
         Ok(fh)
     }
@@ -783,6 +947,21 @@ impl ReadOnlyFs {
         name: &str,
         options: OpenOptions,
     ) -> Result<(Attr, u64), FsError> {
+        self.create_with_metadata(parent_ino, name, options, 0o666, 0, 0, 0)
+    }
+
+    /// Create a file with request ownership, mode, and umask metadata.
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_with_metadata(
+        &self,
+        parent_ino: u64,
+        name: &str,
+        options: OpenOptions,
+        mode: u32,
+        umask: u32,
+        uid: u32,
+        gid: u32,
+    ) -> Result<(Attr, u64), FsError> {
         if !options.read && !options.write {
             return Err(FsError::Invalid);
         }
@@ -790,10 +969,13 @@ impl ReadOnlyFs {
             return Err(FsError::Invalid);
         }
         let mut g = self.inner.lock_recover();
-        let parent = g.nodes.get(&parent_ino).ok_or(FsError::NotFound)?;
-        if parent.kind != FileKind::Directory {
-            return Err(FsError::NotDir);
-        }
+        let (parent_perm, parent_gid) = {
+            let parent = g.nodes.get(&parent_ino).ok_or(FsError::NotFound)?;
+            if parent.kind != FileKind::Directory {
+                return Err(FsError::NotDir);
+            }
+            (parent.perm, parent.gid)
+        };
         if g.index.contains_key(&(parent_ino, name.to_string())) {
             return Err(FsError::Exists);
         }
@@ -807,6 +989,11 @@ impl ReadOnlyFs {
         let ino = g.next_ino;
         g.next_ino += 1;
         let now = SystemTime::now();
+        let child_gid = if parent_perm & 0o2000 != 0 {
+            parent_gid
+        } else {
+            gid
+        };
         let node = Node {
             ino,
             parent: Some(parent_ino),
@@ -818,8 +1005,10 @@ impl ReadOnlyFs {
             directory_marker: false,
             symlink_target: None,
             linked: true,
-            perm: 0o444,
+            perm: ((mode & !umask) & 0o7777) as u16,
             rdev: 0,
+            uid,
+            gid: child_gid,
             atime: now,
             mtime: now,
             ctime: now,
@@ -866,6 +1055,7 @@ impl ReadOnlyFs {
     }
 
     /// Validate and describe a regular or mount-local special node creation.
+    #[allow(clippy::too_many_arguments)]
     pub fn mknod_plan(
         &self,
         parent_ino: u64,
@@ -873,6 +1063,8 @@ impl ReadOnlyFs {
         mode: u32,
         umask: u32,
         rdev: u32,
+        uid: u32,
+        gid: u32,
     ) -> Result<MknodPlan, FsError> {
         Self::validate_component(name)?;
         let kind = match mode & MODE_TYPE_MASK {
@@ -894,6 +1086,11 @@ impl ReadOnlyFs {
         }
         let path = Self::child_path(parent, name);
         Self::validate_visible_object_path(&path)?;
+        let child_gid = if parent.perm & 0o2000 != 0 {
+            parent.gid
+        } else {
+            gid
+        };
         Ok(MknodPlan {
             parent: parent_ino,
             name: name.to_string(),
@@ -905,6 +1102,8 @@ impl ReadOnlyFs {
             } else {
                 0
             },
+            uid,
+            gid: child_gid,
         })
     }
 
@@ -936,6 +1135,8 @@ impl ReadOnlyFs {
                 linked: true,
                 perm: plan.perm,
                 rdev: plan.rdev,
+                uid: plan.uid,
+                gid: plan.gid,
                 atime: now,
                 mtime: now,
                 ctime: now,
@@ -1290,6 +1491,7 @@ impl ReadOnlyFs {
         if current_source != Some(plan.source_ino) {
             return Err(FsError::NotFound);
         }
+        let now = SystemTime::now();
         if let Some((target_ino, _)) = plan.target {
             let current_target = g
                 .index
@@ -1309,6 +1511,7 @@ impl ReadOnlyFs {
                     target.name.clone_from(name);
                     target.path.clone_from(path);
                 }
+                target.ctime = now;
             } else {
                 g.nodes.remove(&target_ino);
             }
@@ -1337,7 +1540,6 @@ impl ReadOnlyFs {
             source.name.clone_from(&plan.target_name);
             source.path.clone_from(&plan.target_path);
         }
-        let now = SystemTime::now();
         source.ctime = now;
         Self::mark_directory_changed(&mut g, plan.source_parent, now);
         Self::mark_directory_changed(&mut g, plan.target_parent, now);
@@ -1555,6 +1757,18 @@ impl ReadOnlyFs {
 
     /// Insert a symbolic-link inode after its target bytes are written through.
     pub fn symlink(&self, parent_ino: u64, name: &str, target: Vec<u8>) -> Result<Attr, FsError> {
+        self.symlink_with_owner(parent_ino, name, target, 0, 0)
+    }
+
+    /// Insert a symbolic link owned by the requesting credentials.
+    pub fn symlink_with_owner(
+        &self,
+        parent_ino: u64,
+        name: &str,
+        target: Vec<u8>,
+        uid: u32,
+        gid: u32,
+    ) -> Result<Attr, FsError> {
         let path = self.new_symlink_path(parent_ino, name, &target)?;
         let mut g = self.inner.lock_recover();
         if g.index.contains_key(&(parent_ino, name.to_string())) {
@@ -1563,6 +1777,15 @@ impl ReadOnlyFs {
         let ino = g.next_ino;
         g.next_ino += 1;
         let now = SystemTime::now();
+        let (parent_perm, parent_gid) = {
+            let parent = g.nodes.get(&parent_ino).ok_or(FsError::NotFound)?;
+            (parent.perm, parent.gid)
+        };
+        let child_gid = if parent_perm & 0o2000 != 0 {
+            parent_gid
+        } else {
+            gid
+        };
         let node = Node {
             ino,
             parent: Some(parent_ino),
@@ -1576,6 +1799,8 @@ impl ReadOnlyFs {
             linked: true,
             perm: 0o777,
             rdev: 0,
+            uid,
+            gid: child_gid,
             atime: now,
             mtime: now,
             ctime: now,
@@ -1619,20 +1844,41 @@ impl ReadOnlyFs {
 
     /// Insert a new explicit directory after its marker has been committed.
     pub fn mkdir(&self, parent_ino: u64, name: &str) -> Result<Attr, FsError> {
+        self.mkdir_with_metadata(parent_ino, name, 0o777, 0, 0, 0)
+    }
+
+    /// Insert a directory with request ownership, mode, and umask metadata.
+    pub fn mkdir_with_metadata(
+        &self,
+        parent_ino: u64,
+        name: &str,
+        mode: u32,
+        umask: u32,
+        uid: u32,
+        gid: u32,
+    ) -> Result<Attr, FsError> {
         Self::validate_component(name)?;
         let mut g = self.inner.lock_recover();
-        let parent = g.nodes.get(&parent_ino).ok_or(FsError::NotFound)?;
-        if parent.kind != FileKind::Directory {
-            return Err(FsError::NotDir);
-        }
+        let (path, parent_perm, parent_gid) = {
+            let parent = g.nodes.get(&parent_ino).ok_or(FsError::NotFound)?;
+            if parent.kind != FileKind::Directory {
+                return Err(FsError::NotDir);
+            }
+            (Self::child_path(parent, name), parent.perm, parent.gid)
+        };
         if g.index.contains_key(&(parent_ino, name.to_string())) {
             return Err(FsError::Exists);
         }
-        let path = Self::child_path(parent, name);
         Self::validate_visible_object_path(&path)?;
         let ino = g.next_ino;
         g.next_ino += 1;
         let now = SystemTime::now();
+        let child_gid = if parent_perm & 0o2000 != 0 {
+            parent_gid
+        } else {
+            gid
+        };
+        let inherited_setgid = parent_perm & 0o2000;
         let node = Node {
             ino,
             parent: Some(parent_ino),
@@ -1644,8 +1890,10 @@ impl ReadOnlyFs {
             directory_marker: true,
             symlink_target: None,
             linked: true,
-            perm: 0o555,
+            perm: (((mode & !umask) & 0o7777) as u16) | inherited_setgid,
             rdev: 0,
+            uid,
+            gid: child_gid,
             atime: now,
             mtime: now,
             ctime: now,
@@ -1908,6 +2156,33 @@ impl ReadOnlyFs {
         }
     }
 
+    fn access_allowed(node: &Node, uid: u32, gid: u32, mask: u16) -> bool {
+        Self::access_allowed_with_groups(node, uid, gid, &[], mask)
+    }
+
+    fn access_allowed_with_groups(
+        node: &Node,
+        uid: u32,
+        gid: u32,
+        groups: &[u32],
+        mask: u16,
+    ) -> bool {
+        if mask == 0 {
+            return true;
+        }
+        if uid == 0 {
+            return mask & 0o1 == 0 || node.kind == FileKind::Directory || node.perm & 0o111 != 0;
+        }
+        let bits = if uid == node.uid {
+            (node.perm >> 6) & 0o7
+        } else if gid == node.gid || groups.contains(&node.gid) {
+            (node.perm >> 3) & 0o7
+        } else {
+            node.perm & 0o7
+        };
+        bits & mask == mask
+    }
+
     fn orphan_path(&self, source_path: &str, ino: u64) -> Result<String, FsError> {
         let object = path_to_object(source_path).map_err(|_| FsError::Invalid)?;
         Ok(format!(
@@ -1956,13 +2231,17 @@ mod tests {
         let fs = fs();
         let s3 = fs.lookup(ROOT_INO, "s3").unwrap();
         assert_eq!(s3.kind, FileKind::Directory);
-        assert_eq!(s3.perm, 0o555);
+        assert_eq!(s3.perm, 0o755);
+        assert_eq!(fs.getattr(ROOT_INO).unwrap().nlink, 4);
+        assert_eq!(s3.nlink, 3);
         let bucket = fs.lookup(s3.ino, "bucket").unwrap();
         let data = fs.lookup(bucket.ino, "data").unwrap();
+        assert_eq!(bucket.nlink, 3);
+        assert_eq!(data.nlink, 2);
         let a = fs.lookup(data.ino, "a.bin").unwrap();
         assert_eq!(a.kind, FileKind::File);
         assert_eq!(a.size, 1000);
-        assert_eq!(a.perm, 0o444);
+        assert_eq!(a.perm, 0o644);
         assert_eq!(fs.getattr(a.ino).unwrap(), a);
 
         assert_eq!(fs.lookup(ROOT_INO, "nope"), Err(FsError::NotFound));
@@ -2030,6 +2309,32 @@ mod tests {
     }
 
     #[test]
+    fn truncating_open_updates_size_mtime_and_ctime() {
+        let fs = fs();
+        let file = fs.lookup(data_dir(&fs).ino, "a.bin").unwrap();
+        let before = fs.getattr(file.ino).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1));
+
+        let fh = fs
+            .open_with_options_and_truncate(
+                file.ino,
+                OpenOptions {
+                    read: false,
+                    write: true,
+                    append: false,
+                },
+                Some(Vec::new()),
+                true,
+            )
+            .unwrap();
+        let after = fs.getattr(file.ino).unwrap();
+        assert_eq!(after.size, 0);
+        assert!(after.mtime > before.mtime);
+        assert!(after.ctime > before.ctime);
+        fs.release(fh).unwrap();
+    }
+
+    #[test]
     fn populate_from_listing_builds_tree_and_readdir() {
         let fs = ReadOnlyFs::new();
         let n = fs.populate_from_listing([
@@ -2068,6 +2373,23 @@ mod tests {
         let a_ino = a.ino;
         fs.populate_from_listing([("s3/bkt/dir/a.bin", 10u64)]);
         assert_eq!(fs.lookup(dir.ino, "a.bin").unwrap().ino, a_ino);
+    }
+
+    #[test]
+    fn listed_nodes_use_the_configured_mount_owner() {
+        let fs = ReadOnlyFs::new_with_owner(1000, 100);
+        fs.populate_from_listing([("s3/bucket/file.bin", 4), ("s3/bucket/empty/", 0)]);
+
+        let root = fs.getattr(ROOT_INO).unwrap();
+        let s3 = fs.lookup(ROOT_INO, "s3").unwrap();
+        let bucket = fs.lookup(s3.ino, "bucket").unwrap();
+        let file = fs.lookup(bucket.ino, "file.bin").unwrap();
+        let empty = fs.lookup(bucket.ino, "empty").unwrap();
+
+        for attr in [root, s3, bucket, file, empty] {
+            assert_eq!(attr.uid, 1000);
+            assert_eq!(attr.gid, 100);
+        }
     }
 
     #[test]
@@ -2260,7 +2582,7 @@ mod tests {
         for (index, (mode, kind, rdev)) in cases.into_iter().enumerate() {
             let name = format!("node-{index}");
             let plan = fs
-                .mknod_plan(parent.ino, &name, mode | 0o666, 0o022, rdev)
+                .mknod_plan(parent.ino, &name, mode | 0o666, 0o022, rdev, 1000, 100)
                 .unwrap();
             assert_eq!(plan.kind, kind);
             assert_eq!(plan.perm, 0o644);
@@ -2281,11 +2603,227 @@ mod tests {
     }
 
     #[test]
+    fn create_metadata_applies_credentials_umask_and_setgid_inheritance() {
+        let fs = fs();
+        let parent = data_dir(&fs);
+        fs.set_metadata(
+            parent.ino,
+            0,
+            0,
+            &[],
+            Some(0o2775),
+            None,
+            Some(42),
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+        let (file, _) = fs
+            .create_with_metadata(
+                parent.ino,
+                "owned.bin",
+                OpenOptions {
+                    read: true,
+                    write: true,
+                    append: false,
+                },
+                0o666,
+                0o027,
+                1000,
+                100,
+            )
+            .unwrap();
+        assert_eq!(file.perm, 0o640);
+        assert_eq!(file.uid, 1000);
+        assert_eq!(file.gid, 42);
+
+        let directory = fs
+            .mkdir_with_metadata(parent.ino, "owned-dir", 0o777, 0o027, 1000, 100)
+            .unwrap();
+        assert_eq!(directory.perm, 0o2750);
+        assert_eq!(directory.uid, 1000);
+        assert_eq!(directory.gid, 42);
+    }
+
+    #[test]
+    fn chmod_chown_and_access_enforce_owner_rules() {
+        let fs = fs();
+        let file = fs.lookup(data_dir(&fs).ino, "a.bin").unwrap();
+        let owned = fs
+            .set_metadata(
+                file.ino,
+                0,
+                0,
+                &[],
+                Some(0o6754),
+                Some(1000),
+                Some(100),
+                None,
+                None,
+                false,
+            )
+            .unwrap();
+        assert_eq!(owned.uid, 1000);
+        assert_eq!(owned.gid, 100);
+        assert_eq!(owned.perm, 0o754);
+
+        let chmod = fs
+            .set_metadata(
+                file.ino,
+                1000,
+                100,
+                &[],
+                Some(0o6750),
+                None,
+                None,
+                None,
+                None,
+                false,
+            )
+            .unwrap();
+        assert_eq!(chmod.perm, 0o6750);
+        assert_eq!(
+            fs.set_metadata(
+                file.ino,
+                2000,
+                200,
+                &[],
+                Some(0o600),
+                None,
+                None,
+                None,
+                None,
+                false,
+            ),
+            Err(FsError::OperationNotPermitted)
+        );
+
+        let chgrp = fs
+            .set_metadata(
+                file.ino,
+                1000,
+                200,
+                &[],
+                None,
+                None,
+                Some(200),
+                None,
+                None,
+                false,
+            )
+            .unwrap();
+        assert_eq!(chgrp.gid, 200);
+        assert_eq!(chgrp.perm & 0o6000, 0);
+        assert_eq!(
+            fs.set_metadata(
+                file.ino,
+                1000,
+                200,
+                &[],
+                None,
+                Some(2000),
+                None,
+                None,
+                None,
+                false,
+            ),
+            Err(FsError::OperationNotPermitted)
+        );
+
+        assert_eq!(fs.check_access(file.ino, 1000, 200, 0o6), Ok(()));
+        assert_eq!(
+            fs.check_access(file.ino, 3000, 300, 0o2),
+            Err(FsError::PermissionDenied)
+        );
+    }
+
+    #[test]
+    fn supplementary_groups_allow_chgrp_and_preserve_setgid() {
+        let fs = fs();
+        let file = fs.lookup(data_dir(&fs).ino, "a.bin").unwrap();
+        fs.set_metadata(
+            file.ino,
+            0,
+            0,
+            &[],
+            Some(0o750),
+            Some(1000),
+            Some(100),
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+
+        let chgrp = fs
+            .set_metadata(
+                file.ino,
+                1000,
+                200,
+                &[100, 300],
+                None,
+                None,
+                Some(300),
+                None,
+                None,
+                false,
+            )
+            .unwrap();
+        assert_eq!(chgrp.gid, 300);
+
+        let chmod = fs
+            .set_metadata(
+                file.ino,
+                1000,
+                200,
+                &[300],
+                Some(0o2750),
+                None,
+                None,
+                None,
+                None,
+                false,
+            )
+            .unwrap();
+        assert_eq!(chmod.perm, 0o2750);
+
+        fs.set_metadata(
+            file.ino,
+            1000,
+            200,
+            &[300],
+            Some(0o2670),
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+        let cleared = fs
+            .set_metadata(
+                file.ino,
+                2000,
+                200,
+                &[300],
+                Some(0o670),
+                None,
+                None,
+                None,
+                None,
+                false,
+            )
+            .unwrap();
+        assert_eq!(cleared.perm, 0o670);
+    }
+
+    #[test]
     fn mount_local_special_nodes_link_rename_and_unlink_without_backend_paths() {
         let fs = fs();
         let parent = data_dir(&fs);
         let plan = fs
-            .mknod_plan(parent.ino, "fifo", MODE_NAMED_PIPE | 0o600, 0, 0)
+            .mknod_plan(parent.ino, "fifo", MODE_NAMED_PIPE | 0o600, 0, 0, 1000, 100)
             .unwrap();
         let fifo = fs.commit_mknod(&plan).unwrap();
 
@@ -2527,6 +3065,31 @@ mod tests {
             ),
             Err(FsError::IsDir)
         );
+    }
+
+    #[test]
+    fn file_rename_updates_replaced_inode_ctime_when_links_remain() {
+        let fs = fs();
+        let parent = data_dir(&fs);
+        let source = fs.lookup(parent.ino, "a.bin").unwrap();
+        let target = fs.lookup(parent.ino, "b.bin").unwrap();
+        let link = fs
+            .hard_link_plan(target.ino, parent.ino, "b-link.bin")
+            .unwrap();
+        fs.commit_hard_link(&link).unwrap();
+        let before = fs.getattr(target.ino).unwrap().ctime;
+        std::thread::sleep(std::time::Duration::from_millis(1));
+
+        let rename = fs
+            .file_rename_plan(parent.ino, "a.bin", parent.ino, "b.bin")
+            .unwrap();
+        fs.commit_file_rename(&rename).unwrap();
+
+        let remaining = fs.lookup(parent.ino, "b-link.bin").unwrap();
+        assert_eq!(remaining.ino, target.ino);
+        assert_eq!(remaining.nlink, 1);
+        assert!(remaining.ctime > before);
+        assert_eq!(fs.lookup(parent.ino, "b.bin").unwrap().ino, source.ino);
     }
 
     #[test]

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -26,11 +26,12 @@ use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::os::fd::AsRawFd;
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::fs::{FileExt, FileTypeExt, MetadataExt, OpenOptionsExt};
+use std::os::unix::fs::{FileExt, FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::os::unix::net::UnixListener;
+use std::os::unix::process::CommandExt;
 use std::process::Command;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use talon_core::{NodeId, NodeInfo, NodeRole};
@@ -209,6 +210,13 @@ async fn mount_read_is_byte_exact_through_the_kernel() {
 
 /// Shared object store for the read-write mock worker: object path → bytes.
 type Store = Arc<Mutex<HashMap<String, Vec<u8>>>>;
+
+async fn serialize_mount_test() -> tokio::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await
+}
 
 /// Spawn a mock worker that honours the full data plane: `Put` writes an object
 /// into the shared store (replying with a committed version), `Delete` removes
@@ -1682,6 +1690,130 @@ async fn mount_device_nodes_preserve_rdev() {
     drop(session);
     std::fs::remove_dir_all(&mountpoint).ok();
     result.expect("exercise block and character device nodes through mount");
+}
+
+/// Exercise ownership and mode enforcement with real non-root request IDs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires privileged /dev/fuse and TALON_TEST_MULTIUSER=1"]
+async fn mount_metadata_enforces_multiuser_permissions() {
+    use fuser::MountOption;
+
+    let _mount_test_guard = serialize_mount_test().await;
+    if std::env::var_os("TALON_TEST_MULTIUSER").is_none() {
+        return;
+    }
+    let block_size: u32 = 4 * 1024 * 1024;
+    let store: Store = Arc::new(Mutex::new(HashMap::from([(
+        "/s3/bucket/placeholder".to_string(),
+        Vec::new(),
+    )])));
+    let worker = spawn_rw_worker(Arc::clone(&store)).await;
+    let coord = spawn_coordinator(worker).await;
+    let fs = Arc::new(ReadOnlyFs::new());
+    fs.insert_object("s3/bucket/placeholder", 0);
+
+    let cache = Arc::new(PlacementCache::new(10_000));
+    let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
+    let adapter = TalonFuse::new(
+        Arc::clone(&fs),
+        reader,
+        tokio::runtime::Handle::current(),
+        block_size,
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
+    )
+    .with_read_write(true);
+
+    let mountpoint =
+        std::env::temp_dir().join(format!("talon-mount-e2e-metadata-{}", std::process::id()));
+    std::fs::create_dir_all(&mountpoint).unwrap();
+    let options = vec![
+        MountOption::FSName("talon".into()),
+        MountOption::DefaultPermissions,
+        MountOption::AllowOther,
+    ];
+    let session = fuser::spawn_mount2(adapter, &mountpoint, &options)
+        .expect("multi-user metadata test requires an allow_other FUSE mount");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let test_dir = mountpoint.join("s3").join("bucket").join("multiuser");
+    std::fs::create_dir(&test_dir).unwrap();
+    std::fs::set_permissions(&test_dir, std::fs::Permissions::from_mode(0o777)).unwrap();
+    let result = tokio::task::spawn_blocking(move || {
+        let owned = test_dir.join("owned.bin");
+        let script = format!(
+            "umask 027; : > '{}'; chmod 6750 '{}'",
+            owned.display(),
+            owned.display()
+        );
+        let mut create = Command::new("/bin/sh");
+        create.arg("-c").arg(script);
+        unsafe {
+            create.pre_exec(|| {
+                if libc::setgid(65_534) != 0 || libc::setuid(65_534) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        assert!(create.status()?.success());
+
+        let created = std::fs::metadata(&owned)?;
+        assert_eq!(created.uid(), 65_534);
+        assert_eq!(created.gid(), 65_534);
+        assert_eq!(created.mode() & 0o7777, 0o6750);
+
+        let result = unsafe {
+            libc::chown(
+                std::ffi::CString::new(owned.as_os_str().as_bytes())
+                    .unwrap()
+                    .as_ptr(),
+                65_533,
+                65_532,
+            )
+        };
+        if result != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let changed = std::fs::metadata(&owned)?;
+        assert_eq!(changed.uid(), 65_533);
+        assert_eq!(changed.gid(), 65_532);
+        assert_eq!(changed.mode() & 0o6000, 0);
+
+        let script = format!("chmod 0600 '{}'", owned.display());
+        let mut denied = Command::new("/bin/sh");
+        denied.arg("-c").arg(script);
+        unsafe {
+            denied.pre_exec(|| {
+                if libc::setgid(65_534) != 0 || libc::setuid(65_534) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        assert!(!denied.status()?.success());
+
+        std::fs::set_permissions(&test_dir, std::fs::Permissions::from_mode(0o755))?;
+        let blocked = test_dir.join("blocked.bin");
+        let script = format!(": > '{}'", blocked.display());
+        let mut create_denied = Command::new("/bin/sh");
+        create_denied.arg("-c").arg(script);
+        unsafe {
+            create_denied.pre_exec(|| {
+                if libc::setgid(65_534) != 0 || libc::setuid(65_534) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        assert!(!create_denied.status()?.success());
+        Ok::<(), std::io::Error>(())
+    })
+    .await
+    .unwrap();
+
+    drop(session);
+    std::fs::remove_dir_all(&mountpoint).ok();
+    result.expect("exercise multi-user metadata through mount");
 }
 
 /// Mount the read-write fixture and run the pinned pjdfstest suite against it.


### PR DESCRIPTION
## Summary

Persist mode and ownership in the mount inode model, enforce POSIX metadata authorization, and expose stable uid/gid/mode values through FUSE. This closes the real-kernel `chmod,chown` compatibility gap, including supplementary groups and automatic setuid/setgid clearing after writes.

This PR is stacked on #345. Its diff will shrink to the metadata-specific commit after the prerequisite PRs merge.

## Related issues

- Progresses #328
- Part of #259 and #262
- Test harness: #322
- Large sparse writes beyond the whole-object limit: #347
- Backend namespace reconstruction remains dependent on #332

## Type of change

- [x] Bug fix
- [x] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [x] Docs / tests / tooling

## Metadata model

Mode, uid, gid, and timestamps are stable for the lifetime of a mount and are no longer synthesized from each request. Objects discovered through listing receive documented POSIX defaults and are owned by the mounting process. Durable cross-mount POSIX metadata requires a separate backend metadata contract; this PR does not create hidden sidecar objects.

## Changes

- Store uid, gid, and permission bits on every inode.
- Assign listed objects and synthesized directories to the mounting process uid/gid.
- Apply request credentials, creation mode, umask, and setgid directory inheritance to new files, directories, symlinks, and special nodes.
- Return inode ownership and mode from `getattr` and related metadata replies.
- Enforce owner/root rules for chmod, chown, chgrp, and timestamp updates.
- Resolve supplementary groups from the requesting process for owner chgrp and setgid handling.
- Clear setuid/setgid on ownership changes and permitted non-owner writes according to Linux behavior.
- Enable explicit FUSE access checks and validate multi-user behavior with `default_permissions` and `allow_other`.
- Update `O_TRUNC` mtime/ctime, rename replacement ctime, and POSIX directory link counts.
- Serialize real-kernel mount tests so independent FUSE sessions do not race release processing on shared CI runners.
- Add focused unit tests and privileged real-kernel coverage for ownership transitions, permission denial, umask, group inheritance, special bits, supplementary groups, timestamps, and link counts.

## Test plan

Final implementation commit: `ff08bf4415b899660550c8ee8982a765c5d98721`

Final pjdfstest runner commit: `f3b711fbda2baf85fe30ff22dc2ad8f0218e5421`

- [x] `cargo test -p talon-fuse --lib --features mount`: 121 passed
- [x] `cargo test -p talon-fuse --test mount_e2e --features mount --no-run`
- [x] `cargo check -p talon-fuse --bin talon-fuse`
- [x] `cargo clippy -p talon-fuse --all-targets --features mount -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Exact final implementation passed all 14 privileged root real-kernel mount tests in `falcon-phx-ca`
- [x] Exact final implementation passed all 14 real-kernel mount tests as uid/gid 1000 in `falcon-phx-ca`
- [x] GitHub Actions `fuse mount e2e` passed on the final implementation
- [x] All GitHub Actions checks passed, including backend E2E and Docker image build
- [x] `chmod,chown`: 1,824 passed / 0 failed
- [x] `utimensat,mkfifo,mknod,link,symlink`: 882 passed / 0 failed
- [x] Focused `open/00.t,rename/23.t,rename/24.t`: 102 passed / 0 failed
- [x] Core `open,rename,unlink,truncate,mkdir,rmdir`: 5,978 passed / 3 failed out of 5,981

The isolated `chmod,chown` result improved from 159 passed / 1,665 failed on the baseline to 1,824 passed / 0 failed.

Final selector totals:

- `open`: 334 passed / 3 failed; only assertions 2-4 in the >2 GiB sparse-write test `open/25.t` remain, tracked by #347
- `rename`: 4,857 passed / 0 failed
- `unlink`: 440 passed / 0 failed
- `truncate`: 84 passed / 0 failed
- `mkdir`: 118 passed / 0 failed
- `rmdir`: 145 passed / 0 failed
- `utimensat`: 122 passed / 0 failed
- `mkfifo`: 120 passed / 0 failed
- `mknod`: 186 passed / 0 failed
- `link`: 359 passed / 0 failed
- `symlink`: 95 passed / 0 failed

`open/25.t` writes one byte at offset `2 GiB + 1`. Talon returns `EFBIG` at the current 1 GiB whole-object limit instead of allocating and uploading more than 2 GiB of zero-filled data. Supporting this case requires a bounded-memory sparse/chunked write representation rather than only raising the cap.

## Performance impact

Metadata checks add in-memory mode and group comparisons. `setattr` resolves supplementary groups from `/proc/<request-pid>/status`; data reads and writes are unchanged. Write-through file operations continue to commit directly to the blob store.

A privileged PHX kernel-FUSE benchmark over local Talon protocol mocks measured:

- 4 KiB random read: 4,723.58 IOPS
- Cold sequential read: 47.63 MiB/s
- Warm page-cache read: 5,424.23 MiB/s
- 64 MiB write-through: 72.86 MiB/s

These numbers measure the kernel FUSE and local Talon userspace path. They do not include cloud blob-store or cross-region latency.

- [x] No data-plane backend I/O added

## Checklist

- [x] PR title follows Conventional Commits
- [x] Public behavior is covered by tests
- [x] No new dependencies
- [x] Based on `main` through the stacked prerequisite branches