### PR TITLE
feat(observability): propagate RequestId and log serve failures

### DIFF
--- a/crates/talon-fuse/src/worker_client.rs
+++ b/crates/talon-fuse/src/worker_client.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use talon_core::{ObjectId, Version};
+use talon_core::{ObjectId, RequestId, Version};
 use talon_transport::frame::{FrameHeader, MsgType, HEADER_LEN};
 use talon_transport::{
     encode_delete, encode_put_header, encode_request, DeleteRequest, Flags, PutRequest,
@@ -119,7 +119,10 @@ impl WorkerClient {
             offset,
             len,
         };
-        let out = encode_request(0, &req)?;
+        // Allocate a correlation id and put it on the wire, so the worker's
+        // logs for this fetch can be joined with the client's (#304).
+        let req_id = RequestId::next();
+        let out = encode_request(req_id.0, &req)?;
         // Try a pooled connection first; if it was reused and fails (the peer may
         // have closed it while idle), retry once on a fresh dial so a stale
         // pooled socket never turns a healthy peer into a spurious failure. A
@@ -139,7 +142,18 @@ impl WorkerClient {
                 self.pool.release(&self.addr, stream);
                 Ok(bytes)
             }
-            Err((false, err)) => Err(err),
+            Err((false, err)) => {
+                tracing::error!(
+                    req = %req_id,
+                    worker = %self.addr,
+                    object = %object.to_path(),
+                    offset,
+                    len,
+                    error = %err,
+                    "worker range fetch failed"
+                );
+                Err(err)
+            }
         }
     }
 
