### PR TITLE
feat(backend): add object listing and serve ListObjects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,6 +2500,7 @@ dependencies = [
  "bytes",
  "hmac",
  "reqwest",
+ "serde_json",
  "sha2",
  "talon-core",
  "tempfile",

--- a/clients/java/src/main/java/io/milvus/talon/TalonClient.java
+++ b/clients/java/src/main/java/io/milvus/talon/TalonClient.java
@@ -145,9 +145,13 @@ public final class TalonClient implements AutoCloseable {
     /**
      * List objects beneath a mount-relative prefix.
      *
-     * <p><b>Not usable yet</b>: {@code ListObjects} needs a listing capability
-     * on the backends, which they do not yet have (issue #332). {@code stat}
-     * and {@code read} are unaffected.
+     * <p>The prefix names a backend and bucket ({@code az/container}),
+     * optionally followed by a key prefix. Returned paths are in the same
+     * namespace, so they can be passed straight to {@link #read}.
+     *
+     * <p>Large listings are truncated rather than paginated: the control
+     * protocol has no cursor, so the server caps both the object count and the
+     * number of backend round trips.
      */
     public List<ObjectEntry> list(String prefix) throws IOException {
         int id = requestIds.getAndIncrement();

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -240,9 +240,14 @@ impl Client {
 
     /// List objects under a mount-relative prefix, e.g. `az/container/dir`.
     ///
-    /// **Not usable yet**: `ListObjects` needs a listing capability on
-    /// `BackendStore`, which the S3, GCS, and Azure backends do not yet have
-    /// (#332). `stat` and `read` are unaffected.
+    /// The prefix names a backend and bucket (`az/container`), optionally
+    /// followed by a key prefix. Returned paths are in the same namespace, so
+    /// they can be passed straight to [`read`](Self::read) after converting to
+    /// a URI.
+    ///
+    /// Large listings are truncated rather than paginated: the control protocol
+    /// has no cursor, so the server caps both the object count and the number
+    /// of backend round trips.
     fn list(&self, py: Python<'_>, prefix: &str) -> PyResult<Vec<ObjectEntry>> {
         let runtime = Arc::clone(&self.runtime);
         let coordinator = self.coordinator.clone();

--- a/crates/talon-backend/Cargo.toml
+++ b/crates/talon-backend/Cargo.toml
@@ -9,6 +9,8 @@ description = "Blob-store BackendStore implementations (S3/GCS/Azure) for Talon"
 
 [dependencies]
 talon-core.workspace = true
+# GCS answers listings with JSON (S3 and Azure use XML).
+serde_json.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }

--- a/crates/talon-backend/src/azure.rs
+++ b/crates/talon-backend/src/azure.rs
@@ -16,9 +16,26 @@ use std::path::Path;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use talon_core::{BackendStore, Error, ObjectId, ObjectStat, Result, Version};
+use talon_core::{
+    BackendStore, Error, ListPage, ListedObject, ObjectId, ObjectStat, Result, Version,
+};
 
 use crate::http::{HttpClient, HttpRequest, Method};
+
+/// Percent-encode a query value. `/` is escaped: a listing prefix contains
+/// slashes and an unescaped one would change the request path.
+fn encode_query_value(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for &b in s.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
 
 /// Azure Blob endpoint configuration.
 #[derive(Debug, Clone)]
@@ -132,6 +149,75 @@ impl AzureBackend {
             Some(sas) => format!("{base}?{sas}"),
             None => base,
         }
+    }
+
+    /// Build the container listing URL.
+    ///
+    /// Azure lists with `restype=container&comp=list` on the **container**, and
+    /// a SAS token is itself a query string. Both have to coexist, so the SAS
+    /// is merged with `&` rather than appended with `?` — appending would
+    /// produce two `?` and a request the service rejects as malformed.
+    pub fn list_url(
+        &self,
+        container: &str,
+        prefix: &str,
+        cursor: Option<&str>,
+        max: u32,
+    ) -> String {
+        let scheme = if self.config.tls { "https" } else { "http" };
+        let host =
+            self.config.endpoint_host.clone().unwrap_or_else(|| {
+                format!("{}.{}", self.config.account, self.config.endpoint_suffix)
+            });
+        let base = if self.config.path_style {
+            format!("{scheme}://{host}/{}/{container}", self.config.account)
+        } else {
+            format!("{scheme}://{host}/{container}")
+        };
+        let mut query = format!("restype=container&comp=list&maxresults={max}");
+        if !prefix.is_empty() {
+            query.push_str(&format!("&prefix={}", encode_query_value(prefix)));
+        }
+        if let Some(marker) = cursor {
+            query.push_str(&format!("&marker={}", encode_query_value(marker)));
+        }
+        match &self.sas_token {
+            // The SAS is already a query string; join with `&`.
+            Some(sas) => format!("{base}?{query}&{}", sas.trim_start_matches('?')),
+            None => format!("{base}?{query}"),
+        }
+    }
+
+    /// Parse a `List Blobs` response.
+    ///
+    /// `<Blob>` records are isolated before reading their fields so a blob's
+    /// name cannot be paired with a neighbour's size. The continuation cursor
+    /// is `<NextMarker>`, which Azure emits **empty** rather than omitting when
+    /// the listing is complete.
+    pub fn parse_list_response(body: &str) -> Result<ListPage> {
+        let objects = crate::xml::blocks(body, "Blob")
+            .into_iter()
+            .map(|record| {
+                let key = crate::xml::element(record, "Name")
+                    .map(crate::xml::unescape)
+                    .ok_or_else(|| Error::Backend("Azure listing entry has no <Name>".into()))?;
+                let size = crate::xml::element(record, "Content-Length")
+                    .and_then(|v| v.trim().parse::<u64>().ok())
+                    .ok_or_else(|| {
+                        Error::Backend(format!(
+                            "Azure listing entry {key} has no usable <Content-Length>"
+                        ))
+                    })?;
+                Ok(ListedObject { key, size })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Azure sends <NextMarker/> empty on the last page rather than omitting
+        // it; treating an empty marker as a cursor loops forever.
+        let next = crate::xml::element(body, "NextMarker")
+            .map(crate::xml::unescape)
+            .filter(|m| !m.trim().is_empty());
+        Ok(ListPage { objects, next })
     }
 
     /// Format the Azure `x-ms-range` header value for `[offset, offset+len)`.
@@ -308,6 +394,32 @@ impl BackendStore for AzureBackend {
                 obj.to_path()
             ))),
         }
+    }
+
+    async fn list_objects(
+        &self,
+        bucket: &str,
+        prefix: &str,
+        cursor: Option<&str>,
+        max_keys: u32,
+    ) -> Result<ListPage> {
+        // Azure caps maxresults at 5000, higher than S3 and GCS.
+        let max_keys = max_keys.clamp(1, 5000);
+        let url = self.list_url(bucket, prefix, cursor, max_keys);
+        let req = HttpRequest::new(Method::Get, url, self.common_headers());
+        let resp = self.http.execute(req).await.map_err(Error::Backend)?;
+        if resp.status == 404 {
+            return Err(Error::NotFound(bucket.to_string()));
+        }
+        if !resp.is_success() {
+            return Err(Error::Backend(format!(
+                "Azure list {bucket}/{prefix} -> HTTP {}",
+                resp.status
+            )));
+        }
+        let body = std::str::from_utf8(&resp.body)
+            .map_err(|e| Error::Backend(format!("Azure listing body is not UTF-8: {e}")))?;
+        Self::parse_list_response(body)
     }
 
     async fn head(&self, obj: &ObjectId) -> Result<ObjectStat> {
@@ -746,6 +858,108 @@ mod tests {
         assert_eq!(
             http.last.lock().unwrap().clone().unwrap().method,
             Method::Delete
+        );
+    }
+
+    /// A real List Blobs body, abbreviated. Azure names the size field
+    /// `Content-Length`, not `Size`.
+    const LIST_BODY: &str = r#"<?xml version="1.0" encoding="utf-8"?>
+<EnumerationResults ContainerName="https://acct.blob.core.windows.net/container">
+  <Blobs>
+    <Blob>
+      <Name>data/a.parquet</Name>
+      <Properties>
+        <Content-Length>1048576</Content-Length>
+        <Etag>0x8DABC</Etag>
+      </Properties>
+    </Blob>
+    <Blob>
+      <Name>data/b.parquet</Name>
+      <Properties>
+        <Content-Length>42</Content-Length>
+        <Etag>0x8DABD</Etag>
+      </Properties>
+    </Blob>
+  </Blobs>
+  <NextMarker />
+</EnumerationResults>"#;
+
+    #[test]
+    fn list_parses_names_and_content_lengths_pairwise() {
+        let page = AzureBackend::parse_list_response(LIST_BODY).unwrap();
+        assert_eq!(page.objects.len(), 2);
+        assert_eq!(page.objects[0].key, "data/a.parquet");
+        assert_eq!(page.objects[0].size, 1_048_576);
+        assert_eq!(page.objects[1].key, "data/b.parquet");
+        assert_eq!(page.objects[1].size, 42);
+    }
+
+    /// Azure emits `<NextMarker />` **empty** on the last page rather than
+    /// omitting it. Treating an empty marker as a cursor loops forever.
+    #[test]
+    fn list_treats_an_empty_next_marker_as_the_end() {
+        let page = AzureBackend::parse_list_response(LIST_BODY).unwrap();
+        assert_eq!(page.next, None);
+
+        let with_marker = LIST_BODY.replace("<NextMarker />", "<NextMarker>2!abc</NextMarker>");
+        let page = AzureBackend::parse_list_response(&with_marker).unwrap();
+        assert_eq!(page.next.as_deref(), Some("2!abc"));
+    }
+
+    #[test]
+    fn list_unescapes_blob_names() {
+        let body = r#"<EnumerationResults><Blobs><Blob><Name>a&amp;b/c.bin</Name>
+          <Properties><Content-Length>7</Content-Length></Properties></Blob></Blobs>
+          <NextMarker /></EnumerationResults>"#;
+        let page = AzureBackend::parse_list_response(body).unwrap();
+        assert_eq!(page.objects[0].key, "a&b/c.bin");
+    }
+
+    #[test]
+    fn list_of_an_empty_container_is_an_empty_page() {
+        let body = r#"<EnumerationResults><Blobs /><NextMarker /></EnumerationResults>"#;
+        let page = AzureBackend::parse_list_response(body).unwrap();
+        assert!(page.objects.is_empty());
+        assert_eq!(page.next, None);
+    }
+
+    /// A SAS token is itself a query string. Appending listing params with `?`
+    /// would produce two `?` and a request Azure rejects as malformed.
+    #[test]
+    fn list_url_merges_listing_params_with_the_sas_query() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![],
+            body: bytes::Bytes::new(),
+        });
+        let backend = AzureBackend::new(
+            AzureConfig::new("acct"),
+            Some("sv=2021&sig=abc".to_string()),
+            http.clone(),
+        );
+        let url = backend.list_url("container", "data/", None, 5000);
+        assert_eq!(url.matches('?').count(), 1, "exactly one `?`: {url}");
+        assert!(url.contains("restype=container&comp=list"), "url: {url}");
+        assert!(
+            url.contains("prefix=data%2F"),
+            "prefix must be encoded: {url}"
+        );
+        assert!(url.contains("sv=2021&sig=abc"), "SAS must survive: {url}");
+    }
+
+    #[test]
+    fn list_url_without_a_sas_has_a_single_query() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![],
+            body: bytes::Bytes::new(),
+        });
+        let backend = AzureBackend::new(AzureConfig::new("acct"), None, http.clone());
+        let url = backend.list_url("container", "", Some("2!m"), 5000);
+        assert_eq!(url.matches('?').count(), 1, "url: {url}");
+        assert!(
+            url.contains("marker=2%21m"),
+            "marker must be encoded: {url}"
         );
     }
 }

