### PR TITLE
feat(worker): add inclusive L1 DRAM over L2 NVMe

### DIFF
--- a/.github/workflows/k8s-l1-l2-e2e.yml
+++ b/.github/workflows/k8s-l1-l2-e2e.yml
@@ -1,0 +1,47 @@
+name: Kubernetes L1/L2 E2E
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/k8s-l1-l2-e2e.yml"
+      - "crates/talon-client/**"
+      - "crates/talon-core/src/config.rs"
+      - "crates/talon-worker/**"
+      - "deploy/docker/**"
+      - "deploy/helm/talon/**"
+      - "scripts/k8s_l1_l2_e2e.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  multi-node:
+    name: 3-worker L1/L2 E2E and benchmark
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: helm/kind-action@v1.12.0
+        with:
+          install_only: true
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.18.4
+
+      - name: Run multi-node Kubernetes E2E
+        env:
+          BENCH_SECONDS: "3"
+        run: scripts/k8s_l1_l2_e2e.sh
+
+      - name: Upload E2E and benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k8s-l1-l2-e2e
+          path: .artifacts/k8s-l1-l2
+          if-no-files-found: warn

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -188,15 +188,16 @@ today; only the data-plane TCP scheduling layer diverges.
 
 **L1 memory hit** (optional, default off; for very hot small blocks): decode
 header + key → `mem_cache` lookup → send header → plain async socket write from
-a shared buffer (`Arc<Vec<u8>>` on the current Tokio runtime; `Rc<Vec<u8>>`
-under a thread-per-core ring, where the buffer never leaves its core). No disk,
-no `sendfile`.
+a shared `Bytes` buffer. L1 is inclusive: every DRAM entry also has an L2 copy,
+and an L2 eviction/delete/version replacement invalidates the L1 entry. No disk,
+no `sendfile`; capacity and maximum entry size are independently bounded.
 
-**L2 NVMe hit** (primary hot path): decode header + key → `BlockIndex` lookup →
-open cached `.blk` fd → write response header → `sendfile(cached_fd → socket)` in
-the blocking helper. The block is **never** read into a `Vec<u8>`, avoiding
-NVMe→userspace and userspace→socket copies, heap pressure, and buffer bloat on
-the runtime. Path is `NVMe/page-cache → kernel → TCP socket`.
+**L2 NVMe hit** (primary large-block path): decode header + key → `BlockIndex`
+lookup → open cached `.blk` fd → write response header →
+`sendfile(cached_fd → socket)` in the blocking helper. Large blocks are never
+read into a `Vec<u8>`, avoiding NVMe→userspace and userspace→socket copies, heap
+pressure, and buffer bloat. An L1-eligible small block is read once from L2 and
+promoted instead. Large-block path: `NVMe/page-cache → kernel → TCP socket`.
 
 **GET_RANGE hit:** identical to L2 hit but `sendfile` uses `(offset, length)` —
 suited to Lance / checkpoint footer / partial reads.
@@ -301,10 +302,11 @@ dedup (a correctness requirement — per-shard dedup would refetch the same
 
 ## 3. Worker storage
 
-- **Tiering:** primary store is local **NVMe SSD**. Memory holds only the index,
-  small-object cache, and hot metadata. No `mmap` as the default abstraction —
-  the Linux page cache already provides the memory tier; explicit
-  `pread`/`sendfile` is more controllable.
+- **Tiering:** optional byte-bounded **L1 DRAM** for small whole blocks over an
+  inclusive local **L2 NVMe SSD** store. L1 is empty after restart and promotes
+  eligible L2 hits; L2 remains persistent and authoritative for cache residency.
+  Large blocks bypass L1 and retain the `sendfile` path. No `mmap` as the default
+  abstraction.
 - **Eviction:** byte-accounted **LRU / segmented-LRU** first. LFU risks pinning
   stale hotspots; TinyLFU is more complex — revisit with real workload data.
   Capacity is per-worker, with support for multiple cache dirs each with its own

--- a/crates/talon-client/src/main.rs
+++ b/crates/talon-client/src/main.rs
@@ -37,6 +37,9 @@ struct Args {
     /// Connect directly to one worker, bypassing placement (diagnostics/tests).
     #[arg(long)]
     worker: Option<String>,
+    /// Resolve and print placement without connecting to the selected worker.
+    #[arg(long, conflicts_with = "worker")]
+    placement_only: bool,
     /// Object path, e.g. `/az/<container>/<blob>`.
     #[arg(long)]
     path: String,
@@ -87,6 +90,11 @@ async fn main() -> anyhow::Result<()> {
             worker_addr
         }
     };
+
+    if args.placement_only {
+        println!("placed {} on {}", args.path, worker_addr);
+        return Ok(());
+    }
 
     // Fetch the range from the selected worker.
     let start = Instant::now();
@@ -225,7 +233,35 @@ mod tests {
         .unwrap();
 
         assert_eq!(args.worker.as_deref(), Some("10.0.0.7:7001"));
+        assert!(!args.placement_only);
         assert_eq!(args.coordinator, "127.0.0.1:7000");
         assert_eq!(args.len, 4096);
+    }
+
+    #[test]
+    fn placement_only_mode_conflicts_with_direct_worker() {
+        let args = Args::try_parse_from([
+            "talon-client",
+            "--placement-only",
+            "--path",
+            "/s3/bucket/object",
+            "--len",
+            "4096",
+        ])
+        .unwrap();
+        assert!(args.placement_only);
+        assert!(args.worker.is_none());
+
+        assert!(Args::try_parse_from([
+            "talon-client",
+            "--placement-only",
+            "--worker",
+            "10.0.0.7:7001",
+            "--path",
+            "/s3/bucket/object",
+            "--len",
+            "4096",
+        ])
+        .is_err());
     }
 }

--- a/crates/talon-client/src/main.rs
+++ b/crates/talon-client/src/main.rs
@@ -14,7 +14,7 @@
 use std::time::Instant;
 
 use clap::Parser;
-use talon_core::{BlockId, ObjectId, Version};
+use talon_core::{BlockId, NodeRole, ObjectId, Version};
 use talon_transport::data::{self, RangeRequest};
 use talon_transport::frame::{Flags, HEADER_LEN};
 use talon_transport::{codec, ControlMessage, FrameHeader};