@@ -222,8 +236,9 @@ impl WriteClient {
     /// connection, it is safe — the first attempt sent nothing the backend
     /// committed (a mid-stream failure is not retried, it propagates).
     pub async fn put_object(&self, object: &ObjectId, body: &[u8]) -> Result<Version, WorkerError> {
+        let req_id = RequestId::next();
         let header = encode_put_header(
-            0,
+            req_id.0,
             &PutRequest {
                 object: object.clone(),
                 body_len: body.len() as u64,
@@ -246,7 +261,17 @@ impl WriteClient {
                 self.pool.release(&self.addr, stream);
                 Ok(version)
             }
-            Err((false, err)) => Err(err),
+            Err((false, err)) => {
+                tracing::error!(
+                    req = %req_id,
+                    worker = %self.addr,
+                    object = %object.to_path(),
+                    bytes = body.len(),
+                    error = %err,
+                    "worker put failed"
+                );
+                Err(err)
+            }
         }
     }
 
@@ -257,8 +282,9 @@ impl WriteClient {
         path: &Path,
         len: u64,
     ) -> Result<Version, WorkerError> {
+        let req_id = RequestId::next();
         let header = encode_put_header(
-            0,
+            req_id.0,
             &PutRequest {
                 object: object.clone(),
                 body_len: len,
@@ -283,7 +309,17 @@ impl WriteClient {
                 self.pool.release(&self.addr, stream);
                 Ok(version)
             }
-            Err((false, error)) => Err(error),
+            Err((false, error)) => {
+                tracing::error!(
+                    req = %req_id,
+                    worker = %self.addr,
+                    object = %object.to_path(),
+                    bytes = len,
+                    %error,
+                    "worker streamed put failed"
+                );
+                Err(error)
+            }
         }
     }
 
@@ -347,8 +383,9 @@ impl WriteClient {
 
     /// Delete `object` at the worker (which deletes it at the backend).
     pub async fn delete_object(&self, object: &ObjectId) -> Result<(), WorkerError> {
+        let req_id = RequestId::next();
         let frame = encode_delete(
-            0,
+            req_id.0,
             &DeleteRequest {
                 object: object.clone(),
             },
@@ -367,7 +404,16 @@ impl WriteClient {
                 self.pool.release(&self.addr, stream);
                 Ok(())
             }
-            Err((false, err)) => Err(err),
+            Err((false, err)) => {
+                tracing::error!(
+                    req = %req_id,
+                    worker = %self.addr,
+                    object = %object.to_path(),
+                    error = %err,
+                    "worker delete failed"
+                );
+                Err(err)
+            }
         }
     }
 
@@ -547,9 +593,53 @@ mod tests {
         addr
     }
 
+    /// Spawn a worker that records the `request_id` of each frame it receives,
+    /// serving `count` sequential requests with an empty-range reply.
+    async fn request_id_recording_worker(
+        count: usize,
+    ) -> (String, Arc<std::sync::Mutex<Vec<u32>>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let seen: Arc<std::sync::Mutex<Vec<u32>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorded = Arc::clone(&seen);
+        tokio::spawn(async move {
+            for _ in 0..count {
+                let (mut sock, _) = listener.accept().await.unwrap();
+                let mut hdr = [0u8; HEADER_LEN];
+                sock.read_exact(&mut hdr).await.unwrap();
+                let header = FrameHeader::decode(&hdr).unwrap();
+                let mut body = vec![0u8; header.length as usize];
+                sock.read_exact(&mut body).await.unwrap();
+                recorded.lock().unwrap().push(header.request_id);
+                // Echo the id back on the reply, as a real worker does.
+                let reply = response_header_ok(header.request_id, 0).to_vec();
+                sock.write_all(&reply).await.unwrap();
+                sock.flush().await.unwrap();
+            }
+        });
+        (addr, seen)
+    }
+
+    #[tokio::test]
+    async fn fetch_puts_a_unique_nonzero_request_id_on_the_wire() {
+        // Correlation (#304) depends on the client stamping a real id into the
+        // frame header: a hardcoded 0 makes client and worker logs unjoinable.
+        let (addr, seen) = request_id_recording_worker(2).await;
+        let client = WorkerClient::new(addr);
+        client.fetch_range(&object(), 0, 0).await.unwrap();
+        client.fetch_range(&object(), 0, 0).await.unwrap();
+
+        let ids = seen.lock().unwrap().clone();
+        assert_eq!(ids.len(), 2, "worker should have seen two requests");
+        assert!(ids[0] != 0 && ids[1] != 0, "request_id must not be zero");
+        assert_ne!(
+            ids[0], ids[1],
+            "each request needs a distinct id to be correlatable"
+        );
+    }
+
     #[tokio::test]
     async fn fetch_returns_raw_bytes() {
-        // Worker returns deterministic bytes for the requested range.
         let addr = mock_worker(|req| {
             let payload: Vec<u8> = (0..req.len).map(|i| (i % 251) as u8).collect();
             let mut out = response_header_ok(0, payload.len() as u32).to_vec();

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -32,7 +32,7 @@ use talon_backend::{
 };
 use talon_core::{
     azure_sas_from_env, gcs_bearer_from_env, s3_secret_key_from_env, s3_session_token_from_env,
-    BackendStore, NodeId, NodeInfo, NodeRole, WorkerConfig, WorkerConfigPatch,
+    BackendStore, NodeId, NodeInfo, NodeRole, RequestId, WorkerConfig, WorkerConfigPatch,
 };
 use talon_transport::data;
 use talon_transport::frame::{MsgType, HEADER_LEN};
@@ -762,6 +762,14 @@ async fn handle_conn(
                     .record_request_success(bytes.len() as u64, request_started.elapsed());
             }
             Err(e) => {
+                tracing::error!(
+                    req = %RequestId(h.request_id),
+                    object = %req.object.to_path(),
+                    offset = req.offset,
+                    len = req.len,
+                    error = %e,
+                    "serving range failed"
+                );
                 let err = data::encode_error(h.request_id, &e.to_string());
                 stream.write_all(&err).await?;
                 stream.flush().await?;

--- a/crates/talon-worker/src/uring_conn.rs
+++ b/crates/talon-worker/src/uring_conn.rs
@@ -57,7 +57,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use monoio::net::TcpStream;
-use talon_core::BlockHandle;
+use talon_core::{BlockHandle, RequestId};
 use talon_transport::data;
 use talon_transport::frame::{FrameHeader, MsgType, HEADER_LEN};
 use talon_transport::uring::{read_frame, write_all};
@@ -193,6 +193,14 @@ pub async fn handle_conn(
                     .record_request_success(n, request_started.elapsed());
             }
             Err(e) => {
+                tracing::error!(
+                    req = %RequestId(h.request_id),
+                    object = %req.object.to_path(),
+                    offset = req.offset,
+                    len = req.len,
+                    error = %e,
+                    "serving range failed"
+                );
                 let err = data::encode_error(h.request_id, &e.to_string());
                 write_all(&mut stream, err).await?;
                 observability


### PR DESCRIPTION
Fixes #304.

## Problem

`talon-core::trace` defines `RequestId` and documents it as being "propagated across hops" so that "a single request is traceable end-to-end", explicitly `u32`-shaped to match the frame header's `request_id` field. It was never called. The only reference outside `trace.rs` was the re-export in `lib.rs:34`.

All four data-plane client call sites passed a literal `0`:

```rust
let out = encode_request(0, &req)?;              // worker_client.rs:122
let header = encode_put_header(0, &PutRequest {  // :239
let header = encode_put_header(0, &PutRequest {  // :285
let frame = encode_delete(0, &DeleteRequest {    // :386
```

So every frame carried id 0 and there was nothing to correlate on. A read through the mount crosses client → coordinator → worker; when one is slow or returns `EIO`, joining those log streams meant guessing from timestamps.

Compounding this, the two data-plane serve paths encoded an error frame back to the client and bumped an error metric while writing **nothing** to the log:

```rust
Err(e) => {
    let err = data::encode_error(h.request_id, &e.to_string());
    stream.write_all(&err).await?;          // ...and the cause is gone
```

The workspace had 2 `error!` call sites total across ~30k lines of non-test code.

## Change

**Client** — allocate a `RequestId` per operation and put it on the wire, for `fetch_range`, `put_object`, `put_object_file`, `delete_object`. Log `error!` with the id, worker address, object and range when an operation fails on a *fresh* connection (the stale-pooled-retry path is not a real failure and stays quiet).

**Worker** — log `error!` with the propagated id, object and range when `serve` fails, on both data-plane paths: `main.rs` (Tokio fallback) and `uring_conn.rs` (io_uring, the default since #299). Both paths were changed so behaviour does not depend on which runtime is active.

Net: 4 new `error!` sites on paths that previously failed silently.

## Test

`fetch_puts_a_unique_nonzero_request_id_on_the_wire` — a mock worker records the `request_id` of each frame it receives and the test asserts the ids are non-zero and distinct across two fetches.

Verified the test actually catches the regression: reverting the one-line client change to `encode_request(0, ..)` makes it fail.

```
$ cargo test -p talon-fuse --all-features
test result: ok. 132 passed; 0 failed
$ cargo test --workspace --all-features
all green
```

## Notes

- I deliberately did **not** hold a span guard across `.await`. Entering a span and holding the guard over an await point leaks the span into whatever the executor runs next on that thread; the `get_span!`/`put_span!`/`load_span!` macros in `trace.rs` are still unused for that reason. Wiring them properly wants `tracing::Instrument` on the futures, which is a larger change and worth doing separately.
- The coordinator hop is not covered here — this PR is data-plane only. Extending the same id through `coordinator_client` placement lookups is the natural follow-up.
- Field names (`req`, `object`, `worker`) follow the existing convention in `trace.rs`, which deliberately keeps span fields identical to metrics label names.