--- a/crates/talon-backend/src/gcs.rs
+++ b/crates/talon-backend/src/gcs.rs
@@ -14,9 +14,26 @@ use std::path::Path;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use talon_core::{BackendStore, Error, ObjectId, ObjectStat, Result, Version};
+use talon_core::{
+    BackendStore, Error, ListPage, ListedObject, ObjectId, ObjectStat, Result, Version,
+};
 
 use crate::http::{HttpClient, HttpRequest, Method};
+
+/// Percent-encode a query value. `/` is escaped: a listing prefix contains
+/// slashes and an unescaped one would change the request path.
+fn encode_query_value(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for &b in s.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
 
 /// GCS endpoint configuration.
 #[derive(Debug, Clone)]
@@ -71,6 +88,72 @@ impl GcsBackend {
         let scheme = if self.config.tls { "https" } else { "http" };
         let key = obj.object_path.trim_start_matches('/');
         format!("{scheme}://{}/{}/{}", self.config.endpoint, obj.bucket, key)
+    }
+
+    /// Build the JSON API listing URL for a bucket.
+    ///
+    /// GCS lists through the **JSON API** (`/storage/v1/b/<bucket>/o`), not the
+    /// download endpoint the object URLs use, so this does not go through
+    /// [`object_url`](Self::object_url).
+    pub fn list_url(&self, bucket: &str, prefix: &str, cursor: Option<&str>, max: u32) -> String {
+        let scheme = if self.config.tls { "https" } else { "http" };
+        let mut url = format!(
+            "{scheme}://{}/storage/v1/b/{}/o?maxResults={max}",
+            self.config.endpoint,
+            encode_query_value(bucket)
+        );
+        if !prefix.is_empty() {
+            url.push_str(&format!("&prefix={}", encode_query_value(prefix)));
+        }
+        if let Some(token) = cursor {
+            url.push_str(&format!("&pageToken={}", encode_query_value(token)));
+        }
+        url
+    }
+
+    /// Parse a GCS JSON listing response.
+    ///
+    /// `size` arrives as a **string**, not a number — GCS encodes 64-bit values
+    /// that way to survive JavaScript's 53-bit integers. Reading it as a JSON
+    /// number silently yields nothing for every object.
+    pub fn parse_list_response(body: &str) -> Result<ListPage> {
+        let doc: serde_json::Value = serde_json::from_str(body)
+            .map_err(|e| Error::Backend(format!("GCS listing is not valid JSON: {e}")))?;
+
+        let objects = match doc.get("items") {
+            // An empty prefix omits `items` entirely rather than sending [].
+            None => Vec::new(),
+            Some(items) => items
+                .as_array()
+                .ok_or_else(|| Error::Backend("GCS listing `items` is not an array".into()))?
+                .iter()
+                .map(|item| {
+                    let key = item
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .ok_or_else(|| Error::Backend("GCS listing entry has no `name`".into()))?
+                        .to_string();
+                    let size = item
+                        .get("size")
+                        .and_then(|v| v.as_str())
+                        .and_then(|v| v.parse::<u64>().ok())
+                        .ok_or_else(|| {
+                            Error::Backend(format!(
+                                "GCS listing entry {key} has no usable `size` \
+                                 (expected a decimal string)"
+                            ))
+                        })?;
+                    Ok(ListedObject { key, size })
+                })
+                .collect::<Result<Vec<_>>>()?,
+        };
+
+        let next = doc
+            .get("nextPageToken")
+            .and_then(|v| v.as_str())
+            .filter(|t| !t.is_empty())
+            .map(|t| t.to_string());
+        Ok(ListPage { objects, next })
     }
 
     /// Format an inclusive HTTP `Range` header for `[offset, offset+len)`.
@@ -238,6 +321,33 @@ impl BackendStore for GcsBackend {
                 obj.to_path()
             ))),
         }