@@ -38,17 +38,20 @@ struct Args {
     #[arg(long)]
     worker: Option<String>,
     /// Resolve and print placement without connecting to the selected worker.
-    #[arg(long, conflicts_with = "worker")]
+    #[arg(long, conflicts_with_all = ["worker", "membership_only"])]
     placement_only: bool,
+    /// Print the coordinator's current worker membership and exit.
+    #[arg(long, conflicts_with_all = ["worker", "placement_only"])]
+    membership_only: bool,
     /// Object path, e.g. `/az/<container>/<blob>`.
-    #[arg(long)]
-    path: String,
+    #[arg(long, required_unless_present = "membership_only")]
+    path: Option<String>,
     /// Byte offset to start reading at.
     #[arg(long, default_value_t = 0)]
     offset: u64,
     /// Number of bytes to read.
-    #[arg(long)]
-    len: u64,
+    #[arg(long, required_unless_present = "membership_only")]
+    len: Option<u64>,
     /// Optional output file for the fetched bytes.
     #[arg(long)]
     out: Option<std::path::PathBuf>,
@@ -63,7 +66,29 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let args = Args::parse();
-    let object = ObjectId::from_path(&args.path)?;
+    if args.membership_only {
+        let mut nodes = membership_lookup(&args.coordinator).await?;
+        nodes.sort_by(|left, right| {
+            left.address
+                .cmp(&right.address)
+                .then_with(|| left.id.0.cmp(&right.id.0))
+        });
+        for node in nodes {
+            if node.role == NodeRole::Worker {
+                println!("member {} {}", node.id, node.address);
+            }
+        }
+        return Ok(());
+    }
+
+    let path = args
+        .path
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("--path is required for reads"))?;
+    let len = args
+        .len
+        .ok_or_else(|| anyhow::anyhow!("--len is required for reads"))?;
+    let object = ObjectId::from_path(path)?;
     let block = BlockId::new(
         object.clone(),
         (args.offset / PLACEMENT_BLOCK_SIZE as u64) * PLACEMENT_BLOCK_SIZE as u64,
@@ -92,22 +117,22 @@ async fn main() -> anyhow::Result<()> {
     };
 
     if args.placement_only {
-        println!("placed {} on {}", args.path, worker_addr);
+        println!("placed {path} on {worker_addr}");
         return Ok(());
     }
 
     // Fetch the range from the selected worker.
     let start = Instant::now();
-    let bytes = fetch_range(&worker_addr, &object, args.offset, args.len).await?;
+    let bytes = fetch_range(&worker_addr, &object, args.offset, len).await?;
     let elapsed = start.elapsed();
 
     // Verify the worker returned the full requested range. A short read means
     // truncation (or the object ended inside the range); either way, silently
     // reporting it as success would hide corruption (issue #112).
-    if (bytes.len() as u64) < args.len {
+    if (bytes.len() as u64) < len {
         anyhow::bail!(
             "short read: requested {} bytes at offset {}, got {} (truncated or past EOF)",
-            args.len,
+            len,
             args.offset,
             bytes.len()
         );
@@ -145,12 +170,18 @@ async fn placement_lookup(coordinator: &str, block: &BlockId) -> anyhow::Result<
 
 /// Send a `MembershipQuery` and resolve `owner_id` to its worker address.
 async fn resolve_address(coordinator: &str, owner_id: &str) -> anyhow::Result<String> {
+    membership_lookup(coordinator)
+        .await?
+        .into_iter()
+        .find(|n| n.id.0 == owner_id)
+        .map(|n| n.address)
+        .ok_or_else(|| anyhow::anyhow!("owner {owner_id} not in membership list"))
+}
+
+/// Return the coordinator's current membership snapshot.
+async fn membership_lookup(coordinator: &str) -> anyhow::Result<Vec<talon_core::NodeInfo>> {
     match request_control(coordinator, &ControlMessage::MembershipQuery {}).await? {
-        ControlMessage::MembershipList { nodes } => nodes
-            .into_iter()
-            .find(|n| n.id.0 == owner_id)
-            .map(|n| n.address)
-            .ok_or_else(|| anyhow::anyhow!("owner {owner_id} not in membership list")),
+        ControlMessage::MembershipList { nodes } => Ok(nodes),
         other => anyhow::bail!("unexpected membership reply: {other:?}"),
     }
 }
@@ -234,8 +265,9 @@ mod tests {
 
         assert_eq!(args.worker.as_deref(), Some("10.0.0.7:7001"));
         assert!(!args.placement_only);
+        assert!(!args.membership_only);
         assert_eq!(args.coordinator, "127.0.0.1:7000");
-        assert_eq!(args.len, 4096);
+        assert_eq!(args.len, Some(4096));
     }
 
     #[test]
@@ -250,6 +282,7 @@ mod tests {
         ])
         .unwrap();
         assert!(args.placement_only);
+        assert!(!args.membership_only);
         assert!(args.worker.is_none());
 
         assert!(Args::try_parse_from([
@@ -263,5 +296,38 @@ mod tests {
             "4096",
         ])
         .is_err());
+    }
+
+    #[test]
+    fn membership_only_mode_does_not_require_read_arguments() {
+        let args = Args::try_parse_from([
+            "talon-client",
+            "--membership-only",
+            "--coordinator",
+            "c:7000",
+        ])
+        .unwrap();
+
+        assert!(args.membership_only);
+        assert!(!args.placement_only);
+        assert!(args.worker.is_none());
+        assert!(args.path.is_none());
+        assert!(args.len.is_none());
+    }
+
+    #[test]
+    fn read_modes_still_require_path_and_length() {
+        assert!(Args::try_parse_from(["talon-client"]).is_err());
+        assert!(Args::try_parse_from([
+            "talon-client",
+            "--placement-only",
+            "--path",
+            "/s3/bucket/object",
+        ])
+        .is_err());
+        assert!(
+            Args::try_parse_from(["talon-client", "--membership-only", "--placement-only",])
+                .is_err()
+        );
     }
 }

--- a/crates/talon-client/src/main.rs
+++ b/crates/talon-client/src/main.rs
@@ -34,6 +34,9 @@ struct Args {
     /// Address of the coordinator to query for placement.
     #[arg(long, default_value = "127.0.0.1:7000")]
     coordinator: String,
+    /// Connect directly to one worker, bypassing placement (diagnostics/tests).
+    #[arg(long)]
+    worker: Option<String>,
     /// Object path, e.g. `/az/<container>/<blob>`.
     #[arg(long)]
     path: String,
@@ -65,18 +68,27 @@ async fn main() -> anyhow::Result<()> {
         Version::new(PLACEHOLDER_VERSION),
     );
 
-    // 1. Placement lookup: which worker owns this block?
-    let owners = placement_lookup(&args.coordinator, &block).await?;
-    let owner = owners
-        .first()
-        .ok_or_else(|| anyhow::anyhow!("no worker owns this block (empty cluster?)"))?;
-    tracing::info!(owner = %owner, "resolved owner");
+    let worker_addr = match args.worker {
+        Some(worker) => {
+            tracing::info!(worker_addr = %worker, "using direct worker");
+            worker
+        }
+        None => {
+            // 1. Placement lookup: which worker owns this block?
+            let owners = placement_lookup(&args.coordinator, &block).await?;
+            let owner = owners
+                .first()
+                .ok_or_else(|| anyhow::anyhow!("no worker owns this block (empty cluster?)"))?;
+            tracing::info!(owner = %owner, "resolved owner");
 
-    // 2. Resolve the owner id to a worker address.
-    let worker_addr = resolve_address(&args.coordinator, owner).await?;
-    tracing::info!(%worker_addr, "resolved worker address");
+            // 2. Resolve the owner id to a worker address.
+            let worker_addr = resolve_address(&args.coordinator, owner).await?;
+            tracing::info!(%worker_addr, "resolved worker address");
+            worker_addr
+        }
+    };
 
-    // 3. Fetch the range from the worker.
+    // Fetch the range from the selected worker.
     let start = Instant::now();
     let bytes = fetch_range(&worker_addr, &object, args.offset, args.len).await?;
     let elapsed = start.elapsed();
@@ -191,4 +203,29 @@ fn hex_prefix(bytes: &[u8]) -> String {
         let _ = write!(s, "{b:02x}");
     }
     s
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::Args;
+
+    #[test]
+    fn direct_worker_mode_is_parsed_without_changing_default_coordinator() {
+        let args = Args::try_parse_from([
+            "talon-client",
+            "--worker",
+            "10.0.0.7:7001",
+            "--path",
+            "/s3/bucket/object",
+            "--len",
+            "4096",
+        ])
+        .unwrap();
+
+        assert_eq!(args.worker.as_deref(), Some("10.0.0.7:7001"));
+        assert_eq!(args.coordinator, "127.0.0.1:7000");
+        assert_eq!(args.len, 4096);
+    }
 }

--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -83,6 +83,10 @@ pub struct WorkerConfig {
     pub cache_dirs: Vec<PathBuf>,
     /// Total cache capacity in bytes across all cache dirs.
     pub capacity_bytes: u64,
+    /// L1 DRAM cache capacity in bytes. Zero disables L1.
+    pub l1_capacity_bytes: u64,
+    /// Largest whole block eligible for admission into L1.
+    pub l1_max_entry_bytes: u64,
     /// Object-store backend selector: `azure` (default), `s3`, or `gcs`. The
     /// per-backend endpoint/credential fields below apply to the selected one.
     pub backend: Option<String>,
@@ -205,6 +209,8 @@ impl Default for WorkerConfig {
             block_size: 256 << 20,
             cache_dirs: vec![PathBuf::from("/var/cache/talon")],
             capacity_bytes: 64 << 30,
+            l1_capacity_bytes: 0,
+            l1_max_entry_bytes: 4 << 20,
             backend: None,
             azure_account: None,
             azure_endpoint: None,
@@ -253,6 +259,10 @@ pub struct WorkerConfigPatch {
     pub cache_dirs: Option<Vec<PathBuf>>,
     /// Override for [`WorkerConfig::capacity_bytes`].
     pub capacity_bytes: Option<u64>,
+    /// Override for [`WorkerConfig::l1_capacity_bytes`].
+    pub l1_capacity_bytes: Option<u64>,
+    /// Override for [`WorkerConfig::l1_max_entry_bytes`].
+    pub l1_max_entry_bytes: Option<u64>,
     /// Override for [`WorkerConfig::backend`].
     pub backend: Option<String>,
     /// Override for [`WorkerConfig::azure_account`].
@@ -302,6 +312,8 @@ impl Patch for WorkerConfigPatch {
             block_size: self.block_size.or(base.block_size),
             cache_dirs: self.cache_dirs.or(base.cache_dirs),
             capacity_bytes: self.capacity_bytes.or(base.capacity_bytes),
+            l1_capacity_bytes: self.l1_capacity_bytes.or(base.l1_capacity_bytes),
+            l1_max_entry_bytes: self.l1_max_entry_bytes.or(base.l1_max_entry_bytes),
             backend: self.backend.or(base.backend),
             azure_account: self.azure_account.or(base.azure_account),
             azure_endpoint: self.azure_endpoint.or(base.azure_endpoint),
@@ -414,6 +426,22 @@ pub const WORKER_ENV_SCHEMA: &[ConfigVar] = &[
         cli: false,
         secret: false,
         help: "Worker cache capacity (bytes).",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_L1_CAPACITY_BYTES",
+        key: "l1_capacity_bytes",
+        default: Some("0"),
+        cli: false,
+        secret: false,
+        help: "L1 DRAM cache capacity in bytes; 0 disables L1.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_L1_MAX_ENTRY_BYTES",
+        key: "l1_max_entry_bytes",
+        default: Some("4194304"),
+        cli: false,
+        secret: false,
+        help: "Largest whole block eligible for the L1 DRAM cache.",
     },
     ConfigVar {
         env: "TALON_WORKER_BACKEND",
@@ -596,6 +624,8 @@ pub(crate) mod worker_env {
     pub const BLOCK_SIZE: &str = "TALON_WORKER_BLOCK_SIZE";
     pub const CACHE_DIRS: &str = "TALON_WORKER_CACHE_DIRS";
     pub const CAPACITY_BYTES: &str = "TALON_WORKER_CAPACITY_BYTES";
+    pub const L1_CAPACITY_BYTES: &str = "TALON_WORKER_L1_CAPACITY_BYTES";
+    pub const L1_MAX_ENTRY_BYTES: &str = "TALON_WORKER_L1_MAX_ENTRY_BYTES";
     pub const BACKEND: &str = "TALON_WORKER_BACKEND";
     pub const AZURE_ACCOUNT: &str = "TALON_WORKER_AZURE_ACCOUNT";
     pub const AZURE_ENDPOINT: &str = "TALON_WORKER_AZURE_ENDPOINT";
@@ -684,6 +714,12 @@ impl WorkerConfigPatch {
             capacity_bytes: get(worker_env::CAPACITY_BYTES)
                 .map(|v| parse_u64(v, worker_env::CAPACITY_BYTES))
                 .transpose()?,
+            l1_capacity_bytes: get(worker_env::L1_CAPACITY_BYTES)
+                .map(|v| parse_u64(v, worker_env::L1_CAPACITY_BYTES))
+                .transpose()?,
+            l1_max_entry_bytes: get(worker_env::L1_MAX_ENTRY_BYTES)
+                .map(|v| parse_u64(v, worker_env::L1_MAX_ENTRY_BYTES))
+                .transpose()?,
             azure_account: get(worker_env::AZURE_ACCOUNT),
             azure_endpoint: get(worker_env::AZURE_ENDPOINT),
             backend: get(worker_env::BACKEND),
@@ -755,6 +791,8 @@ impl WorkerConfig {
             block_size: merged.block_size.unwrap_or(d.block_size),
             cache_dirs: merged.cache_dirs.unwrap_or(d.cache_dirs),
             capacity_bytes: merged.capacity_bytes.unwrap_or(d.capacity_bytes),
+            l1_capacity_bytes: merged.l1_capacity_bytes.unwrap_or(d.l1_capacity_bytes),
+            l1_max_entry_bytes: merged.l1_max_entry_bytes.unwrap_or(d.l1_max_entry_bytes),
             azure_account: merged.azure_account.or(d.azure_account),
             azure_endpoint: merged.azure_endpoint.or(d.azure_endpoint),
             backend: merged.backend.or(d.backend),
@@ -861,6 +899,19 @@ impl WorkerConfig {
                 "capacity_bytes ({}) must be >= block_size ({})",
                 self.capacity_bytes, self.block_size
             )));
+        }
+        if self.l1_capacity_bytes > 0 {
+            if self.l1_max_entry_bytes == 0 {
+                return Err(Error::Other(
+                    "l1_max_entry_bytes must be > 0 when L1 is enabled".into(),
+                ));
+            }
+            if self.l1_max_entry_bytes > self.l1_capacity_bytes {
+                return Err(Error::Other(format!(
+                    "l1_max_entry_bytes ({}) must be <= l1_capacity_bytes ({})",
+                    self.l1_max_entry_bytes, self.l1_capacity_bytes
+                )));
+            }
         }
         Ok(())
     }
@@ -1147,13 +1198,38 @@ mod tests {
     }
 
     #[test]
+    fn l1_config_respects_layer_precedence() {
+        let file = WorkerConfigPatch {
+            l1_capacity_bytes: Some(16 << 20),
+            l1_max_entry_bytes: Some(1 << 20),
+            ..Default::default()
+        };
+        let env = WorkerConfigPatch {
+            l1_capacity_bytes: Some(32 << 20),
+            l1_max_entry_bytes: Some(2 << 20),
+            ..Default::default()
+        };
+        let cli = WorkerConfigPatch {
+            l1_capacity_bytes: Some(64 << 20),
+            ..Default::default()
+        };
+
+        let cfg = WorkerConfig::resolve(file, env, cli).unwrap();
+        assert_eq!(cfg.l1_capacity_bytes, 64 << 20);
+        assert_eq!(cfg.l1_max_entry_bytes, 2 << 20);
+    }
+
+    #[test]
     fn from_toml_parses_and_rejects_unknown() {
         let patch = WorkerConfigPatch::from_toml(
-            "listen = \"0.0.0.0:9000\"\ncache_dirs = [\"/a\", \"/b\"]\n",
+            "listen = \"0.0.0.0:9000\"\ncache_dirs = [\"/a\", \"/b\"]\n\
+             l1_capacity_bytes = 67108864\nl1_max_entry_bytes = 1048576\n",
         )
         .unwrap();
         assert_eq!(patch.listen.as_deref(), Some("0.0.0.0:9000"));
         assert_eq!(patch.cache_dirs.unwrap().len(), 2);
+        assert_eq!(patch.l1_capacity_bytes, Some(64 << 20));
+        assert_eq!(patch.l1_max_entry_bytes, Some(1 << 20));
         assert!(WorkerConfigPatch::from_toml("bogus_key = 1").is_err());
     }
 
@@ -1168,6 +1244,8 @@ mod tests {
             "TALON_WORKER_BACKEND_DELAY_MS" => Some("300".to_string()),
             "TALON_WORKER_BACKEND_JITTER_MS" => Some("50".to_string()),
             "TALON_WORKER_BACKEND_THROUGHPUT_BYTES" => Some("1048576".to_string()),
+            "TALON_WORKER_L1_CAPACITY_BYTES" => Some("67108864".to_string()),
+            "TALON_WORKER_L1_MAX_ENTRY_BYTES" => Some("1048576".to_string()),
             "TALON_WORKER_BACKEND" => Some("s3".to_string()),
             "TALON_WORKER_S3_REGION" => Some("us-east-1".to_string()),
             "TALON_WORKER_S3_PATH_STYLE" => Some("true".to_string()),
@@ -1186,6 +1264,8 @@ mod tests {
         assert_eq!(patch.backend_delay_ms, Some(300));
         assert_eq!(patch.backend_jitter_ms, Some(50));
         assert_eq!(patch.backend_throughput_bytes, Some(1 << 20));
+        assert_eq!(patch.l1_capacity_bytes, Some(64 << 20));
+        assert_eq!(patch.l1_max_entry_bytes, Some(1 << 20));
         assert_eq!(patch.backend.as_deref(), Some("s3"));
         assert_eq!(patch.s3_region.as_deref(), Some("us-east-1"));
         assert_eq!(patch.s3_path_style, Some(true));
@@ -1228,6 +1308,22 @@ mod tests {
         };
         let err = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
         assert!(err.to_string().contains("cluster_id"));
+
+        let cli = WorkerConfigPatch {
+            l1_capacity_bytes: Some(1024),
+            l1_max_entry_bytes: Some(2048),
+            ..Default::default()
+        };
+        let err = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
+        assert!(err.to_string().contains("l1_max_entry_bytes"));
+
+        let cli = WorkerConfigPatch {
+            l1_capacity_bytes: Some(1024),
+            l1_max_entry_bytes: Some(0),
+            ..Default::default()
+        };
+        let err = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
+        assert!(err.to_string().contains("must be > 0"));
     }
 
     #[test]

--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -776,10 +776,14 @@ impl WorkerConfig {
         let merged = cli.merge(env).merge(file);
         let d = WorkerConfig::default();
         let listen = merged.listen.unwrap_or(d.listen);
+        let advertise_addr = normalize_worker_advertise_addr(
+            merged.advertise_addr.unwrap_or_else(|| listen.clone()),
+            &listen,
+        );
         let cfg = WorkerConfig {
             // Advertise the routable address if set, else fall back to the bind
             // address (issue #118: never silently advertise a wildcard bind).
-            advertise_addr: merged.advertise_addr.unwrap_or_else(|| listen.clone()),
+            advertise_addr,
             listen,
             admin_listen: merged.admin_listen.unwrap_or(d.admin_listen),
             coordinator: merged.coordinator.unwrap_or(d.coordinator),
@@ -915,6 +919,18 @@ impl WorkerConfig {
         }
         Ok(())
     }
+}
+
+/// The Kubernetes Downward API can expose a Pod IP but cannot append a port.
+/// Accept that common shape and inherit the configured data-plane listen port.
+fn normalize_worker_advertise_addr(advertise_addr: String, listen: &str) -> String {
+    let Ok(ip) = advertise_addr.parse::<std::net::IpAddr>() else {
+        return advertise_addr;
+    };
+    let Ok(listen) = listen.parse::<std::net::SocketAddr>() else {
+        return advertise_addr;
+    };
+    std::net::SocketAddr::new(ip, listen.port()).to_string()
 }
 
 /// Fully-resolved FUSE client configuration.
@@ -1335,6 +1351,24 @@ mod tests {
         };
         let cfg = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap();
         assert_eq!(cfg.advertise_addr, "10.0.0.5:7001");
+
+        // Kubernetes injects a bare Pod IP through the Downward API. It inherits
+        // the data-plane port so the registered address remains dialable.
+        let cli = WorkerConfigPatch {
+            listen: Some("0.0.0.0:7101".into()),
+            advertise_addr: Some("10.244.1.7".into()),
+            ..Default::default()
+        };
+        let cfg = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap();
+        assert_eq!(cfg.advertise_addr, "10.244.1.7:7101");
+
+        let cli = WorkerConfigPatch {
+            listen: Some("[::]:7201".into()),
+            advertise_addr: Some("fd00::7".into()),
+            ..Default::default()
+        };
+        let cfg = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap();
+        assert_eq!(cfg.advertise_addr, "[fd00::7]:7201");
 
         // A wildcard bind can be used for `listen` as long as `advertise_addr`
         // is a routable address.

--- a/crates/talon-worker/src/lib.rs
+++ b/crates/talon-worker/src/lib.rs
@@ -26,7 +26,7 @@ pub use capacity::{CacheDirConfig, CacheDirs};
 pub use eviction::{CacheUnit, Lru};
 pub use index::{BlockIndex, Presence};
 pub use loader::{LoadOutcome, LoadTask, LoaderPool};
-pub use memory_store::MemoryStore;
+pub use memory_store::{MemoryInsert, MemoryStore};
 pub use miss::{touched_pages, Admission, InFlightGuard, InFlightLoads, LoadKey};
 pub use observability::{serve_admin, WorkerMetrics, WorkerObservability, WorkerReadiness};
 pub use paged_store::PagedBlockStore;

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -134,6 +134,8 @@ impl Args {
             data_plane_rings: self.data_plane_rings,
             cache_dirs: None,
             capacity_bytes: None,
+            l1_capacity_bytes: None,
+            l1_max_entry_bytes: None,
             backend: None,
             azure_account: None,
             azure_endpoint: None,
@@ -268,6 +270,8 @@ async fn main() -> anyhow::Result<()> {
         block_size = cfg.block_size,
         cache_dirs = ?cfg.cache_dirs,
         capacity_bytes = cfg.capacity_bytes,
+        l1_capacity_bytes = cfg.l1_capacity_bytes,
+        l1_max_entry_bytes = cfg.l1_max_entry_bytes,
         azure_account = ?cfg.azure_account,
         azure_endpoint = ?cfg.azure_endpoint,
         "starting talon-worker"
@@ -325,6 +329,9 @@ async fn main() -> anyhow::Result<()> {
     )?);
     observability.readiness().set_backend_ready(true);
     observability.readiness().set_store_ready(true);
+    observability
+        .metrics()
+        .set_l1_capacity(cfg.l1_capacity_bytes);
 
     // The networked HTTP client, shared by whichever backend is selected. Two
     // decorators may wrap it, innermost first: retry (always on — a cache with
@@ -412,13 +419,15 @@ async fn main() -> anyhow::Result<()> {
     };
     tracing::info!(backend = backend_kind, "object-store backend ready");
 
-    let worker = Arc::new(WorkerRuntime::new(
+    let worker = Arc::new(WorkerRuntime::new_with_l1(
         store,
         index,
         inflight,
         backend,
         cfg.block_size,
         cfg.capacity_bytes,
+        cfg.l1_capacity_bytes,
+        cfg.l1_max_entry_bytes,
         observability.metrics().clone(),
     ));
 

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -308,6 +308,7 @@ async fn main() -> anyhow::Result<()> {
         }
     }
     let inflight = Arc::new(InFlightLoads::new());
+    let backend_kind = cfg.backend.as_deref().unwrap_or("azure");
     let node = NodeInfo {
         id: NodeId::new(
             cfg.node_id
@@ -319,11 +320,12 @@ async fn main() -> anyhow::Result<()> {
         address: cfg.advertise_addr.clone(),
         role: NodeRole::Worker,
     };
-    let observability = Arc::new(WorkerObservability::new(
+    let observability = Arc::new(WorkerObservability::new_with_backend(
         cfg.cluster_id.clone(),
         node.clone(),
         cfg.admin_listen.clone(),
         cfg.capacity_bytes,
+        backend_kind,
         Arc::clone(&index),
         Arc::clone(&inflight),
     )?);
@@ -408,7 +410,6 @@ async fn main() -> anyhow::Result<()> {
 
     // Select the object-store backend from config (default: azure). Each backend
     // reads its endpoint from config and its secret from the environment only.
-    let backend_kind = cfg.backend.as_deref().unwrap_or("azure");
     let backend: Arc<dyn BackendStore> = match backend_kind {
         "azure" => Arc::new(build_azure_backend(&cfg, http)?),
         "s3" => Arc::new(build_s3_backend(&cfg, http)?),

--- a/crates/talon-worker/src/memory_store.rs
+++ b/crates/talon-worker/src/memory_store.rs
@@ -1,43 +1,218 @@
-//! A simple in-memory [`ObjectStore`] implementation.
+//! Byte-accounted in-memory L1 block store.
 //!
-//! This backs the optional L1 memory path and tests. It fully implements the
-//! byte-oriented methods (`get_bytes`/`put`/`delete`/`contains`); the zero-copy
-//! fd methods (`get_block`/`get_page`/`get_range`) are wired in the dedicated
-//! worker-store PR and currently report the block/page as absent.
+//! The store is intentionally scoped to small whole blocks. Large blocks stay in
+//! the NVMe-backed L2 where the data plane can serve them with `sendfile(2)`.
+//! Reads clone [`Bytes`], which is reference-counted and does not copy payload
+//! bytes, and atomically mark the entry most-recently-used.
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use std::collections::HashMap;
-use std::sync::RwLock;
+use std::sync::Mutex;
 use talon_core::{BlockHandle, BlockId, Error, ObjectStore, PageIndex, Result};
 
-/// An in-memory object store backed by a hash map.
-#[derive(Default)]
+/// Outcome of attempting to admit a block into L1.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MemoryInsert {
+    /// L1 is disabled (`capacity_bytes == 0`).
+    Disabled,
+    /// The block exceeds the configured per-entry limit or total L1 capacity.
+    TooLarge,
+    /// The block was admitted; these colder entries were evicted to make room.
+    Inserted {
+        /// Evicted L1 block identities, coldest first.
+        evicted: Vec<BlockId>,
+    },
+}
+
+struct Entry {
+    value: Bytes,
+    last_used: u64,
+}
+
+struct Inner {
+    entries: HashMap<BlockId, Entry>,
+    resident_bytes: u64,
+    clock: u64,
+}
+
+/// An in-memory L1 store with byte capacity and LRU eviction.
 pub struct MemoryStore {
-    inner: RwLock<HashMap<BlockId, Bytes>>,
+    inner: Mutex<Inner>,
+    capacity_bytes: u64,
+    max_entry_bytes: u64,
 }
 
 impl MemoryStore {
-    /// Create an empty store.
+    /// Create an empty store without a practical payload limit.
+    ///
+    /// This preserves the original `MemoryStore::new()` behavior for callers
+    /// using it as a standalone in-memory [`ObjectStore`]. Worker L1 instances
+    /// should use [`MemoryStore::with_limits`].
     pub fn new() -> Self {
-        Self::default()
+        Self::with_limits(u64::MAX, u64::MAX)
     }
 
-    /// Return the number of stored blocks.
+    /// Create a store with L1 admission disabled.
+    pub fn disabled() -> Self {
+        Self::with_limits(0, 0)
+    }
+
+    /// Create an L1 store bounded by total and per-entry byte limits.
+    ///
+    /// A zero capacity disables admission. `max_entry_bytes` is clamped to the
+    /// total capacity so an entry can never evict the cache and then fail to fit.
+    pub fn with_limits(capacity_bytes: u64, max_entry_bytes: u64) -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                entries: HashMap::new(),
+                resident_bytes: 0,
+                clock: 0,
+            }),
+            capacity_bytes,
+            max_entry_bytes: max_entry_bytes.min(capacity_bytes),
+        }
+    }
+
+    /// Whether L1 admission is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.capacity_bytes > 0 && self.max_entry_bytes > 0
+    }
+
+    /// Configured total L1 capacity.
+    pub fn capacity_bytes(&self) -> u64 {
+        self.capacity_bytes
+    }
+
+    /// Maximum size of one admitted L1 entry.
+    pub fn max_entry_bytes(&self) -> u64 {
+        self.max_entry_bytes
+    }
+
+    /// Whether a block of `len` bytes is eligible for L1.
+    pub fn is_eligible(&self, len: u64) -> bool {
+        self.is_enabled() && len <= self.max_entry_bytes && len <= self.capacity_bytes
+    }
+
+    /// Return the number of resident L1 blocks.
     pub fn len(&self) -> usize {
-        self.inner.read().unwrap().len()
+        self.inner.lock().unwrap().entries.len()
     }
 
-    /// Return whether the store is empty.
+    /// Return whether L1 contains no blocks.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Return resident L1 payload bytes.
+    pub fn resident_bytes(&self) -> u64 {
+        self.inner.lock().unwrap().resident_bytes
+    }
+
+    /// Fetch and mark a block most-recently-used.
+    pub fn get(&self, id: &BlockId) -> Option<Bytes> {
+        let mut inner = self.inner.lock().unwrap();
+        inner.clock = inner.clock.saturating_add(1);
+        let tick = inner.clock;
+        let entry = inner.entries.get_mut(id)?;
+        entry.last_used = tick;
+        Some(entry.value.clone())
+    }
+
+    /// Admit or replace a block and enforce the configured L1 capacity.
+    pub fn insert(&self, id: BlockId, value: Bytes) -> MemoryInsert {
+        let len = value.len() as u64;
+        if !self.is_enabled() {
+            return MemoryInsert::Disabled;
+        }
+        if !self.is_eligible(len) {
+            return MemoryInsert::TooLarge;
+        }
+
+        let mut inner = self.inner.lock().unwrap();
+        inner.clock = inner.clock.saturating_add(1);
+        let tick = inner.clock;
+        if let Some(previous) = inner.entries.remove(&id) {
+            inner.resident_bytes = inner
+                .resident_bytes
+                .saturating_sub(previous.value.len() as u64);
+        }
+        inner.resident_bytes = inner.resident_bytes.saturating_add(len);
+        inner.entries.insert(
+            id,
+            Entry {
+                value,
+                last_used: tick,
+            },
+        );
+
+        let mut evicted = Vec::new();
+        while inner.resident_bytes > self.capacity_bytes {
+            let victim = inner
+                .entries
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_used)
+                .map(|(id, _)| id.clone());
+            let Some(victim) = victim else {
+                break;
+            };
+            if let Some(entry) = inner.entries.remove(&victim) {
+                inner.resident_bytes = inner
+                    .resident_bytes
+                    .saturating_sub(entry.value.len() as u64);
+                evicted.push(victim);
+            }
+        }
+        MemoryInsert::Inserted { evicted }
+    }
+
+    /// Remove one block, returning whether it was resident.
+    pub fn remove(&self, id: &BlockId) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+        let Some(entry) = inner.entries.remove(id) else {
+            return false;
+        };
+        inner.resident_bytes = inner
+            .resident_bytes
+            .saturating_sub(entry.value.len() as u64);
+        true
+    }
+
+    /// Remove every old version of the same logical block as `keep`.
+    pub fn remove_superseded(&self, keep: &BlockId) -> Vec<BlockId> {
+        let mut inner = self.inner.lock().unwrap();
+        let victims: Vec<BlockId> = inner
+            .entries
+            .keys()
+            .filter(|id| {
+                id.object == keep.object
+                    && id.offset == keep.offset
+                    && id.block_size == keep.block_size
+                    && id.version != keep.version
+            })
+            .cloned()
+            .collect();
+        for victim in &victims {
+            if let Some(entry) = inner.entries.remove(victim) {
+                inner.resident_bytes = inner
+                    .resident_bytes
+                    .saturating_sub(entry.value.len() as u64);
+            }
+        }
+        victims
+    }
+}
+
+impl Default for MemoryStore {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 #[async_trait]
 impl ObjectStore for MemoryStore {
     async fn get_block(&self, id: &BlockId) -> Result<BlockHandle> {
-        // Zero-copy fd path is provided by the NVMe-backed worker store.
+        // A DRAM entry has no file descriptor; callers use `get_bytes`.
         Err(Error::NotFound(id.to_string()))
     }
 
@@ -50,21 +225,21 @@ impl ObjectStore for MemoryStore {
     }
 
     async fn get_bytes(&self, id: &BlockId) -> Result<Bytes> {
-        self.inner
-            .read()
-            .unwrap()
-            .get(id)
-            .cloned()
-            .ok_or_else(|| Error::NotFound(id.to_string()))
+        self.get(id).ok_or_else(|| Error::NotFound(id.to_string()))
     }
 
     async fn put(&self, id: &BlockId, value: Bytes) -> Result<()> {
-        self.inner.write().unwrap().insert(id.clone(), value);
-        Ok(())
+        match self.insert(id.clone(), value) {
+            MemoryInsert::Inserted { .. } => Ok(()),
+            MemoryInsert::Disabled => Err(Error::Other("L1 memory store is disabled".into())),
+            MemoryInsert::TooLarge => Err(Error::Other(format!(
+                "block {id} exceeds L1 entry/capacity limit"
+            ))),
+        }
     }
 
     async fn delete(&self, id: &BlockId) -> Result<()> {
-        self.inner.write().unwrap().remove(id);
+        self.remove(id);
         Ok(())
     }
 }
@@ -74,19 +249,19 @@ mod tests {
     use super::*;
     use talon_core::{Backend, ObjectId, Version};
 
-    fn block(name: &str) -> BlockId {
+    fn block(name: &str, version: &str) -> BlockId {
         BlockId::new(
             ObjectId::new(Backend::S3, "bucket", name),
             0,
             256 * 1024 * 1024,
-            Version::new("v1"),
+            Version::new(version),
         )
     }
 
     #[tokio::test]
     async fn put_get_delete_roundtrip() {
-        let store = MemoryStore::new();
-        let id = block("hello");
+        let store = MemoryStore::with_limits(64, 64);
+        let id = block("hello", "v1");
 
         store.put(&id, Bytes::from_static(b"world")).await.unwrap();
         assert_eq!(
@@ -94,8 +269,138 @@ mod tests {
             Bytes::from_static(b"world")
         );
         assert!(store.contains(&id).await.unwrap());
+        assert_eq!(store.resident_bytes(), 5);
 
         store.delete(&id).await.unwrap();
         assert!(!store.contains(&id).await.unwrap());
+        assert_eq!(store.resident_bytes(), 0);
+    }
+
+    #[test]
+    fn disabled_and_oversized_entries_are_not_admitted() {
+        let disabled = MemoryStore::disabled();
+        assert_eq!(
+            disabled.insert(block("a", "v1"), Bytes::from_static(b"a")),
+            MemoryInsert::Disabled
+        );
+        assert!(disabled.is_empty());
+
+        let store = MemoryStore::with_limits(8, 4);
+        assert_eq!(
+            store.insert(block("a", "v1"), Bytes::from_static(b"12345")),
+            MemoryInsert::TooLarge
+        );
+        assert!(store.is_empty());
+    }
+
+    #[tokio::test]
+    async fn default_store_remains_writable_and_disabled_put_is_an_error() {
+        let store = MemoryStore::new();
+        let id = block("default", "v1");
+        store
+            .put(&id, Bytes::from_static(b"payload"))
+            .await
+            .unwrap();
+        assert_eq!(
+            store.get_bytes(&id).await.unwrap(),
+            Bytes::from_static(b"payload")
+        );
+
+        let disabled = MemoryStore::disabled();
+        let error = disabled
+            .put(&id, Bytes::from_static(b"payload"))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("disabled"));
+        assert!(disabled.is_empty());
+    }
+
+    #[test]
+    fn max_entry_limit_is_clamped_to_capacity() {
+        let store = MemoryStore::with_limits(4, 8);
+        assert_eq!(store.capacity_bytes(), 4);
+        assert_eq!(store.max_entry_bytes(), 4);
+        assert!(store.is_eligible(4));
+        assert!(!store.is_eligible(5));
+    }
+
+    #[test]
+    fn lru_eviction_is_byte_accounted_and_touch_sensitive() {
+        let store = MemoryStore::with_limits(8, 4);
+        let a = block("a", "v1");
+        let b = block("b", "v1");
+        let c = block("c", "v1");
+        assert_eq!(
+            store.insert(a.clone(), Bytes::from_static(b"aaaa")),
+            MemoryInsert::Inserted { evicted: vec![] }
+        );
+        assert_eq!(
+            store.insert(b.clone(), Bytes::from_static(b"bbbb")),
+            MemoryInsert::Inserted { evicted: vec![] }
+        );
+        assert_eq!(store.get(&a), Some(Bytes::from_static(b"aaaa")));
+
+        assert_eq!(
+            store.insert(c.clone(), Bytes::from_static(b"cccc")),
+            MemoryInsert::Inserted {
+                evicted: vec![b.clone()]
+            }
+        );
+        assert!(store.get(&b).is_none());
+        assert!(store.get(&a).is_some());
+        assert!(store.get(&c).is_some());
+        assert_eq!(store.resident_bytes(), 8);
+    }
+
+    #[test]
+    fn replacing_an_entry_updates_accounting_without_self_eviction() {
+        let store = MemoryStore::with_limits(8, 8);
+        let id = block("a", "v1");
+        store.insert(id.clone(), Bytes::from_static(b"123456"));
+        assert_eq!(store.resident_bytes(), 6);
+        assert_eq!(
+            store.insert(id.clone(), Bytes::from_static(b"xy")),
+            MemoryInsert::Inserted { evicted: vec![] }
+        );
+        assert_eq!(store.resident_bytes(), 2);
+        assert_eq!(store.get(&id), Some(Bytes::from_static(b"xy")));
+    }
+
+    #[test]
+    fn superseded_versions_are_removed_without_touching_other_blocks() {
+        let store = MemoryStore::with_limits(64, 16);
+        let old = block("same", "v1");
+        let keep = block("same", "v2");
+        let other = block("other", "v1");
+        for id in [&old, &keep, &other] {
+            store.insert(id.clone(), Bytes::from_static(b"data"));
+        }
+
+        assert_eq!(store.remove_superseded(&keep), vec![old.clone()]);
+        assert!(store.get(&old).is_none());
+        assert!(store.get(&keep).is_some());
+        assert!(store.get(&other).is_some());
+        assert_eq!(store.resident_bytes(), 8);
+    }
+
+    #[test]
+    fn concurrent_reads_and_inserts_stay_within_capacity() {
+        let store = std::sync::Arc::new(MemoryStore::with_limits(1024, 32));
+        let mut threads = Vec::new();
+        for worker in 0..8 {
+            let store = std::sync::Arc::clone(&store);
+            threads.push(std::thread::spawn(move || {
+                for n in 0..500 {
+                    let id = block(&format!("{worker}-{n}"), "v1");
+                    store.insert(id.clone(), Bytes::from(vec![worker as u8; 16]));
+                    let _ = store.get(&id);
+                }
+            }));
+        }
+        for thread in threads {
+            thread.join().unwrap();
+        }
+        assert!(store.resident_bytes() <= store.capacity_bytes());
+        assert!(store.len() <= 64);
     }
 }

--- a/crates/talon-worker/src/observability.rs
+++ b/crates/talon-worker/src/observability.rs
@@ -22,8 +22,6 @@ use tokio::net::TcpListener;
 
 use crate::{BlockIndex, InFlightLoads};
 
-const BACKEND_LABELS: &[(&str, &str)] = &[("backend", "azure")];
-
 /// Pre-registered metric handles used on worker hot paths.
 #[derive(Clone)]
 pub struct WorkerMetrics {
@@ -80,7 +78,13 @@ impl Drop for ActiveConnectionGuard {
 impl WorkerMetrics {
     /// Create all worker metric families and initialize configured capacity.
     pub fn new(configured_capacity_bytes: u64) -> Self {
+        Self::new_with_backend(configured_capacity_bytes, "azure")
+    }
+
+    /// Create worker metrics labeled with the configured object-store backend.
+    pub fn new_with_backend(configured_capacity_bytes: u64, backend: &str) -> Self {
         let registry = Metrics::new();
+        let backend_labels = labels(&[("backend", backend)]);
         registry
             .gauge(
                 "talon_worker_build_info",
@@ -147,42 +151,42 @@ impl WorkerMetrics {
         let backend_fetch_bytes_total = registry.counter(
             "talon_worker_backend_fetch_bytes_total",
             "Bytes fetched from the origin backend.",
-            labels(BACKEND_LABELS),
+            backend_labels.clone(),
         );
         let backend_fetch_errors_total = registry.counter(
             "talon_worker_backend_fetch_errors_total",
             "Origin backend range fetch failures.",
-            labels(BACKEND_LABELS),
+            backend_labels.clone(),
         );
         let backend_retries_total = registry.counter(
             "talon_worker_backend_retries_total",
             "Origin backend requests re-issued after a transient failure.",
-            labels(BACKEND_LABELS),
+            backend_labels.clone(),
         );
         let backend_timeouts_total = registry.counter(
             "talon_worker_backend_timeouts_total",
             "Origin backend request attempts that exceeded their deadline.",
-            labels(BACKEND_LABELS),
+            backend_labels.clone(),
         );
         let backend_write_bytes_total = registry.counter(
             "talon_worker_backend_write_bytes_total",
             "Bytes written through to the origin backend.",
-            labels(BACKEND_LABELS),
+            backend_labels.clone(),
         );
         let backend_write_errors_total = registry.counter(
             "talon_worker_backend_write_errors_total",
             "Origin backend object PUT failures.",
-            labels(BACKEND_LABELS),
+            backend_labels.clone(),
         );
         let backend_delete_total = registry.counter(
             "talon_worker_backend_delete_total",
             "Objects deleted from the origin backend.",
-            labels(BACKEND_LABELS),
+            backend_labels.clone(),
         );
         let backend_delete_errors_total = registry.counter(
             "talon_worker_backend_delete_errors_total",
             "Origin backend object DELETE failures.",
-            labels(BACKEND_LABELS),
+            backend_labels.clone(),
         );
         let evictions_total = registry.counter(
             "talon_worker_evictions_total",
@@ -207,7 +211,7 @@ impl WorkerMetrics {
         let backend_fetch_duration_seconds = registry.histogram(
             "talon_worker_backend_fetch_duration_seconds",
             "Origin backend range fetch latency in seconds.",
-            labels(BACKEND_LABELS),
+            backend_labels,
         );
         let active_connections = registry.gauge(
             "talon_worker_active_connections",
@@ -608,6 +612,27 @@ impl WorkerObservability {
         index: Arc<BlockIndex>,
         inflight: Arc<InFlightLoads>,
     ) -> std::io::Result<Self> {
+        Self::new_with_backend(
+            cluster_id,
+            node,
+            admin_address,
+            capacity_bytes,
+            "azure",
+            index,
+            inflight,
+        )
+    }
+
+    /// Create worker observability labeled with the selected object-store backend.
+    pub fn new_with_backend(
+        cluster_id: String,
+        node: NodeInfo,
+        admin_address: String,
+        capacity_bytes: u64,
+        backend: &str,
+        index: Arc<BlockIndex>,
+        inflight: Arc<InFlightLoads>,
+    ) -> std::io::Result<Self> {
         Ok(Self {
             node,
             cluster_id,
@@ -617,7 +642,7 @@ impl WorkerObservability {
             started_at_unix_ms: now_unix_ms(),
             started: Instant::now(),
             heartbeat_seq: AtomicU64::new(0),
-            metrics: WorkerMetrics::new(capacity_bytes),
+            metrics: WorkerMetrics::new_with_backend(capacity_bytes, backend),
             readiness: WorkerReadiness::default(),
             index,
             inflight,
@@ -798,6 +823,16 @@ mod tests {
             )
             .unwrap(),
         )
+    }
+
+    #[test]
+    fn backend_metrics_use_the_configured_backend_label() {
+        let metrics = WorkerMetrics::new_with_backend(4096, "s3");
+        metrics.record_backend_fetch_success(1024, Duration::from_millis(5));
+
+        let rendered = metrics.render();
+        assert!(rendered.contains("talon_worker_backend_fetch_bytes_total{backend=\"s3\"} 1024"));
+        assert!(!rendered.contains("backend=\"azure\""));
     }
 
     #[test]

--- a/crates/talon-worker/src/observability.rs
+++ b/crates/talon-worker/src/observability.rs
@@ -35,6 +35,12 @@ pub struct WorkerMetrics {
     bytes_served_total: Counter,
     cache_hits_total: Counter,
     cache_misses_total: Counter,
+    l1_hits_total: Counter,
+    l1_misses_total: Counter,
+    l2_hits_total: Counter,
+    l2_misses_total: Counter,
+    l1_admissions_total: Counter,
+    l1_evictions_total: Counter,
     backend_fetch_bytes_total: Counter,
     backend_fetch_errors_total: Counter,
     backend_retries_total: Counter,
@@ -53,6 +59,9 @@ pub struct WorkerMetrics {
     block_count: Gauge,
     page_count: Gauge,
     resident_bytes: Gauge,
+    l1_blocks: Gauge,
+    l1_resident_bytes: Gauge,
+    l1_capacity_bytes: Gauge,
     ready: Gauge,
     process_uptime_seconds: Gauge,
 }
@@ -104,6 +113,36 @@ impl WorkerMetrics {
             "talon_worker_cache_misses_total",
             "Worker cache misses.",
             labels(&[("form", "whole")]),
+        );
+        let l1_hits_total = registry.counter(
+            "talon_worker_cache_tier_hits_total",
+            "Worker cache hits by storage tier.",
+            labels(&[("tier", "l1")]),
+        );
+        let l1_misses_total = registry.counter(
+            "talon_worker_cache_tier_misses_total",
+            "Worker cache misses by storage tier.",
+            labels(&[("tier", "l1")]),
+        );
+        let l2_hits_total = registry.counter(
+            "talon_worker_cache_tier_hits_total",
+            "Worker cache hits by storage tier.",
+            labels(&[("tier", "l2")]),
+        );
+        let l2_misses_total = registry.counter(
+            "talon_worker_cache_tier_misses_total",
+            "Worker cache misses by storage tier.",
+            labels(&[("tier", "l2")]),
+        );
+        let l1_admissions_total = registry.counter(
+            "talon_worker_l1_admissions_total",
+            "Blocks admitted or promoted into the L1 DRAM cache.",
+            BTreeMap::new(),
+        );
+        let l1_evictions_total = registry.counter(
+            "talon_worker_l1_evictions_total",
+            "Blocks evicted from the L1 DRAM cache.",
+            BTreeMap::new(),
         );
         let backend_fetch_bytes_total = registry.counter(
             "talon_worker_backend_fetch_bytes_total",
@@ -195,6 +234,21 @@ impl WorkerMetrics {
             "Bytes currently resident in the worker cache.",
             BTreeMap::new(),
         );
+        let l1_blocks = registry.gauge(
+            "talon_worker_l1_blocks",
+            "Blocks currently resident in the L1 DRAM cache.",
+            BTreeMap::new(),
+        );
+        let l1_resident_bytes = registry.gauge(
+            "talon_worker_l1_resident_bytes",
+            "Payload bytes currently resident in the L1 DRAM cache.",
+            BTreeMap::new(),
+        );
+        let l1_capacity_bytes = registry.gauge(
+            "talon_worker_l1_capacity_bytes",
+            "Configured L1 DRAM cache capacity in bytes.",
+            BTreeMap::new(),
+        );
         let capacity_bytes = registry.gauge(
             "talon_worker_capacity_bytes",
             "Configured worker cache capacity in bytes.",
@@ -221,6 +275,12 @@ impl WorkerMetrics {
             bytes_served_total,
             cache_hits_total,
             cache_misses_total,
+            l1_hits_total,
+            l1_misses_total,
+            l2_hits_total,
+            l2_misses_total,
+            l1_admissions_total,
+            l1_evictions_total,
             backend_fetch_bytes_total,
             backend_fetch_errors_total,
             backend_retries_total,
@@ -239,6 +299,9 @@ impl WorkerMetrics {
             block_count,
             page_count,
             resident_bytes,
+            l1_blocks,
+            l1_resident_bytes,
+            l1_capacity_bytes,
             ready,
             process_uptime_seconds,
         }
@@ -266,6 +329,47 @@ impl WorkerMetrics {
     /// Record a whole-block cache miss.
     pub fn record_cache_miss(&self) {
         self.cache_misses_total.inc();
+    }
+
+    /// Record an L1 DRAM hit.
+    pub fn record_l1_hit(&self) {
+        self.l1_hits_total.inc();
+    }
+
+    /// Record an L1 DRAM miss.
+    pub fn record_l1_miss(&self) {
+        self.l1_misses_total.inc();
+    }
+
+    /// Record an L2 NVMe hit.
+    pub fn record_l2_hit(&self) {
+        self.l2_hits_total.inc();
+    }
+
+    /// Record an L2 NVMe miss.
+    pub fn record_l2_miss(&self) {
+        self.l2_misses_total.inc();
+    }
+
+    /// Record a block admitted or promoted into L1.
+    pub fn record_l1_admission(&self) {
+        self.l1_admissions_total.inc();
+    }
+
+    /// Record a capacity eviction from L1.
+    pub fn record_l1_eviction(&self) {
+        self.l1_evictions_total.inc();
+    }
+
+    /// Set the configured L1 capacity.
+    pub fn set_l1_capacity(&self, capacity_bytes: u64) {
+        self.l1_capacity_bytes.set(capacity_bytes as f64);
+    }
+
+    /// Publish current L1 entry and byte residency.
+    pub fn update_l1_residency(&self, blocks: u64, resident_bytes: u64) {
+        self.l1_blocks.set(blocks as f64);
+        self.l1_resident_bytes.set(resident_bytes as f64);
     }
 
     /// Record a successful backend fetch.

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -12,7 +12,8 @@ use talon_core::{
 use talon_transport::data::RangeRequest;
 
 use crate::{
-    BlockIndex, CacheUnit, InFlightLoads, LoadKey, Lru, Presence, WholeBlockStore, WorkerMetrics,
+    BlockIndex, CacheUnit, InFlightLoads, LoadKey, Lru, MemoryInsert, MemoryStore, Presence,
+    WholeBlockStore, WorkerMetrics,
 };
 
 /// Default lifetime of a cached resolved object version.
@@ -47,6 +48,9 @@ pub enum ServeOutcome {
 
 /// Shared state required to serve instrumented data-plane range requests.
 pub struct WorkerRuntime {
+    /// Small-block DRAM cache. L1 is inclusive: every entry also exists in L2.
+    l1: Arc<MemoryStore>,
+    /// Persistent local-NVMe cache.
     store: WholeBlockStore,
     index: Arc<BlockIndex>,
     inflight: Arc<InFlightLoads>,
@@ -81,11 +85,44 @@ impl WorkerRuntime {
         capacity_bytes: u64,
         metrics: WorkerMetrics,
     ) -> Self {
+        Self::new_with_l1(
+            store,
+            index,
+            inflight,
+            backend,
+            block_size,
+            capacity_bytes,
+            0,
+            0,
+            metrics,
+        )
+    }
+
+    /// Create a runtime with an explicit L1 DRAM tier over the L2 NVMe store.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_l1(
+        store: WholeBlockStore,
+        index: Arc<BlockIndex>,
+        inflight: Arc<InFlightLoads>,
+        backend: Arc<dyn BackendStore>,
+        block_size: u32,
+        capacity_bytes: u64,
+        l1_capacity_bytes: u64,
+        l1_max_entry_bytes: u64,
+        metrics: WorkerMetrics,
+    ) -> Self {
         let lru = Arc::new(Lru::new());
         for (id, len) in index.snapshot_lens() {
             lru.insert(CacheUnit::Whole(id), len);
         }
+        let l1 = Arc::new(MemoryStore::with_limits(
+            l1_capacity_bytes,
+            l1_max_entry_bytes,
+        ));
+        metrics.set_l1_capacity(l1_capacity_bytes);
+        metrics.update_l1_residency(0, 0);
         Self {
+            l1,
             store,
             index,
             inflight,
@@ -207,14 +244,43 @@ impl WorkerRuntime {
             .ok_or_else(|| anyhow::anyhow!("range offset+len overflows u64"))?;
         let start_block = (request.offset / block_size) * block_size;
 
-        // Zero-copy fast path: whole range within one block that is resident.
+        // Single-block fast paths: L1 bytes first, then an L2 sendfile handle.
         if end <= start_block + block_size {
             let block = self.block_for(&request.object, request.offset, version);
+            let offset_in_block = request.offset - block.offset;
+            if let Some(bytes) = self.l1_get(&block) {
+                return Ok(ServeOutcome::Bytes(slice(
+                    &bytes,
+                    offset_in_block,
+                    request.len,
+                )?));
+            }
             if matches!(
                 self.index.presence(&block, PageIndex(0), PageIndex(1)),
                 Presence::Whole
             ) {
-                let offset_in_block = request.offset - block.offset;
+                // Small blocks are promoted into L1 on their first post-restart L2
+                // hit. Large blocks preserve the zero-copy sendfile path.
+                if self
+                    .index
+                    .get(&block)
+                    .is_some_and(|meta| self.l1.is_eligible(meta.len))
+                {
+                    match self.store.get_bytes(&block).await {
+                        Ok(bytes) => {
+                            self.record_l2_hit(&block);
+                            self.admit_l1(&block, bytes.clone());
+                            return Ok(ServeOutcome::Bytes(slice(
+                                &bytes,
+                                offset_in_block,
+                                request.len,
+                            )?));
+                        }
+                        Err(error) => {
+                            tracing::debug!(%block, %error, "L2 promotion read lost an eviction race");
+                        }
+                    }
+                }
                 // Open an fd over exactly the requested window. This can fail if
                 // the block was evicted between the presence check and the open
                 // (a benign race); fall through to the byte path in that case.
@@ -227,9 +293,8 @@ impl WorkerRuntime {
                     // the requested window.
                     Ok(mut handles) if handles.len() == 1 => {
                         let handle = handles.pop().expect("one handle");
-                        self.metrics.record_cache_hit();
-                        self.lru.touch(&CacheUnit::Whole(block.clone()));
-                        tracing::info!(block = %block, "HIT (sendfile)");
+                        self.record_l2_hit(&block);
+                        tracing::info!(block = %block, tier = "l2", "HIT (sendfile)");
                         return Ok(ServeOutcome::Sendfile(handle));
                     }
                     Ok(_) | Err(_) => {
@@ -239,6 +304,15 @@ impl WorkerRuntime {
                     }
                 }
             }
+
+            self.metrics.record_l2_miss();
+            self.metrics.record_cache_miss();
+            let bytes = self.load_block_bytes(request, &block).await?;
+            return Ok(ServeOutcome::Bytes(slice(
+                &bytes,
+                offset_in_block,
+                request.len,
+            )?));
         }
 
         // Fallback: miss or boundary-spanning read → in-memory bytes.
@@ -396,6 +470,15 @@ impl WorkerRuntime {
         }
 
         self.metrics.record_cache_miss();
+        self.load_block_bytes(request, block).await
+    }
+
+    /// Load one block after both L1 and L2 have missed.
+    async fn load_block_bytes(
+        &self,
+        request: &RangeRequest,
+        block: &BlockId,
+    ) -> anyhow::Result<bytes::Bytes> {
         let key = LoadKey::Whole(block.clone());
         match self.inflight.admit_owned(key.clone()) {
             Some(guard) => {
@@ -437,24 +520,79 @@ impl WorkerRuntime {
 
     /// Return a block's bytes from the local cache if resident, else `None`.
     async fn cached_block(&self, block: &BlockId) -> anyhow::Result<Option<bytes::Bytes>> {
+        if let Some(bytes) = self.l1_get(block) {
+            return Ok(Some(bytes));
+        }
         if matches!(
             self.index.presence(block, PageIndex(0), PageIndex(1)),
             Presence::Whole
         ) {
-            self.metrics.record_cache_hit();
-            // Mark the block most-recently-used so a hot block is not the eviction
-            // victim under pressure (issue #159).
-            self.lru.touch(&CacheUnit::Whole(block.clone()));
-            tracing::info!(block = %block, "HIT");
+            self.record_l2_hit(block);
+            tracing::info!(block = %block, tier = "l2", "HIT");
             let bytes = self
                 .store
                 .get_bytes(block)
                 .await
                 .map_err(|error| anyhow::anyhow!("read committed block: {error}"))?;
+            self.admit_l1(block, bytes.clone());
             Ok(Some(bytes))
         } else {
+            self.metrics.record_l2_miss();
             Ok(None)
         }
+    }
+
+    /// Read L1 and keep the inclusive L2 parent hot when present.
+    fn l1_get(&self, block: &BlockId) -> Option<bytes::Bytes> {
+        if !self.l1.is_enabled() {
+            return None;
+        }
+        match self.l1.get(block) {
+            Some(bytes) => {
+                self.metrics.record_l1_hit();
+                self.metrics.record_cache_hit();
+                self.lru.touch(&CacheUnit::Whole(block.clone()));
+                tracing::info!(block = %block, tier = "l1", "HIT");
+                Some(bytes)
+            }
+            None => {
+                self.metrics.record_l1_miss();
+                None
+            }
+        }
+    }
+
+    /// Record an L2 hit and touch its capacity LRU.
+    fn record_l2_hit(&self, block: &BlockId) {
+        self.metrics.record_l2_hit();
+        self.metrics.record_cache_hit();
+        self.lru.touch(&CacheUnit::Whole(block.clone()));
+    }
+
+    /// Admit eligible bytes into L1 and publish resulting residency/evictions.
+    fn admit_l1(&self, block: &BlockId, bytes: bytes::Bytes) {
+        match self.l1.insert(block.clone(), bytes) {
+            MemoryInsert::Inserted { evicted } => {
+                self.metrics.record_l1_admission();
+                for victim in evicted {
+                    self.metrics.record_l1_eviction();
+                    tracing::debug!(block = %victim, tier = "l1", "evicted block");
+                }
+                self.refresh_l1_metrics();
+            }
+            MemoryInsert::Disabled | MemoryInsert::TooLarge => {}
+        }
+    }
+
+    fn invalidate_l1(&self, block: &BlockId) {
+        if self.l1.remove(block) {
+            self.refresh_l1_metrics();
+        }
+    }
+
+    fn refresh_l1_metrics(&self) {
+        self.metrics
+            .update_l1_residency(self.l1.len() as u64, self.l1.resident_bytes());
     }
 
     /// Fetch a block from the backend and commit it to the local cache.
@@ -511,6 +649,10 @@ impl WorkerRuntime {
         self.unlink_units(superseded).await;
         self.enforce_capacity().await;
         self.lru.unpin(&CacheUnit::Whole(block.clone()));
+        if !self.l1.remove_superseded(block).is_empty() {
+            self.refresh_l1_metrics();
+        }
+        self.admit_l1(block, bytes.clone());
         tracing::info!(block = %block, bytes = len, "committed block");
         Ok(bytes)
     }
@@ -559,7 +701,7 @@ impl WorkerRuntime {
         let block = self.block_for(object, 0, &version);
         let len = body.len() as u64;
         self.store
-            .put(&block, body)
+            .put(&block, body.clone())
             .await
             .map_err(|error| anyhow::anyhow!("commit written block failed: {error}"))?;
         self.index.commit(BlockMeta {
@@ -574,6 +716,10 @@ impl WorkerRuntime {
         self.unlink_units(superseded).await;
         self.enforce_capacity().await;
         self.lru.unpin(&CacheUnit::Whole(block.clone()));
+        if !self.l1.remove_superseded(&block).is_empty() {
+            self.refresh_l1_metrics();
+        }
+        self.admit_l1(&block, body);
         tracing::info!(object = %object.to_path(), bytes = len, version = %version, "wrote object");
         Ok(version)
     }
@@ -674,6 +820,7 @@ impl WorkerRuntime {
             let CacheUnit::Whole(id) = unit else {
                 continue;
             };
+            self.invalidate_l1(&id);
             if let Err(error) = self.store.delete(&id).await {
                 tracing::warn!(block = %id, %error, "failed to unlink evicted block");
             }
@@ -693,20 +840,30 @@ impl WorkerRuntime {
         self.index.resident_bytes()
     }
 
+    /// Number of blocks resident in L1.
+    pub fn l1_block_count(&self) -> u64 {
+        self.l1.len() as u64
+    }
+
+    /// Bytes resident in L1.
+    pub fn l1_resident_bytes(&self) -> u64 {
+        self.l1.resident_bytes()
+    }
+
     /// Number of backend loads currently in flight.
     pub fn inflight_loads(&self) -> u64 {
         self.inflight.len() as u64
     }
 }
 
-fn slice(buffer: &[u8], offset: u64, len: u64) -> anyhow::Result<bytes::Bytes> {
+fn slice(buffer: &bytes::Bytes, offset: u64, len: u64) -> anyhow::Result<bytes::Bytes> {
     let start = usize::try_from(offset).map_err(|_| anyhow::anyhow!("offset is too large"))?;
     if start > buffer.len() {
         anyhow::bail!("offset {offset} beyond block length {} bytes", buffer.len());
     }
     let requested = usize::try_from(len).unwrap_or(usize::MAX);
     let end = start.saturating_add(requested).min(buffer.len());
-    Ok(bytes::Bytes::copy_from_slice(&buffer[start..end]))
+    Ok(buffer.slice(start..end))
 }
 
 /// Whether an error chain carries a backend [`Error::VersionMismatch`], i.e. an
@@ -782,6 +939,28 @@ mod tests {
         .with_version_ttl(Duration::ZERO)
     }
 
+    fn runtime_l1(
+        backend: Arc<MockBackend>,
+        metrics: WorkerMetrics,
+        root: &PathBuf,
+        l2_capacity: u64,
+        l1_capacity: u64,
+        l1_max_entry: u64,
+    ) -> WorkerRuntime {
+        WorkerRuntime::new_with_l1(
+            WholeBlockStore::open(root).unwrap(),
+            Arc::new(BlockIndex::new()),
+            Arc::new(InFlightLoads::new()),
+            backend,
+            8,
+            l2_capacity,
+            l1_capacity,
+            l1_max_entry,
+            metrics,
+        )
+        .with_version_ttl(Duration::ZERO)
+    }
+
     #[tokio::test]
     async fn miss_then_hit_records_cache_and_backend_metrics() {
         let root = tmp_root();
@@ -806,6 +985,322 @@ mod tests {
         assert!(rendered.contains("talon_worker_cache_misses_total{form=\"whole\"} 1"));
         assert!(rendered.contains("talon_worker_cache_hits_total{form=\"whole\"} 1"));
         assert!(rendered.contains("talon_worker_backend_fetch_bytes_total{backend=\"azure\"} 8"));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn l1_origin_fill_then_hit_uses_memory_bytes() {
+        let root = tmp_root();
+        let backend = Arc::new(MockBackend {
+            calls: AtomicUsize::new(0),
+        });
+        let metrics = WorkerMetrics::new(1024);
+        let runtime = runtime_l1(Arc::clone(&backend), metrics.clone(), &root, 1024, 16, 8);
+
+        match runtime.serve(&request("l1")).await.unwrap() {
+            ServeOutcome::Bytes(bytes) => assert_eq!(bytes, Bytes::from_static(b"abcd")),
+            ServeOutcome::Sendfile(_) => panic!("origin miss must return fetched bytes"),
+        }
+        assert_eq!(runtime.l1_block_count(), 1);
+        assert_eq!(runtime.l1_resident_bytes(), 8);
+
+        match runtime.serve(&request("l1")).await.unwrap() {
+            ServeOutcome::Bytes(bytes) => assert_eq!(bytes, Bytes::from_static(b"abcd")),
+            ServeOutcome::Sendfile(_) => panic!("eligible warm block must hit L1"),
+        }
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+        let rendered = metrics.render();
+        assert!(rendered.contains("talon_worker_cache_tier_hits_total{tier=\"l1\"} 1"));
+        assert!(rendered.contains("talon_worker_cache_tier_misses_total{tier=\"l1\"} 1"));
+        assert!(rendered.contains("talon_worker_cache_tier_misses_total{tier=\"l2\"} 1"));
+        assert!(rendered.contains("talon_worker_l1_admissions_total 1"));
+        assert!(rendered.contains("talon_worker_l1_blocks 1"));
+        assert!(rendered.contains("talon_worker_l1_resident_bytes 8"));
+        assert!(rendered.contains("talon_worker_l1_capacity_bytes 16"));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn disabled_l1_preserves_l2_sendfile_behavior() {
+        let root = tmp_root();
+        let backend = Arc::new(MockBackend {
+            calls: AtomicUsize::new(0),
+        });
+        let metrics = WorkerMetrics::new(1024);
+        let runtime = runtime_l1(Arc::clone(&backend), metrics.clone(), &root, 1024, 0, 0);
+
+        let _ = runtime.serve(&request("disabled")).await.unwrap();
+        assert_eq!(
+            read_handle(runtime.serve(&request("disabled")).await.unwrap()),
+            b"abcd"
+        );
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(runtime.l1_block_count(), 0);
+        assert_eq!(runtime.l1_resident_bytes(), 0);
+        let rendered = metrics.render();
+        assert!(rendered.contains("talon_worker_cache_tier_hits_total{tier=\"l2\"} 1"));
+        assert!(rendered.contains("talon_worker_l1_admissions_total 0"));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn entry_at_l1_size_limit_is_admitted() {
+        let root = tmp_root();
+        let backend = Arc::new(MockBackend {
+            calls: AtomicUsize::new(0),
+        });
+        let runtime = runtime_l1(
+            Arc::clone(&backend),
+            WorkerMetrics::new(1024),
+            &root,
+            1024,
+            8,
+            8,
+        );
+
+        let _ = runtime.serve(&request("boundary")).await.unwrap();
+        assert_eq!(runtime.l1_block_count(), 1);
+        assert_eq!(runtime.l1_resident_bytes(), 8);
+        match runtime.serve(&request("boundary")).await.unwrap() {
+            ServeOutcome::Bytes(bytes) => assert_eq!(bytes, Bytes::from_static(b"abcd")),
+            ServeOutcome::Sendfile(_) => panic!("entry at the limit must be admitted to L1"),
+        }
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn oversized_block_stays_on_l2_sendfile_path() {
+        let root = tmp_root();
+        let backend = Arc::new(MockBackend {
+            calls: AtomicUsize::new(0),
+        });
+        let metrics = WorkerMetrics::new(1024);
+        let runtime = runtime_l1(Arc::clone(&backend), metrics.clone(), &root, 1024, 16, 4);
+
+        let _ = runtime.serve(&request("large")).await.unwrap();
+        assert_eq!(runtime.l1_block_count(), 0);
+        assert_eq!(
+            read_handle(runtime.serve(&request("large")).await.unwrap()),
+            b"abcd"
+        );
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+        assert!(metrics
+            .render()
+            .contains("talon_worker_cache_tier_hits_total{tier=\"l2\"} 1"));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn l1_eviction_falls_back_to_l2_without_origin_fetch() {
+        let root = tmp_root();
+        let backend = Arc::new(MockBackend {
+            calls: AtomicUsize::new(0),
+        });
+        let metrics = WorkerMetrics::new(1024);
+        let runtime = runtime_l1(Arc::clone(&backend), metrics.clone(), &root, 1024, 8, 8);
+
+        let _ = runtime.serve(&request("a")).await.unwrap();
+        let _ = runtime.serve(&request("b")).await.unwrap();
+        assert_eq!(runtime.block_count(), 2, "both parents remain in L2");
+        assert_eq!(runtime.l1_block_count(), 1, "L1 holds only the MRU block");
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 2);
+
+        match runtime.serve(&request("a")).await.unwrap() {
+            ServeOutcome::Bytes(bytes) => assert_eq!(bytes, Bytes::from_static(b"abcd")),
+            ServeOutcome::Sendfile(_) => panic!("eligible L2 hit should promote to L1"),
+        }
+        assert_eq!(
+            backend.calls.load(Ordering::SeqCst),
+            2,
+            "L1 eviction must degrade to L2, not origin"
+        );
+        assert_eq!(runtime.block_count(), 2);
+        assert_eq!(runtime.l1_block_count(), 1);
+        assert!(metrics
+            .render()
+            .contains("talon_worker_l1_evictions_total 2"));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn l2_eviction_invalidates_inclusive_l1_copy() {
+        let root = tmp_root();
+        let backend = Arc::new(MockBackend {
+            calls: AtomicUsize::new(0),
+        });
+        let runtime = runtime_l1(Arc::clone(&backend), WorkerMetrics::new(8), &root, 8, 16, 8);
+
+        let _ = runtime.serve(&request("a")).await.unwrap();
+        let _ = runtime.serve(&request("b")).await.unwrap();
+        assert_eq!(runtime.block_count(), 1, "L2 capacity keeps one block");
+        assert_eq!(
+            runtime.l1_block_count(),
+            1,
+            "evicted L2 parent must not leave an orphan L1 copy"
+        );
+
+        let _ = runtime.serve(&request("a")).await.unwrap();
+        assert_eq!(
+            backend.calls.load(Ordering::SeqCst),
+            3,
+            "reading the L2-evicted block must fetch origin again"
+        );
+        assert_eq!(runtime.block_count(), 1);
+        assert_eq!(runtime.l1_block_count(), 1);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn restart_rebuilds_l2_then_promotes_without_refetching_body() {
+        let root = tmp_root();
+        let backend = Arc::new(MockBackend {
+            calls: AtomicUsize::new(0),
+        });
+        let first = runtime_l1(
+            Arc::clone(&backend),
+            WorkerMetrics::new(1024),
+            &root,
+            1024,
+            16,
+            8,
+        );
+        let _ = first.serve(&request("restart")).await.unwrap();
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+        drop(first);
+
+        let store = WholeBlockStore::open(&root).unwrap();
+        let index = Arc::new(BlockIndex::new());
+        for meta in store.scan().unwrap() {
+            index.commit(meta);
+        }
+        let restarted = WorkerRuntime::new_with_l1(
+            store,
+            index,
+            Arc::new(InFlightLoads::new()),
+            Arc::clone(&backend) as Arc<dyn BackendStore>,
+            8,
+            1024,
+            16,
+            8,
+            WorkerMetrics::new(1024),
+        )
+        .with_version_ttl(Duration::ZERO);
+        assert_eq!(restarted.l1_block_count(), 0);
+        assert_eq!(restarted.block_count(), 1);
+
+        match restarted.serve(&request("restart")).await.unwrap() {
+            ServeOutcome::Bytes(bytes) => assert_eq!(bytes, Bytes::from_static(b"abcd")),
+            ServeOutcome::Sendfile(_) => panic!("eligible L2 block should promote after restart"),
+        }
+        assert_eq!(
+            backend.calls.load(Ordering::SeqCst),
+            1,
+            "restart promotion must not refetch object bytes"
+        );
+        assert_eq!(restarted.l1_block_count(), 1);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn concurrent_warm_reads_are_all_served_from_l1() {
+        let root = tmp_root();
+        let backend = Arc::new(MockBackend {
+            calls: AtomicUsize::new(0),
+        });
+        let metrics = WorkerMetrics::new(1024);
+        let runtime = Arc::new(runtime_l1(
+            Arc::clone(&backend),
+            metrics.clone(),
+            &root,
+            1024,
+            16,
+            8,
+        ));
+        let _ = runtime.serve(&request("hot")).await.unwrap();
+
+        let mut tasks = Vec::new();
+        for _ in 0..64 {
+            let runtime = Arc::clone(&runtime);
+            tasks.push(tokio::spawn(async move {
+                runtime.serve_range(&request("hot")).await.unwrap()
+            }));
+        }
+        for task in tasks {
+            assert_eq!(task.await.unwrap(), Bytes::from_static(b"abcd"));
+        }
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+        assert!(metrics
+            .render()
+            .contains("talon_worker_cache_tier_hits_total{tier=\"l1\"} 64"));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn cross_block_read_is_filled_then_served_entirely_from_l1() {
+        let root = tmp_root();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let backend = Arc::new(CountingRampBackend {
+            block_size: 8,
+            calls: Arc::clone(&calls),
+        });
+        let metrics = WorkerMetrics::new(1024);
+        let runtime = WorkerRuntime::new_with_l1(
+            WholeBlockStore::open(&root).unwrap(),
+            Arc::new(BlockIndex::new()),
+            Arc::new(InFlightLoads::new()),
+            backend,
+            8,
+            1024,
+            16,
+            8,
+            metrics.clone(),
+        )
+        .with_version_ttl(Duration::ZERO);
+        let req = RangeRequest {
+            object: ObjectId::new(Backend::Azure, "container", "cross-l1"),
+            offset: 6,
+            len: 8,
+        };
+
+        assert_eq!(runtime.serve_range(&req).await.unwrap(), expected(6, 8));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(runtime.l1_block_count(), 2);
+        assert_eq!(runtime.l1_resident_bytes(), 16);
+
+        assert_eq!(runtime.serve_range(&req).await.unwrap(), expected(6, 8));
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "both blocks must be served from L1 after the first read"
+        );
+        assert!(metrics
+            .render()
+            .contains("talon_worker_cache_tier_hits_total{tier=\"l1\"} 2"));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn backend_failure_does_not_populate_either_cache_tier() {
+        let root = tmp_root();
+        let backend = Arc::new(MockBackend {
+            calls: AtomicUsize::new(0),
+        });
+        let runtime = runtime_l1(
+            Arc::clone(&backend),
+            WorkerMetrics::new(1024),
+            &root,
+            1024,
+            16,
+            8,
+        );
+
+        assert!(runtime.serve(&request("failure")).await.is_err());
+        assert_eq!(runtime.inflight_loads(), 0);
+        assert_eq!(runtime.block_count(), 0);
+        assert_eq!(runtime.resident_bytes(), 0);
+        assert_eq!(runtime.l1_block_count(), 0);
+        assert_eq!(runtime.l1_resident_bytes(), 0);
         std::fs::remove_dir_all(root).ok();
     }
 
@@ -906,6 +1401,28 @@ mod tests {
         async fn fetch_range(&self, _object: &ObjectId, offset: u64, len: u64) -> Result<Bytes> {
             // Return one block worth of bytes starting at `offset`; byte i has
             // value (offset + i) % 251 (prime, so no accidental alignment).
+            let n = len.min(self.block_size) as usize;
+            let buf: Vec<u8> = (0..n).map(|i| ((offset + i as u64) % 251) as u8).collect();
+            Ok(Bytes::from(buf))
+        }
+
+        async fn head(&self, _object: &ObjectId) -> Result<ObjectStat> {
+            Ok(ObjectStat {
+                len: u64::MAX,
+                version: Version::new("v1"),
+            })
+        }
+    }
+
+    struct CountingRampBackend {
+        block_size: u64,
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl BackendStore for CountingRampBackend {
+        async fn fetch_range(&self, _object: &ObjectId, offset: u64, len: u64) -> Result<Bytes> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
             let n = len.min(self.block_size) as usize;
             let buf: Vec<u8> = (0..n).map(|i| ((offset + i as u64) % 251) as u8).collect();
             Ok(Bytes::from(buf))
@@ -1203,6 +1720,153 @@ mod tests {
         // version remains resident — version churn no longer accumulates stale
         // .blk files (issue #159).
         assert_eq!(runtime.block_count(), 1);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn source_overwrite_replaces_old_version_in_both_tiers() {
+        let root = tmp_root();
+        let backend = Arc::new(VersionedBackend {
+            version: std::sync::Mutex::new("v1".into()),
+            body: std::sync::Mutex::new(Bytes::from_static(b"old-data")),
+            fetches: AtomicUsize::new(0),
+        });
+        let runtime = WorkerRuntime::new_with_l1(
+            WholeBlockStore::open(&root).unwrap(),
+            Arc::new(BlockIndex::new()),
+            Arc::new(InFlightLoads::new()),
+            Arc::clone(&backend) as Arc<dyn BackendStore>,
+            8,
+            1024,
+            16,
+            8,
+            WorkerMetrics::new(1024),
+        )
+        .with_version_ttl(Duration::ZERO);
+
+        assert_eq!(
+            runtime.serve_range(&request("versioned")).await.unwrap(),
+            Bytes::from_static(b"old-")
+        );
+        assert_eq!(runtime.block_count(), 1);
+        assert_eq!(runtime.l1_block_count(), 1);
+
+        *backend.version.lock().unwrap() = "v2".into();
+        *backend.body.lock().unwrap() = Bytes::from_static(b"new-data");
+        assert_eq!(
+            runtime.serve_range(&request("versioned")).await.unwrap(),
+            Bytes::from_static(b"new-")
+        );
+        assert_eq!(runtime.block_count(), 1, "old L2 version must be removed");
+        assert_eq!(
+            runtime.l1_block_count(),
+            1,
+            "old L1 version must be removed"
+        );
+        assert_eq!(runtime.l1_resident_bytes(), 8);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    struct MutableBackend {
+        body: std::sync::Mutex<Option<Bytes>>,
+        version: std::sync::Mutex<String>,
+        fetches: AtomicUsize,
+        puts: AtomicUsize,
+        deletes: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl BackendStore for MutableBackend {
+        async fn fetch_range(&self, _object: &ObjectId, _offset: u64, _len: u64) -> Result<Bytes> {
+            self.fetches.fetch_add(1, Ordering::SeqCst);
+            self.body
+                .lock()
+                .unwrap()
+                .clone()
+                .ok_or_else(|| Error::NotFound("deleted".into()))
+        }
+
+        async fn head(&self, _object: &ObjectId) -> Result<ObjectStat> {
+            let body = self.body.lock().unwrap();
+            let body = body
+                .as_ref()
+                .ok_or_else(|| Error::NotFound("deleted".into()))?;
+            Ok(ObjectStat {
+                len: body.len() as u64,
+                version: Version::new(self.version.lock().unwrap().clone()),
+            })
+        }
+
+        async fn put(&self, _object: &ObjectId, body: Bytes) -> Result<Version> {
+            self.puts.fetch_add(1, Ordering::SeqCst);
+            *self.body.lock().unwrap() = Some(body);
+            *self.version.lock().unwrap() = "written-v2".into();
+            Ok(Version::new("written-v2"))
+        }
+
+        async fn delete(&self, _object: &ObjectId) -> Result<()> {
+            self.deletes.fetch_add(1, Ordering::SeqCst);
+            *self.body.lock().unwrap() = None;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn write_through_populates_l1_and_l2_then_delete_invalidates_both() {
+        let root = tmp_root();
+        let backend = Arc::new(MutableBackend {
+            body: std::sync::Mutex::new(Some(Bytes::from_static(b"old-data"))),
+            version: std::sync::Mutex::new("v1".into()),
+            fetches: AtomicUsize::new(0),
+            puts: AtomicUsize::new(0),
+            deletes: AtomicUsize::new(0),
+        });
+        let runtime = WorkerRuntime::new_with_l1(
+            WholeBlockStore::open(&root).unwrap(),
+            Arc::new(BlockIndex::new()),
+            Arc::new(InFlightLoads::new()),
+            Arc::clone(&backend) as Arc<dyn BackendStore>,
+            8,
+            1024,
+            16,
+            8,
+            WorkerMetrics::new(1024),
+        );
+        let object = ObjectId::new(Backend::Azure, "container", "mutable");
+
+        assert_eq!(
+            runtime
+                .write_object(&object, Bytes::from_static(b"new-data"))
+                .await
+                .unwrap(),
+            Version::new("written-v2")
+        );
+        assert_eq!(backend.puts.load(Ordering::SeqCst), 1);
+        assert_eq!(runtime.block_count(), 1);
+        assert_eq!(runtime.l1_block_count(), 1);
+
+        assert_eq!(
+            runtime
+                .serve_range(&RangeRequest {
+                    object: object.clone(),
+                    offset: 0,
+                    len: 8,
+                })
+                .await
+                .unwrap(),
+            Bytes::from_static(b"new-data")
+        );
+        assert_eq!(
+            backend.fetches.load(Ordering::SeqCst),
+            0,
+            "read-after-write must be an L1 hit"
+        );
+
+        runtime.delete_object(&object).await.unwrap();
+        assert_eq!(backend.deletes.load(Ordering::SeqCst), 1);
+        assert_eq!(runtime.block_count(), 0);
+        assert_eq!(runtime.l1_block_count(), 0);
+        assert_eq!(runtime.l1_resident_bytes(), 0);
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/deploy/helm/talon/README.md
+++ b/deploy/helm/talon/README.md
@@ -52,6 +52,8 @@ SSD) instead of an `emptyDir`. Disable workers entirely with
 | `worker.enabled` | `true` | Deploy cache workers |
 | `worker.replicas` | `3` | Worker replicas |
 | `worker.capacityBytes` | `8589934592` | Per-worker cache capacity |
+| `worker.l1CapacityBytes` | `0` | L1 DRAM capacity; zero disables L1 |
+| `worker.l1MaxEntryBytes` | `4194304` | Largest block admitted to L1 |
 | `image.registry` / `image.tag` | `ghcr.io/milvus-io` / chart appVersion | Image source |
 | `serviceMonitor.enabled` | `false` | Prometheus Operator ServiceMonitor |
 

--- a/deploy/helm/talon/README.md
+++ b/deploy/helm/talon/README.md
@@ -51,6 +51,7 @@ SSD) instead of an `emptyDir`. Disable workers entirely with
 | `coordinator.replicas` | `3` | Coordinator replicas (forced to 1 for `memory`) |
 | `worker.enabled` | `true` | Deploy cache workers |
 | `worker.replicas` | `3` | Worker replicas |
+| `worker.topologySpreadWhenUnsatisfiable` | `ScheduleAnyway` | Worker hostname spread policy |
 | `worker.blockSizeBytes` | `268435456` | Cache block size in bytes |
 | `worker.capacityBytes` | `8589934592` | Per-worker cache capacity |
 | `worker.l1CapacityBytes` | `0` | L1 DRAM capacity; zero disables L1 |

--- a/deploy/helm/talon/README.md
+++ b/deploy/helm/talon/README.md
@@ -51,6 +51,7 @@ SSD) instead of an `emptyDir`. Disable workers entirely with
 | `coordinator.replicas` | `3` | Coordinator replicas (forced to 1 for `memory`) |
 | `worker.enabled` | `true` | Deploy cache workers |
 | `worker.replicas` | `3` | Worker replicas |
+| `worker.blockSizeBytes` | `268435456` | Cache block size in bytes |
 | `worker.capacityBytes` | `8589934592` | Per-worker cache capacity |
 | `worker.l1CapacityBytes` | `0` | L1 DRAM capacity; zero disables L1 |
 | `worker.l1MaxEntryBytes` | `4194304` | Largest block admitted to L1 |

--- a/deploy/helm/talon/templates/worker.yaml
+++ b/deploy/helm/talon/templates/worker.yaml
@@ -96,6 +96,8 @@ spec:
                   fieldPath: status.podIP
             - name: TALON_WORKER_CACHE_DIRS
               value: /var/cache/talon
+            - name: TALON_WORKER_BLOCK_SIZE
+              value: {{ .Values.worker.blockSizeBytes | quote }}
             - name: TALON_WORKER_CAPACITY_BYTES
               value: {{ .Values.worker.capacityBytes | quote }}
             - name: TALON_WORKER_L1_CAPACITY_BYTES

--- a/deploy/helm/talon/templates/worker.yaml
+++ b/deploy/helm/talon/templates/worker.yaml
@@ -98,6 +98,10 @@ spec:
               value: /var/cache/talon
             - name: TALON_WORKER_CAPACITY_BYTES
               value: {{ .Values.worker.capacityBytes | quote }}
+            - name: TALON_WORKER_L1_CAPACITY_BYTES
+              value: {{ .Values.worker.l1CapacityBytes | quote }}
+            - name: TALON_WORKER_L1_MAX_ENTRY_BYTES
+              value: {{ .Values.worker.l1MaxEntryBytes | quote }}
             - name: TALON_WORKER_AZURE_ACCOUNT
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/talon/templates/worker.yaml
+++ b/deploy/helm/talon/templates/worker.yaml
@@ -47,7 +47,7 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: {{ .Values.worker.topologySpreadWhenUnsatisfiable }}
           labelSelector:
             matchLabels:
               {{- include "talon.selectorLabels" (dict "component" "worker") | nindent 14 }}

--- a/deploy/helm/talon/values.yaml
+++ b/deploy/helm/talon/values.yaml
@@ -56,6 +56,8 @@ worker:
   # -- Deploy cache workers alongside the coordinator.
   enabled: true
   replicas: 3
+  # -- Cache block size in bytes. Capacity must be at least one block.
+  blockSizeBytes: 268435456
   # -- Cache capacity in bytes the worker is allowed to fill.
   capacityBytes: 8589934592
   # -- L1 DRAM cache capacity in bytes. Zero keeps L1 disabled.

--- a/deploy/helm/talon/values.yaml
+++ b/deploy/helm/talon/values.yaml
@@ -56,6 +56,8 @@ worker:
   # -- Deploy cache workers alongside the coordinator.
   enabled: true
   replicas: 3
+  # -- Scheduler behavior when workers cannot be evenly spread across nodes.
+  topologySpreadWhenUnsatisfiable: ScheduleAnyway
   # -- Cache block size in bytes. Capacity must be at least one block.
   blockSizeBytes: 268435456
   # -- Cache capacity in bytes the worker is allowed to fill.

--- a/deploy/helm/talon/values.yaml
+++ b/deploy/helm/talon/values.yaml
@@ -58,6 +58,10 @@ worker:
   replicas: 3
   # -- Cache capacity in bytes the worker is allowed to fill.
   capacityBytes: 8589934592
+  # -- L1 DRAM cache capacity in bytes. Zero keeps L1 disabled.
+  l1CapacityBytes: 0
+  # -- Largest whole block eligible for L1 admission.
+  l1MaxEntryBytes: 4194304
   # -- Object-store credentials. Reference a Secret you create out-of-band (see
   # deploy/kubernetes/worker-secret.example.yaml).
   backend:

--- a/deploy/kubernetes/worker.yaml
+++ b/deploy/kubernetes/worker.yaml
@@ -106,6 +106,12 @@ spec:
             # below the emptyDir/PVC size and the container memory limit.
             - name: TALON_WORKER_CAPACITY_BYTES
               value: "8589934592"
+            # Optional L1 DRAM cache. Keep disabled unless the pod memory limit
+            # includes this capacity plus the worker's normal heap/runtime use.
+            - name: TALON_WORKER_L1_CAPACITY_BYTES
+              value: "0"
+            - name: TALON_WORKER_L1_MAX_ENTRY_BYTES
+              value: "4194304"
             # Object-store backend credentials from the Secret — never logged.
             - name: TALON_WORKER_AZURE_ACCOUNT
               valueFrom:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -258,6 +258,22 @@ Worker cache capacity (bytes).
 - **Default:** `68719476736`
 - **CLI flag:** not settable via CLI (config file or environment only)
 
+### `l1_capacity_bytes`
+
+L1 DRAM cache capacity in bytes; 0 disables L1.
+
+- **Environment variable:** `TALON_WORKER_L1_CAPACITY_BYTES`
+- **Default:** `0`
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `l1_max_entry_bytes`
+
+Largest whole block eligible for the L1 DRAM cache.
+
+- **Environment variable:** `TALON_WORKER_L1_MAX_ENTRY_BYTES`
+- **Default:** `4194304`
+- **CLI flag:** not settable via CLI (config file or environment only)
+
 ### `backend`
 
 Object-store backend: azure (default), s3, or gcs.

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -56,7 +56,7 @@ require() {
   command -v "$1" >/dev/null || fail "required command not found: $1"
 }
 
-for command in kubectl helm cargo curl awk sort uniq cmp kind docker; do
+for command in kubectl helm cargo curl awk sort uniq cmp kind docker timeout; do
   require "$command"
 done
 
@@ -193,9 +193,10 @@ placed_read() {
   local path="$1"
   local len="$2"
   local out="$3"
-  target/release/talon-client \
+  timeout 15s target/release/talon-client \
     --coordinator "127.0.0.1:$COORD_PORT" \
-    --path "/s3/$BUCKET/$path" --len "$len" --out "$out"
+    --placement-only --path "/s3/$BUCKET/$path" --len "$len" >"$out"
+  cat "$out"
 }
 
 if [[ "$CREATE_KIND_CLUSTER" == "1" ]]; then
@@ -355,7 +356,7 @@ declare -A placed_workers=()
 for i in $(seq 0 29); do
   output="$(placed_read "shard-$i.bin" 4096 "$ARTIFACT_DIR/shard-$i.out" 2>&1)"
   echo "$output" >>"$ARTIFACT_DIR/placement.log"
-  address="$(sed -n 's/^read .* from \\([^ ]*\\) in .*/\\1/p' <<<"$output")"
+  address="$(sed -n 's/^placed .* on \\([^ ]*\\)$/\\1/p' <<<"$output")"
   [[ -n "$address" ]] || fail "could not parse worker address from client output"
   placed_workers["$address"]=1
 done

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -291,6 +291,7 @@ helm upgrade --install "$RELEASE" deploy/helm/talon -n "$NAMESPACE" \
   --set coordinator.replicas=3 \
   --set coordinator.clusterId=e2e \
   --set worker.replicas=3 \
+  --set worker.topologySpreadWhenUnsatisfiable=DoNotSchedule \
   --set worker.blockSizeBytes=$BLOCK_SIZE \
   --set worker.capacityBytes=$((64 * BLOCK_SIZE)) \
   --set worker.l1CapacityBytes=$((32 * BLOCK_SIZE)) \

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -450,10 +450,20 @@ l2_hits_after="$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{
 direct_read evict-3.bin 0 4096 "$ARTIFACT_DIR/evict-3.out" >/dev/null
 direct_read evict-4.bin 0 4096 "$ARTIFACT_DIR/evict-4.out" >/dev/null
 fetch_before="$(metric_value "$TARGET_POD" 'talon_worker_backend_fetch_bytes_total{backend="s3"}')"
+l1_hits_before="$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l1"}')"
 direct_read evict-1.bin 0 4096 "$ARTIFACT_DIR/evict-1-refetched.out" >/dev/null
 fetch_after="$(metric_value "$TARGET_POD" 'talon_worker_backend_fetch_bytes_total{backend="s3"}')"
-[[ $((fetch_after - fetch_before)) -eq "$BLOCK_SIZE" ]] ||
-  fail "L2 eviction left an orphan L1 copy or fetched an unexpected byte count"
+l1_hits_after="$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l1"}')"
+{
+  echo "backend_fetch_bytes_before=$fetch_before"
+  echo "backend_fetch_bytes_after=$fetch_after"
+  echo "l1_hits_before=$l1_hits_before"
+  echo "l1_hits_after=$l1_hits_after"
+} >"$ARTIFACT_DIR/l2-invalidation-metrics.txt"
+[[ "$fetch_after" -gt "$fetch_before" ]] ||
+  fail "L2 eviction left an orphan L1 copy instead of refetching origin"
+[[ "$l1_hits_after" -eq "$l1_hits_before" ]] ||
+  fail "L2-evicted block was incorrectly served from an orphan L1 copy"
 [[ "$(metric_value "$TARGET_POD" talon_worker_l1_blocks)" -le 2 ]] ||
   fail "L1 exceeded its configured block capacity"
 

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -85,6 +85,7 @@ start_coordinator_forward() {
     >"$ARTIFACT_DIR/coordinator-port-forward.log" 2>&1 &
   PF_PIDS+=("$!")
   wait_port "$COORD_PORT"
+  wait_membership_converged
 }
 
 start_worker_forward() {
@@ -101,6 +102,48 @@ worker_pods() {
     -o custom-columns=NAME:.metadata.name,DELETING:.metadata.deletionTimestamp,READY:.status.containerStatuses[0].ready \
     --no-headers |
     awk '$2 == "<none>" && $3 == "true" {print $1}'
+}
+
+worker_addresses() {
+  while read -r pod; do
+    kubectl -n "$NAMESPACE" get pod "$pod" \
+      -o jsonpath='{.status.podIP}{":7001\n"}'
+  done < <(worker_pods)
+}
+
+wait_membership_converged() {
+  local expected actual output
+  local consecutive=0
+  expected="$(worker_addresses | sort)"
+  [[ "$(wc -l <<<"$expected")" -eq 3 ]] ||
+    fail "cannot validate membership without exactly 3 ready workers"
+
+  for _ in $(seq 1 90); do
+    if output="$(timeout 10s target/release/talon-client \
+      --coordinator "127.0.0.1:$COORD_PORT" --membership-only 2>&1)"; then
+      actual="$(awk '$1 == "member" {print $NF}' <<<"$output" | sort)"
+      if [[ "$actual" == "$expected" ]]; then
+        consecutive=$((consecutive + 1))
+        if [[ "$consecutive" -ge 5 ]]; then
+          printf '%s\n' "$output" >"$ARTIFACT_DIR/membership-converged.txt"
+          return 0
+        fi
+      else
+        consecutive=0
+      fi
+    else
+      consecutive=0
+    fi
+    sleep 1
+  done
+
+  {
+    echo "expected:"
+    echo "$expected"
+    echo "last coordinator response:"
+    echo "${output:-<none>}"
+  } >"$ARTIFACT_DIR/membership-failure.txt"
+  fail "coordinator membership did not converge to the 3 ready worker pods"
 }
 
 first_worker() {

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -356,7 +356,7 @@ declare -A placed_workers=()
 for i in $(seq 0 29); do
   output="$(placed_read "shard-$i.bin" 4096 "$ARTIFACT_DIR/shard-$i.out" 2>&1)"
   echo "$output" >>"$ARTIFACT_DIR/placement.log"
-  address="$(sed -n 's/^placed .* on \\([^ ]*\\)$/\\1/p' <<<"$output")"
+  address="$(awk '$1 == "placed" {print $NF}' <<<"$output")"
   [[ -n "$address" ]] || fail "could not parse worker address from client output"
   placed_workers["$address"]=1
 done

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -172,6 +172,29 @@ rollout_workers() {
   assert_workers_spread
 }
 
+restart_worker_container() {
+  local pod="$1"
+  local node container_id
+  node="$(kubectl -n "$NAMESPACE" get pod "$pod" -o jsonpath='{.spec.nodeName}')"
+  container_id="$(kubectl -n "$NAMESPACE" get pod "$pod" \
+    -o jsonpath='{.status.containerStatuses[0].containerID}')"
+  container_id="${container_id#*://}"
+  [[ -n "$node" && -n "$container_id" ]] ||
+    fail "cannot resolve worker container runtime identity"
+
+  {
+    echo "pod=$pod"
+    echo "node=$node"
+    echo "container_id=$container_id"
+  } >"$ARTIFACT_DIR/restart-target.txt"
+
+  if docker inspect "$node" >/dev/null 2>&1; then
+    docker exec "$node" crictl stop --timeout 0 "$container_id"
+  else
+    kubectl -n "$NAMESPACE" exec "$pod" -- /bin/sh -c 'kill -9 1'
+  fi
+}
+
 set_cache_limits() {
   local l1="$1"
   local l2="$2"
@@ -476,7 +499,7 @@ start_worker_forward "$TARGET_POD"
 direct_read restart.bin 0 4096 "$ARTIFACT_DIR/restart-before.out" >/dev/null
 restart_before="$(kubectl -n "$NAMESPACE" get pod "$TARGET_POD" \
   -o jsonpath='{.status.containerStatuses[0].restartCount}')"
-kubectl -n "$NAMESPACE" exec "$TARGET_POD" -- /bin/sh -c 'kill -9 1' >/dev/null 2>&1 || true
+restart_worker_container "$TARGET_POD"
 for _ in $(seq 1 120); do
   restart_after="$(kubectl -n "$NAMESPACE" get pod "$TARGET_POD" \
     -o jsonpath='{.status.containerStatuses[0].restartCount}' 2>/dev/null || echo 0)"

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -97,7 +97,10 @@ start_worker_forward() {
 
 worker_pods() {
   kubectl -n "$NAMESPACE" get pods -l app.kubernetes.io/component=worker \
-    -o jsonpath='{range .items[?(@.status.containerStatuses[0].ready==true)]}{.metadata.name}{"\n"}{end}'
+    --field-selector=status.phase=Running \
+    -o custom-columns=NAME:.metadata.name,DELETING:.metadata.deletionTimestamp,READY:.status.containerStatuses[0].ready \
+    --no-headers |
+    awk '$2 == "<none>" && $3 == "true" {print $1}'
 }
 
 first_worker() {
@@ -105,12 +108,19 @@ first_worker() {
 }
 
 assert_workers_spread() {
-  local ready nodes
-  ready="$(kubectl -n "$NAMESPACE" get pods -l app.kubernetes.io/component=worker \
-    -o jsonpath='{range .items[?(@.status.containerStatuses[0].ready==true)]}{.metadata.name}{"\n"}{end}' | wc -l)"
+  local ready=0 nodes pod
+  for _ in $(seq 1 60); do
+    ready="$(worker_pods | wc -l)"
+    [[ "$ready" -eq 3 ]] && break
+    sleep 1
+  done
   [[ "$ready" -eq 3 ]] || fail "expected 3 ready workers, found $ready"
-  nodes="$(kubectl -n "$NAMESPACE" get pods -l app.kubernetes.io/component=worker \
-    -o jsonpath='{range .items[?(@.status.containerStatuses[0].ready==true)]}{.spec.nodeName}{"\n"}{end}' | sort -u | wc -l)"
+  nodes="$(
+    while read -r pod; do
+      kubectl -n "$NAMESPACE" get pod "$pod" -o jsonpath='{.spec.nodeName}{"\n"}'
+    done < <(worker_pods)
+  )"
+  nodes="$(sort -u <<<"$nodes" | wc -l)"
   [[ "$nodes" -eq 3 ]] || fail "expected workers on 3 Kubernetes nodes, found $nodes"
 }
 

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -476,7 +476,7 @@ start_worker_forward "$TARGET_POD"
 direct_read restart.bin 0 4096 "$ARTIFACT_DIR/restart-before.out" >/dev/null
 restart_before="$(kubectl -n "$NAMESPACE" get pod "$TARGET_POD" \
   -o jsonpath='{.status.containerStatuses[0].restartCount}')"
-kubectl -n "$NAMESPACE" exec "$TARGET_POD" -- /bin/sh -c 'kill 1' >/dev/null 2>&1 || true
+kubectl -n "$NAMESPACE" exec "$TARGET_POD" -- /bin/sh -c 'kill -9 1' >/dev/null 2>&1 || true
 for _ in $(seq 1 120); do
   restart_after="$(kubectl -n "$NAMESPACE" get pod "$TARGET_POD" \
     -o jsonpath='{.status.containerStatuses[0].restartCount}' 2>/dev/null || echo 0)"

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -167,11 +167,8 @@ make_repeated_file() {
 upload_file() {
   local source="$1"
   local key="$2"
-  local name
-  name="$(basename "$source")"
-  kubectl -n "$NAMESPACE" cp "$source" "minio-client:/tmp/$name"
-  kubectl -n "$NAMESPACE" exec minio-client -- \
-    mc cp --quiet "/tmp/$name" "local/$BUCKET/$key"
+  kubectl -n "$NAMESPACE" exec -i minio-client -- \
+    mc pipe "local/$BUCKET/$key" <"$source"
 }
 
 direct_read() {
@@ -340,8 +337,7 @@ for i in $(seq 0 7); do
   upload_file "$ARTIFACT_DIR/evict-$i.bin" "evict-$i.bin"
 done
 for i in $(seq 0 29); do
-  kubectl -n "$NAMESPACE" exec minio-client -- \
-    mc cp --quiet /tmp/hot.bin "local/$BUCKET/shard-$i.bin"
+  upload_file "$ARTIFACT_DIR/hot.bin" "shard-$i.bin"
 done
 
 log "verifying multi-node placement reaches all three workers"

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -1,0 +1,514 @@
+#!/usr/bin/env bash
+# Multi-node Kubernetes E2E and benchmark for the inclusive L1/L2 worker cache.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+CLUSTER_NAME="${CLUSTER_NAME:-talon-l1-l2}"
+NAMESPACE="${NAMESPACE:-talon-e2e}"
+RELEASE="${RELEASE:-talon}"
+IMAGE_TAG="${IMAGE_TAG:-e2e}"
+CREATE_KIND_CLUSTER="${CREATE_KIND_CLUSTER:-1}"
+KEEP_CLUSTER="${KEEP_CLUSTER:-0}"
+BENCH_SECONDS="${BENCH_SECONDS:-5}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT/.artifacts/k8s-l1-l2}"
+COORD_PORT="${COORD_PORT:-17000}"
+WORKER_PORT="${WORKER_PORT:-17001}"
+BLOCK_SIZE=$((1024 * 1024))
+MINIO_ACCESS_KEY="minioadmin"
+MINIO_SECRET_KEY="minioadmin"
+BUCKET="talon-e2e"
+
+mkdir -p "$ARTIFACT_DIR"
+PF_PIDS=()
+
+log() {
+  printf '\n[%s] %s\n' "$(date -u +%H:%M:%S)" "$*"
+}
+
+fail() {
+  echo "FAILED: $*" >&2
+  exit 1
+}
+
+cleanup() {
+  for pid in "${PF_PIDS[@]:-}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  kubectl -n "$NAMESPACE" get pods -o wide >"$ARTIFACT_DIR/pods-final.txt" 2>/dev/null || true
+  kubectl -n "$NAMESPACE" logs -l app.kubernetes.io/component=worker --all-containers \
+    --prefix >"$ARTIFACT_DIR/workers.log" 2>/dev/null || true
+  kubectl -n "$NAMESPACE" logs -l app.kubernetes.io/component=coordinator --all-containers \
+    --prefix >"$ARTIFACT_DIR/coordinators.log" 2>/dev/null || true
+  if [[ "$CREATE_KIND_CLUSTER" == "1" && "$KEEP_CLUSTER" != "1" ]]; then
+    kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+require() {
+  command -v "$1" >/dev/null || fail "required command not found: $1"
+}
+
+for command in kubectl helm cargo curl awk sort uniq cmp kind docker; do
+  require "$command"
+done
+
+wait_port() {
+  local port="$1"
+  for _ in $(seq 1 60); do
+    if (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+      exec 3>&-
+      return 0
+    fi
+    sleep 1
+  done
+  fail "port 127.0.0.1:$port did not become ready"
+}
+
+stop_port_forwards() {
+  for pid in "${PF_PIDS[@]:-}"; do
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  done
+  PF_PIDS=()
+}
+
+start_coordinator_forward() {
+  kubectl -n "$NAMESPACE" port-forward "svc/$RELEASE-coordinator" "$COORD_PORT:7000" \
+    >"$ARTIFACT_DIR/coordinator-port-forward.log" 2>&1 &
+  PF_PIDS+=("$!")
+  wait_port "$COORD_PORT"
+}
+
+start_worker_forward() {
+  local pod="$1"
+  kubectl -n "$NAMESPACE" port-forward "pod/$pod" "$WORKER_PORT:7001" \
+    >"$ARTIFACT_DIR/worker-port-forward.log" 2>&1 &
+  PF_PIDS+=("$!")
+  wait_port "$WORKER_PORT"
+}
+
+worker_pods() {
+  kubectl -n "$NAMESPACE" get pods -l app.kubernetes.io/component=worker \
+    -o jsonpath='{range .items[?(@.status.containerStatuses[0].ready==true)]}{.metadata.name}{"\n"}{end}'
+}
+
+first_worker() {
+  worker_pods | sort | head -1
+}
+
+assert_workers_spread() {
+  local ready nodes
+  ready="$(kubectl -n "$NAMESPACE" get pods -l app.kubernetes.io/component=worker \
+    -o jsonpath='{range .items[?(@.status.containerStatuses[0].ready==true)]}{.metadata.name}{"\n"}{end}' | wc -l)"
+  [[ "$ready" -eq 3 ]] || fail "expected 3 ready workers, found $ready"
+  nodes="$(kubectl -n "$NAMESPACE" get pods -l app.kubernetes.io/component=worker \
+    -o jsonpath='{range .items[?(@.status.containerStatuses[0].ready==true)]}{.spec.nodeName}{"\n"}{end}' | sort -u | wc -l)"
+  [[ "$nodes" -eq 3 ]] || fail "expected workers on 3 Kubernetes nodes, found $nodes"
+}
+
+rollout_workers() {
+  kubectl -n "$NAMESPACE" rollout status "deployment/$RELEASE-worker" --timeout=180s
+  assert_workers_spread
+}
+
+set_cache_limits() {
+  local l1="$1"
+  local l2="$2"
+  kubectl -n "$NAMESPACE" set env "deployment/$RELEASE-worker" \
+    "TALON_WORKER_L1_CAPACITY_BYTES=$l1" \
+    "TALON_WORKER_L1_MAX_ENTRY_BYTES=$BLOCK_SIZE" \
+    "TALON_WORKER_CAPACITY_BYTES=$l2" >/dev/null
+  rollout_workers
+}
+
+metric_value() {
+  local pod="$1"
+  local prefix="$2"
+  kubectl -n "$NAMESPACE" exec "$pod" -- \
+    curl -fsS http://127.0.0.1:8001/metrics |
+    awk -v prefix="$prefix" 'index($1, prefix) == 1 {sum += $2} END {printf "%.0f", sum + 0}'
+}
+
+metric_sum() {
+  local prefix="$1"
+  local sum=0 value
+  while read -r pod; do
+    value="$(metric_value "$pod" "$prefix")"
+    sum=$((sum + value))
+  done < <(worker_pods)
+  echo "$sum"
+}
+
+make_repeated_file() {
+  local byte="$1"
+  local size="$2"
+  local path="$3"
+  head -c "$size" /dev/zero | tr '\000' "$byte" >"$path"
+}
+
+upload_file() {
+  local source="$1"
+  local key="$2"
+  local name
+  name="$(basename "$source")"
+  kubectl -n "$NAMESPACE" cp "$source" "minio-client:/tmp/$name"
+  kubectl -n "$NAMESPACE" exec minio-client -- \
+    mc cp --quiet "/tmp/$name" "local/$BUCKET/$key"
+}
+
+direct_read() {
+  local path="$1"
+  local offset="$2"
+  local len="$3"
+  local out="$4"
+  target/release/talon-client \
+    --worker "127.0.0.1:$WORKER_PORT" \
+    --path "/s3/$BUCKET/$path" --offset "$offset" --len "$len" --out "$out"
+}
+
+placed_read() {
+  local path="$1"
+  local len="$2"
+  local out="$3"
+  target/release/talon-client \
+    --coordinator "127.0.0.1:$COORD_PORT" \
+    --path "/s3/$BUCKET/$path" --len "$len" --out "$out"
+}
+
+if [[ "$CREATE_KIND_CLUSTER" == "1" ]]; then
+  log "creating a Kubernetes cluster with one control plane and three workers"
+  kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
+  kind create cluster --name "$CLUSTER_NAME" --wait 120s --config=- <<'EOF'
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker
+  - role: worker
+EOF
+
+  log "building and loading Talon images"
+  docker build -f deploy/docker/coordinator.Dockerfile \
+    -t "talon-e2e/talon-coordinator:$IMAGE_TAG" .
+  docker build -f deploy/docker/worker.Dockerfile \
+    -t "talon-e2e/talon-worker:$IMAGE_TAG" .
+  kind load docker-image --name "$CLUSTER_NAME" \
+    "talon-e2e/talon-coordinator:$IMAGE_TAG" \
+    "talon-e2e/talon-worker:$IMAGE_TAG"
+fi
+
+log "building E2E clients"
+cargo build --release -p talon-client --bin talon-client
+cargo build --release -p talon-worker --bin talon-loadgen
+
+log "deploying MinIO and Talon"
+kubectl create namespace "$NAMESPACE"
+kubectl -n "$NAMESPACE" apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: minio }
+  template:
+    metadata:
+      labels: { app: minio }
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          args: ["server", "/data"]
+          env:
+            - { name: MINIO_ROOT_USER, value: "$MINIO_ACCESS_KEY" }
+            - { name: MINIO_ROOT_PASSWORD, value: "$MINIO_SECRET_KEY" }
+          ports:
+            - { name: s3, containerPort: 9000 }
+          readinessProbe:
+            httpGet: { path: /minio/health/ready, port: s3 }
+            periodSeconds: 2
+          resources:
+            requests: { cpu: 100m, memory: 128Mi }
+            limits: { cpu: "1", memory: 512Mi }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  selector: { app: minio }
+  ports:
+    - { name: s3, port: 9000, targetPort: s3 }
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: minio-client
+spec:
+  containers:
+    - name: mc
+      image: minio/mc:latest
+      command: ["/bin/sh", "-c", "sleep 7200"]
+      resources:
+        requests: { cpu: 10m, memory: 32Mi }
+        limits: { cpu: 200m, memory: 128Mi }
+  restartPolicy: Never
+EOF
+kubectl -n "$NAMESPACE" rollout status deployment/minio --timeout=180s
+kubectl -n "$NAMESPACE" wait --for=condition=Ready pod/minio-client --timeout=180s
+kubectl -n "$NAMESPACE" exec minio-client -- \
+  mc alias set local http://minio:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
+kubectl -n "$NAMESPACE" exec minio-client -- mc mb --ignore-existing "local/$BUCKET"
+
+kubectl -n "$NAMESPACE" create secret generic talon-worker-backend \
+  --from-literal=azure-account=unused --from-literal=azure-sas=unused
+
+helm upgrade --install "$RELEASE" deploy/helm/talon -n "$NAMESPACE" \
+  --set image.registry=talon-e2e \
+  --set image.tag="$IMAGE_TAG" \
+  --set image.pullPolicy=Never \
+  --set coordinator.backend=kubernetes \
+  --set coordinator.replicas=3 \
+  --set coordinator.clusterId=e2e \
+  --set worker.replicas=3 \
+  --set worker.capacityBytes=$((64 * BLOCK_SIZE)) \
+  --set worker.l1CapacityBytes=$((32 * BLOCK_SIZE)) \
+  --set worker.l1MaxEntryBytes=$BLOCK_SIZE \
+  --set worker.resources.requests.cpu=100m \
+  --set worker.resources.requests.memory=128Mi \
+  --set worker.resources.limits.cpu=2 \
+  --set worker.resources.limits.memory=512Mi \
+  --wait --timeout 5m
+
+kubectl -n "$NAMESPACE" set env "deployment/$RELEASE-worker" \
+  TALON_WORKER_BACKEND=s3 \
+  TALON_WORKER_S3_REGION=us-east-1 \
+  TALON_WORKER_S3_ENDPOINT=http://minio:9000 \
+  TALON_WORKER_S3_ACCESS_KEY_ID="$MINIO_ACCESS_KEY" \
+  TALON_WORKER_S3_SECRET_ACCESS_KEY="$MINIO_SECRET_KEY" \
+  TALON_WORKER_S3_PATH_STYLE=true \
+  TALON_WORKER_BLOCK_SIZE="$BLOCK_SIZE" \
+  TALON_WORKER_BACKEND_DELAY_MS=50 \
+  TALON_WORKER_FORCE_TOKIO_DATA_PLANE=1 >/dev/null
+rollout_workers
+
+kubectl -n "$NAMESPACE" get pods -o wide | tee "$ARTIFACT_DIR/pods-initial.txt"
+start_coordinator_forward
+
+log "seeding deterministic objects"
+make_repeated_file H "$BLOCK_SIZE" "$ARTIFACT_DIR/hot.bin"
+make_repeated_file S "$BLOCK_SIZE" "$ARTIFACT_DIR/singleflight.bin"
+make_repeated_file O "$BLOCK_SIZE" "$ARTIFACT_DIR/version-old.bin"
+make_repeated_file N "$BLOCK_SIZE" "$ARTIFACT_DIR/version-new.bin"
+make_repeated_file R "$BLOCK_SIZE" "$ARTIFACT_DIR/restart.bin"
+make_repeated_file B $((16 * BLOCK_SIZE)) "$ARTIFACT_DIR/bench"
+{
+  head -c "$BLOCK_SIZE" /dev/zero | tr '\000' A
+  head -c "$BLOCK_SIZE" /dev/zero | tr '\000' B
+  head -c "$BLOCK_SIZE" /dev/zero | tr '\000' C
+} >"$ARTIFACT_DIR/cross.bin"
+
+for object in hot.bin singleflight.bin version.bin restart.bin bench cross.bin; do
+  case "$object" in
+    version.bin) upload_file "$ARTIFACT_DIR/version-old.bin" "$object" ;;
+    *) upload_file "$ARTIFACT_DIR/$object" "$object" ;;
+  esac
+done
+for i in $(seq 0 7); do
+  make_repeated_file "$(printf '\\%03o' $((65 + i)))" "$BLOCK_SIZE" "$ARTIFACT_DIR/evict-$i.bin"
+  upload_file "$ARTIFACT_DIR/evict-$i.bin" "evict-$i.bin"
+done
+for i in $(seq 0 29); do
+  kubectl -n "$NAMESPACE" exec minio-client -- \
+    mc cp --quiet /tmp/hot.bin "local/$BUCKET/shard-$i.bin"
+done
+
+log "verifying multi-node placement reaches all three workers"
+declare -A placed_workers=()
+for i in $(seq 0 29); do
+  output="$(placed_read "shard-$i.bin" 4096 "$ARTIFACT_DIR/shard-$i.out" 2>&1)"
+  echo "$output" >>"$ARTIFACT_DIR/placement.log"
+  address="$(sed -n 's/^read .* from \\([^ ]*\\) in .*/\\1/p' <<<"$output")"
+  [[ -n "$address" ]] || fail "could not parse worker address from client output"
+  placed_workers["$address"]=1
+done
+[[ "${#placed_workers[@]}" -eq 3 ]] ||
+  fail "expected placement reads to reach 3 workers, reached ${#placed_workers[@]}"
+
+log "verifying byte-exact L1 hit and a cross-block read"
+stop_port_forwards
+start_coordinator_forward
+TARGET_POD="$(first_worker)"
+start_worker_forward "$TARGET_POD"
+head -c 65536 "$ARTIFACT_DIR/hot.bin" >"$ARTIFACT_DIR/hot.expected"
+direct_read hot.bin 0 65536 "$ARTIFACT_DIR/hot-cold.out" |
+  tee "$ARTIFACT_DIR/hot-cold.log"
+direct_read hot.bin 0 65536 "$ARTIFACT_DIR/hot-warm.out" |
+  tee "$ARTIFACT_DIR/hot-warm.log"
+cmp "$ARTIFACT_DIR/hot.expected" "$ARTIFACT_DIR/hot-cold.out"
+cmp "$ARTIFACT_DIR/hot.expected" "$ARTIFACT_DIR/hot-warm.out"
+[[ "$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l1"}')" -ge 1 ]] ||
+  fail "warm read did not register an L1 hit"
+
+CROSS_OFFSET=$((BLOCK_SIZE - 32768))
+CROSS_LEN=65536
+tail -c +$((CROSS_OFFSET + 1)) "$ARTIFACT_DIR/cross.bin" |
+  head -c "$CROSS_LEN" >"$ARTIFACT_DIR/cross.expected"
+direct_read cross.bin "$CROSS_OFFSET" "$CROSS_LEN" "$ARTIFACT_DIR/cross.out"
+cmp "$ARTIFACT_DIR/cross.expected" "$ARTIFACT_DIR/cross.out"
+
+log "verifying L1 eviction falls back to L2 and L2 eviction invalidates L1"
+stop_port_forwards
+set_cache_limits $((2 * BLOCK_SIZE)) $((4 * BLOCK_SIZE))
+start_coordinator_forward
+TARGET_POD="$(first_worker)"
+start_worker_forward "$TARGET_POD"
+for i in 0 1 2; do
+  direct_read "evict-$i.bin" 0 4096 "$ARTIFACT_DIR/evict-$i.out" >/dev/null
+done
+[[ "$(metric_value "$TARGET_POD" talon_worker_l1_evictions_total)" -ge 1 ]] ||
+  fail "L1 capacity pressure did not evict an entry"
+fetch_before="$(metric_value "$TARGET_POD" 'talon_worker_backend_fetch_bytes_total{backend="s3"}')"
+l2_hits_before="$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l2"}')"
+direct_read evict-0.bin 0 4096 "$ARTIFACT_DIR/evict-0-l2.out" >/dev/null
+fetch_after="$(metric_value "$TARGET_POD" 'talon_worker_backend_fetch_bytes_total{backend="s3"}')"
+l2_hits_after="$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l2"}')"
+[[ "$fetch_after" -eq "$fetch_before" ]] || fail "L1 eviction refetched origin instead of L2"
+[[ "$l2_hits_after" -gt "$l2_hits_before" ]] || fail "L1 eviction did not fall back to L2"
+
+direct_read evict-3.bin 0 4096 "$ARTIFACT_DIR/evict-3.out" >/dev/null
+direct_read evict-4.bin 0 4096 "$ARTIFACT_DIR/evict-4.out" >/dev/null
+fetch_before="$(metric_value "$TARGET_POD" 'talon_worker_backend_fetch_bytes_total{backend="s3"}')"
+direct_read evict-1.bin 0 4096 "$ARTIFACT_DIR/evict-1-refetched.out" >/dev/null
+fetch_after="$(metric_value "$TARGET_POD" 'talon_worker_backend_fetch_bytes_total{backend="s3"}')"
+[[ $((fetch_after - fetch_before)) -eq "$BLOCK_SIZE" ]] ||
+  fail "L2 eviction left an orphan L1 copy or fetched an unexpected byte count"
+[[ "$(metric_value "$TARGET_POD" talon_worker_l1_blocks)" -le 2 ]] ||
+  fail "L1 exceeded its configured block capacity"
+
+log "verifying container restart rebuilds L2 and promotes into an empty L1"
+stop_port_forwards
+set_cache_limits $((32 * BLOCK_SIZE)) $((64 * BLOCK_SIZE))
+start_coordinator_forward
+TARGET_POD="$(first_worker)"
+start_worker_forward "$TARGET_POD"
+direct_read restart.bin 0 4096 "$ARTIFACT_DIR/restart-before.out" >/dev/null
+restart_before="$(kubectl -n "$NAMESPACE" get pod "$TARGET_POD" \
+  -o jsonpath='{.status.containerStatuses[0].restartCount}')"
+kubectl -n "$NAMESPACE" exec "$TARGET_POD" -- /bin/sh -c 'kill 1' >/dev/null 2>&1 || true
+for _ in $(seq 1 120); do
+  restart_after="$(kubectl -n "$NAMESPACE" get pod "$TARGET_POD" \
+    -o jsonpath='{.status.containerStatuses[0].restartCount}' 2>/dev/null || echo 0)"
+  ready="$(kubectl -n "$NAMESPACE" get pod "$TARGET_POD" \
+    -o jsonpath='{.status.containerStatuses[0].ready}' 2>/dev/null || echo false)"
+  if [[ "$restart_after" -gt "$restart_before" && "$ready" == "true" ]]; then
+    break
+  fi
+  sleep 1
+done
+[[ "${restart_after:-0}" -gt "$restart_before" ]] || fail "worker container did not restart"
+stop_port_forwards
+start_coordinator_forward
+start_worker_forward "$TARGET_POD"
+[[ "$(metric_value "$TARGET_POD" talon_worker_l1_blocks)" -eq 0 ]] ||
+  fail "L1 was not empty after process restart"
+direct_read restart.bin 0 4096 "$ARTIFACT_DIR/restart-after.out" >/dev/null
+cmp "$ARTIFACT_DIR/restart-before.out" "$ARTIFACT_DIR/restart-after.out"
+[[ "$(metric_value "$TARGET_POD" 'talon_worker_backend_fetch_bytes_total{backend="s3"}')" -eq 0 ]] ||
+  fail "restart promotion refetched the object body"
+[[ "$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l2"}')" -ge 1 ]] ||
+  fail "restart read did not hit rebuilt L2"
+[[ "$(metric_value "$TARGET_POD" talon_worker_l1_blocks)" -eq 1 ]] ||
+  fail "rebuilt L2 block was not promoted into L1"
+
+log "verifying concurrent cold misses collapse to one backend body fetch"
+fetch_before="$(metric_value "$TARGET_POD" 'talon_worker_backend_fetch_bytes_total{backend="s3"}')"
+pids=()
+for i in $(seq 1 32); do
+  direct_read singleflight.bin 0 4096 "$ARTIFACT_DIR/singleflight-$i.out" \
+    >"$ARTIFACT_DIR/singleflight-$i.log" 2>&1 &
+  pids+=("$!")
+done
+for pid in "${pids[@]}"; do
+  wait "$pid"
+done
+fetch_after="$(metric_value "$TARGET_POD" 'talon_worker_backend_fetch_bytes_total{backend="s3"}')"
+[[ $((fetch_after - fetch_before)) -eq "$BLOCK_SIZE" ]] ||
+  fail "32 concurrent misses fetched $((fetch_after - fetch_before)) bytes, expected $BLOCK_SIZE"
+
+log "verifying source overwrite replaces stale L1 and L2 versions"
+direct_read version.bin 0 4096 "$ARTIFACT_DIR/version-old.out" >/dev/null
+head -c 4096 "$ARTIFACT_DIR/version-old.bin" >"$ARTIFACT_DIR/version-old.expected"
+cmp "$ARTIFACT_DIR/version-old.expected" "$ARTIFACT_DIR/version-old.out"
+upload_file "$ARTIFACT_DIR/version-new.bin" version.bin
+sleep 4
+direct_read version.bin 0 4096 "$ARTIFACT_DIR/version-new.out" >/dev/null
+head -c 4096 "$ARTIFACT_DIR/version-new.bin" >"$ARTIFACT_DIR/version-new.expected"
+cmp "$ARTIFACT_DIR/version-new.expected" "$ARTIFACT_DIR/version-new.out"
+
+log "verifying coordinator and worker pod replacement recovery"
+coord_victim="$(kubectl -n "$NAMESPACE" get pods -l app.kubernetes.io/component=coordinator \
+  -o jsonpath='{.items[0].metadata.name}')"
+kubectl -n "$NAMESPACE" delete pod "$coord_victim" --wait=false
+kubectl -n "$NAMESPACE" rollout status "deployment/$RELEASE-coordinator" --timeout=180s
+stop_port_forwards
+start_coordinator_forward
+start_worker_forward "$(first_worker)"
+placed_read hot.bin 4096 "$ARTIFACT_DIR/after-coordinator-restart.out" >/dev/null
+
+worker_victim="$(first_worker)"
+kubectl -n "$NAMESPACE" delete pod "$worker_victim" --wait=false
+rollout_workers
+stop_port_forwards
+start_coordinator_forward
+recovered=0
+for _ in $(seq 1 45); do
+  if placed_read hot.bin 4096 "$ARTIFACT_DIR/after-worker-restart.out" >/dev/null 2>&1; then
+    recovered=1
+    break
+  fi
+  sleep 1
+done
+[[ "$recovered" -eq 1 ]] || fail "placement did not recover after worker replacement"
+
+log "benchmarking cold, warm L1, and warm L2 paths"
+stop_port_forwards
+set_cache_limits $((32 * BLOCK_SIZE)) $((64 * BLOCK_SIZE))
+start_coordinator_forward
+TARGET_POD="$(first_worker)"
+start_worker_forward "$TARGET_POD"
+{
+  /usr/bin/time -f 'cold_elapsed_s=%e' \
+    target/release/talon-client --worker "127.0.0.1:$WORKER_PORT" \
+    --path "/s3/$BUCKET/bench" --len 65536 --out "$ARTIFACT_DIR/bench-cold.out"
+  /usr/bin/time -f 'warm_l1_elapsed_s=%e' \
+    target/release/talon-client --worker "127.0.0.1:$WORKER_PORT" \
+    --path "/s3/$BUCKET/bench" --len 65536 --out "$ARTIFACT_DIR/bench-warm.out"
+} 2>&1 | tee "$ARTIFACT_DIR/cold-warm.txt"
+target/release/talon-loadgen --addr "127.0.0.1:$WORKER_PORT" \
+  --container "$BUCKET" --object bench --range 65536 \
+  --conns 1,32,128 --seconds "$BENCH_SECONDS" --warmup 2 --json |
+  tee "$ARTIFACT_DIR/l1-benchmark.jsonl"
+[[ "$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l1"}')" -gt 0 ]] ||
+  fail "L1 benchmark produced no L1 hits"
+
+stop_port_forwards
+set_cache_limits 0 $((64 * BLOCK_SIZE))
+start_coordinator_forward
+TARGET_POD="$(first_worker)"
+start_worker_forward "$TARGET_POD"
+target/release/talon-loadgen --addr "127.0.0.1:$WORKER_PORT" \
+  --container "$BUCKET" --object bench --range 65536 \
+  --conns 1,32,128 --seconds "$BENCH_SECONDS" --warmup 2 --json |
+  tee "$ARTIFACT_DIR/l2-benchmark.jsonl"
+[[ "$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l2"}')" -gt 0 ]] ||
+  fail "L2 benchmark produced no L2 hits"
+
+log "all multi-node Kubernetes L1/L2 E2E checks passed"
+kubectl -n "$NAMESPACE" get pods -o wide
+echo "Artifacts: $ARTIFACT_DIR"

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -267,8 +267,8 @@ spec:
       image: minio/mc:latest
       command: ["/bin/sh", "-c", "sleep 7200"]
       resources:
-        requests: { cpu: 10m, memory: 32Mi }
-        limits: { cpu: 200m, memory: 128Mi }
+        requests: { cpu: 10m, memory: 64Mi }
+        limits: { cpu: 200m, memory: 512Mi }
   restartPolicy: Never
 EOF
 kubectl -n "$NAMESPACE" rollout status deployment/minio --timeout=180s

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -39,8 +39,13 @@ cleanup() {
   kubectl -n "$NAMESPACE" get pods -o wide >"$ARTIFACT_DIR/pods-final.txt" 2>/dev/null || true
   kubectl -n "$NAMESPACE" logs -l app.kubernetes.io/component=worker --all-containers \
     --prefix >"$ARTIFACT_DIR/workers.log" 2>/dev/null || true
+  kubectl -n "$NAMESPACE" logs -l app.kubernetes.io/component=worker --all-containers \
+    --prefix --previous >"$ARTIFACT_DIR/workers-previous.log" 2>/dev/null || true
   kubectl -n "$NAMESPACE" logs -l app.kubernetes.io/component=coordinator --all-containers \
     --prefix >"$ARTIFACT_DIR/coordinators.log" 2>/dev/null || true
+  kubectl -n "$NAMESPACE" describe pods >"$ARTIFACT_DIR/pods-describe.txt" 2>/dev/null || true
+  kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp \
+    >"$ARTIFACT_DIR/events.txt" 2>/dev/null || true
   if [[ "$CREATE_KIND_CLUSTER" == "1" && "$KEEP_CLUSTER" != "1" ]]; then
     kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
   fi
@@ -276,6 +281,7 @@ helm upgrade --install "$RELEASE" deploy/helm/talon -n "$NAMESPACE" \
   --set coordinator.replicas=3 \
   --set coordinator.clusterId=e2e \
   --set worker.replicas=3 \
+  --set worker.blockSizeBytes=$BLOCK_SIZE \
   --set worker.capacityBytes=$((64 * BLOCK_SIZE)) \
   --set worker.l1CapacityBytes=$((32 * BLOCK_SIZE)) \
   --set worker.l1MaxEntryBytes=$BLOCK_SIZE \
@@ -292,7 +298,6 @@ kubectl -n "$NAMESPACE" set env "deployment/$RELEASE-worker" \
   TALON_WORKER_S3_ACCESS_KEY_ID="$MINIO_ACCESS_KEY" \
   TALON_WORKER_S3_SECRET_ACCESS_KEY="$MINIO_SECRET_KEY" \
   TALON_WORKER_S3_PATH_STYLE=true \
-  TALON_WORKER_BLOCK_SIZE="$BLOCK_SIZE" \
   TALON_WORKER_BACKEND_DELAY_MS=50 \
   TALON_WORKER_FORCE_TOKIO_DATA_PLANE=1 >/dev/null
 rollout_workers

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -56,7 +56,7 @@ require() {
   command -v "$1" >/dev/null || fail "required command not found: $1"
 }
 
-for command in kubectl helm cargo curl awk sort uniq cmp kind docker timeout; do
+for command in kubectl helm cargo curl awk sort uniq cmp dd kind docker timeout; do
   require "$command"
 done
 
@@ -423,8 +423,8 @@ cmp "$ARTIFACT_DIR/hot.expected" "$ARTIFACT_DIR/hot-warm.out"
 
 CROSS_OFFSET=$((BLOCK_SIZE - 32768))
 CROSS_LEN=65536
-tail -c +$((CROSS_OFFSET + 1)) "$ARTIFACT_DIR/cross.bin" |
-  head -c "$CROSS_LEN" >"$ARTIFACT_DIR/cross.expected"
+dd if="$ARTIFACT_DIR/cross.bin" of="$ARTIFACT_DIR/cross.expected" \
+  bs=1 skip="$CROSS_OFFSET" count="$CROSS_LEN" status=none
 direct_read cross.bin "$CROSS_OFFSET" "$CROSS_LEN" "$ARTIFACT_DIR/cross.out"
 cmp "$ARTIFACT_DIR/cross.expected" "$ARTIFACT_DIR/cross.out"
 

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -171,6 +171,14 @@ upload_file() {
     mc pipe "local/$BUCKET/$key" <"$source"
 }
 
+stage_file() {
+  local source="$1"
+  local key="$2"
+  # shellcheck disable=SC2016 # $1 expands in the container shell.
+  kubectl -n "$NAMESPACE" exec -i minio-client -- \
+    sh -c 'mkdir -p /tmp/fixtures && cat >"/tmp/fixtures/$1"' sh "$key" <"$source"
+}
+
 direct_read() {
   local path="$1"
   local offset="$2"
@@ -328,17 +336,19 @@ make_repeated_file B $((16 * BLOCK_SIZE)) "$ARTIFACT_DIR/bench"
 
 for object in hot.bin singleflight.bin version.bin restart.bin bench cross.bin; do
   case "$object" in
-    version.bin) upload_file "$ARTIFACT_DIR/version-old.bin" "$object" ;;
-    *) upload_file "$ARTIFACT_DIR/$object" "$object" ;;
+    version.bin) stage_file "$ARTIFACT_DIR/version-old.bin" "$object" ;;
+    *) stage_file "$ARTIFACT_DIR/$object" "$object" ;;
   esac
 done
 for i in $(seq 0 7); do
   make_repeated_file "$(printf '\\%03o' $((65 + i)))" "$BLOCK_SIZE" "$ARTIFACT_DIR/evict-$i.bin"
-  upload_file "$ARTIFACT_DIR/evict-$i.bin" "evict-$i.bin"
+  stage_file "$ARTIFACT_DIR/evict-$i.bin" "evict-$i.bin"
 done
-for i in $(seq 0 29); do
-  upload_file "$ARTIFACT_DIR/hot.bin" "shard-$i.bin"
-done
+# shellcheck disable=SC2016 # Loop variables expand in the container shell.
+kubectl -n "$NAMESPACE" exec minio-client -- sh -c \
+  'i=0; while [ "$i" -lt 30 ]; do cp /tmp/fixtures/hot.bin "/tmp/fixtures/shard-$i.bin"; i=$((i + 1)); done'
+kubectl -n "$NAMESPACE" exec minio-client -- \
+  mc mirror --overwrite /tmp/fixtures "local/$BUCKET"
 
 log "verifying multi-node placement reaches all three workers"
 declare -A placed_workers=()


### PR DESCRIPTION
## Summary

Implements the L1/L2 portion of the storage-tiering roadmap in #274 as one PR.

- adds a byte-bounded, thread-safe LRU L1 DRAM store for eligible small whole blocks
- keeps L1 inclusive of persistent local-NVMe L2 and invalidates L1 on L2 eviction, delete, and version replacement
- promotes eligible L2 blocks into L1 after process restart while preserving the large-block `sendfile` path
- populates both tiers after origin reads and write-through operations, with single-flight misses unchanged
- adds worker config, validation, Prometheus tier metrics, Kubernetes/Helm settings, and design/reference docs
- labels backend metrics with the configured backend instead of the previous hard-coded Azure label
- keeps L1 disabled by default; L3 remote SSD/HDD is intentionally out of scope

## Test coverage

- byte accounting, LRU touch order, replacement, exact limits, oversized entries, and concurrent access
- L1 disabled compatibility and L2 `sendfile` behavior
- origin fill, warm L1 reads, L1 eviction fallback to L2, and L2 eviction invalidation
- restart reconstruction and L2-to-L1 promotion without origin refetch
- 32 concurrent cold misses collapsing to one backend body fetch
- concurrent warm reads and cross-block reads served from L1
- backend failure leaving both tiers clean
- source version replacement, write-through population, and delete invalidation
- config env/TOML parsing, precedence, and validation

## Kubernetes E2E

A dedicated CI workflow creates a 4-node kind cluster: 1 control plane plus 3 worker nodes. It deploys 3 coordinators, 3 Talon workers forced onto separate nodes, and MinIO as the origin.

Verified in successful run `30393437095`:

- coordinator membership converges exactly to the 3 current Ready worker Pod IPs
- 30 placed objects reach all 3 workers (17/8/5 distribution)
- byte-exact cold, warm L1, and cross-block reads
- L1 eviction falls back to L2 without origin fetch
- L2 eviction invalidates the inclusive L1 copy and forces a 1 MiB origin refetch
- CRI-level container restart preserves L2, clears L1, rebuilds the L2 index, and promotes on first read without origin refetch
- source overwrite replaces stale L1/L2 versions
- coordinator and worker Pod replacement recover and membership reconverges
- all 32 single-flight outputs and restart/replacement outputs are retained as CI artifacts

## Benchmark

64 KiB direct-worker reads, 5 seconds per concurrency level:

| Path | Conns | RPS | p50 | p99 |
| --- | ---: | ---: | ---: | ---: |
| L1 DRAM | 1 | 1,657 | 566.6 us | 1,381.5 us |
| L2 local disk | 1 | 1,468 | 616.9 us | 1,448.5 us |
| L1 DRAM | 32 | 4,143 | 7,359.7 us | 14,078.8 us |
| L2 local disk | 32 | 3,797 | 8,016.8 us | 15,903.6 us |
| L1 DRAM | 128 | 4,260 | 29,402.6 us | 60,327.2 us |
| L2 local disk | 128 | 4,273 | 29,269.5 us | 55,041.6 us |

A single cold 64 KiB read took 325.2 ms and the immediate L1 read took 2.5 ms. At 1 and 32 connections, L1 delivered 12.9% and 9.1% more RPS than L2; at 128 connections the shared worker/network path was saturated and results were effectively equal.

> The kind L2 volume is file-backed local container storage, not physical NVMe. These numbers validate tier selection and relative behavior; they are not production NVMe performance claims.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --locked`
- generated configuration reference diff check with `etcd,kubernetes` features
- Helm strict lint and template rendering for memory, Kubernetes, and etcd coordinator backends
- all PR checks green, including backend E2E, FUSE E2E, image build, docs, clients, and the multi-node Kubernetes E2E/benchmark