### PR TITLE
ci: add coverage reporting and a cargo-deny advisory gate

### DIFF
--- a/.github/workflows/audit-schedule.yml
+++ b/.github/workflows/audit-schedule.yml
@@ -1,0 +1,26 @@
+name: Dependency advisories (nightly)
+
+# The `audit` job in ci.yml covers every PR and push. This workflow exists for
+# the case that one cannot catch: a RUSTSEC advisory published against a crate
+# that is already in the tree, with no repository activity to trigger a run.
+#
+# Deliberately off the :00 mark — every scheduled workflow on GitHub asking for
+# "6am" fires at the same instant.
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  # Allow a manual run when triaging a newly-published advisory.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: dependency advisories
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-deny
+      - name: Check advisories, bans, and sources
+        run: cargo deny check advisories bans sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,3 +460,48 @@ jobs:
       - name: Publish report to job summary
         if: always()
         run: cat bench-report.md >> "$GITHUB_STEP_SUMMARY"
+
+  coverage:
+    name: coverage (informational)
+    runs-on: ubuntu-latest
+    # Informational. The workspace sits around 81% line coverage; the value of
+    # this job is making the *per-file* numbers visible so gaps get noticed
+    # (a new module landing at 0%, a rewrite dropping a file to half), not
+    # gating on a single aggregate. A threshold can follow once there is a
+    # baseline to argue from.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Install toolchain (llvm-tools)
+        run: rustup component add llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Measure coverage
+        run: cargo llvm-cov --workspace --all-features --summary-only | tee coverage.txt
+      - name: Publish report to job summary
+        if: always()
+        run: |
+          {
+            echo '### Coverage'
+            echo '```'
+            cat coverage.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  audit:
+    name: dependency advisories
+    runs-on: ubuntu-latest
+    # Blocking, unlike coverage: this has a crisp pass/fail. A crate in the tree
+    # either carries an unacknowledged RUSTSEC advisory or it does not. Known
+    # ones are acknowledged with a written justification in deny.toml.
+    #
+    # A nightly run lives in audit-schedule.yml: an advisory can be published
+    # against an already-merged crate, so the check needs a heartbeat that does
+    # not depend on someone opening a PR.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-deny
+      - name: Check advisories, bans, and sources
+        run: cargo deny check advisories bans sources

--- a/Justfile
+++ b/Justfile
@@ -88,3 +88,19 @@ bench-check *ARGS:
 # Print the current committed baseline.
 bench-baseline NAME="main":
     @cat bench/baselines/{{NAME}}.json
+
+# --- supply chain / coverage ---
+
+# Check the dependency tree for RUSTSEC advisories, banned crates, and unknown
+# sources (install: cargo install cargo-deny). Mirrors the CI `audit` gate.
+# Known advisories are acknowledged with written justifications in deny.toml.
+audit:
+    cargo deny check advisories bans sources
+
+# Per-file line coverage (install: cargo install cargo-llvm-cov).
+coverage:
+    cargo llvm-cov --workspace --all-features --summary-only
+
+# Coverage as a browsable HTML report under target/llvm-cov/html.
+coverage-html:
+    cargo llvm-cov --workspace --all-features --html

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,63 @@
+# cargo-deny configuration — supply-chain gate for the dependency tree.
+#
+# Run locally with `just audit`; CI runs the same command on every PR and on a
+# nightly schedule (an advisory published after a merge still needs to be caught).
+#
+# Scope: this file gates **security advisories** and **duplicate versions**.
+# License policy is deliberately not configured yet — see the note at the bottom.
+
+[advisories]
+# Fail on any advisory affecting a crate we actually build, except the
+# individually justified exceptions below. Each entry must say why it is
+# tolerated and what would remove it; an exception without an exit path is a
+# bug, not a policy.
+ignore = [
+    # RUSTSEC-2025-0141 — bincode 1.3.3 is unmaintained (the team ceased
+    # development; not a vulnerability). We use it for the control-plane codec.
+    # No known exploit; migration to bincode 2.x or postcard is a wire-format
+    # change and needs its own issue.
+    "RUSTSEC-2025-0141",
+
+    # RUSTSEC-2025-0057 — fxhash is unmaintained (not a vulnerability). Pulled
+    # in transitively by monoio 0.2.4, which is the io_uring data-plane runtime.
+    # Not directly reachable from our code; removal depends on monoio.
+    "RUSTSEC-2025-0057",
+
+    # RUSTSEC-2026-0177 — pyo3 <0.29 missing `Sync` bound on
+    # `PyCFunction::new_closure`. The Python client does not call that API
+    # (verified by grep over clients/python/src). Fixing means pyo3 0.22 -> 0.29,
+    # a semver-major bump with its own migration.
+    "RUSTSEC-2026-0177",
+
+    # RUSTSEC-2025-0020 — pyo3 <0.24.1 buffer overflow risk in
+    # `PyString::from_object`. Same reasoning: the API is not called by the
+    # Python client, and the fix is the same major bump.
+    "RUSTSEC-2025-0020",
+]
+
+[bans]
+# Duplicate major versions of the same crate bloat the binary and make it
+# ambiguous which copy a CVE applies to. Warn rather than deny: the tree
+# currently has legitimate duplicates via kube/tonic/etcd-client that we do not
+# control, and turning this red would make the gate noise rather than signal.
+multiple-versions = "warn"
+# Every wildcard requirement in this workspace is an intra-workspace `path`
+# dependency (`talon-core.workspace = true` and friends), which is normal and
+# not a supply-chain risk. cargo-deny's `allow-wildcard-paths` exemption only
+# applies to crates marked unpublishable, which ours are not, so this stays at
+# `warn` rather than flagging our own crates on every run.
+wildcards = "warn"
+
+[sources]
+# Only crates.io. A git or registry source appearing here would be a supply-chain
+# change worth failing on.
+unknown-registry = "deny"
+unknown-git = "deny"
+
+# NOTE on licenses: `cargo deny check licenses` currently rejects all 236
+# dependencies because no allow-list is configured. Choosing that list is a
+# licensing-policy decision for the project (which SPDX identifiers are
+# acceptable for an Apache-2.0 product), not something to settle in a CI plumbing
+# change. Until then CI runs `check advisories bans sources` explicitly rather
+# than bare `cargo deny check`, so the license gate is off rather than silently
+# passing. Enabling it is tracked separately.


### PR DESCRIPTION
Fixes #305.

## Problem

CI has 20 jobs and gates hard on correctness — `-D warnings`, `--locked`, real LocalStack/Azurite/fake-gcs/etcd contract tests, a kernel FUSE mount job that cannot silently pass. But it had no coverage measurement and no supply-chain scanning: neither `cargo-llvm-cov`, `tarpaulin`, `cargo-audit`, nor `cargo-deny` appeared anywhere in `.github/workflows/` or the `Justfile`.

## What `cargo-deny` found immediately

This is the concrete argument for the gate — running it against the current tree surfaced four advisories:

| Advisory | Crate | Kind |
|---|---|---|
| RUSTSEC-2026-0177 | pyo3 <0.29 | missing `Sync` bound on `PyCFunction::new_closure` |
| RUSTSEC-2025-0020 | pyo3 <0.24.1 | buffer overflow risk in `PyString::from_object` |
| RUSTSEC-2025-0141 | bincode 1.3.3 | unmaintained |
| RUSTSEC-2025-0057 | fxhash (via monoio 0.2.4) | unmaintained |

All four are **acknowledged in `deny.toml`, not silenced**. Each entry states why it is tolerated and what would remove it:

- Both pyo3 advisories cover APIs the Python client does not call — verified by grepping `clients/python/src` for `new_closure` and `PyString::from_object`, neither appears. Fixing them means pyo3 0.22 → 0.29, a semver-major bump that deserves its own PR.
- bincode and fxhash are unmaintained-crate notices, not vulnerabilities. bincode is our control-plane codec, so replacing it is a wire-format change; fxhash is transitive through monoio and not ours to drop.

## Coverage: the number is better than I assumed

I filed #305 implying coverage was probably thin. Measuring it first: the workspace is at **81.42% line / 80.80% region**, which is healthy. So this job is deliberately **informational with no threshold** — a single aggregate would encourage testing the easy crates, and there is nothing here to "fix".

Its value is per-file visibility. The current low spots:

```
crates/talon-fuse/src/mount.rs                18.20%
crates/talon-coordinator/src/main.rs          39.30%
crates/talon-coordinator/state_store/etcd.rs  47.02%
crates/talon-worker/src/main.rs               48.77%
crates/talon-coordinator/state_store/k8s.rs   55.43%
crates/talon-worker/src/uring_conn.rs         78.94%
```

Those are mostly `main.rs` wiring and the state-store backends behind contract tests, which is a reasonable shape. The job is there to catch a *new* module landing at 0% or a rewrite halving a file — not to argue about the total.

## Change

- **`coverage` job** — `cargo-llvm-cov`, `continue-on-error: true`, publishes the per-file table to the job summary.
- **`audit` job** — `cargo deny check advisories bans sources`, **blocking**. Unlike coverage this is unambiguous: a crate either carries an unacknowledged advisory or it does not.
- **`audit-schedule.yml`** — nightly (`17 6 * * *`) plus `workflow_dispatch`. An advisory can be published against an already-merged crate with no repo activity to trigger CI, so the check needs a heartbeat. Kept in a separate workflow so the schedule does not fire all 20 CI jobs; the cron minute is off the `:00` mark deliberately.
- **`just audit` / `just coverage` / `just coverage-html`** — mirror the gates locally, matching the existing convention where `just ci` mirrors CI.

## Deliberately not included

**License checking.** `cargo deny check licenses` currently rejects all 236 dependencies because no allow-list is configured. Deciding which SPDX identifiers are acceptable for an Apache-2.0 product is a licensing-policy call for the project, not something to settle in a CI plumbing PR. So CI runs the three subcommands explicitly (`advisories bans sources`) rather than bare `cargo deny check` — the license gate is *off* rather than silently passing, and `deny.toml` says so.

**`wildcards = "deny"`.** Every wildcard in this workspace is an intra-workspace path dep (`talon-core.workspace = true`). cargo-deny's `allow-wildcard-paths` exemption only applies to crates marked unpublishable, which ours are not, so denying would flag our own crates on every run. Left at `warn`.

## Verification

```
$ just audit
advisories ok, bans ok, sources ok

$ cargo llvm-cov --workspace --all-features --summary-only
TOTAL  37359  6942  81.42%   2533  451  82.20%   22328  4288  80.80%
```