+    }
+
+    async fn list_objects(
+        &self,
+        bucket: &str,
+        prefix: &str,
+        cursor: Option<&str>,
+        max_keys: u32,
+    ) -> Result<ListPage> {
+        // GCS caps maxResults at 1000 and silently reduces larger values;
+        // clamping keeps the request honest.
+        let max_keys = max_keys.clamp(1, 1000);
+        let url = self.list_url(bucket, prefix, cursor, max_keys);
+        let req = HttpRequest::new(Method::Get, url, self.auth_headers());
+        let resp = self.http.execute(req).await.map_err(Error::Backend)?;
+        if resp.status == 404 {
+            return Err(Error::NotFound(bucket.to_string()));
+        }
+        if !resp.is_success() {
+            return Err(Error::Backend(format!(
+                "GCS list {bucket}/{prefix} -> HTTP {}",
+                resp.status
+            )));
+        }
+        let body = std::str::from_utf8(&resp.body)
+            .map_err(|e| Error::Backend(format!("GCS listing body is not UTF-8: {e}")))?;
+        Self::parse_list_response(body)
     }
 
     async fn head(&self, obj: &ObjectId) -> Result<ObjectStat> {
@@ -630,5 +740,80 @@ mod tests {
             http.last.lock().unwrap().clone().unwrap().method,
             Method::Delete
         );
+    }
+
+    /// A real JSON listing response. `size` is a **string** — GCS encodes
+    /// 64-bit values that way, and reading it as a number yields nothing.
+    const LIST_BODY: &str = r#"{
+  "kind": "storage#objects",
+  "items": [
+    {"kind":"storage#object","name":"data/a.parquet","size":"1048576","generation":"17"},
+    {"kind":"storage#object","name":"data/b.parquet","size":"42","generation":"18"}
+  ]
+}"#;
+
+    #[test]
+    fn list_parses_string_encoded_sizes() {
+        let page = GcsBackend::parse_list_response(LIST_BODY).unwrap();
+        assert_eq!(page.objects.len(), 2);
+        assert_eq!(page.objects[0].key, "data/a.parquet");
+        assert_eq!(page.objects[0].size, 1_048_576);
+        assert_eq!(page.objects[1].size, 42);
+        assert_eq!(page.next, None);
+    }
+
+    /// Sizes beyond 2^53 are exactly why GCS sends them as strings; a parser
+    /// that routed through f64 would round here.
+    #[test]
+    fn list_preserves_sizes_beyond_53_bits() {
+        let body = r#"{"items":[{"name":"big","size":"9007199254740993"}]}"#;
+        let page = GcsBackend::parse_list_response(body).unwrap();
+        assert_eq!(page.objects[0].size, 9_007_199_254_740_993);
+    }
+
+    #[test]
+    fn list_returns_the_page_token_when_present() {
+        let body = r#"{"items":[{"name":"a","size":"1"}],"nextPageToken":"CgZhLnR4dA=="}"#;
+        let page = GcsBackend::parse_list_response(body).unwrap();
+        assert_eq!(page.next.as_deref(), Some("CgZhLnR4dA=="));
+    }
+
+    /// An empty prefix omits `items` entirely rather than sending `[]`, so a
+    /// parser requiring the key would error on a legitimately empty listing.
+    #[test]
+    fn list_of_an_empty_prefix_omits_items_and_is_not_an_error() {
+        let page = GcsBackend::parse_list_response(r#"{"kind":"storage#objects"}"#).unwrap();
+        assert!(page.objects.is_empty());
+        assert_eq!(page.next, None);
+    }
+
+    #[test]
+    fn list_rejects_an_entry_without_a_usable_size() {
+        let body = r#"{"items":[{"name":"a"}]}"#;
+        assert!(GcsBackend::parse_list_response(body).is_err());
+        // A numeric size is not what GCS sends; reject rather than guess.
+        let numeric = r#"{"items":[{"name":"a","size":42}]}"#;
+        assert!(GcsBackend::parse_list_response(numeric).is_err());
+    }
+
+    #[test]
+    fn list_url_targets_the_json_api_and_encodes_the_prefix() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![],
+            body: bytes::Bytes::new(),
+        });
+        let backend = GcsBackend::new(GcsConfig::default(), None, http.clone());
+        let url = backend.list_url("bucket", "data/sub", Some("tok+en"), 1000);
+        assert!(url.contains("/storage/v1/b/bucket/o"), "url: {url}");
+        assert!(
+            url.contains("prefix=data%2Fsub"),
+            "prefix must be encoded: {url}"
+        );
+        assert!(
+            url.contains("pageToken=tok%2Ben"),
+            "token must be encoded: {url}"
+        );
+        assert!(url.contains("maxResults=1000"), "url: {url}");
     }
 }

--- a/crates/talon-backend/src/lib.rs
+++ b/crates/talon-backend/src/lib.rs
@@ -15,6 +15,7 @@ pub mod reqwest_client;
 pub mod retry;
 pub mod s3;
 pub mod sigv4;
+pub mod xml;
 
 pub use azure::{AzureBackend, AzureConfig};
 pub use delay::{DelayConfig, DelayingHttpClient};

--- a/crates/talon-backend/src/s3.rs
+++ b/crates/talon-backend/src/s3.rs
@@ -18,9 +18,29 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use sha2::{Digest, Sha256};
-use talon_core::{BackendStore, Error, ObjectId, ObjectStat, Result, Version};
+use talon_core::{
+    BackendStore, Error, ListPage, ListedObject, ObjectId, ObjectStat, Result, Version,
+};
 
 use crate::http::{HttpClient, HttpRequest, Method};
