### PR TITLE
fix(fuse): validate worker reply lengths

### DIFF
--- a/crates/talon-fuse/src/block_reader.rs
+++ b/crates/talon-fuse/src/block_reader.rs
@@ -208,7 +208,11 @@ impl BlockReader {
                 .fetch_range(&block.object, abs_offset, len as u64)
                 .await
             {
-                Ok(bytes) => return Ok(bytes),
+                Ok(bytes) if bytes.len() as u64 == u64::from(len) => return Ok(bytes),
+                Ok(_) => {
+                    self.stats.record_worker_failure();
+                    last = RefreshReason::WrongOwner;
+                }
                 Err(e) => {
                     self.stats.record_worker_failure();
                     last = match e {
@@ -265,6 +269,13 @@ impl BlockReader {
             let bytes = self
                 .read_block(&seg.block, seg.offset_in_block, seg.len, now_ms)
                 .await?;
+            if bytes.len() as u64 != u64::from(seg.len) {
+                return Err(WorkerError::RangeLengthMismatch {
+                    expected: u64::from(seg.len),
+                    actual: bytes.len() as u64,
+                }
+                .into());
+            }
             out.extend_from_slice(&bytes);
         }
         Ok(out)
@@ -467,6 +478,42 @@ mod tests {
         addr
     }
 
+    /// A mock worker that returns a self-consistent but one-byte-short success
+    /// frame, counting how many requests it saw.
+    async fn spawn_short_reply_worker(count: Arc<std::sync::atomic::AtomicU32>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            loop {
+                let (mut s, _) = match listener.accept().await {
+                    Ok(v) => v,
+                    Err(_) => return,
+                };
+                let count = Arc::clone(&count);
+                tokio::spawn(async move {
+                    let mut hdr = [0u8; HEADER_LEN];
+                    if s.read_exact(&mut hdr).await.is_err() {
+                        return;
+                    }
+                    let h = FrameHeader::decode(&hdr).unwrap();
+                    let mut body = vec![0u8; h.length as usize];
+                    s.read_exact(&mut body).await.unwrap();
+                    let mut full = hdr.to_vec();
+                    full.extend_from_slice(&body);
+                    let (_h, req): (_, RangeRequest) = decode_request(&full).unwrap();
+                    count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    let short_len = req.len.saturating_sub(1) as usize;
+                    let payload = vec![0u8; short_len];
+                    let mut out = response_header_ok(0, short_len as u32).to_vec();
+                    out.extend_from_slice(&payload);
+                    s.write_all(&out).await.unwrap();
+                    s.flush().await.unwrap();
+                });
+            }
+        });
+        addr
+    }
+
     /// A mock coordinator that returns two ordered owners (w1, w2) and resolves
     /// their addresses via membership.
     async fn mock_coordinator_two(w1: String, w2: String) -> String {
@@ -640,6 +687,36 @@ mod tests {
         );
         // Placement stays cached (fallback within the list, no invalidation).
         assert_eq!(cache.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn short_reply_from_worker_falls_back_to_next_replica() {
+        let short = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let good = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let w1 = spawn_short_reply_worker(Arc::clone(&short)).await;
+        let w2 = mock_worker(Arc::clone(&good)).await;
+        let coord = mock_coordinator_two(w1, w2).await;
+        let cache = Arc::new(PlacementCache::new(10_000));
+        let reader = BlockReader::new(CoordinatorClient::new(coord), Arc::clone(&cache), 2);
+
+        let bytes = reader.read_block(&block(), 0, 32, 0).await.unwrap();
+        assert_eq!(bytes.len(), 32);
+        assert_eq!(
+            short.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "short primary reply was rejected"
+        );
+        assert_eq!(
+            good.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "read fell back to the healthy replica"
+        );
+        assert_eq!(cache.len(), 1, "fallback did not invalidate placement");
+        let stats = reader.stats().snapshot();
+        assert_eq!(stats.worker_fetches, 2);
+        assert_eq!(stats.worker_failures, 1);
+        assert_eq!(stats.coordinator_refreshes, 0);
+        assert_eq!(stats.bytes_served, 32);
     }
 
     #[tokio::test]

--- a/crates/talon-fuse/src/coordinator_client.rs
+++ b/crates/talon-fuse/src/coordinator_client.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use talon_core::{BlockId, NodeId, NodeInfo, ObjectId};
 use talon_transport::frame::{FrameHeader, MsgType, HEADER_LEN};
-use talon_transport::ControlMessage;
+use talon_transport::{ControlMessage, MAX_CONTROL_PAYLOAD_LEN};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
@@ -54,6 +54,14 @@ pub enum CoordinatorError {
     /// A frame could not be encoded/decoded.
     #[error("coordinator codec: {0}")]
     Codec(#[from] talon_transport::CodecError),
+    /// The coordinator advertised a control payload above the safety cap.
+    #[error("coordinator payload length {length} exceeds cap {cap}")]
+    PayloadTooLarge {
+        /// Number of bytes advertised by the coordinator.
+        length: u32,
+        /// Maximum accepted control payload size.
+        cap: u32,
+    },
     /// The coordinator replied, but with an unexpected message shape.
     #[error("unexpected reply to {expected}: {got:?}")]
     Unexpected {
@@ -286,9 +294,9 @@ impl ResolvedPlacement {
 
 /// Read one framed [`ControlMessage`] from `stream`.
 ///
-/// Reads the 16-byte header, then exactly `length` payload bytes, then decodes
-/// the full frame with the control codec. `expected` names the request for
-/// error context only.
+/// Reads the 16-byte header, validates the payload against
+/// [`MAX_CONTROL_PAYLOAD_LEN`] before allocation, then decodes the full frame
+/// with the control codec. `expected` names the request for error context only.
 async fn read_control_frame(
     stream: &mut TcpStream,
     expected: &'static str,
@@ -302,6 +310,12 @@ async fn read_control_frame(
         return Err(CoordinatorError::Codec(
             talon_transport::CodecError::NotControl(header.msg_type),
         ));
+    }
+    if header.length > MAX_CONTROL_PAYLOAD_LEN {
+        return Err(CoordinatorError::PayloadTooLarge {
+            length: header.length,
+            cap: MAX_CONTROL_PAYLOAD_LEN,
+        });
     }
     let mut payload = vec![0u8; header.length as usize];
     stream.read_exact(&mut payload).await?;
@@ -440,6 +454,43 @@ mod tests {
         let client = CoordinatorClient::new("127.0.0.1:1");
         let err = client.membership().await.unwrap_err();
         assert!(matches!(err, CoordinatorError::Io(_)));
+    }
+
+    #[tokio::test]
+    async fn oversized_control_payload_is_rejected_before_body() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut hdr = [0u8; HEADER_LEN];
+            sock.read_exact(&mut hdr).await.unwrap();
+            let request = FrameHeader::decode(&hdr).unwrap();
+            let mut body = vec![0u8; request.length as usize];
+            sock.read_exact(&mut body).await.unwrap();
+            let reply = FrameHeader::new(
+                MsgType::Control,
+                request.request_id,
+                MAX_CONTROL_PAYLOAD_LEN + 1,
+            );
+            sock.write_all(&reply.encode()).await.unwrap();
+            sock.flush().await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            drop(sock);
+        });
+        let pool = Arc::new(ConnectionPool::new().with_timeouts(
+            std::time::Duration::from_secs(5),
+            std::time::Duration::from_millis(150),
+        ));
+        let client = CoordinatorClient::with_pool(addr, pool);
+
+        let err = client.membership().await.unwrap_err();
+        assert!(matches!(
+            err,
+            CoordinatorError::PayloadTooLarge {
+                length,
+                cap: MAX_CONTROL_PAYLOAD_LEN
+            } if length == MAX_CONTROL_PAYLOAD_LEN + 1
+        ));
     }
 
     #[tokio::test]

--- a/crates/talon-fuse/src/worker_client.rs
+++ b/crates/talon-fuse/src/worker_client.rs
@@ -21,7 +21,7 @@ use talon_core::{ObjectId, Version};
 use talon_transport::frame::{FrameHeader, MsgType, HEADER_LEN};
 use talon_transport::{
     encode_delete, encode_put_header, encode_request, DeleteRequest, Flags, PutRequest,
-    RangeRequest,
+    RangeRequest, MAX_CONTROL_PAYLOAD_LEN,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -43,6 +43,22 @@ pub enum WorkerError {
     /// The worker replied with a non-`GetRange` frame.
     #[error("expected a GetRange reply, got {0:?}")]
     NotGetRange(MsgType),
+    /// A successful range reply did not contain exactly the requested bytes.
+    #[error("worker range length mismatch: expected {expected}, got {actual}")]
+    RangeLengthMismatch {
+        /// Number of bytes requested from the worker.
+        expected: u64,
+        /// Number of bytes advertised or returned by the worker.
+        actual: u64,
+    },
+    /// A non-range payload exceeded the small-message safety cap.
+    #[error("worker payload length {length} exceeds cap {cap}")]
+    PayloadTooLarge {
+        /// Number of bytes advertised by the worker.
+        length: u32,
+        /// Maximum accepted payload size for this reply.
+        cap: u32,
+    },
     /// The worker set the ERROR flag and returned this message.
     #[error("worker error: {0}")]
     Remote(String),
@@ -108,7 +124,7 @@ impl WorkerClient {
         // have closed it while idle), retry once on a fresh dial so a stale
         // pooled socket never turns a healthy peer into a spurious failure. A
         // failure on a *fresh* connection is a real peer error and propagates.
-        match self.exchange(&out).await {
+        match self.exchange(&out, len).await {
             Ok(bytes) => Ok(bytes),
             Err((true, _stale)) => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
@@ -117,7 +133,7 @@ impl WorkerClient {
                     .with_request_deadline("worker fetch_range retry", async {
                         stream.write_all(&out).await?;
                         stream.flush().await?;
-                        read_range_reply(&mut stream).await
+                        read_range_reply(&mut stream, len).await
                     })
                     .await?;
                 self.pool.release(&self.addr, stream);
@@ -132,7 +148,11 @@ impl WorkerClient {
     /// On success releases the connection for reuse. On error returns
     /// `(was_reused, err)` so the caller can decide whether to retry (a reused
     /// connection may simply have been closed while idle).
-    async fn exchange(&self, out: &[u8]) -> Result<Vec<u8>, (bool, WorkerError)> {
+    async fn exchange(
+        &self,
+        out: &[u8],
+        expected_len: u64,
+    ) -> Result<Vec<u8>, (bool, WorkerError)> {
         let (mut stream, reused) = self
             .pool
             .checkout(&self.addr)
@@ -145,7 +165,7 @@ impl WorkerClient {
             .with_request_deadline("worker fetch_range", async {
                 stream.write_all(out).await?;
                 stream.flush().await?;
-                read_range_reply(&mut stream).await
+                read_range_reply(&mut stream, expected_len).await
             })
             .await;
         match result {
@@ -409,6 +429,15 @@ async fn read_version_reply(stream: &mut TcpStream) -> Result<Version, WorkerErr
     let mut header_buf = [0u8; HEADER_LEN];
     stream.read_exact(&mut header_buf).await?;
     let header = FrameHeader::decode(&header_buf)?;
+    if header.msg_type != MsgType::GetRange {
+        return Err(WorkerError::NotGetRange(header.msg_type));
+    }
+    if header.length > MAX_CONTROL_PAYLOAD_LEN {
+        return Err(WorkerError::PayloadTooLarge {
+            length: header.length,
+            cap: MAX_CONTROL_PAYLOAD_LEN,
+        });
+    }
     let mut body = vec![0u8; header.length as usize];
     stream.read_exact(&mut body).await?;
     if header.flags.contains(Flags::ERROR) {
@@ -419,16 +448,34 @@ async fn read_version_reply(stream: &mut TcpStream) -> Result<Version, WorkerErr
     Ok(Version::new(String::from_utf8_lossy(&body).into_owned()))
 }
 
-/// Read one framed data-plane reply: header, then exactly `length` bytes.
+/// Read one framed data-plane reply for a request of `expected_len` bytes.
 ///
-/// If the header carries [`Flags::ERROR`], the body is a UTF-8 message and is
-/// returned as [`WorkerError::Remote`]; otherwise the body is the raw range.
-async fn read_range_reply(stream: &mut TcpStream) -> Result<Vec<u8>, WorkerError> {
+/// A successful reply must advertise exactly `expected_len` before its buffer is
+/// allocated. If the header carries [`Flags::ERROR`], the body is instead a
+/// UTF-8 message capped at [`MAX_CONTROL_PAYLOAD_LEN`] and returned as
+/// [`WorkerError::Remote`].
+async fn read_range_reply(
+    stream: &mut TcpStream,
+    expected_len: u64,
+) -> Result<Vec<u8>, WorkerError> {
     let mut header_buf = [0u8; HEADER_LEN];
     stream.read_exact(&mut header_buf).await?;
     let header = FrameHeader::decode(&header_buf)?;
     if header.msg_type != MsgType::GetRange {
         return Err(WorkerError::NotGetRange(header.msg_type));
+    }
+    if header.flags.contains(Flags::ERROR) {
+        if header.length > MAX_CONTROL_PAYLOAD_LEN {
+            return Err(WorkerError::PayloadTooLarge {
+                length: header.length,
+                cap: MAX_CONTROL_PAYLOAD_LEN,
+            });
+        }
+    } else if u64::from(header.length) != expected_len {
+        return Err(WorkerError::RangeLengthMismatch {
+            expected: expected_len,
+            actual: u64::from(header.length),
+        });
     }
     let mut body = vec![0u8; header.length as usize];
     stream.read_exact(&mut body).await?;
@@ -475,6 +522,27 @@ mod tests {
             let reply = respond(req);
             sock.write_all(&reply).await.unwrap();
             sock.flush().await.unwrap();
+        });
+        addr
+    }
+
+    /// Spawn a one-shot range worker that writes only `reply_header`, then keeps
+    /// the socket open. A correct client must reject the header before trying to
+    /// allocate or read its advertised body.
+    async fn header_only_range_worker(reply_header: FrameHeader) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut hdr = [0u8; HEADER_LEN];
+            sock.read_exact(&mut hdr).await.unwrap();
+            let header = FrameHeader::decode(&hdr).unwrap();
+            let mut body = vec![0u8; header.length as usize];
+            sock.read_exact(&mut body).await.unwrap();
+            sock.write_all(&reply_header.encode()).await.unwrap();
+            sock.flush().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            drop(sock);
         });
         addr
     }
@@ -631,6 +699,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mismatched_range_length_is_rejected_before_body() {
+        let header = FrameHeader::new(MsgType::GetRange, 0, 17);
+        let addr = header_only_range_worker(header).await;
+        let client = WorkerClient::with_pool(addr, impatient_pool());
+
+        let err = client.fetch_range(&object(), 0, 16).await.unwrap_err();
+        assert!(matches!(
+            err,
+            WorkerError::RangeLengthMismatch {
+                expected: 16,
+                actual: 17
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn oversized_error_payload_is_rejected_before_body() {
+        let mut header = FrameHeader::new(MsgType::GetRange, 0, MAX_CONTROL_PAYLOAD_LEN + 1);
+        header.flags = Flags(Flags::ERROR);
+        let addr = header_only_range_worker(header).await;
+        let client = WorkerClient::with_pool(addr, impatient_pool());
+
+        let err = client.fetch_range(&object(), 0, 16).await.unwrap_err();
+        assert!(matches!(
+            err,
+            WorkerError::PayloadTooLarge {
+                length,
+                cap: MAX_CONTROL_PAYLOAD_LEN
+            } if length == MAX_CONTROL_PAYLOAD_LEN + 1
+        ));
+    }
+
+    #[tokio::test]
     async fn connect_failure_is_io_error() {
         let client = WorkerClient::new("127.0.0.1:1");
         let err = client.fetch_range(&object(), 0, 16).await.unwrap_err();
@@ -665,6 +766,32 @@ mod tests {
         addr
     }
 
+    /// Spawn a one-shot write worker that consumes a complete Put request and
+    /// writes only `reply_header`, keeping the connection open afterwards.
+    async fn header_only_write_worker(reply_header: FrameHeader) -> String {
+        use talon_transport::decode_put_header;
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut hdr = [0u8; HEADER_LEN];
+            sock.read_exact(&mut hdr).await.unwrap();
+            let header = FrameHeader::decode(&hdr).unwrap();
+            let mut hbody = vec![0u8; header.length as usize];
+            sock.read_exact(&mut hbody).await.unwrap();
+            let mut full = hdr.to_vec();
+            full.extend_from_slice(&hbody);
+            let (_header, req) = decode_put_header(&full).unwrap();
+            let mut body = vec![0u8; req.body_len as usize];
+            sock.read_exact(&mut body).await.unwrap();
+            sock.write_all(&reply_header.encode()).await.unwrap();
+            sock.flush().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            drop(sock);
+        });
+        addr
+    }
+
     #[tokio::test]
     async fn put_object_sends_header_and_body_and_returns_version() {
         let recorded = Arc::new(std::sync::Mutex::new(None));
@@ -676,6 +803,32 @@ mod tests {
         let (obj, got) = recorded.lock().unwrap().take().unwrap();
         assert_eq!(obj, object());
         assert_eq!(got, body, "worker received the exact object bytes");
+    }
+
+    #[tokio::test]
+    async fn version_reply_with_wrong_message_type_is_rejected() {
+        let header = FrameHeader::new(MsgType::Control, 0, 0);
+        let addr = header_only_write_worker(header).await;
+        let client = WriteClient::new(addr);
+
+        let err = client.put_object(&object(), b"x").await.unwrap_err();
+        assert!(matches!(err, WorkerError::NotGetRange(MsgType::Control)));
+    }
+
+    #[tokio::test]
+    async fn oversized_version_payload_is_rejected_before_body() {
+        let header = FrameHeader::new(MsgType::GetRange, 0, MAX_CONTROL_PAYLOAD_LEN + 1);
+        let addr = header_only_write_worker(header).await;
+        let client = WriteClient::with_pool(addr, impatient_pool());
+
+        let err = client.put_object(&object(), b"x").await.unwrap_err();
+        assert!(matches!(
+            err,
+            WorkerError::PayloadTooLarge {
+                length,
+                cap: MAX_CONTROL_PAYLOAD_LEN
+            } if length == MAX_CONTROL_PAYLOAD_LEN + 1
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The FUSE client previously trusted the payload length advertised by a worker or coordinator. A malformed `GetRange` response could therefore allocate up to the transport-wide 320 MiB limit before the client compared it with the requested range. Even worse, a self-consistent but short success response was accepted as valid data; when a read crossed block boundaries, the client would concatenate that short segment with later segments and return shifted bytes to the kernel as if the read had succeeded.

This change validates reply metadata before allocating or reading payload bodies. Successful range responses must advertise exactly the requested byte count, while error text, committed-version responses, and coordinator control messages use the existing 1 MiB control-payload cap. Write/delete replies must also carry the expected `GetRange` response frame type.

Length violations are treated as worker failures rather than successful reads, allowing `BlockReader` to continue through the ordered replica list. A healthy replica can therefore satisfy the request without invalidating an otherwise valid placement entry. The change does not alter the wire format or normal success/error semantics; it makes the existing protocol boundaries enforceable on the client side.

## Related issues

Closes #254

## Type of change

- [x] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [ ] Docs / tests / tooling

## Design alignment

This tightens the framed data- and control-plane boundaries described in `DESIGN.md` §1 (RPC / transport) and the data-plane read paths. It does not change the wire format.

## Changes

- require successful `GetRange` replies to advertise exactly the requested byte count before allocating or reading the body
- cap error, version, and coordinator control payloads at `MAX_CONTROL_PAYLOAD_LEN`
- validate the message type of write/delete version replies
- treat malformed range lengths as replica failures so reads can fall back to a healthy owner
- add deterministic TCP tests for short replies, oversized headers, wrong message types, and fallback metrics/cache behavior

## Test plan

- [ ] `just ci` passes locally (fmt + clippy + test)
- [ ] Workspace compiles (`cargo build --workspace`)
- [x] Added/updated tests for new behavior

Validated locally on macOS with:

- `cargo fmt --all --check`
- `cargo clippy -p talon-fuse --lib --tests -- -D warnings`
- `cargo test -p talon-fuse --locked` — 121 unit tests and 3 read-path integration tests passed
- `cargo doc -p talon-fuse --no-deps`

The workspace `--all-features` gate is Linux-only because the existing FUSE and io_uring dependencies do not build on macOS; the PR CI will run that gate on Linux.

## Performance impact

- [ ] Not performance-sensitive, OR
- [x] `just bench-check` run; results below (baseline refreshed if the change is intentional)

Ran the equivalent package command, `python3 scripts/bench.py check -p talon-fuse --soft`. The modified connection-pool fetch benchmarks currently have no committed baseline (`fetch_fresh_per_call`: 5.30 ms; `fetch_pooled`: 1.02 ms). The only reported regression was the unchanged readahead benchmark; no readahead or read-planning code is modified by this PR.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`<type>(<scope>): <description>`) — it becomes the squash-merge commit subject and is checked by CI
- [x] Public items are documented; no broken intra-doc links
- [x] No new dependencies without discussion
- [x] Rebased on the latest `main`
