### PR TITLE
feat(fuse): stream large sparse writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,6 +2064,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2083,12 +2084,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -2499,7 +2502,9 @@ dependencies = [
  "reqwest",
  "sha2",
  "talon-core",
+ "tempfile",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2569,6 +2574,7 @@ dependencies = [
  "libc",
  "talon-core",
  "talon-transport",
+ "tempfile",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -2626,6 +2632,7 @@ dependencies = [
  "talon-backend",
  "talon-core",
  "talon-transport",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3194,6 +3201,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ serde_yaml = "0.9"
 kube = { version = "0.97", default-features = false, features = ["client", "config", "rustls-tls", "runtime"] }
 k8s-openapi = { version = "0.23", default-features = false, features = ["v1_30"] }
 futures = "0.3"
+tempfile = "3"
+tokio-util = { version = "0.7", features = ["io"] }
 # etcd v3 client for the production ClusterStateStore backend. `tls-roots`
 # enables TLS via tonic/ring with the platform's native root certificates and
 # avoids a system OpenSSL build dependency.

--- a/crates/talon-backend/Cargo.toml
+++ b/crates/talon-backend/Cargo.toml
@@ -11,11 +11,13 @@ description = "Blob-store BackendStore implementations (S3/GCS/Azure) for Talon"
 talon-core.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
 tokio = { workspace = true, features = ["time"] }
+tokio-util.workspace = true
 sha2 = "0.10"
 hmac = "0.12"
 base64 = "0.22"
 
 [dev-dependencies]
+tempfile.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "test-util", "time"] }

--- a/crates/talon-backend/src/azure.rs
+++ b/crates/talon-backend/src/azure.rs
@@ -12,6 +12,7 @@
 //! either a SAS token (in the URL query) or Shared Key (see
 //! [`crate::azure_sharedkey`]), signed just before each request executes.
 
+use std::path::Path;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -236,6 +237,18 @@ impl AzureBackend {
         }
     }
 