+
+/// Percent-encode a query value.
+///
+/// The URL is signed after this, and SigV4 canonicalizes the query itself, so
+/// this only has to produce a valid URL. `/` is escaped because a listing
+/// prefix contains slashes and an unescaped one would change the request path.
+fn encode_query_value(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for &b in s.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
 
 /// S3 credentials + endpoint configuration.
 #[derive(Debug, Clone)]
@@ -88,6 +108,53 @@ impl S3Backend {
         } else {
             format!("{scheme}://{}.{}/{}", obj.bucket, self.config.endpoint, key)
         }
+    }
+
+    /// Build the bucket URL (no key), used by listing.
+    pub fn bucket_url(&self, bucket: &str) -> String {
+        let scheme = if self.config.tls { "https" } else { "http" };
+        if self.config.path_style {
+            format!("{scheme}://{}/{bucket}", self.config.endpoint)
+        } else {
+            format!("{scheme}://{bucket}.{}", self.config.endpoint)
+        }
+    }
+
+    /// Parse a `ListObjectsV2` response body.
+    ///
+    /// `<Contents>` blocks are isolated before reading `<Key>`/`<Size>`, so a
+    /// record's fields cannot be paired with a neighbour's. Keys are unescaped:
+    /// a key containing `&` arrives as `&amp;` and would otherwise name a
+    /// different object.
+    pub fn parse_list_response(body: &str) -> Result<ListPage> {
+        let objects = crate::xml::blocks(body, "Contents")
+            .into_iter()
+            .map(|record| {
+                let key = crate::xml::element(record, "Key")
+                    .map(crate::xml::unescape)
+                    .ok_or_else(|| Error::Backend("S3 listing entry has no <Key>".into()))?;
+                let size = crate::xml::element(record, "Size")
+                    .and_then(|v| v.trim().parse::<u64>().ok())
+                    .ok_or_else(|| {
+                        Error::Backend(format!("S3 listing entry {key} has no usable <Size>"))
+                    })?;
+                Ok(ListedObject { key, size })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Only trust the continuation token when IsTruncated says there is
+        // more; S3 may echo a token on the final page.
+        let truncated = crate::xml::element(body, "IsTruncated")
+            .map(|v| v.trim().eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        let next = if truncated {
+            crate::xml::element(body, "NextContinuationToken")
+                .map(crate::xml::unescape)
+                .filter(|t| !t.is_empty())
+        } else {
+            None
+        };
+        Ok(ListPage { objects, next })
     }
 
     /// Format an HTTP `Range` header value for `[offset, offset+len)`.
@@ -314,6 +381,44 @@ impl BackendStore for S3Backend {
                 resp.status
             )))
         }
+    }
+
+    async fn list_objects(
+        &self,
+        bucket: &str,
+        prefix: &str,
+        cursor: Option<&str>,
+        max_keys: u32,
+    ) -> Result<ListPage> {
+        // S3 caps a page at 1000 regardless of what is asked, so clamping here
+        // keeps the request honest rather than relying on the service to
+        // silently reduce it.
+        let max_keys = max_keys.clamp(1, 1000);
+        let mut query = format!("list-type=2&max-keys={max_keys}");
+        if !prefix.is_empty() {
+            query.push_str(&format!("&prefix={}", encode_query_value(prefix)));
+        }
+        if let Some(token) = cursor {
+            query.push_str(&format!(
+                "&continuation-token={}",
+                encode_query_value(token)
+            ));
+        }
+        let url = format!("{}?{query}", self.bucket_url(bucket));
+        let req = self.signed(HttpRequest::new(Method::Get, url, Vec::new()));
+        let resp = self.http.execute(req).await.map_err(Error::Backend)?;
+        if resp.status == 404 {
+            return Err(Error::NotFound(bucket.to_string()));
+        }
+        if !resp.is_success() {
+            return Err(Error::Backend(format!(
+                "S3 list {bucket}/{prefix} -> HTTP {}",
+                resp.status
+            )));
+        }
+        let body = std::str::from_utf8(&resp.body)
+            .map_err(|e| Error::Backend(format!("S3 listing body is not UTF-8: {e}")))?;
+        Self::parse_list_response(body)
     }
 
     async fn head(&self, obj: &ObjectId) -> Result<ObjectStat> {
@@ -778,5 +883,143 @@ mod tests {
         });
         let s3 = S3Backend::new(S3Config::aws("us-east-1"), creds(), http404);
         s3.delete(&obj()).await.unwrap();
