### PR TITLE
fix(backend): retry transient object-store failures with timeouts

### DIFF
--- a/crates/talon-backend/src/lib.rs
+++ b/crates/talon-backend/src/lib.rs
@@ -12,6 +12,7 @@ pub mod delay;
 pub mod gcs;
 pub mod http;
 pub mod reqwest_client;
+pub mod retry;
 pub mod s3;
 pub mod sigv4;
 
@@ -20,5 +21,6 @@ pub use delay::{DelayConfig, DelayingHttpClient};
 pub use gcs::{GcsBackend, GcsConfig};
 pub use http::{HttpClient, HttpRequest, HttpResponse, Method};
 pub use reqwest_client::ReqwestClient;
+pub use retry::{RetryConfig, RetryObserver, RetryingHttpClient};
 pub use s3::{S3Backend, S3Config, S3Credentials};
 pub use sigv4::{sign_request, AmzDate};

--- a/crates/talon-backend/src/reqwest_client.rs
+++ b/crates/talon-backend/src/reqwest_client.rs
@@ -15,6 +15,17 @@ use async_trait::async_trait;
 
 use crate::http::{HttpClient, HttpRequest, HttpResponse, Method};
 
+/// Cap on establishing a TCP+TLS connection. Independent of transfer size, so a
+/// slow connect always indicates a fault rather than a large object.
+const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Last-resort ceiling on a whole request. Sized well above any deadline the
+/// retry decorator would compute so it never fires first in normal operation.
+const REQUEST_BACKSTOP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// How long an idle pooled connection is kept before being dropped.
+const POOL_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
+
 /// A `reqwest`-backed HTTP client.
 pub struct ReqwestClient {
     inner: reqwest::Client,
@@ -22,10 +33,25 @@ pub struct ReqwestClient {
 
 impl ReqwestClient {
     /// Build a client with sensible pooled defaults.
+    ///
+    /// The timeouts here are a **backstop for undecorated use**, not the primary
+    /// deadline. [`RetryingHttpClient`](crate::retry::RetryingHttpClient) owns
+    /// the real per-attempt deadline, which scales with transfer size; the flat
+    /// ceiling below is deliberately far larger so it never preempts that
+    /// calculation, and exists only so a bare `ReqwestClient` cannot hang
+    /// forever on a wedged origin. `connect_timeout` is separate and short:
+    /// establishing a connection is size-independent, so a slow connect is
+    /// always a fault.
     pub fn new() -> Self {
-        Self {
-            inner: reqwest::Client::new(),
-        }
+        let inner = reqwest::Client::builder()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(REQUEST_BACKSTOP_TIMEOUT)
+            .pool_idle_timeout(POOL_IDLE_TIMEOUT)
+            .build()
+            // The builder only fails if the TLS backend cannot initialize, which
+            // is a process-level fault; fall back so construction stays infallible.
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self { inner }
     }
 
     /// Build over a pre-configured [`reqwest::Client`] (timeouts, proxies, etc.).

--- a/crates/talon-backend/src/retry.rs
+++ b/crates/talon-backend/src/retry.rs
@@ -1,0 +1,705 @@
+//! A retrying [`HttpClient`] decorator with backoff, jitter, and per-attempt
+//! timeouts.
+//!
+//! Object stores throttle (`429`) and shed load (`503`) as a matter of routine,
+//! and TCP connections to them die for uninteresting reasons. Without a retry
+//! layer every one of those becomes a failed block fetch, which surfaces to the
+//! application as a failed read — a cache that is *less* reliable than reading
+//! the origin directly. This decorator wraps any inner [`HttpClient`] so all
+//! three backends (S3/GCS/Azure) get the same policy from one place.
+//!
+//! **What is retried.** Transport errors (connect/DNS/reset) and the transient
+//! status set `408, 429, 500, 502, 503, 504`. Everything else is returned to the
+//! caller untouched — in particular `404` (mapped to `ENOENT` upstream) and
+//! `412`, which is not a failure at all but the version-mismatch signal the
+//! `If-Match` read path relies on (issue #163); retrying it would defeat the
+//! TOCTOU guard it exists to provide.
+//!
+//! **What is never retried.** A request that both carries a body *and* a
+//! precondition header — i.e. a conditional PUT. If such a request succeeds but
+//! the response is lost, the retry sees the precondition it already consumed and
+//! returns `412`, turning a success into a spurious failure. Unconditional PUT
+//! and DELETE are safe (whole-object replace and idempotent delete respectively)
+//! and are retried; conditional *reads* are also safe, since a GET has no side
+//! effect and the precondition simply re-evaluates.
+//!
+//! **Backoff** is full jitter — `random(0, min(cap, base * 2^attempt))` — which
+//! spreads a fleet's retries instead of aligning them into a second thundering
+//! herd against an already-struggling origin. The randomness is a deterministic
+//! SplitMix64 seeded per client, matching [`crate::delay`]: reproducible in
+//! tests, no RNG dependency. A `Retry-After` header on `429`/`503` overrides the
+//! computed delay (clamped to `max_delay`), because obeying the origin's own
+//! backoff hint is what actually clears a throttle.
+//!
+//! **Timeouts scale with transfer size.** Requests here span a ~200-byte HEAD
+//! and a 256 MiB block fetch — six orders of magnitude. A single flat deadline
+//! cannot serve both: sized for the HEAD, every large fetch times out and
+//! retries, each retry re-transferring 256 MiB and worsening the congestion;
+//! sized for the fetch, a hung HEAD wedges the read path for minutes. So the
+//! per-attempt deadline is `timeout_floor + bytes / min_throughput`, where
+//! `bytes` comes from the request body (PUT) or the requested range (GET), both
+//! known before the request goes out.
+//!
+//! Timeouts are applied whether or not retries are enabled; `max_retries = 0`
+//! disables retrying but still bounds each attempt.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use crate::http::{HttpClient, HttpRequest, HttpResponse};
+
+/// Statuses worth another attempt: request timeout, throttling, and the
+/// transient server-side 5xx set. Deliberately excludes `501 Not Implemented`
+/// and `505` (permanent), and every 4xx other than `408`/`429`.
+fn is_retryable_status(status: u16) -> bool {
+    matches!(status, 408 | 429 | 500 | 502 | 503 | 504)
+}
+
+/// Precondition headers across the three backends. S3 and Azure use the RFC
+/// `If-Match`/`If-None-Match`; GCS additionally accepts a generation number via
+/// `x-goog-if-generation-match`.
+const PRECONDITION_HEADERS: [&str; 3] = ["if-match", "if-none-match", "x-goog-if-generation-match"];
+
+/// Whether `req` may be re-issued after an inconclusive attempt.
+///
+/// The unsafe case is a *conditional mutation*: the precondition is consumed by
+/// the first (apparently failed) attempt, so the retry gets `412` and reports
+/// failure for a write that actually landed. A body is the proxy for "mutates" —
+/// GET/HEAD/DELETE carry none.
+fn is_retryable_request(req: &HttpRequest) -> bool {
+    if req.body.is_empty() {
+        return true;
+    }
+    !PRECONDITION_HEADERS.iter().any(|h| req.header(h).is_some())
+}
+
+/// Parse a `Retry-After` value expressed as delta-seconds.
+///
+/// RFC 7231 also permits an HTTP-date, but S3 and GCS send delta-seconds in
+/// practice, and supporting dates would mean taking on a date-parsing
+/// dependency for a format we never see. A non-numeric value is ignored and the
+/// computed backoff is used instead.
+fn parse_retry_after(value: &str) -> Option<Duration> {
+    value.trim().parse::<u64>().ok().map(Duration::from_secs)
+}
+
+/// Bytes expected to cross the wire for `req`, used to size the deadline.
+///
+/// A PUT carries them in the body. A ranged GET declares them in `Range`
+/// (S3/GCS) or `x-ms-range` (Azure), both formatted `bytes=<start>-<end>`
+/// inclusive. Anything else (HEAD, DELETE, unranged GET) is treated as
+/// metadata-sized and gets the floor.
+fn expected_transfer_bytes(req: &HttpRequest) -> u64 {
+    if !req.body.is_empty() {
+        return req.body.len() as u64;
+    }
+    let range = req
+        .header("range")
+        .or_else(|| req.header("x-ms-range"))
+        .unwrap_or_default();
+    let Some(spec) = range.trim().strip_prefix("bytes=") else {
+        return 0;
+    };
+    let Some((start, end)) = spec.split_once('-') else {
+        return 0;
+    };
+    match (start.trim().parse::<u64>(), end.trim().parse::<u64>()) {
+        // Inclusive range, so the length is end - start + 1.
+        (Ok(s), Ok(e)) if e >= s => e - s + 1,
+        _ => 0,
+    }
+}
+
+/// Notified when the decorator retries or times out, so the worker can surface
+/// both as metrics.
+///
+/// A retrying cache hides backend degradation by design: reads keep succeeding
+/// while the origin gets slower and more expensive. Without these counters that
+/// decline is invisible until it becomes an outage.
+pub trait RetryObserver: Send + Sync {
+    /// A request is about to be re-issued. `attempt` is 0-indexed (0 = the first
+    /// retry). `status` is the response code that triggered it, or `None` for a
+    /// transport error.
+    fn on_retry(&self, attempt: u32, status: Option<u16>);
+    /// An attempt exceeded its deadline.
+    fn on_timeout(&self);
+}
+
+/// Retry and timeout policy for [`RetryingHttpClient`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetryConfig {
+    /// Retries after the initial attempt. `0` disables retrying; timeouts still
+    /// apply.
+    pub max_retries: u32,
+    /// Base of the exponential backoff.
+    pub base_delay: Duration,
+    /// Ceiling for any single backoff wait, including a `Retry-After` hint.
+    pub max_delay: Duration,
+    /// Fixed part of the per-attempt deadline, covering connect and
+    /// time-to-first-byte.
+    pub timeout_floor: Duration,
+    /// Throughput floor used to extend the deadline by transfer size. A transfer
+    /// slower than this is treated as hung. `0` disables the size-scaled part,
+    /// leaving a flat `timeout_floor`.
+    pub min_throughput_bytes_per_sec: u64,
+}
+
+impl RetryConfig {
+    /// Retry disabled, with a flat one-minute deadline. For tests that want the
+    /// decorator inert rather than absent.
+    pub const NONE: RetryConfig = RetryConfig {
+        max_retries: 0,
+        base_delay: Duration::ZERO,
+        max_delay: Duration::ZERO,
+        timeout_floor: Duration::from_secs(60),
+        min_throughput_bytes_per_sec: 0,
+    };
+
+    /// Whether this config would retry at all.
+    pub fn is_active(&self) -> bool {
+        self.max_retries > 0
+    }
+
+    /// Deadline for a single attempt transferring `bytes`.
+    ///
+    /// Saturating throughout: a pathological `bytes` or a tiny throughput floor
+    /// yields a very long deadline rather than an overflow panic.
+    pub fn attempt_timeout(&self, bytes: u64) -> Duration {
+        if self.min_throughput_bytes_per_sec == 0 {
+            return self.timeout_floor;
+        }
+        let transfer_secs = bytes / self.min_throughput_bytes_per_sec;
+        self.timeout_floor
+            .saturating_add(Duration::from_secs(transfer_secs))
+    }
+}
+
+impl Default for RetryConfig {
+    /// Retry is **on by default**, unlike the latency knobs in [`crate::delay`].
+    /// A cache with no retry is the bug this module exists to fix, so the safe
+    /// default is the protective one.
+    ///
+    /// The defaults give a worst case of roughly `0.1 + 0.2 + 0.4 = 0.7s` of
+    /// backoff across three retries, and a deadline of 5s for a HEAD or ~30s for
+    /// a 256 MiB block at 10 MiB/s.
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            base_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(5),
+            timeout_floor: Duration::from_secs(5),
+            min_throughput_bytes_per_sec: 10 * 1024 * 1024,
+        }
+    }
+}
+
+/// An [`HttpClient`] that retries transient failures of an inner client.
+pub struct RetryingHttpClient {
+    inner: Arc<dyn HttpClient>,
+    config: RetryConfig,
+    observer: Option<Arc<dyn RetryObserver>>,
+    /// Deterministic SplitMix64 state, advanced once per backoff draw.
+    rng_state: AtomicU64,
+}
+
+impl RetryingHttpClient {
+    /// Wrap `inner` with `config`. `seed` fixes the jitter sequence so runs are
+    /// reproducible; pass a per-node value so peers do not retry in lockstep.
+    pub fn new(inner: Arc<dyn HttpClient>, config: RetryConfig, seed: u64) -> Self {
+        Self {
+            inner,
+            config,
+            observer: None,
+            rng_state: AtomicU64::new(seed ^ 0x9E37_79B9_7F4A_7C15),
+        }
+    }
+
+    /// Attach a [`RetryObserver`] to receive retry and timeout notifications.
+    pub fn with_observer(mut self, observer: Arc<dyn RetryObserver>) -> Self {
+        self.observer = Some(observer);
+        self
+    }
+
+    /// Draw the next pseudo-random value (SplitMix64), as in [`crate::delay`].
+    fn next_random(&self) -> u64 {
+        let prev = self
+            .rng_state
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |s| {
+                Some(s.wrapping_add(0x9E37_79B9_7F4A_7C15))
+            })
+            .unwrap_or(0);
+        let mut z = prev.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// Backoff before the retry following `attempt` (0-indexed).
+    ///
+    /// Full jitter over the exponential window. `retry_after`, when the origin
+    /// supplied one, replaces the draw — it is a real instruction rather than a
+    /// guess — but is still clamped to `max_delay` so a hostile or mistaken
+    /// header cannot stall a read indefinitely.
+    pub fn backoff_delay(&self, attempt: u32, retry_after: Option<Duration>) -> Duration {
+        if let Some(hint) = retry_after {
+            return hint.min(self.config.max_delay);
+        }
+        // Saturating shift: attempt is capped so `1 << attempt` cannot overflow.
+        let window = self
+            .config
+            .base_delay
+            .saturating_mul(1u32 << attempt.min(16))
+            .min(self.config.max_delay);
+        let window_ms = window.as_millis() as u64;
+        if window_ms == 0 {
+            return Duration::ZERO;
+        }
+        Duration::from_millis(self.next_random() % (window_ms + 1))
+    }
+}
+
+#[async_trait]
+impl HttpClient for RetryingHttpClient {
+    async fn execute(&self, req: HttpRequest) -> Result<HttpResponse, String> {
+        let retryable_request = is_retryable_request(&req);
+        let timeout = self.config.attempt_timeout(expected_transfer_bytes(&req));
+        let mut attempt: u32 = 0;
+
+        loop {
+            // Clone per attempt: `HttpRequest` is cheap to clone (the body is
+            // `Bytes`), and the inner client consumes it.
+            let outcome = tokio::time::timeout(timeout, self.inner.execute(req.clone())).await;
+
+            // `Err` here is the deadline, not a transport failure.
+            let result = match outcome {
+                Ok(result) => result,
+                Err(_) => {
+                    if let Some(observer) = &self.observer {
+                        observer.on_timeout();
+                    }
+                    Err(format!("request timed out after {timeout:?}"))
+                }
+            };
+
+            // Decide whether another attempt is warranted, and capture the
+            // origin's backoff hint while the response is still in hand.
+            let (should_retry, status, retry_after) = match &result {
+                Ok(resp) if is_retryable_status(resp.status) => {
+                    let hint = match resp.status {
+                        429 | 503 => resp.header("retry-after").and_then(parse_retry_after),
+                        _ => None,
+                    };
+                    (true, Some(resp.status), hint)
+                }
+                Ok(_) => (false, None, None),
+                Err(_) => (true, None, None),
+            };
+
+            let exhausted = attempt >= self.config.max_retries;
+            if !should_retry || !retryable_request || exhausted {
+                // Return the last outcome as-is. A retryable status that ran out
+                // of attempts is handed back unchanged so the backend maps it to
+                // its usual error rather than a synthesized one; a timeout
+                // surfaces as a transport error.
+                return result;
+            }
+
+            if let Some(observer) = &self.observer {
+                observer.on_retry(attempt, status);
+            }
+            let delay = self.backoff_delay(attempt, retry_after);
+            if !delay.is_zero() {
+                tokio::time::sleep(delay).await;
+            }
+            attempt += 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::Method;
+    use std::sync::Mutex;
+
+    /// A client that returns a scripted sequence of outcomes, then repeats the
+    /// last one, counting calls.
+    struct ScriptedHttp {
+        script: Mutex<Vec<Result<u16, String>>>,
+        calls: Mutex<u32>,
+        retry_after: Option<String>,
+    }
+
+    impl ScriptedHttp {
+        fn new(script: Vec<Result<u16, String>>) -> Arc<Self> {
+            Arc::new(Self {
+                script: Mutex::new(script),
+                calls: Mutex::new(0),
+                retry_after: None,
+            })
+        }
+
+        fn with_retry_after(script: Vec<Result<u16, String>>, value: &str) -> Arc<Self> {
+            Arc::new(Self {
+                script: Mutex::new(script),
+                calls: Mutex::new(0),
+                retry_after: Some(value.to_string()),
+            })
+        }
+
+        fn calls(&self) -> u32 {
+            *self.calls.lock().unwrap()
+        }
+    }
+
+    #[async_trait]
+    impl HttpClient for ScriptedHttp {
+        async fn execute(&self, _req: HttpRequest) -> Result<HttpResponse, String> {
+            let mut calls = self.calls.lock().unwrap();
+            let idx = *calls as usize;
+            *calls += 1;
+            drop(calls);
+            let script = self.script.lock().unwrap();
+            let entry = script.get(idx).unwrap_or_else(|| script.last().unwrap());
+            match entry {
+                Ok(status) => {
+                    let mut headers = vec![];
+                    if let Some(v) = &self.retry_after {
+                        headers.push(("Retry-After".to_string(), v.clone()));
+                    }
+                    Ok(HttpResponse {
+                        status: *status,
+                        headers,
+                        body: bytes::Bytes::new(),
+                    })
+                }
+                Err(e) => Err(e.clone()),
+            }
+        }
+    }
+
+    /// A client that never responds, to exercise the deadline.
+    struct HangingHttp;
+
+    #[async_trait]
+    impl HttpClient for HangingHttp {
+        async fn execute(&self, _req: HttpRequest) -> Result<HttpResponse, String> {
+            // Far longer than any deadline under test.
+            tokio::time::sleep(Duration::from_secs(86_400)).await;
+            unreachable!("deadline should fire first")
+        }
+    }
+
+    #[derive(Default)]
+    struct CountingObserver {
+        retries: AtomicU64,
+        timeouts: AtomicU64,
+    }
+
+    impl RetryObserver for CountingObserver {
+        fn on_retry(&self, _attempt: u32, _status: Option<u16>) {
+            self.retries.fetch_add(1, Ordering::Relaxed);
+        }
+        fn on_timeout(&self) {
+            self.timeouts.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn get() -> HttpRequest {
+        HttpRequest::new(Method::Get, "https://origin/o".into(), vec![])
+    }
+
+    fn ranged_get(offset: u64, end: u64) -> HttpRequest {
+        HttpRequest::new(
+            Method::Get,
+            "https://origin/o".into(),
+            vec![("Range".into(), format!("bytes={offset}-{end}"))],
+        )
+    }
+
+    fn conditional_put() -> HttpRequest {
+        HttpRequest::with_body(
+            Method::Put,
+            "https://origin/o".into(),
+            vec![("If-Match".into(), "\"v1\"".into())],
+            bytes::Bytes::from_static(b"payload"),
+        )
+    }
+
+    fn unconditional_put() -> HttpRequest {
+        HttpRequest::with_body(
+            Method::Put,
+            "https://origin/o".into(),
+            vec![],
+            bytes::Bytes::from_static(b"payload"),
+        )
+    }
+
+    fn client(inner: Arc<dyn HttpClient>) -> RetryingHttpClient {
+        RetryingHttpClient::new(inner, RetryConfig::default(), 7)
+    }
+
+    // ── classification ───────────────────────────────────────────────
+
+    #[test]
+    fn transient_statuses_are_retryable_and_others_are_not() {
+        for s in [408, 429, 500, 502, 503, 504] {
+            assert!(is_retryable_status(s), "{s} should be retryable");
+        }
+        // 404 is ENOENT upstream; 412 is the #163 version-mismatch signal.
+        for s in [200, 206, 301, 400, 403, 404, 412, 501] {
+            assert!(!is_retryable_status(s), "{s} should not be retryable");
+        }
+    }
+
+    #[test]
+    fn conditional_mutations_are_not_retryable_but_other_shapes_are() {
+        assert!(!is_retryable_request(&conditional_put()));
+        assert!(is_retryable_request(&unconditional_put()));
+        assert!(is_retryable_request(&get()));
+        // A conditional GET is safe: no side effect, precondition re-evaluates.
+        let cond_get = HttpRequest::new(
+            Method::Get,
+            "https://origin/o".into(),
+            vec![("If-Match".into(), "\"v1\"".into())],
+        );
+        assert!(is_retryable_request(&cond_get));
+    }
+
+    #[test]
+    fn gcs_generation_precondition_blocks_retry_of_a_write() {
+        let req = HttpRequest::with_body(
+            Method::Put,
+            "https://origin/o".into(),
+            vec![("x-goog-if-generation-match".into(), "42".into())],
+            bytes::Bytes::from_static(b"payload"),
+        );
+        assert!(!is_retryable_request(&req));
+    }
+
+    // ── deadline sizing ──────────────────────────────────────────────
+
+    #[test]
+    fn transfer_size_comes_from_body_or_range_header() {
+        assert_eq!(expected_transfer_bytes(&get()), 0);
+        assert_eq!(expected_transfer_bytes(&unconditional_put()), 7);
+        // Inclusive range: bytes=0-1023 is 1024 bytes.
+        assert_eq!(expected_transfer_bytes(&ranged_get(0, 1023)), 1024);
+        assert_eq!(expected_transfer_bytes(&ranged_get(4096, 8191)), 4096);
+        // Azure's header name is honored too.
+        let azure = HttpRequest::new(
+            Method::Get,
+            "https://origin/o".into(),
+            vec![("x-ms-range".into(), "bytes=8-15".into())],
+        );
+        assert_eq!(expected_transfer_bytes(&azure), 8);
+    }
+
+    #[test]
+    fn malformed_range_falls_back_to_the_floor() {
+        for value in ["garbage", "bytes=", "bytes=abc-def", "bytes=100-1"] {
+            let req = HttpRequest::new(
+                Method::Get,
+                "https://origin/o".into(),
+                vec![("Range".into(), value.into())],
+            );
+            assert_eq!(expected_transfer_bytes(&req), 0, "value {value:?}");
+        }
+    }
+
+    #[test]
+    fn deadline_scales_with_size() {
+        let cfg = RetryConfig::default();
+        // A HEAD-sized request gets the bare floor.
+        assert_eq!(cfg.attempt_timeout(0), Duration::from_secs(5));
+        // 256 MiB at 10 MiB/s ≈ 25.6s of transfer on top of the floor.
+        assert_eq!(
+            cfg.attempt_timeout(256 * 1024 * 1024),
+            Duration::from_secs(30)
+        );
+    }
+
+    #[test]
+    fn deadline_is_flat_when_throughput_floor_is_disabled() {
+        let cfg = RetryConfig {
+            min_throughput_bytes_per_sec: 0,
+            ..RetryConfig::default()
+        };
+        assert_eq!(cfg.attempt_timeout(u64::MAX), cfg.timeout_floor);
+    }
+
+    // ── backoff ──────────────────────────────────────────────────────
+
+    #[test]
+    fn full_jitter_stays_within_the_exponential_window() {
+        let c = client(ScriptedHttp::new(vec![Ok(200)]));
+        for attempt in 0..4u32 {
+            let window = c
+                .config
+                .base_delay
+                .saturating_mul(1 << attempt)
+                .min(c.config.max_delay);
+            for _ in 0..64 {
+                let d = c.backoff_delay(attempt, None);
+                assert!(d <= window, "attempt {attempt}: {d:?} exceeds {window:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn jitter_varies_and_is_reproducible_for_a_seed() {
+        let a =
+            RetryingHttpClient::new(ScriptedHttp::new(vec![Ok(200)]), RetryConfig::default(), 99);
+        let b =
+            RetryingHttpClient::new(ScriptedHttp::new(vec![Ok(200)]), RetryConfig::default(), 99);
+        let seq_a: Vec<_> = (0..16).map(|_| a.backoff_delay(3, None)).collect();
+        let seq_b: Vec<_> = (0..16).map(|_| b.backoff_delay(3, None)).collect();
+        assert_eq!(seq_a, seq_b, "same seed must replay the same sequence");
+        assert!(
+            seq_a.iter().collect::<std::collections::HashSet<_>>().len() > 1,
+            "jitter did not vary"
+        );
+    }
+
+    #[test]
+    fn retry_after_overrides_backoff_but_is_clamped() {
+        let c = client(ScriptedHttp::new(vec![Ok(200)]));
+        assert_eq!(
+            c.backoff_delay(0, Some(Duration::from_secs(2))),
+            Duration::from_secs(2)
+        );
+        // A 1-hour hint must not stall the read path past max_delay.
+        assert_eq!(
+            c.backoff_delay(0, Some(Duration::from_secs(3600))),
+            c.config.max_delay
+        );
+    }
+
+    #[test]
+    fn retry_after_parses_delta_seconds_only() {
+        assert_eq!(parse_retry_after("3"), Some(Duration::from_secs(3)));
+        assert_eq!(parse_retry_after("  7 "), Some(Duration::from_secs(7)));
+        // HTTP-date form is unsupported by design; fall back to computed backoff.
+        assert_eq!(parse_retry_after("Wed, 21 Oct 2015 07:28:00 GMT"), None);
+        assert_eq!(parse_retry_after(""), None);
+    }
+
+    // ── retry loop ───────────────────────────────────────────────────
+
+    #[tokio::test(start_paused = true)]
+    async fn transient_failures_are_retried_until_success() {
+        let inner = ScriptedHttp::new(vec![Err("connection reset".into()), Ok(503), Ok(200)]);
+        let observer = Arc::new(CountingObserver::default());
+        let c = client(inner.clone()).with_observer(observer.clone());
+        let resp = c.execute(get()).await.unwrap();
+        assert_eq!(resp.status, 200);
+        assert_eq!(inner.calls(), 3);
+        assert_eq!(observer.retries.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn success_is_not_retried() {
+        let inner = ScriptedHttp::new(vec![Ok(206)]);
+        let c = client(inner.clone());
+        assert_eq!(c.execute(get()).await.unwrap().status, 206);
+        assert_eq!(inner.calls(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn exhausted_retries_return_the_last_response_unchanged() {
+        // The backend, not this decorator, decides what a terminal 503 means.
+        let inner = ScriptedHttp::new(vec![Ok(503)]);
+        let c = client(inner.clone());
+        let resp = c.execute(get()).await.unwrap();
+        assert_eq!(resp.status, 503);
+        assert_eq!(inner.calls(), 4, "1 initial + 3 retries");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn permanent_statuses_are_not_retried() {
+        for status in [404, 412, 403] {
+            let inner = ScriptedHttp::new(vec![Ok(status)]);
+            let c = client(inner.clone());
+            assert_eq!(c.execute(get()).await.unwrap().status, status);
+            assert_eq!(inner.calls(), 1, "status {status} must not be retried");
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn conditional_put_is_attempted_exactly_once() {
+        let inner = ScriptedHttp::new(vec![Ok(503)]);
+        let c = client(inner.clone());
+        assert_eq!(c.execute(conditional_put()).await.unwrap().status, 503);
+        assert_eq!(inner.calls(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unconditional_put_is_retried() {
+        let inner = ScriptedHttp::new(vec![Ok(500), Ok(200)]);
+        let c = client(inner.clone());
+        assert_eq!(c.execute(unconditional_put()).await.unwrap().status, 200);
+        assert_eq!(inner.calls(), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn zero_max_retries_disables_retrying() {
+        let inner = ScriptedHttp::new(vec![Ok(503)]);
+        let cfg = RetryConfig {
+            max_retries: 0,
+            ..RetryConfig::default()
+        };
+        assert!(!cfg.is_active());
+        let c = RetryingHttpClient::new(inner.clone(), cfg, 1);
+        assert_eq!(c.execute(get()).await.unwrap().status, 503);
+        assert_eq!(inner.calls(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_after_hint_is_honored_on_503() {
+        let inner = ScriptedHttp::with_retry_after(vec![Ok(503), Ok(200)], "2");
+        let c = client(inner.clone());
+        let start = tokio::time::Instant::now();
+        assert_eq!(c.execute(get()).await.unwrap().status, 200);
+        // Computed backoff at attempt 0 is at most base_delay (100ms), so a wait
+        // of ~2s can only have come from the header.
+        assert!(start.elapsed() >= Duration::from_secs(2));
+    }
+
+    // ── deadlines ────────────────────────────────────────────────────
+
+    #[tokio::test(start_paused = true)]
+    async fn a_hung_attempt_times_out_and_is_retried() {
+        let observer = Arc::new(CountingObserver::default());
+        let cfg = RetryConfig {
+            max_retries: 1,
+            ..RetryConfig::default()
+        };
+        let c =
+            RetryingHttpClient::new(Arc::new(HangingHttp), cfg, 1).with_observer(observer.clone());
+        let err = c.execute(get()).await.unwrap_err();
+        assert!(err.contains("timed out"), "unexpected error: {err}");
+        // Initial attempt plus one retry, each hitting the deadline.
+        assert_eq!(observer.timeouts.load(Ordering::Relaxed), 2);
+        assert_eq!(observer.retries.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn deadline_is_bounded_by_the_configured_floor() {
+        let cfg = RetryConfig {
+            max_retries: 0,
+            timeout_floor: Duration::from_secs(5),
+            ..RetryConfig::default()
+        };
+        let c = RetryingHttpClient::new(Arc::new(HangingHttp), cfg, 1);
+        let start = tokio::time::Instant::now();
+        assert!(c.execute(get()).await.is_err());
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_secs(5) && elapsed < Duration::from_secs(6),
+            "elapsed {elapsed:?} should be just over the 5s floor"
+        );
+    }
+}

--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -106,6 +106,25 @@ pub struct WorkerConfig {
     pub backend_jitter_ms: Option<u64>,
     /// Optional bandwidth ceiling (bytes/second) modeled by the delay decorator.
     pub backend_throughput_bytes: Option<u64>,
+    /// Retries after the initial attempt for a transient backend failure
+    /// (`408/429/5xx` or a transport error). `Some(0)` disables retrying;
+    /// per-attempt timeouts still apply. `None` uses the built-in default.
+    pub backend_max_retries: Option<u32>,
+    /// Base of the exponential backoff between retries, in milliseconds. The
+    /// actual wait is drawn uniformly from `[0, base * 2^attempt]` (full jitter)
+    /// so a fleet does not retry in lockstep.
+    pub backend_retry_base_ms: Option<u64>,
+    /// Ceiling on any single backoff wait, in milliseconds. Also clamps a
+    /// `Retry-After` hint from the origin.
+    pub backend_retry_max_delay_ms: Option<u64>,
+    /// Fixed part of the per-attempt deadline, in milliseconds, covering connect
+    /// and time-to-first-byte.
+    pub backend_timeout_floor_ms: Option<u64>,
+    /// Throughput floor (bytes/second) used to extend the per-attempt deadline
+    /// by transfer size, so a 256 MiB block fetch is not held to the same
+    /// deadline as a HEAD. `Some(0)` makes the deadline a flat
+    /// `backend_timeout_floor_ms`.
+    pub backend_min_throughput_bytes: Option<u64>,
     /// S3 region (e.g. `us-east-1`). Required when `backend = s3`.
     pub s3_region: Option<String>,
     /// S3 endpoint host override (e.g. a MinIO/LocalStack host). Defaults to the
@@ -192,6 +211,11 @@ impl Default for WorkerConfig {
             backend_delay_ms: None,
             backend_jitter_ms: None,
             backend_throughput_bytes: None,
+            backend_max_retries: None,
+            backend_retry_base_ms: None,
+            backend_retry_max_delay_ms: None,
+            backend_timeout_floor_ms: None,
+            backend_min_throughput_bytes: None,
             s3_region: None,
             s3_endpoint: None,
             s3_access_key_id: None,
@@ -241,6 +265,16 @@ pub struct WorkerConfigPatch {
     pub backend_jitter_ms: Option<u64>,
     /// Override for [`WorkerConfig::backend_throughput_bytes`].
     pub backend_throughput_bytes: Option<u64>,
+    /// Override for [`WorkerConfig::backend_max_retries`].
+    pub backend_max_retries: Option<u32>,
+    /// Override for [`WorkerConfig::backend_retry_base_ms`].
+    pub backend_retry_base_ms: Option<u64>,
+    /// Override for [`WorkerConfig::backend_retry_max_delay_ms`].
+    pub backend_retry_max_delay_ms: Option<u64>,
+    /// Override for [`WorkerConfig::backend_timeout_floor_ms`].
+    pub backend_timeout_floor_ms: Option<u64>,
+    /// Override for [`WorkerConfig::backend_min_throughput_bytes`].
+    pub backend_min_throughput_bytes: Option<u64>,
     /// Override for [`WorkerConfig::s3_region`].
     pub s3_region: Option<String>,
     /// Override for [`WorkerConfig::s3_endpoint`].
@@ -276,6 +310,17 @@ impl Patch for WorkerConfigPatch {
             backend_throughput_bytes: self
                 .backend_throughput_bytes
                 .or(base.backend_throughput_bytes),
+            backend_max_retries: self.backend_max_retries.or(base.backend_max_retries),
+            backend_retry_base_ms: self.backend_retry_base_ms.or(base.backend_retry_base_ms),
+            backend_retry_max_delay_ms: self
+                .backend_retry_max_delay_ms
+                .or(base.backend_retry_max_delay_ms),
+            backend_timeout_floor_ms: self
+                .backend_timeout_floor_ms
+                .or(base.backend_timeout_floor_ms),
+            backend_min_throughput_bytes: self
+                .backend_min_throughput_bytes
+                .or(base.backend_min_throughput_bytes),
             s3_region: self.s3_region.or(base.s3_region),
             s3_endpoint: self.s3_endpoint.or(base.s3_endpoint),
             s3_access_key_id: self.s3_access_key_id.or(base.s3_access_key_id),
@@ -419,6 +464,46 @@ pub const WORKER_ENV_SCHEMA: &[ConfigVar] = &[
         help: "Synthetic backend bandwidth ceiling in bytes/sec (test/latency lab).",
     },
     ConfigVar {
+        env: "TALON_WORKER_BACKEND_MAX_RETRIES",
+        key: "backend_max_retries",
+        default: Some("3"),
+        cli: false,
+        secret: false,
+        help: "Retries after the first attempt for a transient backend failure (0 disables).",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_BACKEND_RETRY_BASE_MS",
+        key: "backend_retry_base_ms",
+        default: Some("100"),
+        cli: false,
+        secret: false,
+        help: "Exponential backoff base in ms; the wait is jittered over [0, base * 2^attempt].",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_BACKEND_RETRY_MAX_DELAY_MS",
+        key: "backend_retry_max_delay_ms",
+        default: Some("5000"),
+        cli: false,
+        secret: false,
+        help: "Ceiling on a single backoff wait in ms; also clamps an origin Retry-After hint.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_BACKEND_TIMEOUT_FLOOR_MS",
+        key: "backend_timeout_floor_ms",
+        default: Some("5000"),
+        cli: false,
+        secret: false,
+        help: "Fixed part of the per-attempt backend deadline in ms (connect + first byte).",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_BACKEND_MIN_THROUGHPUT_BYTES",
+        key: "backend_min_throughput_bytes",
+        default: Some("10485760 (10 MiB/s)"),
+        cli: false,
+        secret: false,
+        help: "Throughput floor in bytes/sec used to extend the deadline by transfer size (0 = flat).",
+    },
+    ConfigVar {
         env: "TALON_WORKER_DATA_PLANE_RINGS",
         key: "data_plane_rings",
         default: Some("0 (one ring per core)"),
@@ -517,6 +602,11 @@ pub(crate) mod worker_env {
     pub const BACKEND_DELAY_MS: &str = "TALON_WORKER_BACKEND_DELAY_MS";
     pub const BACKEND_JITTER_MS: &str = "TALON_WORKER_BACKEND_JITTER_MS";
     pub const BACKEND_THROUGHPUT_BYTES: &str = "TALON_WORKER_BACKEND_THROUGHPUT_BYTES";
+    pub const BACKEND_MAX_RETRIES: &str = "TALON_WORKER_BACKEND_MAX_RETRIES";
+    pub const BACKEND_RETRY_BASE_MS: &str = "TALON_WORKER_BACKEND_RETRY_BASE_MS";
+    pub const BACKEND_RETRY_MAX_DELAY_MS: &str = "TALON_WORKER_BACKEND_RETRY_MAX_DELAY_MS";
+    pub const BACKEND_TIMEOUT_FLOOR_MS: &str = "TALON_WORKER_BACKEND_TIMEOUT_FLOOR_MS";
+    pub const BACKEND_MIN_THROUGHPUT_BYTES: &str = "TALON_WORKER_BACKEND_MIN_THROUGHPUT_BYTES";
     pub const DATA_PLANE_RINGS: &str = "TALON_WORKER_DATA_PLANE_RINGS";
     pub const S3_REGION: &str = "TALON_WORKER_S3_REGION";
     pub const S3_ENDPOINT: &str = "TALON_WORKER_S3_ENDPOINT";
@@ -616,6 +706,21 @@ impl WorkerConfigPatch {
             backend_throughput_bytes: get(worker_env::BACKEND_THROUGHPUT_BYTES)
                 .map(|v| parse_u64(v, worker_env::BACKEND_THROUGHPUT_BYTES))
                 .transpose()?,
+            backend_max_retries: get(worker_env::BACKEND_MAX_RETRIES)
+                .map(|v| parse_u32(v, worker_env::BACKEND_MAX_RETRIES))
+                .transpose()?,
+            backend_retry_base_ms: get(worker_env::BACKEND_RETRY_BASE_MS)
+                .map(|v| parse_u64(v, worker_env::BACKEND_RETRY_BASE_MS))
+                .transpose()?,
+            backend_retry_max_delay_ms: get(worker_env::BACKEND_RETRY_MAX_DELAY_MS)
+                .map(|v| parse_u64(v, worker_env::BACKEND_RETRY_MAX_DELAY_MS))
+                .transpose()?,
+            backend_timeout_floor_ms: get(worker_env::BACKEND_TIMEOUT_FLOOR_MS)
+                .map(|v| parse_u64(v, worker_env::BACKEND_TIMEOUT_FLOOR_MS))
+                .transpose()?,
+            backend_min_throughput_bytes: get(worker_env::BACKEND_MIN_THROUGHPUT_BYTES)
+                .map(|v| parse_u64(v, worker_env::BACKEND_MIN_THROUGHPUT_BYTES))
+                .transpose()?,
         })
     }
 }
@@ -663,6 +768,17 @@ impl WorkerConfig {
             backend_throughput_bytes: merged
                 .backend_throughput_bytes
                 .or(d.backend_throughput_bytes),
+            backend_max_retries: merged.backend_max_retries.or(d.backend_max_retries),
+            backend_retry_base_ms: merged.backend_retry_base_ms.or(d.backend_retry_base_ms),
+            backend_retry_max_delay_ms: merged
+                .backend_retry_max_delay_ms
+                .or(d.backend_retry_max_delay_ms),
+            backend_timeout_floor_ms: merged
+                .backend_timeout_floor_ms
+                .or(d.backend_timeout_floor_ms),
+            backend_min_throughput_bytes: merged
+                .backend_min_throughput_bytes
+                .or(d.backend_min_throughput_bytes),
             data_plane_rings: merged.data_plane_rings.unwrap_or(d.data_plane_rings),
         };
         cfg.validate()?;

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -57,6 +57,25 @@ const MAX_DATA_PLANE_CONNECTIONS: usize = 1024;
 /// pinned: a large pool per ring would oversubscribe the cores they sit on.
 const URING_BLOCKING_THREADS_PER_RING: usize = 4;
 
+/// Bridges the backend retry decorator to the worker's metrics registry.
+///
+/// `talon-backend` deliberately knows nothing about the worker's registry, so it
+/// emits retry and timeout events through the [`RetryObserver`] trait and this
+/// adapter turns them into counters.
+struct MetricsRetryObserver {
+    observability: Arc<WorkerObservability>,
+}
+
+impl talon_backend::RetryObserver for MetricsRetryObserver {
+    fn on_retry(&self, _attempt: u32, _status: Option<u16>) {
+        self.observability.metrics().record_backend_retry();
+    }
+
+    fn on_timeout(&self) {
+        self.observability.metrics().record_backend_timeout();
+    }
+}
+
 /// Set to `1` to pin the legacy Tokio data plane regardless of io_uring
 /// availability. An escape hatch for operators who hit a regression; the
 /// io_uring path is the default because it wins decisively under the
@@ -123,6 +142,13 @@ impl Args {
             backend_delay_ms: None,
             backend_jitter_ms: None,
             backend_throughput_bytes: None,
+            // Retry/timeout knobs are env- and file-only (`cli: false` in the
+            // ConfigVar schema), so the CLI patch leaves them unset.
+            backend_max_retries: None,
+            backend_retry_base_ms: None,
+            backend_retry_max_delay_ms: None,
+            backend_timeout_floor_ms: None,
+            backend_min_throughput_bytes: None,
             s3_region: None,
             s3_endpoint: None,
             s3_access_key_id: None,
@@ -249,50 +275,6 @@ async fn main() -> anyhow::Result<()> {
         "starting talon-worker"
     );
 
-    // The networked HTTP client, shared by whichever backend is selected. It is
-    // optionally wrapped in a latency decorator (test/latency lab); inert unless
-    // a delay/jitter/throughput knob is set.
-    let http: Arc<dyn talon_backend::http::HttpClient> = {
-        let base: Arc<dyn talon_backend::http::HttpClient> = Arc::new(ReqwestClient::new());
-        let delay = talon_backend::DelayConfig {
-            base: Duration::from_millis(cfg.backend_delay_ms.unwrap_or(0)),
-            jitter: Duration::from_millis(cfg.backend_jitter_ms.unwrap_or(0)),
-            throughput_bytes_per_sec: cfg.backend_throughput_bytes.filter(|&b| b > 0),
-        };
-        if delay.is_active() {
-            tracing::info!(
-                base_ms = cfg.backend_delay_ms.unwrap_or(0),
-                jitter_ms = cfg.backend_jitter_ms.unwrap_or(0),
-                throughput_bytes = ?cfg.backend_throughput_bytes,
-                "synthetic backend latency enabled"
-            );
-            // Seed from the node identity so each worker's jitter is distinct yet
-            // reproducible across restarts.
-            let seed = cfg
-                .node_id
-                .as_deref()
-                .unwrap_or(&cfg.advertise_addr)
-                .bytes()
-                .fold(0u64, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u64));
-            Arc::new(talon_backend::DelayingHttpClient::new(base, delay, seed))
-        } else {
-            base
-        }
-    };
-
-    // Select the object-store backend from config (default: azure). Each backend
-    // reads its endpoint from config and its secret from the environment only.
-    let backend_kind = cfg.backend.as_deref().unwrap_or("azure");
-    let backend: Arc<dyn BackendStore> = match backend_kind {
-        "azure" => Arc::new(build_azure_backend(&cfg, http)?),
-        "s3" => Arc::new(build_s3_backend(&cfg, http)?),
-        "gcs" => Arc::new(build_gcs_backend(&cfg, http)?),
-        other => {
-            anyhow::bail!("unknown TALON_WORKER_BACKEND {other:?}; expected azure, s3, or gcs")
-        }
-    };
-    tracing::info!(backend = backend_kind, "object-store backend ready");
-
     // Local store stack rooted at the first cache dir.
     let root = cfg
         .cache_dirs
@@ -345,6 +327,92 @@ async fn main() -> anyhow::Result<()> {
     )?);
     observability.readiness().set_backend_ready(true);
     observability.readiness().set_store_ready(true);
+
+    // The networked HTTP client, shared by whichever backend is selected. Two
+    // decorators may wrap it, innermost first: retry (always on — a cache with
+    // no retry turns a routine 503 into a failed read) and, optionally, the
+    // latency injector for the test/latency lab.
+    //
+    // Retry is innermost so each attempt gets its own injected latency, which is
+    // what the lab is modeling; wrapping the other way would make the whole
+    // retry ladder share a single delay and understate the cost of a retry.
+    let http: Arc<dyn talon_backend::http::HttpClient> = {
+        let base: Arc<dyn talon_backend::http::HttpClient> = Arc::new(ReqwestClient::new());
+
+        // Seed from the node identity so each worker's jitter is distinct yet
+        // reproducible across restarts. Shared by both decorators.
+        let seed = cfg
+            .node_id
+            .as_deref()
+            .unwrap_or(&cfg.advertise_addr)
+            .bytes()
+            .fold(0u64, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u64));
+
+        let defaults = talon_backend::RetryConfig::default();
+        let retry = talon_backend::RetryConfig {
+            max_retries: cfg.backend_max_retries.unwrap_or(defaults.max_retries),
+            base_delay: cfg
+                .backend_retry_base_ms
+                .map(Duration::from_millis)
+                .unwrap_or(defaults.base_delay),
+            max_delay: cfg
+                .backend_retry_max_delay_ms
+                .map(Duration::from_millis)
+                .unwrap_or(defaults.max_delay),
+            timeout_floor: cfg
+                .backend_timeout_floor_ms
+                .map(Duration::from_millis)
+                .unwrap_or(defaults.timeout_floor),
+            min_throughput_bytes_per_sec: cfg
+                .backend_min_throughput_bytes
+                .unwrap_or(defaults.min_throughput_bytes_per_sec),
+        };
+        tracing::info!(
+            max_retries = retry.max_retries,
+            base_delay_ms = retry.base_delay.as_millis(),
+            max_delay_ms = retry.max_delay.as_millis(),
+            timeout_floor_ms = retry.timeout_floor.as_millis(),
+            min_throughput_bytes = retry.min_throughput_bytes_per_sec,
+            "backend retry policy"
+        );
+        let base: Arc<dyn talon_backend::http::HttpClient> = Arc::new(
+            talon_backend::RetryingHttpClient::new(base, retry, seed).with_observer(Arc::new(
+                MetricsRetryObserver {
+                    observability: Arc::clone(&observability),
+                },
+            )),
+        );
+
+        let delay = talon_backend::DelayConfig {
+            base: Duration::from_millis(cfg.backend_delay_ms.unwrap_or(0)),
+            jitter: Duration::from_millis(cfg.backend_jitter_ms.unwrap_or(0)),
+            throughput_bytes_per_sec: cfg.backend_throughput_bytes.filter(|&b| b > 0),
+        };
+        if delay.is_active() {
+            tracing::info!(
+                base_ms = cfg.backend_delay_ms.unwrap_or(0),
+                jitter_ms = cfg.backend_jitter_ms.unwrap_or(0),
+                throughput_bytes = ?cfg.backend_throughput_bytes,
+                "synthetic backend latency enabled"
+            );
+            Arc::new(talon_backend::DelayingHttpClient::new(base, delay, seed))
+        } else {
+            base
+        }
+    };
+
+    // Select the object-store backend from config (default: azure). Each backend
+    // reads its endpoint from config and its secret from the environment only.
+    let backend_kind = cfg.backend.as_deref().unwrap_or("azure");
+    let backend: Arc<dyn BackendStore> = match backend_kind {
+        "azure" => Arc::new(build_azure_backend(&cfg, http)?),
+        "s3" => Arc::new(build_s3_backend(&cfg, http)?),
+        "gcs" => Arc::new(build_gcs_backend(&cfg, http)?),
+        other => {
+            anyhow::bail!("unknown TALON_WORKER_BACKEND {other:?}; expected azure, s3, or gcs")
+        }
+    };
+    tracing::info!(backend = backend_kind, "object-store backend ready");
 
     let worker = Arc::new(WorkerRuntime::new(
         store,

--- a/crates/talon-worker/src/observability.rs
+++ b/crates/talon-worker/src/observability.rs
@@ -37,6 +37,8 @@ pub struct WorkerMetrics {
     cache_misses_total: Counter,
     backend_fetch_bytes_total: Counter,
     backend_fetch_errors_total: Counter,
+    backend_retries_total: Counter,
+    backend_timeouts_total: Counter,
     backend_write_bytes_total: Counter,
     backend_write_errors_total: Counter,
     backend_delete_total: Counter,
@@ -111,6 +113,16 @@ impl WorkerMetrics {
         let backend_fetch_errors_total = registry.counter(
             "talon_worker_backend_fetch_errors_total",
             "Origin backend range fetch failures.",
+            labels(BACKEND_LABELS),
+        );
+        let backend_retries_total = registry.counter(
+            "talon_worker_backend_retries_total",
+            "Origin backend requests re-issued after a transient failure.",
+            labels(BACKEND_LABELS),
+        );
+        let backend_timeouts_total = registry.counter(
+            "talon_worker_backend_timeouts_total",
+            "Origin backend request attempts that exceeded their deadline.",
             labels(BACKEND_LABELS),
         );
         let backend_write_bytes_total = registry.counter(
@@ -211,6 +223,8 @@ impl WorkerMetrics {
             cache_misses_total,
             backend_fetch_bytes_total,
             backend_fetch_errors_total,
+            backend_retries_total,
+            backend_timeouts_total,
             backend_write_bytes_total,
             backend_write_errors_total,
             backend_delete_total,
@@ -266,6 +280,19 @@ impl WorkerMetrics {
         self.backend_fetch_errors_total.inc();
         self.backend_fetch_duration_seconds
             .observe(elapsed.as_secs_f64());
+    }
+
+    /// Record a backend request being re-issued after a transient failure.
+    ///
+    /// Retries succeed silently by design, so without this counter a degrading
+    /// origin is invisible: reads keep working while latency and cost climb.
+    pub fn record_backend_retry(&self) {
+        self.backend_retries_total.inc();
+    }
+
+    /// Record a backend request attempt that exceeded its deadline.
+    pub fn record_backend_timeout(&self) {
+        self.backend_timeouts_total.inc();
     }
 
     /// Record a successful write-through PUT of `bytes` to the origin backend.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -306,6 +306,46 @@ Synthetic backend bandwidth ceiling in bytes/sec (test/latency lab).
 - **Default:** none
 - **CLI flag:** not settable via CLI (config file or environment only)
 
+### `backend_max_retries`
+
+Retries after the first attempt for a transient backend failure (0 disables).
+
+- **Environment variable:** `TALON_WORKER_BACKEND_MAX_RETRIES`
+- **Default:** `3`
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `backend_retry_base_ms`
+
+Exponential backoff base in ms; the wait is jittered over [0, base * 2^attempt].
+
+- **Environment variable:** `TALON_WORKER_BACKEND_RETRY_BASE_MS`
+- **Default:** `100`
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `backend_retry_max_delay_ms`
+
+Ceiling on a single backoff wait in ms; also clamps an origin Retry-After hint.
+
+- **Environment variable:** `TALON_WORKER_BACKEND_RETRY_MAX_DELAY_MS`
+- **Default:** `5000`
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `backend_timeout_floor_ms`
+
+Fixed part of the per-attempt backend deadline in ms (connect + first byte).
+
+- **Environment variable:** `TALON_WORKER_BACKEND_TIMEOUT_FLOOR_MS`
+- **Default:** `5000`
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `backend_min_throughput_bytes`
+
+Throughput floor in bytes/sec used to extend the deadline by transfer size (0 = flat).
+
+- **Environment variable:** `TALON_WORKER_BACKEND_MIN_THROUGHPUT_BYTES`
+- **Default:** `10485760 (10 MiB/s)`
+- **CLI flag:** not settable via CLI (config file or environment only)
+
 ### `data_plane_rings`
 
 io_uring rings for the data plane; 0 = one per core. Falls back to Tokio if io_uring is unavailable.


### PR DESCRIPTION
## Problem

The backend HTTP client has no retry and no timeout.

`ReqwestClient::new()` is a bare `reqwest::Client::new()` — no `.timeout()`, no `.connect_timeout()` — and `grep -rn "retry\|backoff" crates/talon-backend/src/` returns nothing. So:

- A single `503` from S3/GCS/Azure fails a block fetch.
- A hung origin hangs the fetch **forever**.

Because a failed fetch surfaces to the application as a failed read, this makes the cache strictly *less* reliable than reading the origin directly — the bar it has to beat to be adoptable. Object stores throttle and shed load as a matter of routine, so this is an expected condition, not an edge case.

I could not find an existing issue covering this; happy to file one first if you'd prefer.

## Approach

`RetryingHttpClient`, a decorator over the `HttpClient` trait in the same shape as the existing `DelayingHttpClient`. One policy covers S3, GCS, and Azure, and no trait signature changes, so the backends and their mocks are untouched.

The `HttpClient` seam was chosen over `BackendStore` because the retryable signal — status code and `Retry-After` — is HTTP-level, and has already been flattened into `Error::Backend(String)` by the time it reaches `BackendStore`.

**What is retried:** transport errors and `408/429/500/502/503/504`.

**What is not:** everything else, in particular `404` (mapped to `ENOENT`) and `412`. `412` is not a failure — it is the version-mismatch signal `fetch_range_if_match` relies on to close the HEAD→GET TOCTOU (#163), and `runtime.rs` already re-resolves on it. Retrying it would defeat the guard it exists to provide.

**Conditional mutations are never retried.** If a conditional PUT succeeds but the response is lost, a retry meets a precondition it already consumed and returns `412` — reporting failure for a write that landed. The guard keys on body-plus-precondition rather than HTTP method, which correctly excludes only that case: unconditional PUT (whole-object replace) and DELETE (documented idempotent) are retried, and so are conditional GETs, since a GET has no side effect and the precondition simply re-evaluates. `put_if_match` has no production caller today, so this is future-proofing.

**Backoff is full jitter** — `random(0, min(cap, base * 2^attempt))` — so a fleet does not align its retries into a second thundering herd against an origin that is already struggling. The draw is a deterministic SplitMix64 seeded per node, matching `delay.rs`: no RNG dependency, reproducible under test. `Retry-After` on `429`/`503` overrides the draw, clamped to `max_delay`. Delta-seconds only — the HTTP-date form would mean taking a date-parsing dependency for a format these origins do not send.

**Deadlines scale with transfer size:** `floor + bytes / min_throughput`, with `bytes` from the body (PUT) or the requested range (GET/`Range`/`x-ms-range`). Requests here span a ~200-byte HEAD and a 256 MiB block fetch, six orders of magnitude. A flat deadline cannot serve both: sized for the HEAD, every large fetch times out and retries, each retry re-transferring 256 MiB and worsening the congestion; sized for the fetch, a hung HEAD wedges the read path for minutes.

`ReqwestClient` additionally gains a connect timeout and a generous request ceiling as a backstop for undecorated use. The decorator owns the real per-attempt deadline; the flat ceiling is set far above it so it never preempts the calculation.

## Defaults

Retry is **on by default** (3 retries), unlike the inert-by-default latency knobs — a cache with no retry is the bug being fixed, so the default is the protective one. `TALON_WORKER_BACKEND_MAX_RETRIES=0` disables retrying while keeping timeouts.

Worst case is ~0.7s of added backoff across three retries; deadlines are 5s for a HEAD and ~30s for a 256 MiB block at 10 MiB/s. Five new env/file knobs, all in the existing `ConfigVar` registry (`cli: false`); `docs/reference/configuration.md` regenerated.

## Observability

`talon_worker_backend_retries_total` and `talon_worker_backend_timeouts_total`, fed through a `RetryObserver` trait so `talon-backend` stays independent of the worker's registry. Retries succeed silently by design, so without these a degrading origin is invisible until it becomes an outage.

The HTTP client construction moved to just after `WorkerObservability` is built, so the observer can be attached. Nothing between the old and new positions referenced `http` or `backend`.

## Testing

21 new unit tests covering classification, the conditional-mutation guard, range parsing and deadline sizing, jitter bounds and reproducibility, `Retry-After`, retry-then-succeed, exhaustion, and timeout-then-retry. Backoff and deadline tests run under `#[tokio::test(start_paused = true)]`, so they assert real elapsed time on a virtual clock and add no wall-time to CI.

Verified on Linux (`talon-worker` does not compile on macOS — io_uring, `splice`, `sched_getaffinity`, and the Linux `sendfile` signature), on the toolchain pinned in `rust-toolchain.toml`:

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace --all-features --locked` — 385 passed, 0 failed
- `cargo fmt --all --check` — clean
- config-docs check — clean

## Notes for review

- I'd value a second opinion on the **default `min_throughput` of 10 MiB/s**. It is a floor, not a target, but a cluster reading across regions on a slow link could see spurious timeouts. Raising `timeout_floor` or lowering the throughput floor both widen the margin.
- **Write retry** is enabled here on the reasoning above. If you would rather land reads-only first and treat PUT/DELETE separately, that is a small change — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)