+    fn build_streamed_put(&self, obj: &ObjectId, len: u64) -> HttpRequest {
+        let mut request = self.build_put(obj, bytes::Bytes::new(), None);
+        if let Some((_, value)) = request
+            .headers
+            .iter_mut()
+            .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+        {
+            *value = len.to_string();
+        }
+        request
+    }
+
     /// Build the DELETE request (exposed for testing).
     pub fn build_delete(&self, obj: &ObjectId) -> HttpRequest {
         HttpRequest {
@@ -371,6 +384,30 @@ impl BackendStore for AzureBackend {
         }
     }
 
+    async fn put_file(&self, obj: &ObjectId, path: &Path, len: u64) -> Result<Version> {
+        let request = self.authorized(self.build_streamed_put(obj, len));
+        let resp = self
+            .http
+            .execute_file(request, path, len)
+            .await
+            .map_err(Error::Backend)?;
+        if !resp.is_success() {
+            return Err(Error::Backend(format!(
+                "Azure streamed PUT {} -> HTTP {}",
+                obj.to_path(),
+                resp.status
+            )));
+        }
+        match resp
+            .header("etag")
+            .map(|value| Version::new(value.trim_matches('"').to_string()))
+            .filter(|version| !version.0.trim().is_empty())
+        {
+            Some(version) => Ok(version),
+            None => Ok(self.head(obj).await?.version),
+        }
+    }
+
     async fn delete(&self, obj: &ObjectId) -> Result<()> {
         let resp = self
             .http
@@ -398,6 +435,7 @@ mod tests {
 
     struct MockHttp {
         last: Mutex<Option<HttpRequest>>,
+        last_file: Mutex<Option<(HttpRequest, std::path::PathBuf, u64)>>,
         response: HttpResponse,
     }
 
@@ -405,6 +443,7 @@ mod tests {
         fn new(response: HttpResponse) -> Arc<Self> {
             Arc::new(Self {
                 last: Mutex::new(None),
+                last_file: Mutex::new(None),
                 response,
             })
         }
@@ -414,6 +453,16 @@ mod tests {
     impl HttpClient for MockHttp {
         async fn execute(&self, req: HttpRequest) -> std::result::Result<HttpResponse, String> {
             *self.last.lock().unwrap() = Some(req);
+            Ok(self.response.clone())
+        }
+
+        async fn execute_file(
+            &self,
+            req: HttpRequest,
+            path: &Path,
+            len: u64,
+        ) -> std::result::Result<HttpResponse, String> {
+            *self.last_file.lock().unwrap() = Some((req, path.to_path_buf(), len));
             Ok(self.response.clone())
         }
     }
@@ -626,6 +675,29 @@ mod tests {
         let req = http.last.lock().unwrap().clone().unwrap();
         assert_eq!(req.method, Method::Put);
         assert_eq!(req.body, body);
+        assert_eq!(req.header("x-ms-blob-type"), Some("BlockBlob"));
+    }
+
+    #[tokio::test]
+    async fn put_file_streams_block_blob_and_returns_etag() {
+        let http = MockHttp::new(HttpResponse {
+            status: 201,
+            headers: vec![("ETag".into(), "\"0xSTREAM\"".into())],
+            body: bytes::Bytes::new(),
+        });
+        let a = AzureBackend::new(AzureConfig::new("acct"), None, http.clone());
+        let mut staged = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut staged, b"azure-stream").unwrap();
+
+        let version = a.put_file(&obj(), staged.path(), 12).await.unwrap();
+
+        assert_eq!(version, Version::new("0xSTREAM"));
+        let (req, path, len) = http.last_file.lock().unwrap().clone().unwrap();
+        assert_eq!(path, staged.path());
+        assert_eq!(len, 12);
+        assert_eq!(req.method, Method::Put);
+        assert!(req.body.is_empty());
+        assert_eq!(req.header("Content-Length"), Some("12"));
         assert_eq!(req.header("x-ms-blob-type"), Some("BlockBlob"));
     }
 

--- a/crates/talon-backend/src/delay.rs
+++ b/crates/talon-backend/src/delay.rs
@@ -11,6 +11,7 @@
 //! jitter is a deterministic LCG seeded per client, so behavior is reproducible
 //! in tests without pulling in an RNG dependency and without wall-clock flake.
 
+use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -127,6 +128,20 @@ impl HttpClient for DelayingHttpClient {
         }
         Ok(resp)
     }
+
+    async fn execute_file(
+        &self,
+        req: HttpRequest,
+        path: &Path,
+        len: u64,
+    ) -> Result<HttpResponse, String> {
+        let resp = self.inner.execute_file(req, path, len).await?;
+        let delay = self.delay_for(resp.body.len());
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
+        Ok(resp)
+    }
 }
 
 #[cfg(test)]
@@ -137,6 +152,7 @@ mod tests {
     struct MockHttp {
         body_len: usize,
         calls: Mutex<u32>,
+        file_calls: Mutex<Vec<(std::path::PathBuf, u64)>>,
     }
 
     impl MockHttp {
@@ -144,6 +160,7 @@ mod tests {
             Arc::new(Self {
                 body_len,
                 calls: Mutex::new(0),
+                file_calls: Mutex::new(Vec::new()),
             })
         }
     }
@@ -152,6 +169,23 @@ mod tests {
     impl HttpClient for MockHttp {
         async fn execute(&self, _req: HttpRequest) -> Result<HttpResponse, String> {
             *self.calls.lock().unwrap() += 1;
+            Ok(HttpResponse {
+                status: 200,
+                headers: vec![],
+                body: bytes::Bytes::from(vec![0u8; self.body_len]),
+            })
+        }
+
+        async fn execute_file(
+            &self,
+            _req: HttpRequest,
+            path: &Path,
+            len: u64,
+        ) -> Result<HttpResponse, String> {
+            self.file_calls
+                .lock()
+                .unwrap()
+                .push((path.to_path_buf(), len));
             Ok(HttpResponse {
                 status: 200,
                 headers: vec![],
@@ -255,6 +289,28 @@ mod tests {
         let resp = c.execute(req()).await.unwrap();
         assert_eq!(resp.status, 200);
         assert_eq!(*inner.calls.lock().unwrap(), 1);
+        assert!(start.elapsed() >= Duration::from_secs(2));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn execute_file_forwards_stream_metadata_and_sleeps() {
+        let inner = MockHttp::new(0);
+        let cfg = DelayConfig {
+            base: Duration::from_secs(2),
+            jitter: Duration::ZERO,
+            throughput_bytes_per_sec: None,
+        };
+        let client = DelayingHttpClient::new(inner.clone(), cfg, 1);
+        let path = Path::new("/tmp/staged-object");
+        let start = tokio::time::Instant::now();
+
+        let response = client.execute_file(req(), path, 4096).await.unwrap();
+
+        assert_eq!(response.status, 200);
+        assert_eq!(
+            inner.file_calls.lock().unwrap().as_slice(),
+            &[(path.to_path_buf(), 4096)]
+        );
         assert!(start.elapsed() >= Duration::from_secs(2));
     }
 

--- a/crates/talon-backend/src/gcs.rs
+++ b/crates/talon-backend/src/gcs.rs
@@ -10,6 +10,7 @@
 //! construction and response parsing are unit-testable offline; a real OAuth2
 //! bearer-token client is injected in production.
 
+use std::path::Path;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -165,6 +166,18 @@ impl GcsBackend {
         }
     }
 
+    fn build_streamed_put(&self, obj: &ObjectId, len: u64) -> HttpRequest {
+        let mut request = self.build_put(obj, bytes::Bytes::new(), None);
+        if let Some((_, value)) = request
+            .headers
+            .iter_mut()
+            .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+        {
+            *value = len.to_string();
+        }
+        request
+    }
+
     /// Build the DELETE request (exposed for testing).
     pub fn build_delete(&self, obj: &ObjectId) -> HttpRequest {
         HttpRequest {
@@ -305,6 +318,30 @@ impl BackendStore for GcsBackend {
         }
     }
 
+    async fn put_file(&self, obj: &ObjectId, path: &Path, len: u64) -> Result<Version> {
+        let resp = self
+            .http
+            .execute_file(self.build_streamed_put(obj, len), path, len)
+            .await
+            .map_err(Error::Backend)?;
+        if !resp.is_success() {
+            return Err(Error::Backend(format!(
+                "GCS streamed PUT {} -> HTTP {}",
+                obj.to_path(),
+                resp.status
+            )));
+        }
+        match resp
+            .header("x-goog-generation")
+            .or_else(|| resp.header("etag"))
+            .map(|value| Version::new(value.trim_matches('"').to_string()))
+            .filter(|version| !version.0.trim().is_empty())
+        {
+            Some(version) => Ok(version),
+            None => Ok(self.head(obj).await?.version),
+        }
+    }
+
     async fn delete(&self, obj: &ObjectId) -> Result<()> {
         let resp = self
             .http
@@ -332,6 +369,7 @@ mod tests {
 
     struct MockHttp {
         last: Mutex<Option<HttpRequest>>,
+        last_file: Mutex<Option<(HttpRequest, std::path::PathBuf, u64)>>,
         response: HttpResponse,
     }
 
@@ -339,6 +377,7 @@ mod tests {
         fn new(response: HttpResponse) -> Arc<Self> {
             Arc::new(Self {
                 last: Mutex::new(None),
+                last_file: Mutex::new(None),
                 response,
             })
         }
@@ -348,6 +387,16 @@ mod tests {
     impl HttpClient for MockHttp {
         async fn execute(&self, req: HttpRequest) -> std::result::Result<HttpResponse, String> {
             *self.last.lock().unwrap() = Some(req);
+            Ok(self.response.clone())
+        }
+
+        async fn execute_file(
+            &self,
+            req: HttpRequest,
+            path: &Path,
+            len: u64,
+        ) -> std::result::Result<HttpResponse, String> {
+            *self.last_file.lock().unwrap() = Some((req, path.to_path_buf(), len));
             Ok(self.response.clone())
         }
     }
@@ -516,6 +565,29 @@ mod tests {
         let req = http.last.lock().unwrap().clone().unwrap();
         assert_eq!(req.method, Method::Put);
         assert_eq!(req.body, body);
+        assert_eq!(req.header("Authorization"), Some("Bearer tok"));
+    }
+
+    #[tokio::test]
+    async fn put_file_streams_body_and_returns_generation() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![("x-goog-generation".into(), "1700000011".into())],
+            body: bytes::Bytes::new(),
+        });
+        let g = GcsBackend::new(GcsConfig::default(), Some("tok".into()), http.clone());
+        let mut staged = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut staged, b"gcs-stream").unwrap();
+
+        let version = g.put_file(&obj(), staged.path(), 10).await.unwrap();
+
+        assert_eq!(version, Version::new("1700000011"));
+        let (req, path, len) = http.last_file.lock().unwrap().clone().unwrap();
+        assert_eq!(path, staged.path());
+        assert_eq!(len, 10);
+        assert_eq!(req.method, Method::Put);
+        assert!(req.body.is_empty());
+        assert_eq!(req.header("Content-Length"), Some("10"));
         assert_eq!(req.header("Authorization"), Some("Bearer tok"));
     }
 

--- a/crates/talon-backend/src/http.rs
+++ b/crates/talon-backend/src/http.rs
@@ -8,6 +8,7 @@
 //! asserts on the constructed [`HttpRequest`].
 
 use async_trait::async_trait;
+use std::path::Path;
 
 /// An HTTP method (only the verbs the backends need).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -218,6 +219,20 @@ pub trait HttpClient: Send + Sync {
     /// Execute `req` and return the response, or an error string on transport
     /// failure (DNS/connect/timeout).
     async fn execute(&self, req: HttpRequest) -> Result<HttpResponse, String>;
+
+    /// Execute a request whose body is streamed from `path`.
+    ///
+    /// Implementations must send exactly `len` bytes with bounded memory. The
+    /// default rejects the operation instead of reading the complete file.
+    async fn execute_file(
+        &self,
+        req: HttpRequest,
+        path: &Path,
+        len: u64,
+    ) -> Result<HttpResponse, String> {
+        let _ = (req, path, len);
+        Err("HTTP client does not support streamed file bodies".to_string())
+    }
 }
 
 #[cfg(test)]

--- a/crates/talon-backend/src/reqwest_client.rs
+++ b/crates/talon-backend/src/reqwest_client.rs
@@ -12,6 +12,9 @@
 //! client does no signing of its own.
 
 use async_trait::async_trait;
+use std::path::Path;
+use tokio::io::AsyncReadExt;
+use tokio_util::io::ReaderStream;
 
 use crate::http::{HttpClient, HttpRequest, HttpResponse, Method};
 
@@ -57,6 +60,52 @@ impl HttpClient for ReqwestClient {
         if !req.body.is_empty() {
             builder = builder.body(req.body.clone());
         }
+        let resp = builder.send().await.map_err(sanitize_error)?;
+        let status = resp.status().as_u16();
+        let headers = resp
+            .headers()
+            .iter()
+            .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
+            .collect();
+        let body = resp.bytes().await.map_err(sanitize_error)?;
+        Ok(HttpResponse {
+            status,
+            headers,
+            body,
+        })
+    }
+
+    async fn execute_file(
+        &self,
+        req: HttpRequest,
+        path: &Path,
+        len: u64,
+    ) -> Result<HttpResponse, String> {
+        let method = match req.method {
+            Method::Get => reqwest::Method::GET,
+            Method::Head => reqwest::Method::HEAD,
+            Method::Put => reqwest::Method::PUT,
+            Method::Delete => reqwest::Method::DELETE,
+        };
+        let mut builder = self.inner.request(method, &req.url);
+        for (k, v) in &req.headers {
+            builder = builder.header(k.as_str(), v.as_str());
+        }
+        let file = tokio::fs::File::open(path)
+            .await
+            .map_err(|error| format!("open streamed request body: {error}"))?;
+        let actual_len = file
+            .metadata()
+            .await
+            .map_err(|error| format!("stat streamed request body: {error}"))?
+            .len();
+        if actual_len < len {
+            return Err(format!(
+                "streamed request body is {actual_len} bytes, expected at least {len}"
+            ));
+        }
+        let stream = ReaderStream::new(file.take(len));
+        builder = builder.body(reqwest::Body::wrap_stream(stream));
         let resp = builder.send().await.map_err(sanitize_error)?;
         let status = resp.status().as_u16();
         let headers = resp

--- a/crates/talon-backend/src/s3.rs
+++ b/crates/talon-backend/src/s3.rs
@@ -12,9 +12,12 @@
 //! and the `s3` service. Endpoints are configurable so MinIO/Ceph and other
 //! S3-compatible stores work.
 
+use std::io::{Read, Take};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use sha2::{Digest, Sha256};
 use talon_core::{BackendStore, Error, ObjectId, ObjectStat, Result, Version};
 
 use crate::http::{HttpClient, HttpRequest, Method};
@@ -196,6 +199,62 @@ impl S3Backend {
         crate::sigv4::sign_request(&mut req, &self.creds, &self.config.region, "s3", &date);
         req
     }
+
+    fn signed_with_payload_hash(&self, mut req: HttpRequest, payload_hash: &str) -> HttpRequest {
+        let date = crate::sigv4::AmzDate::from_system_time(std::time::SystemTime::now());
+        crate::sigv4::sign_request_with_payload_hash(
+            &mut req,
+            &self.creds,
+            &self.config.region,
+            "s3",
+            &date,
+            payload_hash,
+        );
+        req
+    }
+
+    fn build_streamed_put(
+        &self,
+        obj: &ObjectId,
+        len: u64,
+        if_match: Option<&Version>,
+    ) -> HttpRequest {
+        let mut request = self.build_put(obj, bytes::Bytes::new(), if_match);
+        if let Some((_, value)) = request
+            .headers
+            .iter_mut()
+            .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+        {
+            *value = len.to_string();
+        }
+        request
+    }
+}
+
+fn hash_file(path: PathBuf, len: u64) -> Result<String> {
+    let file = std::fs::File::open(&path)
+        .map_err(|error| Error::Backend(format!("open {} for hashing: {error}", path.display())))?;
+    let mut reader: Take<std::fs::File> = file.take(len);
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0u8; 1024 * 1024];
+    let mut read_len = 0u64;
+    loop {
+        let count = reader
+            .read(&mut buffer)
+            .map_err(|error| Error::Backend(format!("hash {}: {error}", path.display())))?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+        read_len += count as u64;
+    }
+    if read_len != len {
+        return Err(Error::Backend(format!(
+            "{} ended after {read_len} bytes while hashing {len} bytes",
+            path.display()
+        )));
+    }
+    Ok(format!("{:x}", hasher.finalize()))
 }
 
 /// Normalize an S3 ETag into a [`Version`] (strip surrounding quotes).
@@ -329,6 +388,37 @@ impl BackendStore for S3Backend {
         }
     }
 
+    async fn put_file(&self, obj: &ObjectId, path: &Path, len: u64) -> Result<Version> {
+        let payload_hash = tokio::task::spawn_blocking({
+            let path = path.to_path_buf();
+            move || hash_file(path, len)
+        })
+        .await
+        .map_err(|error| Error::Backend(format!("S3 payload hashing task failed: {error}")))??;
+        let request =
+            self.signed_with_payload_hash(self.build_streamed_put(obj, len, None), &payload_hash);
+        let resp = self
+            .http
+            .execute_file(request, path, len)
+            .await
+            .map_err(Error::Backend)?;
+        if !resp.is_success() {
+            return Err(Error::Backend(format!(
+                "S3 streamed PUT {} -> HTTP {}",
+                obj.to_path(),
+                resp.status
+            )));
+        }
+        match resp
+            .header("etag")
+            .map(etag_to_version)
+            .filter(|version| !version.0.trim().is_empty())
+        {
+            Some(version) => Ok(version),
+            None => Ok(self.head(obj).await?.version),
+        }
+    }
+
     async fn delete(&self, obj: &ObjectId) -> Result<()> {
         let req = self.signed(self.build_delete(obj));
         let resp = self.http.execute(req).await.map_err(Error::Backend)?;
@@ -355,6 +445,7 @@ mod tests {
     /// A mock client that records the last request and returns a canned response.
     struct MockHttp {
         last: Mutex<Option<HttpRequest>>,
+        last_file: Mutex<Option<(HttpRequest, PathBuf, u64)>>,
         response: HttpResponse,
     }
 
@@ -362,6 +453,7 @@ mod tests {
         fn new(response: HttpResponse) -> Arc<Self> {
             Arc::new(Self {
                 last: Mutex::new(None),
+                last_file: Mutex::new(None),
                 response,
             })
         }
@@ -371,6 +463,16 @@ mod tests {
     impl HttpClient for MockHttp {
         async fn execute(&self, req: HttpRequest) -> std::result::Result<HttpResponse, String> {
             *self.last.lock().unwrap() = Some(req);
+            Ok(self.response.clone())
+        }
+
+        async fn execute_file(
+            &self,
+            req: HttpRequest,
+            path: &Path,
+            len: u64,
+        ) -> std::result::Result<HttpResponse, String> {
+            *self.last_file.lock().unwrap() = Some((req, path.to_path_buf(), len));
             Ok(self.response.clone())
         }
     }
@@ -598,6 +700,33 @@ mod tests {
         assert_eq!(req.method, Method::Put);
         assert_eq!(req.body, body);
         assert_eq!(req.header("Content-Length"), Some("12"));
+    }
+
+    #[tokio::test]
+    async fn put_file_streams_signed_body_and_returns_committed_version() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![("ETag".into(), "\"stream-etag\"".into())],
+            body: bytes::Bytes::new(),
+        });
+        let s3 = S3Backend::new(S3Config::aws("us-east-1"), creds(), http.clone());
+        let mut staged = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut staged, b"sparse-stream-body").unwrap();
+
+        let version = s3.put_file(&obj(), staged.path(), 18).await.unwrap();
+
+        assert_eq!(version, Version::new("stream-etag"));
+        let (req, path, len) = http.last_file.lock().unwrap().clone().unwrap();
+        assert_eq!(path, staged.path());
+        assert_eq!(len, 18);
+        assert_eq!(req.method, Method::Put);
+        assert!(req.body.is_empty());
+        assert_eq!(req.header("Content-Length"), Some("18"));
+        assert!(req.header("Authorization").is_some());
+        assert_eq!(
+            req.header("x-amz-content-sha256"),
+            Some("324d3410a4267a26d985db5fb545b6df76b89c53268056ff4eacbb719bdec330")
+        );
     }
 
     #[tokio::test]

--- a/crates/talon-backend/src/sigv4.rs
+++ b/crates/talon-backend/src/sigv4.rs
@@ -133,9 +133,20 @@ pub fn sign_request(
     service: &str,
     date: &AmzDate,
 ) {
-    let (host, path, query) = split_url(&req.url);
     let payload_hash = sha256_hex(&req.body);
+    sign_request_with_payload_hash(req, creds, region, service, date, &payload_hash);
+}
 
+/// Sign `req` using a SHA-256 hash computed by a streaming caller.
+pub fn sign_request_with_payload_hash(
+    req: &mut HttpRequest,
+    creds: &S3Credentials,
+    region: &str,
+    service: &str,
+    date: &AmzDate,
+    payload_hash: &str,
+) {
+    let (host, path, query) = split_url(&req.url);
     // Reset the headers we own, keeping caller headers (Range, If-Match, ...).
     req.headers.retain(|(k, _)| {
         !matches!(
@@ -151,7 +162,7 @@ pub fn sign_request(
     req.headers
         .push(("x-amz-date".into(), date.datetime.clone()));
     req.headers
-        .push(("x-amz-content-sha256".into(), payload_hash.clone()));
+        .push(("x-amz-content-sha256".into(), payload_hash.to_string()));
     if let Some(tok) = &creds.session_token {
         req.headers
             .push(("x-amz-security-token".into(), tok.clone()));
@@ -160,7 +171,7 @@ pub fn sign_request(
     // Canonical headers: the signed set, lowercased, sorted, trimmed values.
     let mut signed: Vec<(String, String)> = vec![
         ("host".into(), host),
-        ("x-amz-content-sha256".into(), payload_hash.clone()),
+        ("x-amz-content-sha256".into(), payload_hash.to_string()),
         ("x-amz-date".into(), date.datetime.clone()),
     ];
     if let Some(tok) = &creds.session_token {

--- a/crates/talon-core/src/backend.rs
+++ b/crates/talon-core/src/backend.rs
@@ -9,6 +9,7 @@
 use crate::{ObjectId, Result, Version};
 use async_trait::async_trait;
 use bytes::Bytes;
+use std::path::Path;
 
 /// Metadata about a source object.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -95,6 +96,19 @@ pub trait BackendStore: Send + Sync {
     ) -> Result<Version> {
         let _ = if_match;
         self.put(obj, body).await
+    }
+
+    /// Upload a file as a whole object without materializing it in memory.
+    ///
+    /// `len` is the exact number of bytes to read from `path`. Real backends
+    /// override this with a streaming request. The default returns an explicit
+    /// error so unsupported backends cannot silently allocate the whole file.
+    async fn put_file(&self, obj: &ObjectId, path: &Path, len: u64) -> Result<Version> {
+        let _ = (path, len);
+        Err(crate::Error::Backend(format!(
+            "backend does not support streamed PUT for {}",
+            obj.to_path()
+        )))
     }
 
     /// Delete the object. Idempotent: a missing object is `Ok(())`.

--- a/crates/talon-fuse/Cargo.toml
+++ b/crates/talon-fuse/Cargo.toml
@@ -21,6 +21,7 @@ tracing-subscriber.workspace = true
 clap.workspace = true
 async-trait.workspace = true
 thiserror.workspace = true
+tempfile.workspace = true
 
 # The kernel mount layer is optional: enabling the `mount` feature pulls in
 # `fuser` and compiles the `fuser::Filesystem` adapter. Default builds (and CI

--- a/crates/talon-fuse/src/lib.rs
+++ b/crates/talon-fuse/src/lib.rs
@@ -27,7 +27,10 @@ pub use mapping::{path_to_object, resolve_read, ReadTarget};
 pub use metrics::{ReadStats, ReadStatsSnapshot};
 #[cfg(feature = "mount")]
 pub use mount::{TalonFuse, CANONICAL_MOUNT_VERSION};
-pub use ops::{Attr, DirEntry, FileKind, FsError, ReadOnlyFs, DEFAULT_MAX_OBJECT_BYTES, ROOT_INO};
+pub use ops::{
+    Attr, DirEntry, FileKind, FsError, ReadOnlyFs, WritebackSource,
+    DEFAULT_MAX_LOGICAL_OBJECT_BYTES, DEFAULT_MAX_OBJECT_BYTES, ROOT_INO,
+};
 pub use placement_cache::{Cached, PlacementCache, RefreshReason};
 pub use pool::{ConnectionPool, DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT};
 pub use prefetch::Prefetcher;

--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -25,7 +25,7 @@ use crate::lock::MutexExt;
 use crate::mapping::path_to_object;
 use crate::ops::{
     Attr, DirectoryRenameEntry, DirectoryRenamePlan, FileKind, FsError, OpenOptions, ReadOnlyFs,
-    ReadSource,
+    ReadSource, WritebackSource,
 };
 use crate::prefetch::Prefetcher;
 use crate::readahead::ReadaheadConfig;
@@ -71,6 +71,7 @@ pub(crate) fn errno(err: FsError) -> i32 {
         FsError::OperationNotPermitted => libc::EPERM,
         FsError::CrossDevice => libc::EXDEV,
         FsError::PermissionDenied => libc::EACCES,
+        FsError::Io => libc::EIO,
     }
 }
 
@@ -303,11 +304,23 @@ impl TalonFuse {
     /// FUSE `flush`/`fsync` callback so a write error surfaces to the app's
     /// `close(2)`/`fsync(2)` (#232).
     fn writeback_object(&self, path: &str, bytes: Vec<u8>) -> anyhow::Result<()> {
+        self.writeback_object_source(path, WritebackSource::Memory(bytes))
+    }
+
+    fn writeback_object_source(&self, path: &str, source: WritebackSource) -> anyhow::Result<()> {
         let object = path_to_object(path)?;
-        self.writeback_object_id(object, bytes)
+        self.writeback_object_source_id(object, source)
     }
 
     fn writeback_object_id(&self, object: ObjectId, bytes: Vec<u8>) -> anyhow::Result<()> {
+        self.writeback_object_source_id(object, WritebackSource::Memory(bytes))
+    }
+
+    fn writeback_object_source_id(
+        &self,
+        object: ObjectId,
+        source: WritebackSource,
+    ) -> anyhow::Result<()> {
         let reader = self.reader.clone();
         let pool = Arc::clone(&self.write_pool);
         let block_size = self.block_size;
@@ -318,18 +331,33 @@ impl TalonFuse {
                 .resolve_owner(&object, block_size, &version, now_ms)
                 .await?;
             let client = crate::worker_client::WriteClient::with_pool(addr, pool);
-            client.put_object(&object, &bytes).await?;
+            match source {
+                WritebackSource::Memory(bytes) => {
+                    client.put_object(&object, &bytes).await?;
+                }
+                WritebackSource::File { path, len } => {
+                    client.put_object_file(&object, &path, len).await?;
+                }
+            }
             Ok::<(), anyhow::Error>(())
         })
     }
 
     fn writeback_object_paths(&self, paths: &[String], bytes: Vec<u8>) -> anyhow::Result<()> {
+        self.writeback_object_source_paths(paths, WritebackSource::Memory(bytes))
+    }
+
+    fn writeback_object_source_paths(
+        &self,
+        paths: &[String],
+        source: WritebackSource,
+    ) -> anyhow::Result<()> {
         if paths.is_empty() {
             anyhow::bail!("inode has no backend object paths");
         }
         let mut first_error = None;
         for path in paths {
-            if let Err(error) = self.writeback_object(path, bytes.clone()) {
+            if let Err(error) = self.writeback_object_source(path, source.clone()) {
                 first_error.get_or_insert(error);
             }
         }
@@ -899,11 +927,11 @@ impl fuser::Filesystem for TalonFuse {
         let contents = match &plan.buffered_contents {
             Some(contents) => contents.clone(),
             None => match self.read_committed_object(&plan.source_path, plan.source_size) {
-                Ok(contents) => contents,
+                Ok(contents) => WritebackSource::Memory(contents),
                 Err(error) => return reply.error(error),
             },
         };
-        if let Err(error) = self.writeback_object(&plan.target_path, contents) {
+        if let Err(error) = self.writeback_object_source(&plan.target_path, contents) {
             tracing::warn!(
                 source = %plan.source_path,
                 target = %plan.target_path,
@@ -1183,15 +1211,15 @@ impl fuser::Filesystem for TalonFuse {
         _lock_owner: u64,
         reply: fuser::ReplyEmpty,
     ) {
-        let bytes = match self.fs.dirty_bytes(fh) {
-            Some(bytes) => bytes,
+        let source = match self.fs.dirty_source(fh) {
+            Some(source) => source,
             None => return reply.ok(),
         };
         let paths = match self.fs.dirty_paths(fh) {
             Ok(paths) => paths,
             Err(error) => return reply.error(errno(error)),
         };
-        match self.writeback_object_paths(&paths, bytes) {
+        match self.writeback_object_source_paths(&paths, source) {
             Ok(()) => reply.ok(),
             Err(error) => {
                 tracing::warn!(?paths, %error, "flush writeback failed");
@@ -1209,15 +1237,15 @@ impl fuser::Filesystem for TalonFuse {
         _datasync: bool,
         reply: fuser::ReplyEmpty,
     ) {
-        let bytes = match self.fs.dirty_bytes(fh) {
-            Some(bytes) => bytes,
+        let source = match self.fs.dirty_source(fh) {
+            Some(source) => source,
             None => return reply.ok(),
         };
         let paths = match self.fs.dirty_paths(fh) {
             Ok(paths) => paths,
             Err(error) => return reply.error(errno(error)),
         };
-        match self.writeback_object_paths(&paths, bytes) {
+        match self.writeback_object_source_paths(&paths, source) {
             Ok(()) => reply.ok(),
             Err(_) => reply.error(libc::EIO),
         }
@@ -1400,11 +1428,11 @@ impl fuser::Filesystem for TalonFuse {
             let contents = match &plan.buffered_contents {
                 Some(contents) => contents.clone(),
                 None => match self.read_committed_object(&plan.source_path, plan.source_size) {
-                    Ok(contents) => contents,
+                    Ok(contents) => WritebackSource::Memory(contents),
                     Err(error) => return reply.error(error),
                 },
             };
-            if let Err(error) = self.writeback_object(orphan_path, contents.clone()) {
+            if let Err(error) = self.writeback_object_source(orphan_path, contents.clone()) {
                 tracing::warn!(
                     source = %plan.source_path,
                     orphan = %orphan_path,
@@ -1426,7 +1454,7 @@ impl fuser::Filesystem for TalonFuse {
             }
             if let Err(error) = self.fs.commit_unlink(&plan) {
                 if let Err(rollback_error) =
-                    self.writeback_object(&plan.source_path, contents.clone())
+                    self.writeback_object_source(&plan.source_path, contents.clone())
                 {
                     tracing::error!(
                         path = %plan.source_path,

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -9,16 +9,18 @@
 //!
 //! Paths under the mount mirror the backend namespace (`/s3/<bucket>/<key…>`,
 //! see [`crate::mapping`]). Directories are synthesized from the path hierarchy;
-//! files correspond to objects. Writes accumulate into a per-handle whole-object
-//! buffer (object stores replace whole objects, not byte ranges); the assembled
-//! object is written through to the backend at flush.
+//! files correspond to objects. Small writes accumulate in memory; large or
+//! sparse writes spill into a sparse staging file and stream through at flush.
 
 use crate::lock::MutexExt;
 use crate::mapping::path_to_object;
 use std::collections::HashMap;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
+use tempfile::NamedTempFile;
 
 /// The root inode number (fixed by FUSE convention).
 pub const ROOT_INO: u64 = 1;
@@ -109,6 +111,8 @@ pub enum FsError {
     CrossDevice,
     /// Access is denied by inode mode bits (`EACCES`).
     PermissionDenied,
+    /// Local staging I/O failed (`EIO`).
+    Io,
 }
 
 /// Access and mutation behavior for an open file handle.
@@ -138,12 +142,12 @@ pub enum ReadSource {
 
 /// Default cap on a single in-memory write buffer (1 GiB).
 ///
-/// v1 buffers a whole object in RAM, so the buffer length is attacker-reachable
-/// from an unprivileged `pwrite`/`ftruncate` at an arbitrary offset. Without a
-/// cap, `pwrite(fd, buf, 1, 1<<40)` asks for a 1 TiB zero-filled allocation and
-/// takes the mount (and likely the host) down. See
-/// [`ReadOnlyFs::with_max_object_bytes`] to tune.
+/// Objects larger than this are staged in a sparse temporary file and streamed
+/// through the worker. The limit is a memory threshold, not a logical file-size
+/// limit. See [`ReadOnlyFs::with_max_object_bytes`] to tune.
 pub const DEFAULT_MAX_OBJECT_BYTES: u64 = 1 << 30;
+/// Default logical size limit for a streamed object (4 GiB).
+pub const DEFAULT_MAX_LOGICAL_OBJECT_BYTES: u64 = 4 << 30;
 
 const INTERNAL_OBJECT_PREFIX: &str = ".__talon_internal";
 const MAX_SYMLINK_TARGET_BYTES: usize = 4095;
@@ -155,6 +159,35 @@ const MODE_BLOCK_DEVICE: u32 = 0o060000;
 const MODE_DIRECTORY: u32 = 0o040000;
 const MODE_CHAR_DEVICE: u32 = 0o020000;
 const MODE_NAMED_PIPE: u32 = 0o010000;
+
+/// A stable snapshot used for backend write-through.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WritebackSource {
+    /// Small object bytes retained in memory.
+    Memory(Vec<u8>),
+    /// A staged file containing exactly `len` logical bytes.
+    File {
+        /// Path kept alive by the open dirty handle.
+        path: PathBuf,
+        /// Exact number of bytes to stream.
+        len: u64,
+    },
+}
+
+impl WritebackSource {
+    /// Logical object length.
+    pub fn len(&self) -> u64 {
+        match self {
+            Self::Memory(bytes) => bytes.len() as u64,
+            Self::File { len, .. } => *len,
+        }
+    }
+
+    /// Whether the object is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
 
 /// A directory entry yielded by `readdir`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -215,7 +248,7 @@ pub struct UnlinkPlan {
     pub(crate) source_path: String,
     pub(crate) source_size: u64,
     pub(crate) orphan_path: Option<String>,
-    pub(crate) buffered_contents: Option<Vec<u8>>,
+    pub(crate) buffered_contents: Option<WritebackSource>,
     pub(crate) backend_object: bool,
 }
 
@@ -225,7 +258,7 @@ pub struct HardLinkPlan {
     pub(crate) source_ino: u64,
     pub(crate) source_path: String,
     pub(crate) source_size: u64,
-    pub(crate) buffered_contents: Option<Vec<u8>>,
+    pub(crate) buffered_contents: Option<WritebackSource>,
     pub(crate) target_parent: u64,
     pub(crate) target_name: String,
     pub(crate) target_path: String,
@@ -283,6 +316,8 @@ pub struct ReadOnlyFs {
     listing_gid: u32,
     /// Cap on the length of any single write handle's in-memory buffer.
     max_object_bytes: u64,
+    /// Cap on logical object length, independent of the staging representation.
+    max_logical_object_bytes: u64,
     /// Mount-scoped backend namespace for open-but-unlinked objects.
     orphan_namespace: String,
 }
@@ -295,11 +330,9 @@ struct Inner {
     // Open file handles -> inode and access mode.
     handles: HashMap<u64, Handle>,
     next_fh: u64,
-    // Write handles -> their in-progress whole-object buffer. A handle opened for
-    // write accumulates bytes here (random-offset writes land by position); the
-    // assembled object is taken at flush/release and written through to the
-    // backend (#226/#231). v1 buffers in memory (objects are single-block/small);
-    // a temp-file-backed buffer for large objects is future work.
+    // Write handles -> their in-progress object contents. Small objects remain
+    // in memory; large or sparse objects use a sparse staging file. The
+    // assembled object is streamed through at flush/release (#226/#231).
     dirty: HashMap<u64, DirtyFile>,
 }
 
@@ -311,13 +344,126 @@ struct Handle {
     append: bool,
 }
 
-/// A per-write-handle whole-object buffer.
+/// Per-write-handle object contents, either in memory or in a staging file.
 struct DirtyFile {
     /// The file inode this handle writes.
     ino: u64,
-    /// The object contents assembled so far (extended with zeros for sparse
-    /// writes past the current end).
-    buf: Vec<u8>,
+    /// The object contents assembled so far.
+    contents: DirtyContents,
+}
+
+enum DirtyContents {
+    Memory(Vec<u8>),
+    Staged { file: NamedTempFile, len: u64 },
+}
+
+impl DirtyContents {
+    fn memory(bytes: Vec<u8>) -> Self {
+        Self::Memory(bytes)
+    }
+
+    fn len(&self) -> u64 {
+        match self {
+            Self::Memory(bytes) => bytes.len() as u64,
+            Self::Staged { len, .. } => *len,
+        }
+    }
+
+    fn promote(&mut self, len: u64) -> Result<(), FsError> {
+        let Self::Memory(bytes) = self else {
+            if let Self::Staged {
+                file,
+                len: staged_len,
+            } = self
+            {
+                file.as_file().set_len(len).map_err(|_| FsError::Io)?;
+                *staged_len = len;
+            }
+            return Ok(());
+        };
+        let mut file = NamedTempFile::new().map_err(|_| FsError::Io)?;
+        file.write_all(bytes).map_err(|_| FsError::Io)?;
+        file.as_file().set_len(len).map_err(|_| FsError::Io)?;
+        *self = Self::Staged { file, len };
+        Ok(())
+    }
+
+    fn write_at(&mut self, offset: u64, data: &[u8], memory_limit: u64) -> Result<u64, FsError> {
+        let end = offset
+            .checked_add(data.len() as u64)
+            .ok_or(FsError::TooLarge)?;
+        if matches!(self, Self::Memory(_)) && end > memory_limit {
+            self.promote(end)?;
+        }
+        match self {
+            Self::Memory(bytes) => {
+                let start: usize = offset.try_into().map_err(|_| FsError::TooLarge)?;
+                let end: usize = end.try_into().map_err(|_| FsError::TooLarge)?;
+                if bytes.len() < end {
+                    bytes.resize(end, 0);
+                }
+                bytes[start..end].copy_from_slice(data);
+            }
+            Self::Staged { file, len } => {
+                let output = file.as_file_mut();
+                output
+                    .seek(SeekFrom::Start(offset))
+                    .and_then(|_| output.write_all(data))
+                    .map_err(|_| FsError::Io)?;
+                if end > *len {
+                    output.set_len(end).map_err(|_| FsError::Io)?;
+                    *len = end;
+                }
+            }
+        }
+        Ok(end)
+    }
+
+    fn read_range(&self, offset: u64, size: u32) -> Result<Vec<u8>, FsError> {
+        let len = self.len();
+        if offset >= len {
+            return Ok(Vec::new());
+        }
+        let count = (len - offset).min(size as u64) as usize;
+        match self {
+            Self::Memory(bytes) => {
+                let start: usize = offset.try_into().map_err(|_| FsError::TooLarge)?;
+                Ok(bytes[start..start + count].to_vec())
+            }
+            Self::Staged { file, .. } => {
+                let mut input = file.reopen().map_err(|_| FsError::Io)?;
+                input
+                    .seek(SeekFrom::Start(offset))
+                    .map_err(|_| FsError::Io)?;
+                let mut bytes = vec![0u8; count];
+                input.read_exact(&mut bytes).map_err(|_| FsError::Io)?;
+                Ok(bytes)
+            }
+        }
+    }
+
+    fn snapshot(&self) -> WritebackSource {
+        match self {
+            Self::Memory(bytes) => WritebackSource::Memory(bytes.clone()),
+            Self::Staged { file, len } => WritebackSource::File {
+                path: file.path().to_path_buf(),
+                len: *len,
+            },
+        }
+    }
+
+    fn to_vec(&self) -> Result<Vec<u8>, FsError> {
+        match self {
+            Self::Memory(bytes) => Ok(bytes.clone()),
+            Self::Staged { file, len } => {
+                let capacity: usize = (*len).try_into().map_err(|_| FsError::TooLarge)?;
+                let mut input = file.reopen().map_err(|_| FsError::Io)?;
+                let mut bytes = Vec::with_capacity(capacity);
+                input.read_to_end(&mut bytes).map_err(|_| FsError::Io)?;
+                Ok(bytes)
+            }
+        }
+    }
 }
 
 static NEXT_FS_INSTANCE: AtomicU64 = AtomicU64::new(1);
@@ -377,13 +523,15 @@ impl ReadOnlyFs {
             listing_uid: uid,
             listing_gid: gid,
             max_object_bytes: DEFAULT_MAX_OBJECT_BYTES,
+            max_logical_object_bytes: DEFAULT_MAX_LOGICAL_OBJECT_BYTES,
             orphan_namespace: format!("{:x}-{timestamp:x}-{instance:x}", std::process::id()),
         }
     }
 
-    /// Override the per-object write-buffer cap (see
-    /// [`DEFAULT_MAX_OBJECT_BYTES`]). Writes or truncates that would push a
-    /// buffer past this fail with [`FsError::TooLarge`] (`EFBIG`).
+    /// Override the in-memory staging threshold (see
+    /// [`DEFAULT_MAX_OBJECT_BYTES`]). Writes beyond this threshold spill to a
+    /// sparse temporary file. Truncate currently remains memory-backed and
+    /// rejects larger sizes with [`FsError::TooLarge`] (`EFBIG`).
     pub fn with_max_object_bytes(mut self, max: u64) -> Self {
         self.max_object_bytes = max;
         self
@@ -392,6 +540,17 @@ impl ReadOnlyFs {
     /// The configured per-object write-buffer cap.
     pub fn max_object_bytes(&self) -> u64 {
         self.max_object_bytes
+    }
+
+    /// Override the logical object-size limit.
+    pub fn with_max_logical_object_bytes(mut self, max: u64) -> Self {
+        self.max_logical_object_bytes = max;
+        self
+    }
+
+    /// The configured logical object-size limit.
+    pub fn max_logical_object_bytes(&self) -> u64 {
+        self.max_logical_object_bytes
     }
 
     /// Register an object at `path` (e.g. `/s3/bucket/a/b/file.bin`) with `size`,
@@ -809,8 +968,14 @@ impl ReadOnlyFs {
             },
         );
         if let Some(buf) = initial_contents {
-            g.dirty.insert(fh, DirtyFile { ino, buf });
-            let size = g.dirty.get(&fh).unwrap().buf.len() as u64;
+            let size = buf.len() as u64;
+            g.dirty.insert(
+                fh,
+                DirtyFile {
+                    ino,
+                    contents: DirtyContents::memory(buf),
+                },
+            );
             let node = g.nodes.get_mut(&ino).unwrap();
             node.size = size;
             if truncate {
@@ -904,13 +1069,7 @@ impl ReadOnlyFs {
         }
         let ino = handle.ino;
         let source = if let Some(dirty) = g.dirty.get(&fh) {
-            let start = usize::try_from(offset).map_err(|_| FsError::Invalid)?;
-            if start >= dirty.buf.len() {
-                ReadSource::Buffered(Vec::new())
-            } else {
-                let end = start.saturating_add(size as usize).min(dirty.buf.len());
-                ReadSource::Buffered(dirty.buf[start..end].to_vec())
-            }
+            ReadSource::Buffered(dirty.contents.read_range(offset, size)?)
         } else {
             let node = g.nodes.get(&ino).ok_or(FsError::NotFound)?;
             ReadSource::Backend {
@@ -1034,7 +1193,7 @@ impl ReadOnlyFs {
             fh,
             DirtyFile {
                 ino,
-                buf: Vec::new(),
+                contents: DirtyContents::memory(Vec::new()),
             },
         );
         let attr = Self::attr_of(&g, g.nodes.get(&ino).unwrap());
@@ -1155,13 +1314,12 @@ impl ReadOnlyFs {
         ))
     }
 
-    /// `write`: write `data` at `offset` into the write handle's buffer.
+    /// `write`: write `data` at `offset` into the handle's working copy.
     ///
     /// Random-offset writes land by position; a write past the current end
-    /// extends the buffer with zeros (sparse). Updates the node's visible size.
-    /// Returns the number of bytes written. Fails with [`FsError::BadHandle`] for
-    /// a handle not opened for write, or [`FsError::TooLarge`] (`EFBIG`) if the
-    /// resulting buffer would exceed [`ReadOnlyFs::max_object_bytes`].
+    /// extends the logical file with a hole. Once the logical end exceeds the
+    /// in-memory threshold, the working copy is promoted to a sparse staging
+    /// file instead of allocating zero-filled RAM.
     ///
     /// The end offset is computed with a checked add: `offset` comes straight
     /// from the kernel and `offset + len` would otherwise overflow `usize` (a
@@ -1174,27 +1332,24 @@ impl ReadOnlyFs {
         }
         let append = handle.append;
         let start = if append {
-            g.dirty.get(&fh).ok_or(FsError::BadHandle)?.buf.len() as u64
+            g.dirty.get(&fh).ok_or(FsError::BadHandle)?.contents.len()
         } else {
             offset
         };
         let end = start
             .checked_add(data.len() as u64)
             .ok_or(FsError::TooLarge)?;
-        if end > self.max_object_bytes {
+        if end > self.max_logical_object_bytes {
             return Err(FsError::TooLarge);
         }
-        let end: usize = end.try_into().map_err(|_| FsError::TooLarge)?;
-        let start: usize = start.try_into().map_err(|_| FsError::TooLarge)?;
         let dirty = g.dirty.get_mut(&fh).ok_or(FsError::BadHandle)?;
-        if dirty.buf.len() < end {
-            dirty.buf.resize(end, 0);
-        }
-        dirty.buf[start..end].copy_from_slice(data);
+        dirty
+            .contents
+            .write_at(start, data, self.max_object_bytes)?;
         let ino = dirty.ino;
-        let new_size = dirty.buf.len() as u64;
+        let new_size = dirty.contents.len();
         if let Some(node) = g.nodes.get_mut(&ino) {
-            node.size = node.size.max(new_size);
+            node.size = new_size;
             let now = SystemTime::now();
             node.mtime = now;
             node.ctime = now;
@@ -1217,7 +1372,7 @@ impl ReadOnlyFs {
         let new_len: usize = size.try_into().map_err(|_| FsError::TooLarge)?;
         let dirty = g.dirty.get(&fh).ok_or(FsError::BadHandle)?;
         let node = g.nodes.get(&dirty.ino).ok_or(FsError::NotFound)?;
-        let mut contents = dirty.buf.clone();
+        let mut contents = dirty.contents.to_vec()?;
         contents.resize(new_len, 0);
         Ok((node.path.clone(), contents))
     }
@@ -1285,7 +1440,7 @@ impl ReadOnlyFs {
         node.mtime = now;
         node.ctime = now;
         for dirty in g.dirty.values_mut().filter(|dirty| dirty.ino == ino) {
-            dirty.buf.clone_from(&contents);
+            dirty.contents = DirtyContents::memory(contents.clone());
         }
         Ok(Self::attr_of(g, g.nodes.get(&ino).unwrap()))
     }
@@ -1295,7 +1450,15 @@ impl ReadOnlyFs {
     /// no-op unless more is written. Returns `None` for a non-write handle.
     pub fn dirty_bytes(&self, fh: u64) -> Option<Vec<u8>> {
         let g = self.inner.lock_recover();
-        g.dirty.get(&fh).map(|d| d.buf.clone())
+        g.dirty
+            .get(&fh)
+            .and_then(|dirty| dirty.contents.to_vec().ok())
+    }
+
+    /// Return a bounded-memory writeback snapshot for a dirty handle.
+    pub fn dirty_source(&self, fh: u64) -> Option<WritebackSource> {
+        let g = self.inner.lock_recover();
+        g.dirty.get(&fh).map(|dirty| dirty.contents.snapshot())
     }
 
     /// The mount-relative object path a write handle targets.
@@ -1370,7 +1533,7 @@ impl ReadOnlyFs {
                 .iter()
                 .filter(|(_, dirty)| dirty.ino == source_ino)
                 .max_by_key(|(fh, _)| *fh)
-                .map(|(_, dirty)| dirty.buf.clone()),
+                .map(|(_, dirty)| dirty.contents.snapshot()),
             target_parent,
             target_name: target_name.to_string(),
             target_path,
@@ -1986,7 +2149,7 @@ impl ReadOnlyFs {
             .iter()
             .filter(|(_, dirty)| dirty.ino == ino)
             .max_by_key(|(fh, _)| *fh)
-            .map(|(_, dirty)| dirty.buf.clone());
+            .map(|(_, dirty)| dirty.contents.snapshot());
         Ok(UnlinkPlan {
             ino,
             parent: parent_ino,
@@ -3221,8 +3384,8 @@ mod tests {
         let orphan_path = plan.orphan_path.clone().unwrap();
         assert!(orphan_path.contains("/.__talon_internal/unlinked/"));
         assert_eq!(
-            plan.buffered_contents.as_deref(),
-            Some(b"contents".as_slice())
+            plan.buffered_contents,
+            Some(WritebackSource::Memory(b"contents".to_vec()))
         );
 
         fs.commit_unlink(&plan).unwrap();
@@ -3380,29 +3543,36 @@ mod tests {
         fs.release(fh).unwrap();
     }
 
-    /// Regression: `offset` comes from the kernel unvalidated, so a single
-    /// `pwrite` at a huge offset used to ask for a proportionally huge
-    /// zero-filled allocation (`buf.resize(offset + len)`) — a one-syscall DoS
-    /// of the whole mount. It is now bounded by `max_object_bytes`.
+    /// Large sparse writes spill to a file rather than allocating the hole.
     #[test]
-    fn write_past_the_cap_is_efbig_and_allocates_nothing() {
-        let fs = fs().with_max_object_bytes(1024);
-        let (attr, fh) = fs.create(data_dir(&fs).ino, "big.bin").unwrap();
+    fn write_past_the_memory_cap_uses_sparse_staging() {
+        let fs = fs()
+            .with_max_object_bytes(1024)
+            .with_max_logical_object_bytes(8192);
+        let (attr, fh) = fs
+            .create_with_options(
+                data_dir(&fs).ino,
+                "big.bin",
+                OpenOptions {
+                    read: true,
+                    write: true,
+                    append: false,
+                },
+            )
+            .unwrap();
 
-        // 1 TiB offset: would have been a 1 TiB resize.
+        // A nonsensical logical size is still rejected.
         assert_eq!(fs.write(fh, 1 << 40, b"x"), Err(FsError::TooLarge));
-        // Just past the cap.
-        assert_eq!(fs.write(fh, 1024, b"x"), Err(FsError::TooLarge));
-        // Straddling the cap.
-        assert_eq!(fs.write(fh, 1020, b"12345"), Err(FsError::TooLarge));
-
-        // Nothing was buffered and the visible size never moved.
-        assert!(fs.dirty_bytes(fh).unwrap().is_empty());
-        assert_eq!(fs.getattr(attr.ino).unwrap().size, 0);
-
-        // Exactly at the cap still succeeds.
-        assert_eq!(fs.write(fh, 1023, b"x").unwrap(), 1);
-        assert_eq!(fs.dirty_bytes(fh).unwrap().len(), 1024);
+        assert_eq!(fs.write(fh, 4096, b"x").unwrap(), 1);
+        assert_eq!(fs.getattr(attr.ino).unwrap().size, 4097);
+        assert!(matches!(
+            fs.dirty_source(fh),
+            Some(WritebackSource::File { len: 4097, .. })
+        ));
+        assert_eq!(
+            fs.read_source(fh, 4094, 3).unwrap(),
+            ReadSource::Buffered(vec![0, 0, b'x'])
+        );
     }
 
     /// `offset + data.len()` overflowed `usize`: a debug panic while holding the

--- a/crates/talon-fuse/src/pool.rs
+++ b/crates/talon-fuse/src/pool.rs
@@ -142,9 +142,23 @@ impl ConnectionPool {
         F: std::future::Future<Output = Result<T, E>>,
         E: From<std::io::Error>,
     {
-        match tokio::time::timeout(self.request_timeout, fut).await {
+        self.with_deadline(what, self.request_timeout, fut).await
+    }
+
+    /// Run an exchange with a caller-selected bounded deadline.
+    pub async fn with_deadline<T, E, F>(
+        &self,
+        what: &str,
+        timeout: Duration,
+        fut: F,
+    ) -> Result<T, E>
+    where
+        F: std::future::Future<Output = Result<T, E>>,
+        E: From<std::io::Error>,
+    {
+        match tokio::time::timeout(timeout, fut).await {
             Ok(result) => result,
-            Err(_) => Err(E::from(timeout_error(what, self.request_timeout))),
+            Err(_) => Err(E::from(timeout_error(what, timeout))),
         }
     }
 

--- a/crates/talon-fuse/src/worker_client.rs
+++ b/crates/talon-fuse/src/worker_client.rs
@@ -13,7 +13,9 @@
 //! opened per fetch for simplicity, mirroring
 //! [`CoordinatorClient`](crate::CoordinatorClient).
 
+use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use talon_core::{ObjectId, Version};
 use talon_transport::frame::{FrameHeader, MsgType, HEADER_LEN};
@@ -228,6 +230,43 @@ impl WriteClient {
         }
     }
 
+    /// Stream a staged file through the worker without loading it into memory.
+    pub async fn put_object_file(
+        &self,
+        object: &ObjectId,
+        path: &Path,
+        len: u64,
+    ) -> Result<Version, WorkerError> {
+        let header = encode_put_header(
+            0,
+            &PutRequest {
+                object: object.clone(),
+                body_len: len,
+            },
+        )?;
+        match self.put_file_exchange(&header, path, len).await {
+            Ok(version) => Ok(version),
+            Err((true, _stale)) => {
+                let mut stream = self.pool.fresh(&self.addr).await?;
+                let version = self
+                    .pool
+                    .with_deadline(
+                        "worker put_object_file retry",
+                        streamed_put_timeout(len),
+                        async {
+                            stream.write_all(&header).await?;
+                            stream_file(&mut stream, path, len).await?;
+                            read_version_reply(&mut stream).await
+                        },
+                    )
+                    .await?;
+                self.pool.release(&self.addr, stream);
+                Ok(version)
+            }
+            Err((false, error)) => Err(error),
+        }
+    }
+
     /// One PUT exchange over a pooled-or-fresh connection; on error returns
     /// `(was_reused, err)` so a stale pooled connection can be retried.
     async fn put_exchange(
@@ -255,6 +294,34 @@ impl WriteClient {
                 Ok(version)
             }
             Err(err) => Err((reused, err)),
+        }
+    }
+
+    async fn put_file_exchange(
+        &self,
+        header: &[u8],
+        path: &Path,
+        len: u64,
+    ) -> Result<Version, (bool, WorkerError)> {
+        let (mut stream, reused) = self
+            .pool
+            .checkout(&self.addr)
+            .await
+            .map_err(|error| (false, WorkerError::from(error)))?;
+        let result: Result<Version, WorkerError> = self
+            .pool
+            .with_deadline("worker put_object_file", streamed_put_timeout(len), async {
+                stream.write_all(header).await?;
+                stream_file(&mut stream, path, len).await?;
+                read_version_reply(&mut stream).await
+            })
+            .await;
+        match result {
+            Ok(version) => {
+                self.pool.release(&self.addr, stream);
+                Ok(version)
+            }
+            Err(error) => Err((reused, error)),
         }
     }
 
@@ -306,6 +373,34 @@ impl WriteClient {
             Err(err) => Err((reused, err)),
         }
     }
+}
+
+fn streamed_put_timeout(len: u64) -> Duration {
+    const MIN_BYTES_PER_SECOND: u64 = 4 * 1024 * 1024;
+    const MAX_SECONDS: u64 = 30 * 60;
+    let transfer_seconds = len.div_ceil(MIN_BYTES_PER_SECOND);
+    Duration::from_secs((30 + transfer_seconds).min(MAX_SECONDS))
+}
+
+async fn stream_file(stream: &mut TcpStream, path: &Path, len: u64) -> Result<(), WorkerError> {
+    let file = tokio::fs::File::open(path).await?;
+    let actual_len = file.metadata().await?.len();
+    if actual_len < len {
+        return Err(WorkerError::Io(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            format!("staged file is {actual_len} bytes, expected at least {len}"),
+        )));
+    }
+    let mut limited = file.take(len);
+    let copied = tokio::io::copy(&mut limited, stream).await?;
+    if copied != len {
+        return Err(WorkerError::Io(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            format!("streamed {copied} bytes, expected {len}"),
+        )));
+    }
+    stream.flush().await?;
+    Ok(())
 }
 
 /// Read a framed write/delete reply: OK carries the committed version bytes (a
@@ -581,6 +676,24 @@ mod tests {
         let (obj, got) = recorded.lock().unwrap().take().unwrap();
         assert_eq!(obj, object());
         assert_eq!(got, body, "worker received the exact object bytes");
+    }
+
+    #[tokio::test]
+    async fn put_object_file_streams_exact_bytes() {
+        let recorded = Arc::new(std::sync::Mutex::new(None));
+        let addr = mock_write_worker("stream-v1", Arc::clone(&recorded)).await;
+        let client = WriteClient::new(addr);
+        let mut staged = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut staged, b"streamed-file-body").unwrap();
+
+        let version = client
+            .put_object_file(&object(), staged.path(), 18)
+            .await
+            .unwrap();
+        assert_eq!(version, talon_core::Version::new("stream-v1"));
+        let (obj, got) = recorded.lock().unwrap().take().unwrap();
+        assert_eq!(obj, object());
+        assert_eq!(got, b"streamed-file-body");
     }
 
     #[tokio::test]

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -403,6 +403,85 @@ async fn mount_write_through_is_visible_in_backend() {
     );
 }
 
+/// Spill a sparse write past the memory threshold and stream it through close.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires /dev/fuse; run with --features mount -- --ignored"]
+async fn mount_large_sparse_write_streams_without_whole_object_memory() {
+    use fuser::MountOption;
+
+    let _mount_test_guard = serialize_mount_test().await;
+    let block_size: u32 = 4 * 1024 * 1024;
+    let store: Store = Arc::new(Mutex::new(HashMap::new()));
+    let worker = spawn_rw_worker(Arc::clone(&store)).await;
+    let coord = spawn_coordinator(worker).await;
+
+    let fs = Arc::new(ReadOnlyFs::new().with_max_object_bytes(1024));
+    fs.insert_object("s3/bucket/placeholder", 0);
+    let cache = Arc::new(PlacementCache::new(10_000));
+    let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
+    let adapter = TalonFuse::new(
+        Arc::clone(&fs),
+        reader,
+        tokio::runtime::Handle::current(),
+        block_size,
+        talon_core::Version::new(talon_fuse::mount::CANONICAL_MOUNT_VERSION),
+    )
+    .with_read_write(true);
+
+    let require_fuse = std::env::var_os("TALON_REQUIRE_FUSE").is_some();
+    let mountpoint =
+        std::env::temp_dir().join(format!("talon-mount-e2e-stream-{}", std::process::id()));
+    std::fs::create_dir_all(&mountpoint).unwrap();
+    let session =
+        match fuser::spawn_mount2(adapter, &mountpoint, &[MountOption::FSName("talon".into())]) {
+            Ok(session) => session,
+            Err(error) => {
+                std::fs::remove_dir_all(&mountpoint).ok();
+                if require_fuse {
+                    panic!("TALON_REQUIRE_FUSE is set but the FUSE mount failed: {error}");
+                }
+                eprintln!("skipping: /dev/fuse unavailable: {error}");
+                return;
+            }
+        };
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let path = mountpoint.join("s3").join("bucket").join("sparse.bin");
+    let write_path = path.clone();
+    let logical_offset = 8 * 1024 * 1024 + 1;
+    tokio::task::spawn_blocking(move || {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&write_path)?;
+        assert_eq!(file.write_at(b"x", logical_offset)?, 1);
+        drop(file);
+
+        assert_eq!(std::fs::metadata(&write_path)?.len(), logical_offset + 1);
+        let file = std::fs::File::open(&write_path)?;
+        let mut byte = [0u8; 1];
+        assert_eq!(file.read_at(&mut byte, logical_offset)?, 1);
+        assert_eq!(byte, [b'x']);
+        Ok::<(), std::io::Error>(())
+    })
+    .await
+    .unwrap()
+    .expect("stream a sparse write through the mount");
+
+    drop(session);
+    std::fs::remove_dir_all(&mountpoint).ok();
+
+    let stored = store
+        .lock()
+        .unwrap()
+        .get("/s3/bucket/sparse.bin")
+        .cloned()
+        .expect("mock backend received streamed object");
+    assert_eq!(stored.len() as u64, logical_offset + 1);
+    assert_eq!(stored[logical_offset as usize], b'x');
+}
+
 /// Exercise open flags through the kernel and verify their blob-store effects.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires /dev/fuse; run with --features mount -- --ignored"]

--- a/crates/talon-worker/Cargo.toml
+++ b/crates/talon-worker/Cargo.toml
@@ -41,6 +41,7 @@ libc.workspace = true
 monoio.workspace = true
 serde_json.workspace = true
 axum.workspace = true
+tempfile.workspace = true
 
 [dev-dependencies]
 divan.workspace = true

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -42,7 +42,7 @@ use talon_worker::{
     send_file_range, serve_admin, BlockIndex, InFlightLoads, ServeOutcome, WholeBlockStore,
     WorkerObservability, WorkerRuntime, DEFAULT_CHUNK,
 };
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
 const CONTROL_OPERATION_TIMEOUT: Duration = Duration::from_secs(3);
@@ -823,13 +823,37 @@ async fn handle_put(
         stream.flush().await?;
         return Ok(());
     }
-    // Read exactly body_len raw object bytes that follow the header on the wire.
-    let mut body = vec![0u8; req.body_len as usize];
-    stream.read_exact(&mut body).await?;
-    match worker
-        .write_object(&req.object, bytes::Bytes::from(body))
-        .await
-    {
+    let write_result = if req.body_len <= worker.max_inline_write_bytes() {
+        let body_len = usize::try_from(req.body_len)
+            .map_err(|_| anyhow::anyhow!("PUT body length is not representable"))?;
+        let mut body = vec![0u8; body_len];
+        stream.read_exact(&mut body).await?;
+        worker
+            .write_object(&req.object, bytes::Bytes::from(body))
+            .await
+    } else {
+        let staged = tempfile::NamedTempFile::new()?;
+        let file = staged.reopen()?;
+        let mut file = tokio::fs::File::from_std(file);
+        let mut remaining = req.body_len;
+        let mut buffer = vec![0u8; 8 * 1024 * 1024];
+        while remaining > 0 {
+            let count = remaining.min(buffer.len() as u64) as usize;
+            stream.read_exact(&mut buffer[..count]).await?;
+            if buffer[..count].iter().all(|byte| *byte == 0) {
+                file.seek(std::io::SeekFrom::Current(count as i64)).await?;
+            } else {
+                file.write_all(&buffer[..count]).await?;
+            }
+            remaining -= count as u64;
+        }
+        file.set_len(req.body_len).await?;
+        file.flush().await?;
+        worker
+            .write_object_file(&req.object, staged.path(), req.body_len)
+            .await
+    };
+    match write_result {
         Ok(version) => {
             // Reply OK; the body carries the committed version so the client can
             // record read-after-write consistency.

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -1,6 +1,7 @@
 //! Instrumented worker cache request runtime.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -577,6 +578,58 @@ impl WorkerRuntime {
         Ok(version)
     }
 
+    /// Write a staged file through to the backend with bounded memory.
+    ///
+    /// Small files retain the existing cache-populating path. Larger files are
+    /// streamed to the origin and intentionally left out of the single-block
+    /// cache; subsequent reads resolve the new version and load ranges normally.
+    pub async fn write_object_file(
+        &self,
+        object: &ObjectId,
+        path: &Path,
+        len: u64,
+    ) -> anyhow::Result<Version> {
+        if len <= self.block_size as u64 {
+            let body = tokio::fs::read(path).await?;
+            if body.len() as u64 != len {
+                anyhow::bail!(
+                    "staged object {} changed size: expected {len}, found {}",
+                    object.to_path(),
+                    body.len()
+                );
+            }
+            return self.write_object(object, bytes::Bytes::from(body)).await;
+        }
+        let old_version = self.cached_version(object);
+        let version = match self.backend.put_file(object, path, len).await {
+            Ok(version) => {
+                self.metrics.record_backend_write_success(len);
+                version
+            }
+            Err(error) => {
+                self.metrics.record_backend_write_error();
+                return Err(error.into());
+            }
+        };
+        if let Some(old_version) = old_version {
+            let old_block = self.block_for(object, 0, &old_version);
+            self.unlink_units(vec![CacheUnit::Whole(old_block)]).await;
+        }
+        self.store_version(object, &version);
+        tracing::info!(
+            object = %object.to_path(),
+            bytes = len,
+            version = %version,
+            "streamed object"
+        );
+        Ok(version)
+    }
+
+    /// Maximum PUT body retained in memory and cached as one block.
+    pub fn max_inline_write_bytes(&self) -> u64 {
+        self.block_size as u64
+    }
+
     /// Delete an object from the backend and evict it locally (#226/#229).
     ///
     /// Deletes at the origin (`backend.delete`, idempotent), then invalidates the
@@ -672,7 +725,8 @@ fn is_version_mismatch(error: &anyhow::Error) -> bool {
 mod tests {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
-    use std::path::PathBuf;
+    use std::os::unix::fs::FileExt;
+    use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::SystemTime;
 
@@ -891,6 +945,59 @@ mod tests {
         // Default to always-resolve so version-sensitivity assertions are not
         // masked by the version cache; caching is exercised explicitly below.
         .with_version_ttl(Duration::ZERO)
+    }
+
+    struct StreamPutBackend {
+        uploaded: std::sync::Mutex<Option<(u64, u8)>>,
+    }
+
+    #[async_trait]
+    impl BackendStore for StreamPutBackend {
+        async fn fetch_range(&self, _object: &ObjectId, _offset: u64, _len: u64) -> Result<Bytes> {
+            Ok(Bytes::new())
+        }
+
+        async fn head(&self, _object: &ObjectId) -> Result<ObjectStat> {
+            Ok(ObjectStat {
+                len: 0,
+                version: Version::new("stream-v1"),
+            })
+        }
+
+        async fn put_file(&self, _object: &ObjectId, path: &Path, len: u64) -> Result<Version> {
+            let file = std::fs::File::open(path).unwrap();
+            let mut tail = [0u8; 1];
+            file.read_exact_at(&mut tail, len - 1).unwrap();
+            *self.uploaded.lock().unwrap() = Some((len, tail[0]));
+            Ok(Version::new("stream-v1"))
+        }
+    }
+
+    #[tokio::test]
+    async fn large_staged_write_streams_without_entering_single_block_cache() {
+        let root = tmp_root();
+        let backend = Arc::new(StreamPutBackend {
+            uploaded: std::sync::Mutex::new(None),
+        });
+        let metrics = WorkerMetrics::new(1024);
+        let runtime = runtime_with(Arc::clone(&backend), metrics.clone(), &root, 8);
+        let staged = tempfile::NamedTempFile::new().unwrap();
+        staged.as_file().set_len(4097).unwrap();
+        staged.as_file().write_all_at(b"x", 4096).unwrap();
+        let object = ObjectId::new(Backend::S3, "bucket", "large.bin");
+
+        let version = runtime
+            .write_object_file(&object, staged.path(), 4097)
+            .await
+            .unwrap();
+
+        assert_eq!(version, Version::new("stream-v1"));
+        assert_eq!(*backend.uploaded.lock().unwrap(), Some((4097, b'x')));
+        assert_eq!(runtime.block_count(), 0);
+        assert!(metrics
+            .render()
+            .contains("talon_worker_backend_write_bytes_total{backend=\"azure\"} 4097"));
+        std::fs::remove_dir_all(root).ok();
     }
 
     #[tokio::test]

--- a/crates/talon-worker/src/uring_conn.rs
+++ b/crates/talon-worker/src/uring_conn.rs
@@ -51,6 +51,7 @@
 //! mean porting `block_store` and the miss path to monoio's own blocking pool —
 //! worth doing eventually, but a separate change from the data plane itself.
 
+use std::io::{Seek, Write};
 use std::os::fd::AsRawFd;
 use std::sync::Arc;
 use std::time::Instant;
@@ -357,15 +358,38 @@ async fn handle_put(
         return Ok(());
     }
 
-    // Read exactly body_len raw object bytes following the header.
     use monoio::io::AsyncReadRentExt;
-    let (res, body) = stream.read_exact(vec![0u8; req.body_len as usize]).await;
-    res?;
+    let write_result = if req.body_len <= worker.max_inline_write_bytes() {
+        let body_len = usize::try_from(req.body_len)
+            .map_err(|_| anyhow::anyhow!("PUT body length is not representable"))?;
+        let (res, body) = stream.read_exact(vec![0u8; body_len]).await;
+        res?;
+        worker
+            .write_object(&req.object, bytes::Bytes::from(body))
+            .await
+    } else {
+        let staged = tempfile::NamedTempFile::new()?;
+        let mut file = staged.reopen()?;
+        let mut remaining = req.body_len;
+        while remaining > 0 {
+            let chunk_len = remaining.min(8 * 1024 * 1024) as usize;
+            let (res, chunk) = stream.read_exact(vec![0u8; chunk_len]).await;
+            res?;
+            if chunk.iter().all(|byte| *byte == 0) {
+                file.seek(std::io::SeekFrom::Current(chunk_len as i64))?;
+            } else {
+                file.write_all(&chunk)?;
+            }
+            remaining -= chunk_len as u64;
+        }
+        file.set_len(req.body_len)?;
+        file.flush()?;
+        worker
+            .write_object_file(&req.object, staged.path(), req.body_len)
+            .await
+    };
 
-    match worker
-        .write_object(&req.object, bytes::Bytes::from(body))
-        .await
-    {
+    match write_result {
         Ok(version) => {
             let vbytes = version.as_str().as_bytes().to_vec();
             let hdr = data::response_header_ok(h.request_id, vbytes.len() as u32).to_vec();


### PR DESCRIPTION
## Summary

Add a bounded-memory write path for large and sparse FUSE objects without increasing the 1 GiB in-memory threshold. Dirty contents spill to a sparse temporary file, stream through the worker data plane, and upload to S3, GCS, or Azure without materializing the complete object in memory.

This PR is stacked on #346. Its diff will shrink to the streaming-write commit after the prerequisite POSIX stack merges.

Closes #347.

## Changes

- Keep objects at or below 1 GiB in the existing in-memory working copy.
- Promote writes beyond the threshold to a sparse `NamedTempFile`.
- Enforce a separate 4 GiB logical object limit so large offsets remain bounded.
- Stream staged files from FUSE to workers with a size-aware timeout.
- Receive large worker PUT bodies in fixed 8 MiB chunks and preserve zero ranges as sparse holes.
- Add `BackendStore::put_file` and streamed HTTP request support.
- Hash S3 payloads with a fixed 1 MiB buffer before SigV4 signing.
- Send GCS and Azure streamed PUTs with an exact `Content-Length`.
- Avoid inserting streamed multi-block objects into the single-block worker cache.
- Cover sparse staging, worker transfer, backend request construction, and real-kernel FUSE writeback.

Large `truncate` remains memory-backed and retains the existing 1 GiB limit. This PR addresses large sparse writes; it does not claim large truncate support.

## Test plan

Implementation commit: `7fd6bbf2725dd80ebbd33a6f0dfa6fe1018a2e6f`

pjdfstest runner commit: `26f10147a214ed8dc6a59298aca4c5c3a4011263`

- [x] `cargo test -p talon-fuse --lib --features mount`: 122 passed
- [x] `cargo test -p talon-backend --lib`: 77 passed
- [x] `cargo test -p talon-worker --lib`: 89 passed
- [x] `cargo test -p talon-fuse --test mount_e2e --features mount --no-run`
- [x] `cargo check --workspace --all-targets`
- [x] Strict clippy for core, backend, worker, and FUSE mount targets
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] Exact implementation SHA passed 15/15 privileged real-kernel mount tests in `falcon-phx-ca`
- [x] `open/25.t`: 6/6 passed through a real kernel FUSE mount
- [x] `open,rename,unlink,truncate,mkdir,rmdir`: 5,981/5,981 passed

The `open/25.t` validation writes one byte at offset `2 GiB + 1`, verifies the resulting size, reads the sparse hole, and reads the written byte. The FUSE layer, worker, and pjdfstest mock all use bounded-memory streaming for this path.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Public behavior is covered by tests
- [x] The 1 GiB in-memory threshold is unchanged
- [x] All code, tests, commit messages, and PR text are in English