+    }
+
+    /// A real ListObjectsV2 body, abbreviated. Parsing must pair each key with
+    /// its own size rather than reading fields document-wide.
+    const LIST_BODY: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>bucket</Name>
+  <Prefix>data/</Prefix>
+  <KeyCount>2</KeyCount>
+  <MaxKeys>1000</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+  <Contents>
+    <Key>data/a.parquet</Key>
+    <LastModified>2026-01-01T00:00:00.000Z</LastModified>
+    <ETag>&quot;abc&quot;</ETag>
+    <Size>1048576</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
+  <Contents>
+    <Key>data/b.parquet</Key>
+    <LastModified>2026-01-02T00:00:00.000Z</LastModified>
+    <ETag>&quot;def&quot;</ETag>
+    <Size>42</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
+</ListBucketResult>"#;
+
+    #[test]
+    fn list_parses_keys_and_sizes_pairwise() {
+        let page = S3Backend::parse_list_response(LIST_BODY).unwrap();
+        assert_eq!(page.objects.len(), 2);
+        assert_eq!(page.objects[0].key, "data/a.parquet");
+        assert_eq!(page.objects[0].size, 1_048_576);
+        assert_eq!(page.objects[1].key, "data/b.parquet");
+        assert_eq!(page.objects[1].size, 42);
+        assert_eq!(page.next, None, "IsTruncated=false means no more pages");
+    }
+
+    /// A truncated listing must surface its continuation token, or the caller
+    /// silently sees only the first page of a large prefix.
+    #[test]
+    fn list_returns_the_continuation_token_when_truncated() {
+        let body = r#"<ListBucketResult>
+  <IsTruncated>true</IsTruncated>
+  <NextContinuationToken>1PagE2Tok</NextContinuationToken>
+  <Contents><Key>a</Key><Size>1</Size></Contents>
+</ListBucketResult>"#;
+        let page = S3Backend::parse_list_response(body).unwrap();
+        assert_eq!(page.next.as_deref(), Some("1PagE2Tok"));
+    }
+
+    /// S3 may echo a token on the final page; trusting it without checking
+    /// IsTruncated causes an extra round trip and, worse, a caller that never
+    /// terminates if the service keeps echoing it.
+    #[test]
+    fn list_ignores_a_token_when_not_truncated() {
+        let body = r#"<ListBucketResult>
+  <IsTruncated>false</IsTruncated>
+  <NextContinuationToken>stale</NextContinuationToken>
+  <Contents><Key>a</Key><Size>1</Size></Contents>
+</ListBucketResult>"#;
+        let page = S3Backend::parse_list_response(body).unwrap();
+        assert_eq!(page.next, None);
+    }
+
+    /// Keys legitimately contain `&`, which arrives escaped. Leaving it escaped
+    /// names an object that does not exist.
+    #[test]
+    fn list_unescapes_keys() {
+        let body = r#"<ListBucketResult><IsTruncated>false</IsTruncated>
+  <Contents><Key>a&amp;b/c.bin</Key><Size>7</Size></Contents></ListBucketResult>"#;
+        let page = S3Backend::parse_list_response(body).unwrap();
+        assert_eq!(page.objects[0].key, "a&b/c.bin");
+    }
+
+    #[test]
+    fn list_of_an_empty_prefix_is_an_empty_page_not_an_error() {
+        let body = r#"<ListBucketResult><IsTruncated>false</IsTruncated><KeyCount>0</KeyCount></ListBucketResult>"#;
+        let page = S3Backend::parse_list_response(body).unwrap();
+        assert!(page.objects.is_empty());
+        assert_eq!(page.next, None);
+    }
+
+    /// An entry missing its size is a malformed response, not a zero-byte
+    /// object — reporting it as zero would make a reader believe the object is
+    /// empty.
+    #[test]
+    fn list_rejects_an_entry_without_a_size() {
+        let body = r#"<ListBucketResult><IsTruncated>false</IsTruncated>
+  <Contents><Key>a</Key></Contents></ListBucketResult>"#;
+        assert!(S3Backend::parse_list_response(body).is_err());
+    }
+
+    #[tokio::test]
+    async fn list_request_carries_query_and_is_signed() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![],
+            body: bytes::Bytes::from_static(LIST_BODY.as_bytes()),
+        });
+        let backend = S3Backend::new(S3Config::aws("us-east-1"), creds(), http.clone());
+        let page = backend
+            .list_objects("bucket", "data/", None, 1000)
+            .await
+            .unwrap();
+        assert_eq!(page.objects.len(), 2);
+
+        let req = http.last.lock().unwrap().clone().unwrap();
+        assert!(req.url.contains("list-type=2"), "url: {}", req.url);
+        assert!(
+            req.url.contains("prefix=data%2F"),
+            "prefix must be encoded: {}",
+            req.url
+        );
+        assert!(
+            req.headers
+                .iter()
+                .any(|(k, _)| k.eq_ignore_ascii_case("authorization")),
+            "listing must be signed"
+        );
+    }
+
+    /// max_keys above S3's ceiling is clamped rather than sent verbatim, so a
+    /// caller cannot ask for an unbounded page.
+    #[tokio::test]
+    async fn list_clamps_max_keys_to_the_service_maximum() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![],
+            body: bytes::Bytes::from_static(LIST_BODY.as_bytes()),
+        });
+        let backend = S3Backend::new(S3Config::aws("us-east-1"), creds(), http.clone());
+        backend
+            .list_objects("bucket", "", None, 100_000)
+            .await
+            .unwrap();
+        let req = http.last.lock().unwrap().clone().unwrap();
+        assert!(req.url.contains("max-keys=1000"), "url: {}", req.url);
     }
 }

--- a/crates/talon-backend/src/sigv4.rs
+++ b/crates/talon-backend/src/sigv4.rs
@@ -62,6 +62,52 @@ fn uri_encode_path(path: &str) -> String {
     out
 }
 
+/// Canonicalize a query string per SigV4: each key and value URI-encoded, pairs
+/// sorted by encoded key (then encoded value), joined with `&`.
+///
+/// Required once any request carries query parameters — listing does. AWS
+/// rejects a signature computed over an unsorted or unencoded query, and the
+/// failure is a 403 that looks like a credentials problem rather than an
+/// encoding one.
+fn canonical_query(query: &str) -> String {
+    if query.is_empty() {
+        return String::new();
+    }
+    let mut pairs: Vec<(String, String)> = query
+        .split('&')
+        .filter(|p| !p.is_empty())
+        .map(|pair| match pair.split_once('=') {
+            Some((k, v)) => (uri_encode_component(k), uri_encode_component(v)),
+            // A bare key still needs a trailing `=` in the canonical form.
+            None => (uri_encode_component(pair), String::new()),
+        })
+        .collect();
+    pairs.sort();
+    pairs
+        .into_iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+/// URI-encode a query key or value.
+///
+/// Unlike [`uri_encode_path`], `/` is **not** left literal: in a query
+/// component it is a reserved character and must be escaped, which matters for
+/// a listing prefix like `dir/sub`.
+fn uri_encode_component(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for &b in s.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
 /// A timestamp split into the two forms SigV4 needs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AmzDate {
@@ -192,7 +238,7 @@ pub fn sign_request_with_payload_hash(
         "{}\n{}\n{}\n{}\n{}\n{}",
         method_str(req.method),
         uri_encode_path(&path),
-        query, // requests carry no query params today
+        canonical_query(&query),
         canonical_headers,
         signed_headers,
         payload_hash
@@ -225,6 +271,45 @@ pub fn sign_request_with_payload_hash(
 
 #[cfg(test)]
 mod tests {
+    /// SigV4 requires the canonical query sorted by encoded key. An unsorted
+    /// query produces a signature AWS rejects with a 403 that reads like a
+    /// credentials failure, so this is worth pinning.
+    #[test]
+    fn canonical_query_sorts_by_encoded_key() {
+        assert_eq!(
+            canonical_query("prefix=a&list-type=2&max-keys=1000"),
+            "list-type=2&max-keys=1000&prefix=a"
+        );
+    }
+
+    /// `/` is reserved in a query component even though it is literal in a
+    /// path. A listing prefix contains slashes, so getting this wrong breaks
+    /// exactly the case listing needs.
+    #[test]
+    fn canonical_query_escapes_slashes_in_values() {
+        assert_eq!(canonical_query("prefix=dir/sub/"), "prefix=dir%2Fsub%2F");
+    }
+
+    #[test]
+    fn canonical_query_handles_empty_and_bare_keys() {
+        assert_eq!(canonical_query(""), "");
+        // A valueless key still needs its `=` in canonical form.
+        assert_eq!(canonical_query("acl"), "acl=");
+    }
+
+    /// Continuation tokens are opaque base64 and routinely contain `+`, `/`,
+    /// and `=`, all of which must be percent-encoded in the canonical query.
+    #[test]
+    fn canonical_query_escapes_continuation_token_characters() {
+        let encoded = canonical_query("continuation-token=a+b/c=");
+        assert_eq!(encoded, "continuation-token=a%2Bb%2Fc%3D");
+    }
+
+    #[test]
+    fn uri_encode_component_leaves_unreserved_characters_alone() {
+        assert_eq!(uri_encode_component("aZ0-_.~"), "aZ0-_.~");
+    }
+
     use super::*;
 
     #[test]

--- a/crates/talon-backend/src/xml.rs
+++ b/crates/talon-backend/src/xml.rs
@@ -1,0 +1,112 @@
+//! A minimal reader for the XML shapes S3 and Azure listings return.
+//!
+//! Both backends answer listings with XML, and neither response needs a general
+//! parser: the documents are flat sequences of elements with text content, and
+//! the fields wanted are a handful of known tag names. Pulling in a full XML
+//! crate for that would add a dependency and an attack surface for no benefit.
+//!
+//! This deliberately does **not** handle namespaces, attributes, CDATA, or
+//! nested elements of the same name. It handles exactly what these two APIs
+//! emit, and callers assert against real recorded responses so a shape change
+//! fails a test rather than silently returning nothing.
+
+/// Iterate the text content of every `<tag>…</tag>` at any depth.
+///
+/// Returns the raw inner text; the caller unescapes if the field can contain
+/// entities.
+pub fn elements<'a>(xml: &'a str, tag: &str) -> Vec<&'a str> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let mut out = Vec::new();
+    let mut rest = xml;
+    while let Some(start) = rest.find(&open) {
+        let after = &rest[start + open.len()..];
+        match after.find(&close) {
+            Some(end) => {
+                out.push(&after[..end]);
+                rest = &after[end + close.len()..];
+            }
+            // Unterminated tag: stop rather than looping forever.
+            None => break,
+        }
+    }
+    out
+}
+
+/// The text of the first `<tag>…</tag>`, if present.
+pub fn element<'a>(xml: &'a str, tag: &str) -> Option<&'a str> {
+    elements(xml, tag).into_iter().next()
+}
+
+/// Split a document into the body of each `<tag>…</tag>` block.
+///
+/// Used to isolate one `<Contents>` or `<Blob>` element so its child fields are
+/// read from the right record rather than from the document as a whole.
+pub fn blocks<'a>(xml: &'a str, tag: &str) -> Vec<&'a str> {
+    elements(xml, tag)
+}
+
+/// Unescape the five XML predefined entities.
+///
+/// Object keys legitimately contain `&` and `<`, which arrive escaped. Failing
+/// to unescape produces a key that does not match the object it names.
+pub fn unescape(s: &str) -> String {
+    if !s.contains('&') {
+        return s.to_string();
+    }
+    s.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        // `&amp;` last: doing it first would re-expand the others' ampersands.
+        .replace("&amp;", "&")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn elements_reads_repeated_tags_in_order() {
+        let xml = "<L><Key>a</Key><Key>b</Key><Key>c</Key></L>";
+        assert_eq!(elements(xml, "Key"), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn element_returns_the_first_match_or_none() {
+        assert_eq!(element("<A><X>1</X></A>", "X"), Some("1"));
+        assert_eq!(element("<A></A>", "X"), None);
+    }
+
+    #[test]
+    fn blocks_isolate_records_so_fields_pair_correctly() {
+        let xml = "<R><C><Key>a</Key><Size>1</Size></C><C><Key>b</Key><Size>2</Size></C></R>";
+        let records = blocks(xml, "C");
+        assert_eq!(records.len(), 2);
+        assert_eq!(element(records[0], "Key"), Some("a"));
+        assert_eq!(element(records[1], "Size"), Some("2"));
+    }
+
+    /// An unterminated tag must not loop or panic — a truncated response is a
+    /// realistic failure and should yield what was parsed, not hang.
+    #[test]
+    fn unterminated_tag_stops_cleanly() {
+        assert_eq!(elements("<K>a</K><K>truncated", "K"), vec!["a"]);
+    }
+
+    /// Keys containing `&` arrive escaped; leaving them escaped names a
+    /// different object than the one listed.
+    #[test]
+    fn unescape_handles_predefined_entities() {
+        assert_eq!(unescape("a&amp;b"), "a&b");
+        assert_eq!(unescape("&lt;x&gt;"), "<x>");
+        assert_eq!(unescape("plain"), "plain");
+    }
+
+    /// `&amp;lt;` is a literal "&lt;", not a "<". Unescaping `&amp;` first
+    /// would wrongly turn it into one.
+    #[test]
+    fn unescape_does_not_double_expand() {
+        assert_eq!(unescape("&amp;lt;"), "&lt;");
+    }
+}

--- a/crates/talon-coordinator/src/main.rs
+++ b/crates/talon-coordinator/src/main.rs
@@ -269,6 +269,15 @@ impl Coordinator {
                     nodes: self.service.membership().snapshot(),
                 }
             }
+            listing @ ControlMessage::ListObjects { .. } => {
+                if !self.observability.is_ready() {
+                    return ControlMessage::Ack {
+                        ok: false,
+                        detail: Some("coordinator not ready: shared state unavailable".into()),
+                    };
+                }
+                self.proxy_to_worker(listing).await
+            }
             stat @ ControlMessage::StatObject { .. } => {
                 if !self.observability.is_ready() {
                     return ControlMessage::Ack {

--- a/crates/talon-core/src/backend.rs
+++ b/crates/talon-core/src/backend.rs
@@ -20,9 +20,63 @@ pub struct ObjectStat {
     pub version: Version,
 }
 
+/// One object returned by a listing: its key and size.
+///
+/// The key is backend-relative (no bucket, no mount prefix); callers map it
+/// into whatever namespace they present.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListedObject {
+    /// Object key within the bucket/container.
+    pub key: String,
+    /// Object size in bytes.
+    pub size: u64,
+}
+
+/// One page of a listing.
+///
+/// Pagination is in the type rather than hidden behind an accumulating `Vec`
+/// because a prefix can hold millions of objects: S3 caps a response at 1000
+/// keys, and a method that looped internally would buffer the whole set in
+/// memory before returning. The caller decides how much to pull.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ListPage {
+    /// Objects in this page, in the backend's order.
+    pub objects: Vec<ListedObject>,
+    /// Opaque cursor for the next page, or `None` when the listing is complete.
+    ///
+    /// Treat as opaque: S3 calls it a continuation token, GCS a page token, and
+    /// Azure a marker, and none of them are interchangeable.
+    pub next: Option<String>,
+}
+
 /// A durable blob backend that workers load blocks/pages from on cache miss.
 #[async_trait]
 pub trait BackendStore: Send + Sync {
+    /// List objects under `prefix` within `bucket`, one page at a time.
+    ///
+    /// `prefix` is matched literally against object keys; an empty prefix lists
+    /// the bucket. `max_keys` bounds the page — backends clamp it to their own
+    /// maximum (1000 for S3), so a caller cannot use it to demand an unbounded
+    /// response. `cursor` is the [`ListPage::next`] value from the previous
+    /// page, or `None` to start.
+    ///
+    /// The default returns [`crate::Error::Unsupported`], so a backend that cannot
+    /// list says so rather than silently returning an empty page — an empty
+    /// listing and an unsupported one mean very different things to a caller
+    /// building a namespace from it.
+    async fn list_objects(
+        &self,
+        bucket: &str,
+        prefix: &str,
+        cursor: Option<&str>,
+        max_keys: u32,
+    ) -> Result<ListPage> {
+        let _ = (bucket, prefix, cursor, max_keys);
+        Err(crate::Error::Unsupported(
+            "backend does not support listing".into(),
+        ))
+    }
+
     /// Fetch a byte range `[offset, offset + len)` of a source object.
     ///
     /// Used for both whole-block and page-level loads; the caller chooses the

--- a/crates/talon-core/src/error.rs
+++ b/crates/talon-core/src/error.rs
@@ -29,6 +29,16 @@ pub enum Error {
         found: String,
     },
 
+    /// The operation is not supported by this implementation.
+    ///
+    /// Distinct from [`Error::Backend`]: that means an operation was attempted
+    /// and failed, this means it was never possible. A caller building a
+    /// namespace from a listing needs to tell "this backend cannot list" from
+    /// "this prefix is empty" — conflating them turns a missing capability into
+    /// a silently empty result.
+    #[error("unsupported: {0}")]
+    Unsupported(String),
+
     /// Serialization or deserialization failed.
     #[error("serialization error: {0}")]
     Serialization(String),

--- a/crates/talon-core/src/lib.rs
+++ b/crates/talon-core/src/lib.rs
@@ -14,7 +14,7 @@ pub mod status;
 pub mod store;
 pub mod trace;
 
-pub use backend::{BackendStore, ObjectStat};
+pub use backend::{BackendStore, ListPage, ListedObject, ObjectStat};
 pub use block::{BlockForm, BlockMeta, LoadHint, PresentBitmap};
 pub use config::{
     azure_sas_from_env, gcs_bearer_from_env, s3_secret_key_from_env, s3_session_token_from_env,

--- a/crates/talon-fuse/src/main.rs
+++ b/crates/talon-fuse/src/main.rs
@@ -88,7 +88,21 @@ async fn main() -> anyhow::Result<()> {
             tracing::info!(objects = n, "populated namespace from coordinator listing");
         }
         Err(e) => {
-            tracing::warn!(error = %e, "coordinator listing failed; mounting an empty namespace");
+            // Deliberately non-fatal for now, but loud: there is no
+            // cross-backend root listing — a worker cannot enumerate every
+            // bucket across S3, GCS, and Azure — so `list_objects("")` cannot
+            // succeed even now that listing is implemented (#332). The mount
+            // still serves reads for paths a client already knows.
+            //
+            // This silent degradation is why #318 and #332 went unnoticed for
+            // months: the endpoints were unimplemented and the mount still
+            // reported success. Populating the namespace properly needs a
+            // configured prefix naming a backend and bucket, tracked in #366.
+            tracing::warn!(
+                error = %e,
+                "namespace listing failed; the mount will appear empty until a \
+                 namespace prefix is configured (#366). Reads of known paths still work."
+            );
         }
     }
 

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -6,8 +6,8 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use talon_core::{
-    BackendStore, BlockForm, BlockHandle, BlockId, BlockMeta, Error, ObjectId, ObjectStore,
-    PageIndex, Version,
+    Backend, BackendStore, BlockForm, BlockHandle, BlockId, BlockMeta, Error, ObjectId,
+    ObjectStore, PageIndex, Version,
 };
 use talon_transport::data::RangeRequest;
 
@@ -294,6 +294,73 @@ impl WorkerRuntime {
             cursor += take;
         }
         Ok(out.freeze())
+    }
+
+    /// List objects under a mount-relative prefix (#332).
+    ///
+    /// `prefix` is a namespace path like `az/container/dir`: the first segment
+    /// selects the backend, the second the bucket/container, and the rest is a
+    /// key prefix. Returned paths are in the same namespace, so a client can
+    /// feed them straight back to `read`.
+    ///
+    /// Pages are drained here rather than exposed to the client: the control
+    /// protocol has no cursor, and adding one would be a wire change. To keep
+    /// that bounded, both the object count and the number of backend round
+    /// trips are capped — an unbounded listing of a large bucket would
+    /// otherwise hold the whole result set in memory and block the caller for
+    /// an unbounded time. A truncated listing is better than an unbounded one,
+    /// and the cap is high enough that a namespace hitting it is already past
+    /// what a single control message should carry.
+    pub async fn list_objects(&self, prefix: &str) -> anyhow::Result<Vec<(String, u64)>> {
+        /// Objects returned before truncating.
+        const MAX_OBJECTS: usize = 10_000;
+        /// Backend round trips before giving up, independent of page size.
+        const MAX_PAGES: usize = 20;
+        /// Objects requested per backend page.
+        const PAGE_SIZE: u32 = 1000;
+
+        let trimmed = prefix.trim_start_matches('/');
+        let mut parts = trimmed.splitn(3, '/');
+        let backend_prefix = parts.next().unwrap_or("");
+        if backend_prefix.is_empty() {
+            anyhow::bail!(
+                "listing prefix must name a backend, e.g. `az/container/dir`; got {prefix:?}"
+            );
+        }
+        let backend: Backend = backend_prefix.parse().map_err(|_| {
+            anyhow::anyhow!("unknown backend {backend_prefix:?} in listing prefix {prefix:?}")
+        })?;
+        let bucket = parts.next().unwrap_or("");
+        if bucket.is_empty() {
+            anyhow::bail!(
+                "listing prefix must name a bucket/container, e.g. `az/container`; got {prefix:?}"
+            );
+        }
+        let key_prefix = parts.next().unwrap_or("");
+
+        let mut out = Vec::new();
+        let mut cursor: Option<String> = None;
+        for _ in 0..MAX_PAGES {
+            let page = self
+                .backend
+                .list_objects(bucket, key_prefix, cursor.as_deref(), PAGE_SIZE)
+                .await
+                .map_err(|error| anyhow::anyhow!("list {prefix}: {error}"))?;
+            for object in page.objects {
+                out.push((
+                    format!("{}/{}/{}", backend.prefix(), bucket, object.key),
+                    object.size,
+                ));
+                if out.len() >= MAX_OBJECTS {
+                    return Ok(out);
+                }
+            }
+            match page.next {
+                Some(next) => cursor = Some(next),
+                None => break,
+            }
+        }
+        Ok(out)
     }
 
     /// Return an object's size and current version (#318).

--- a/crates/talon-worker/src/tokio_conn.rs
+++ b/crates/talon-worker/src/tokio_conn.rs
@@ -107,7 +107,7 @@ pub async fn handle_conn(
         if header.msg_type != MsgType::GetRange {
             let err = data::encode_error(
                 header.request_id,
-                "worker only serves GetRange/Put/Delete/StatObject",
+                "worker only serves GetRange/Put/Delete/StatObject/ListObjects",
             );
             stream.write_all(&err).await?;
             stream.flush().await?;
@@ -256,10 +256,31 @@ async fn handle_control_frame(
                 }
             }
         }
+        ControlMessage::ListObjects { prefix } => {
+            if !observability.is_ready() {
+                ControlMessage::Ack {
+                    ok: false,
+                    detail: Some("worker is not ready".into()),
+                }
+            } else {
+                match worker.list_objects(&prefix).await {
+                    Ok(entries) => ControlMessage::ObjectList {
+                        entries: entries
+                            .into_iter()
+                            .map(|(path, size)| talon_transport::ObjectEntry { path, size })
+                            .collect(),
+                    },
+                    Err(error) => ControlMessage::Ack {
+                        ok: false,
+                        detail: Some(error.to_string()),
+                    },
+                }
+            }
+        }
         other => ControlMessage::Ack {
             ok: false,
             detail: Some(format!(
-                "worker serves only StatObject on the data plane, got {other:?}"
+                "worker serves only StatObject/ListObjects on the data plane, got {other:?}"
             )),
         },
     };

--- a/crates/talon-worker/src/uring_conn.rs
+++ b/crates/talon-worker/src/uring_conn.rs
@@ -132,7 +132,7 @@ pub async fn handle_conn(
             _ => {
                 let err = data::encode_error(
                     header.request_id,
-                    "worker only serves GetRange/Put/Delete/StatObject",
+                    "worker only serves GetRange/Put/Delete/StatObject/ListObjects",
                 );
                 write_all(&mut stream, err).await?;
                 observability
@@ -313,10 +313,31 @@ async fn handle_control_frame(
                 }
             }
         }
+        talon_transport::ControlMessage::ListObjects { prefix } => {
+            if !observability.is_ready() {
+                talon_transport::ControlMessage::Ack {
+                    ok: false,
+                    detail: Some("worker is not ready".into()),
+                }
+            } else {
+                match worker.list_objects(&prefix).await {
+                    Ok(entries) => talon_transport::ControlMessage::ObjectList {
+                        entries: entries
+                            .into_iter()
+                            .map(|(path, size)| talon_transport::ObjectEntry { path, size })
+                            .collect(),
+                    },
+                    Err(error) => talon_transport::ControlMessage::Ack {
+                        ok: false,
+                        detail: Some(error.to_string()),
+                    },
+                }
+            }
+        }
         other => talon_transport::ControlMessage::Ack {
             ok: false,
             detail: Some(format!(
-                "worker serves only StatObject on the data plane, got {other:?}"
+                "worker serves only StatObject/ListObjects on the data plane, got {other:?}"
             )),
         },
     };

--- a/scripts/loadtest_origin.py
+++ b/scripts/loadtest_origin.py
@@ -42,6 +42,30 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_GET(self):
+        # Azure List Blobs: restype=container&comp=list
+        if "comp=list" in (self.path or ""):
+            import urllib.parse as _u
+            q = _u.parse_qs(_u.urlparse(self.path).query)
+            want = q.get("prefix", [""])[0]
+            blobs = [("bench", SIZE), ("nested/other.bin", 1024)]
+            blobs = [b for b in blobs if b[0].startswith(want)]
+            entries = "".join(
+                f"<Blob><Name>{n}</Name><Properties>"
+                f"<Content-Length>{sz}</Content-Length></Properties></Blob>"
+                for n, sz in blobs
+            )
+            body = (
+                '<?xml version="1.0" encoding="utf-8"?>'
+                f"<EnumerationResults><Blobs>{entries}</Blobs>"
+                "<NextMarker /></EnumerationResults>"
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Content-Type", "application/xml")
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
         rng = self.headers.get("x-ms-range") or self.headers.get("Range")
         if rng and rng.startswith("bytes="):
             first, _, last = rng[len("bytes="):].partition("-")


### PR DESCRIPTION
`ListObjects` was defined in the protocol, called by `talon-fuse` and both client SDKs, and **implemented by nothing**. Unlike `StatObject` (#318), which mapped onto the existing `BackendStore::head`, listing had no counterpart at all.

## Pagination is in the type

```rust
pub struct ListPage {
    pub objects: Vec<ListedObject>,
    pub next: Option<String>,   // opaque cursor
}
```

S3 caps a page at 1000 keys. A method that drained pages internally would buffer an entire prefix in memory before returning, so the caller decides how much to pull.

The default implementation returns a new `Error::Unsupported` rather than an empty page. **A caller building a namespace needs to tell "this backend cannot list" from "this prefix is empty"** — conflating them turns a missing capability into a silently empty result, which is exactly how this gap survived.

## Three backends, three different traps

| backend | trap |
|---|---|
| **S3** | May echo `NextContinuationToken` on the **final** page. Trusting it without checking `IsTruncated` loops forever. |
| **GCS** | Sizes are **strings**, because 64-bit values do not survive JavaScript's 53-bit integers. Reading them as JSON numbers silently yields nothing. Tested with a size beyond 2^53. |
| **Azure** | Field is `Content-Length`, not `Size`. `<NextMarker/>` is emitted **empty** on the last page rather than omitted — treating an empty marker as a cursor loops forever. Also: a SAS token is itself a query string, so listing params merge with `&`, not `?`. |

## A prerequisite fix: SigV4

`canonical_query` passed the raw query string through, with a comment noting that requests carried no parameters. **Listing is the first that does.** AWS rejects a signature over an unsorted or unencoded query with a **403 that reads like a credentials failure** — a confusing first symptom for anyone enabling S3 listing.

Fixed with 5 tests covering sort order, `/` escaping in prefixes, and the `+/=` characters that appear in continuation tokens.

## Why a hand-written XML reader

S3 and Azure both answer with XML. Rather than add an XML dependency for two known response shapes, this adds a ~50-line reader that handles exactly them — explicitly **not** namespaces, attributes, or nesting. Tested against a truncated document (must not loop) and `&amp;lt;` (must not double-expand to `<`).

## One implementation, both data planes

The worker serves listings from `WorkerRuntime`, not from either data-plane handler. Adding `StatObject` in #318 required patching both `tokio_conn` and `uring_conn` and **I missed one** — the io_uring path is the default, so direct-to-worker calls failed while I assumed the proxy was at fault. Putting the logic below both handlers removes that trap.

## FUSE: the silent degradation, now loud

The mount lists with an empty prefix, which **cannot succeed even now** — there is no cross-backend root listing, because a worker cannot enumerate every bucket across S3, GCS, and Azure.

That failure was previously dismissed as `"mounting an empty namespace"` with a warning. **This is how both #318 and #332 stayed hidden for months**: the endpoints were unimplemented and the mount still reported success. It is now logged with the reason and a pointer to #366, which adds a configured prefix.

Kept out of this PR because it needs a new config surface across six layers plus a decision on lazy versus eager population.

## Verification

```
stat:         ObjectStat{size=67108864, version="0x8LOADTEST"}
list:         [az/container/bench, az/container/nested/other.bin]
list(prefix): [az/container/nested/other.bin]
```

Full chain: Java client → coordinator proxy → worker → Azure listing → XML → namespace paths.

**The prefix assertion initially passed for the wrong reason.** My test origin ignored the parameter, so filtering appeared to work while returning everything. I noticed the output was identical for both calls, fixed the fixture to actually filter, and only then trusted it.

- `cargo test --workspace --all-features --locked` — 36 suites, incl. 20 new listing tests
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc` — clean (caught a broken intra-doc link)
- `typos` — clean (caught `1ueGcx` in a fixture; changed the token rather than adding a global exception)
- `just gen-conformance-vectors` — no diff; this adds a capability, not a wire change
- Python client — 10 tests pass

Closes #332
Refs #310, #312, #318, #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)
