### PR TITLE
fix(fuse): require namespace prefix for startup listing

### DIFF
--- a/crates/talon-coordinator/src/bin/gen-config-docs.rs
+++ b/crates/talon-coordinator/src/bin/gen-config-docs.rs
@@ -68,7 +68,7 @@ fn section(s: &mut String, title: &str, schema: &[ConfigVar]) {
         s.push_str(&format!(
             "- **CLI flag:** {}\n",
             if v.cli {
-                format!("`--{}`", v.key)
+                format!("`--{}`", v.key.replace('_', "-"))
             } else {
                 "not settable via CLI (config file or environment only)".to_string()
             }

--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -878,6 +878,11 @@ pub struct FuseConfig {
     pub mountpoint: PathBuf,
     /// Address of the coordinator to resolve placement + membership against.
     pub coordinator: String,
+    /// Mount-relative backend namespace to enumerate at startup.
+    ///
+    /// Must name at least a backend and bucket/container, for example
+    /// `s3/my-bucket` or `az/my-container/datasets`.
+    pub namespace_prefix: String,
     /// Logical block size in bytes (must match the cluster's; 256 MiB default).
     pub block_size: u32,
     /// Placement-cache entry TTL in milliseconds.
@@ -896,6 +901,7 @@ impl Default for FuseConfig {
         Self {
             mountpoint: PathBuf::from("/mnt/talon"),
             coordinator: "127.0.0.1:7000".into(),
+            namespace_prefix: String::new(),
             block_size: 256 << 20,
             placement_ttl_ms: 5_000,
             readahead_blocks: 4,
@@ -914,6 +920,8 @@ pub struct FuseConfigPatch {
     pub mountpoint: Option<PathBuf>,
     /// Override for [`FuseConfig::coordinator`].
     pub coordinator: Option<String>,
+    /// Override for [`FuseConfig::namespace_prefix`].
+    pub namespace_prefix: Option<String>,
     /// Override for [`FuseConfig::block_size`].
     pub block_size: Option<u32>,
     /// Override for [`FuseConfig::placement_ttl_ms`].
@@ -927,6 +935,7 @@ impl Patch for FuseConfigPatch {
         Self {
             mountpoint: self.mountpoint.or(base.mountpoint),
             coordinator: self.coordinator.or(base.coordinator),
+            namespace_prefix: self.namespace_prefix.or(base.namespace_prefix),
             block_size: self.block_size.or(base.block_size),
             placement_ttl_ms: self.placement_ttl_ms.or(base.placement_ttl_ms),
             readahead_blocks: self.readahead_blocks.or(base.readahead_blocks),
@@ -952,6 +961,14 @@ pub const FUSE_ENV_SCHEMA: &[ConfigVar] = &[
         cli: true,
         secret: false,
         help: "Coordinator address for placement and membership.",
+    },
+    ConfigVar {
+        env: "TALON_FUSE_NAMESPACE_PREFIX",
+        key: "namespace_prefix",
+        default: None,
+        cli: true,
+        secret: false,
+        help: "Backend namespace to enumerate (for example, `az/container`).",
     },
     ConfigVar {
         env: "TALON_FUSE_BLOCK_SIZE",
@@ -982,6 +999,7 @@ pub const FUSE_ENV_SCHEMA: &[ConfigVar] = &[
 pub(crate) mod fuse_env {
     pub const MOUNTPOINT: &str = "TALON_FUSE_MOUNTPOINT";
     pub const COORDINATOR: &str = "TALON_FUSE_COORDINATOR";
+    pub const NAMESPACE_PREFIX: &str = "TALON_FUSE_NAMESPACE_PREFIX";
     pub const BLOCK_SIZE: &str = "TALON_FUSE_BLOCK_SIZE";
     pub const PLACEMENT_TTL_MS: &str = "TALON_FUSE_PLACEMENT_TTL_MS";
     pub const READAHEAD_BLOCKS: &str = "TALON_FUSE_READAHEAD_BLOCKS";
@@ -1005,8 +1023,8 @@ impl FuseConfigPatch {
     /// Assemble a patch from `TALON_FUSE_*` environment variables.
     ///
     /// Recognized keys: `TALON_FUSE_MOUNTPOINT`, `TALON_FUSE_COORDINATOR`,
-    /// `TALON_FUSE_BLOCK_SIZE`, `TALON_FUSE_PLACEMENT_TTL_MS`,
-    /// `TALON_FUSE_READAHEAD_BLOCKS`.
+    /// `TALON_FUSE_NAMESPACE_PREFIX`, `TALON_FUSE_BLOCK_SIZE`,
+    /// `TALON_FUSE_PLACEMENT_TTL_MS`, `TALON_FUSE_READAHEAD_BLOCKS`.
     pub fn from_env() -> Result<Self> {
         Self::from_env_with(|k| std::env::var(k).ok())
     }
@@ -1024,6 +1042,7 @@ impl FuseConfigPatch {
         Ok(Self {
             mountpoint: get(fuse_env::MOUNTPOINT).map(PathBuf::from),
             coordinator: get(fuse_env::COORDINATOR),
+            namespace_prefix: get(fuse_env::NAMESPACE_PREFIX),
             block_size: get(fuse_env::BLOCK_SIZE)
                 .map(|v| parse_u32(v, fuse_env::BLOCK_SIZE))
                 .transpose()?,
@@ -1049,6 +1068,7 @@ impl FuseConfig {
         let cfg = FuseConfig {
             mountpoint: merged.mountpoint.unwrap_or(d.mountpoint),
             coordinator: merged.coordinator.unwrap_or(d.coordinator),
+            namespace_prefix: merged.namespace_prefix.unwrap_or(d.namespace_prefix),
             block_size: merged.block_size.unwrap_or(d.block_size),
             placement_ttl_ms: merged.placement_ttl_ms.unwrap_or(d.placement_ttl_ms),
             readahead_blocks: merged.readahead_blocks.unwrap_or(d.readahead_blocks),
@@ -1064,6 +1084,21 @@ impl FuseConfig {
         }
         if self.coordinator.is_empty() {
             return Err(Error::Other("coordinator address must not be empty".into()));
+        }
+        let trimmed = self.namespace_prefix.trim_start_matches('/');
+        let mut parts = trimmed.split('/');
+        let backend = parts.next().unwrap_or_default();
+        if backend.parse::<crate::Backend>().is_err() {
+            return Err(Error::Other(format!(
+                "namespace_prefix must start with a supported backend (s3, gcs, or az): {:?}",
+                self.namespace_prefix
+            )));
+        }
+        if !matches!(parts.next(), Some(bucket) if !bucket.is_empty()) {
+            return Err(Error::Other(format!(
+                "namespace_prefix must name a bucket/container (for example, az/container): {:?}",
+                self.namespace_prefix
+            )));
         }
         if self.block_size == 0 {
             return Err(Error::Other("block_size must be > 0".into()));
@@ -1107,7 +1142,11 @@ mod tests {
                 "worker schema missing {name}"
             );
         }
-        for name in [fuse_env::MOUNTPOINT, fuse_env::READAHEAD_BLOCKS] {
+        for name in [
+            fuse_env::MOUNTPOINT,
+            fuse_env::NAMESPACE_PREFIX,
+            fuse_env::READAHEAD_BLOCKS,
+        ] {
             assert!(
                 FUSE_ENV_SCHEMA.iter().any(|v| v.env == name),
                 "fuse schema missing {name}"
@@ -1309,8 +1348,10 @@ mod tests {
     }
 
     #[test]
-    fn fuse_defaults_are_valid() {
-        FuseConfig::default().validate().unwrap();
+    fn fuse_namespace_prefix_is_required() {
+        let err = FuseConfig::resolve(Default::default(), Default::default(), Default::default())
+            .unwrap_err();
+        assert!(err.to_string().contains("namespace_prefix"));
     }
 
     #[test]
@@ -1318,6 +1359,7 @@ mod tests {
         let file = FuseConfigPatch {
             mountpoint: Some(PathBuf::from("/file/mnt")),
             coordinator: Some("file-coord".into()),
+            namespace_prefix: Some("s3/file-bucket".into()),
             block_size: Some(1 << 20),
             ..Default::default()
         };
@@ -1328,11 +1370,13 @@ mod tests {
         };
         let cli = FuseConfigPatch {
             mountpoint: Some(PathBuf::from("/cli/mnt")),
+            namespace_prefix: Some("az/cli-container/datasets".into()),
             ..Default::default()
         };
         let cfg = FuseConfig::resolve(file, env, cli).unwrap();
         assert_eq!(cfg.mountpoint, PathBuf::from("/cli/mnt")); // CLI wins
         assert_eq!(cfg.coordinator, "env-coord"); // env beats file
+        assert_eq!(cfg.namespace_prefix, "az/cli-container/datasets"); // CLI wins
         assert_eq!(cfg.block_size, 1 << 20); // file beats default
         assert_eq!(cfg.readahead_blocks, 8); // env
         assert_eq!(cfg.placement_ttl_ms, FuseConfig::default().placement_ttl_ms);
@@ -1342,7 +1386,7 @@ mod tests {
     #[test]
     fn fuse_from_toml_parses_and_rejects_unknown() {
         let patch = FuseConfigPatch::from_toml(
-            "mountpoint = \"/mnt/x\"\nreadahead_blocks = 16\nplacement_ttl_ms = 250\n",
+            "mountpoint = \"/mnt/x\"\nnamespace_prefix = \"gcs/models/checkpoints\"\nreadahead_blocks = 16\nplacement_ttl_ms = 250\n",
         )
         .unwrap();
         assert_eq!(
@@ -1351,6 +1395,10 @@ mod tests {
         );
         assert_eq!(patch.readahead_blocks, Some(16));
         assert_eq!(patch.placement_ttl_ms, Some(250));
+        assert_eq!(
+            patch.namespace_prefix.as_deref(),
+            Some("gcs/models/checkpoints")
+        );
         assert!(FuseConfigPatch::from_toml("nope = true").is_err());
     }
 
@@ -1359,6 +1407,7 @@ mod tests {
         let map = |k: &str| match k {
             "TALON_FUSE_BLOCK_SIZE" => Some("1048576".to_string()),
             "TALON_FUSE_MOUNTPOINT" => Some("/mnt/talon".to_string()),
+            "TALON_FUSE_NAMESPACE_PREFIX" => Some("az/container".to_string()),
             "TALON_FUSE_READAHEAD_BLOCKS" => Some("2".to_string()),
             _ => None,
         };
@@ -1369,6 +1418,7 @@ mod tests {
             Some(std::path::Path::new("/mnt/talon"))
         );
         assert_eq!(patch.readahead_blocks, Some(2));
+        assert_eq!(patch.namespace_prefix.as_deref(), Some("az/container"));
         assert!(patch.coordinator.is_none());
 
         let bad = |k: &str| (k == "TALON_FUSE_PLACEMENT_TTL_MS").then(|| "NaN".to_string());
@@ -1378,10 +1428,40 @@ mod tests {
     #[test]
     fn fuse_invalid_config_fails_fast() {
         let cli = FuseConfigPatch {
+            namespace_prefix: Some("az/container".into()),
             block_size: Some(0),
             ..Default::default()
         };
         let err = FuseConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
         assert!(err.to_string().contains("block_size"));
+    }
+
+    #[test]
+    fn fuse_namespace_prefix_requires_backend_and_bucket() {
+        for invalid in ["", "unknown/bucket", "s3", "gcs/"] {
+            let cli = FuseConfigPatch {
+                namespace_prefix: Some(invalid.into()),
+                ..Default::default()
+            };
+            let err = FuseConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
+            assert!(
+                err.to_string().contains("namespace_prefix"),
+                "unexpected error for {invalid:?}: {err}"
+            );
+        }
+
+        for valid in [
+            "s3/bucket",
+            "gcs/bucket/dir",
+            "az/container",
+            "/az/container/prefix",
+        ] {
+            let cli = FuseConfigPatch {
+                namespace_prefix: Some(valid.into()),
+                ..Default::default()
+            };
+            let cfg = FuseConfig::resolve(Default::default(), Default::default(), cli).unwrap();
+            assert_eq!(cfg.namespace_prefix, valid);
+        }
     }
 }

--- a/crates/talon-fuse/src/main.rs
+++ b/crates/talon-fuse/src/main.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use clap::Parser;
 use talon_core::{FuseConfig, FuseConfigPatch};
 use talon_fuse::{BlockReader, CoordinatorClient, PlacementCache, ReadOnlyFs};
+use talon_transport::ObjectEntry;
 
 /// Command-line arguments for the Talon FUSE mount.
 #[derive(Debug, Parser)]
@@ -30,6 +31,9 @@ struct Args {
     /// Address of the coordinator to connect to.
     #[arg(long)]
     coordinator: Option<String>,
+    /// Backend namespace to enumerate, for example `az/container`.
+    #[arg(long)]
+    namespace_prefix: Option<String>,
     /// Logical block size in bytes.
     #[arg(long)]
     block_size: Option<u32>,
@@ -41,6 +45,7 @@ impl Args {
         FuseConfigPatch {
             mountpoint: self.mountpoint.clone(),
             coordinator: self.coordinator.clone(),
+            namespace_prefix: self.namespace_prefix.clone(),
             block_size: self.block_size,
             placement_ttl_ms: None,
             readahead_blocks: None,
@@ -67,6 +72,7 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!(
         mountpoint = %cfg.mountpoint.display(),
         coordinator = %cfg.coordinator,
+        namespace_prefix = %cfg.namespace_prefix,
         block_size = cfg.block_size,
         placement_ttl_ms = cfg.placement_ttl_ms,
         readahead_blocks = cfg.readahead_blocks,
@@ -78,35 +84,40 @@ async fn main() -> anyhow::Result<()> {
     let cache = Arc::new(PlacementCache::new(cfg.placement_ttl_ms));
     let reader = BlockReader::new(coordinator.clone(), cache, 1);
 
-    // Populate the namespace from a coordinator listing (best-effort: a listing
-    // failure logs and yields an empty tree rather than aborting the mount).
+    // Populate the namespace before mounting. A listing failure is fatal: an
+    // apparently healthy mount with an empty tree hides backend/configuration
+    // failures and is less useful than an actionable startup error (#366).
     let (mount_uid, mount_gid) = mount_owner();
     let fs = Arc::new(ReadOnlyFs::new_with_owner(mount_uid, mount_gid));
-    match coordinator.list_objects("").await {
-        Ok(entries) => {
-            let n = fs.populate_from_listing(entries.iter().map(|e| (e.path.as_str(), e.size)));
-            tracing::info!(objects = n, "populated namespace from coordinator listing");
-        }
-        Err(e) => {
-            // Deliberately non-fatal for now, but loud: there is no
-            // cross-backend root listing — a worker cannot enumerate every
-            // bucket across S3, GCS, and Azure — so `list_objects("")` cannot
-            // succeed even now that listing is implemented (#332). The mount
-            // still serves reads for paths a client already knows.
-            //
-            // This silent degradation is why #318 and #332 went unnoticed for
-            // months: the endpoints were unimplemented and the mount still
-            // reported success. Populating the namespace properly needs a
-            // configured prefix naming a backend and bucket, tracked in #366.
-            tracing::warn!(
-                error = %e,
-                "namespace listing failed; the mount will appear empty until a \
-                 namespace prefix is configured (#366). Reads of known paths still work."
-            );
-        }
-    }
+    let listing = coordinator.list_objects(&cfg.namespace_prefix).await;
+    populate_namespace(&fs, &cfg.namespace_prefix, listing)?;
 
     run_mount(cfg, fs, reader).await
+}
+
+/// Apply the coordinator's startup listing, refusing to hide listing errors
+/// behind an apparently healthy empty mount.
+fn populate_namespace<E>(
+    fs: &ReadOnlyFs,
+    namespace_prefix: &str,
+    listing: Result<Vec<ObjectEntry>, E>,
+) -> anyhow::Result<usize>
+where
+    E: std::fmt::Display,
+{
+    let entries = listing.map_err(|error| {
+        anyhow::anyhow!("failed to list namespace prefix {namespace_prefix:?}: {error}")
+    })?;
+    if entries.is_empty() {
+        tracing::warn!(namespace_prefix, "namespace listing returned zero objects");
+    }
+    let n = fs.populate_from_listing(entries.iter().map(|e| (e.path.as_str(), e.size)));
+    tracing::info!(
+        objects = n,
+        namespace_prefix,
+        "populated namespace from coordinator listing"
+    );
+    Ok(n)
 }
 
 #[cfg(feature = "mount")]
@@ -186,4 +197,52 @@ async fn run_mount(
          Rebuild with `--features mount` to enable the kernel FUSE mount."
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn namespace_prefix_cli_flag_populates_patch() {
+        let args =
+            Args::try_parse_from(["talon-fuse", "--namespace-prefix", "az/container/datasets"])
+                .unwrap();
+
+        assert_eq!(
+            args.to_patch().namespace_prefix.as_deref(),
+            Some("az/container/datasets")
+        );
+    }
+
+    #[test]
+    fn namespace_listing_failure_is_fatal() {
+        let fs = ReadOnlyFs::new();
+        let error =
+            populate_namespace::<&str>(&fs, "s3/training-data", Err("coordinator unavailable"))
+                .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("s3/training-data"));
+        assert!(message.contains("coordinator unavailable"));
+    }
+
+    #[test]
+    fn successful_namespace_listing_populates_tree() {
+        let fs = ReadOnlyFs::new();
+        let count = populate_namespace::<&str>(
+            &fs,
+            "gcs/models",
+            Ok(vec![ObjectEntry {
+                path: "gcs/models/checkpoint.bin".into(),
+                size: 42,
+            }]),
+        )
+        .unwrap();
+
+        assert_eq!(count, 1);
+        let gcs = fs.lookup(talon_fuse::ops::ROOT_INO, "gcs").unwrap();
+        let models = fs.lookup(gcs.ino, "models").unwrap();
+        assert!(fs.lookup(models.ino, "checkpoint.bin").is_ok());
+    }
 }

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -88,7 +88,8 @@ and the `SYS_ADMIN` capability:
 ```sh
 docker run --rm --device /dev/fuse --cap-add SYS_ADMIN \
   ghcr.io/milvus-io/talon-fuse:latest \
-  --mountpoint /mnt/talon --coordinator coordinator:7000
+  --mountpoint /mnt/talon --coordinator coordinator:7000 \
+  --namespace-prefix az/my-container
 ```
 
 ## Next steps

--- a/docs/installation/source.md
+++ b/docs/installation/source.md
@@ -55,8 +55,13 @@ feature and needs `/dev/fuse` (Linux with FUSE and `libfuse3-dev` installed):
 
 ```sh
 cargo run -p talon-fuse --features mount -- \
-  --mountpoint /tmp/talon-mnt --coordinator 127.0.0.1:7000
+  --mountpoint /tmp/talon-mnt \
+  --coordinator 127.0.0.1:7000 \
+  --namespace-prefix az/my-container
 ```
+
+Set `--namespace-prefix` to the backend and bucket/container the worker can
+enumerate, optionally followed by an object-key prefix.
 
 ## Developing
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -20,7 +20,7 @@ Admin HTTP bind address: metrics, health, API, UI.
 
 - **Environment variable:** `TALON_COORDINATOR_ADMIN_LISTEN`
 - **Default:** `127.0.0.1:8000`
-- **CLI flag:** `--admin_listen`
+- **CLI flag:** `--admin-listen`
 
 ### `admin_advertise`
 
@@ -28,7 +28,7 @@ Admin address advertised in node status.
 
 - **Environment variable:** `TALON_COORDINATOR_ADMIN_ADVERTISE`
 - **Default:** `<admin_listen>`
-- **CLI flag:** `--admin_advertise`
+- **CLI flag:** `--admin-advertise`
 
 ### `cluster_id`
 
@@ -36,7 +36,7 @@ Logical cluster identity.
 
 - **Environment variable:** `TALON_COORDINATOR_CLUSTER_ID`
 - **Default:** `default`
-- **CLI flag:** `--cluster_id`
+- **CLI flag:** `--cluster-id`
 
 ### `node_id`
 
@@ -44,7 +44,7 @@ Stable coordinator node identity.
 
 - **Environment variable:** `TALON_COORDINATOR_NODE_ID`
 - **Default:** `<listen>`
-- **CLI flag:** `--node_id`
+- **CLI flag:** `--node-id`
 
 ### `state_backend`
 
@@ -52,7 +52,7 @@ Shared-state backend: memory | etcd | kubernetes.
 
 - **Environment variable:** `TALON_COORDINATOR_STATE_BACKEND`
 - **Default:** `memory`
-- **CLI flag:** `--state_backend`
+- **CLI flag:** `--state-backend`
 
 ### `ha_enabled`
 
@@ -60,7 +60,7 @@ Enable active-active mode; rejects the memory backend.
 
 - **Environment variable:** `TALON_COORDINATOR_HA_ENABLED`
 - **Default:** `false`
-- **CLI flag:** `--ha_enabled`
+- **CLI flag:** `--ha-enabled`
 
 ### `coordinator_replicas`
 
@@ -68,7 +68,7 @@ Expected coordinator replica count.
 
 - **Environment variable:** `TALON_COORDINATOR_REPLICAS`
 - **Default:** `1`
-- **CLI flag:** `--coordinator_replicas`
+- **CLI flag:** `--coordinator-replicas`
 
 ### `heartbeat_interval_ms`
 
@@ -76,7 +76,7 @@ Node heartbeat interval (ms).
 
 - **Environment variable:** `TALON_COORDINATOR_HEARTBEAT_INTERVAL_MS`
 - **Default:** `5000`
-- **CLI flag:** `--heartbeat_interval_ms`
+- **CLI flag:** `--heartbeat-interval-ms`
 
 ### `unhealthy_after_ms`
 
@@ -84,7 +84,7 @@ Silence before a node is unhealthy (ms); must exceed heartbeat.
 
 - **Environment variable:** `TALON_COORDINATOR_UNHEALTHY_AFTER_MS`
 - **Default:** `15000`
-- **CLI flag:** `--unhealthy_after_ms`
+- **CLI flag:** `--unhealthy-after-ms`
 
 ### `lease_ttl_ms`
 
@@ -92,7 +92,7 @@ Node lease TTL (ms); must exceed unhealthy_after.
 
 - **Environment variable:** `TALON_COORDINATOR_LEASE_TTL_MS`
 - **Default:** `30000`
-- **CLI flag:** `--lease_ttl_ms`
+- **CLI flag:** `--lease-ttl-ms`
 
 ### `request_timeout_ms`
 
@@ -100,7 +100,7 @@ Deadline for one authoritative backend operation (ms).
 
 - **Environment variable:** `TALON_COORDINATOR_REQUEST_TIMEOUT_MS`
 - **Default:** `3000`
-- **CLI flag:** `--request_timeout_ms`
+- **CLI flag:** `--request-timeout-ms`
 
 ### `(env only)` 🔒
 
@@ -192,7 +192,7 @@ Routable address advertised to the coordinator.
 
 - **Environment variable:** `TALON_WORKER_ADVERTISE_ADDR`
 - **Default:** `<listen>`
-- **CLI flag:** `--advertise_addr`
+- **CLI flag:** `--advertise-addr`
 
 ### `admin_listen`
 
@@ -200,7 +200,7 @@ Admin HTTP bind address: metrics, health, status.
 
 - **Environment variable:** `TALON_WORKER_ADMIN_LISTEN`
 - **Default:** `127.0.0.1:8001`
-- **CLI flag:** `--admin_listen`
+- **CLI flag:** `--admin-listen`
 
 ### `coordinator`
 
@@ -216,7 +216,7 @@ Logical cluster advertised in status.
 
 - **Environment variable:** `TALON_WORKER_CLUSTER_ID`
 - **Default:** `default`
-- **CLI flag:** `--cluster_id`
+- **CLI flag:** `--cluster-id`
 
 ### `node_id`
 
@@ -224,7 +224,7 @@ Stable worker node identity.
 
 - **Environment variable:** `TALON_WORKER_NODE_ID`
 - **Default:** `<listen>`
-- **CLI flag:** `--node_id`
+- **CLI flag:** `--node-id`
 
 ### `heartbeat_interval_ms`
 
@@ -232,7 +232,7 @@ Heartbeat interval (ms).
 
 - **Environment variable:** `TALON_WORKER_HEARTBEAT_INTERVAL_MS`
 - **Default:** `5000`
-- **CLI flag:** `--heartbeat_interval_ms`
+- **CLI flag:** `--heartbeat-interval-ms`
 
 ### `block_size`
 
@@ -240,7 +240,7 @@ Logical block size (bytes).
 
 - **Environment variable:** `TALON_WORKER_BLOCK_SIZE`
 - **Default:** `268435456`
-- **CLI flag:** `--block_size`
+- **CLI flag:** `--block-size`
 
 ### `cache_dirs`
 
@@ -352,7 +352,7 @@ io_uring rings for the data plane; 0 = one per core. Falls back to Tokio if io_u
 
 - **Environment variable:** `TALON_WORKER_DATA_PLANE_RINGS`
 - **Default:** `0 (one ring per core)`
-- **CLI flag:** `--data_plane_rings`
+- **CLI flag:** `--data-plane-rings`
 
 ### `s3_region`
 
@@ -448,13 +448,21 @@ Coordinator address for placement and membership.
 - **Default:** `127.0.0.1:7000`
 - **CLI flag:** `--coordinator`
 
+### `namespace_prefix`
+
+Backend namespace to enumerate (for example, `az/container`).
+
+- **Environment variable:** `TALON_FUSE_NAMESPACE_PREFIX`
+- **Default:** none
+- **CLI flag:** `--namespace-prefix`
+
 ### `block_size`
 
 Logical block size (bytes); must match the cluster.
 
 - **Environment variable:** `TALON_FUSE_BLOCK_SIZE`
 - **Default:** `268435456`
-- **CLI flag:** `--block_size`
+- **CLI flag:** `--block-size`
 
 ### `placement_ttl_ms`
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -169,23 +169,28 @@ mkdir -p /tmp/talon-mnt
 
 cargo run -p talon-fuse --features mount -- \
   --mountpoint /tmp/talon-mnt \
-  --coordinator 127.0.0.1:7000
+  --coordinator 127.0.0.1:7000 \
+  --namespace-prefix az/my-container
 ```
 
-Built **without** `--features mount`, the client still performs all of its setup
-and validation, then prints a message instead of mounting — useful on hosts
-without `/dev/fuse`:
+Replace `az/my-container` with a backend namespace the worker can access, such
+as `s3/training-data` or `gcs/models/checkpoints`. The client lists that prefix
+before mounting and exits with an error if listing fails; it never presents a
+healthy-looking but accidentally empty filesystem.
+
+Built **without** `--features mount`, the client still validates configuration
+and lists the namespace, then prints a message instead of mounting — useful on
+hosts without `/dev/fuse` when testing against a real object-store backend:
 
 ```
 built without the `mount` feature: not mounting.
 Rebuild with `--features mount` to enable the kernel FUSE mount.
 ```
 
-> **Reading real objects** requires a worker configured against a real object
-> store (Section 3 used placeholders) and the coordinator's object-listing path.
-> Populating the namespace and serving object reads end-to-end is beyond this
-> introductory tutorial — see [DESIGN.md](../../DESIGN.md) for the read path and
-> the [operator runbook](../operations/runbook.md) for production configuration.
+> **The command above requires real object-store credentials.** Section 3 used
+> placeholders, so use a worker configured for an accessible backend before
+> running it. See [DESIGN.md](../../DESIGN.md) for the read path and the
+> [operator runbook](../operations/runbook.md) for production configuration.
 
 ## Clean up
 


### PR DESCRIPTION
## Summary

FUSE currently populates its startup namespace with `list_objects("")`. An empty prefix asks for a cross-backend root listing, but no worker can enumerate every bucket across S3, GCS, and Azure. The request therefore fails, and the old startup path swallowed that failure and mounted an empty filesystem that appeared healthy.

This change makes the namespace being mounted explicit and makes startup reflect the real health of that namespace.

## What changed

- Add a required `namespace_prefix` to the resolved FUSE configuration and its patch/merge layers.
- Support the setting through:
  - TOML: `namespace_prefix = "az/container"`
  - environment: `TALON_FUSE_NAMESPACE_PREFIX=az/container`
  - CLI: `--namespace-prefix az/container`
- Validate the prefix before connecting. It must start with a supported backend (`s3`, `gcs`, or `az`) and name a bucket/container; a deeper object prefix such as `gcs/models/checkpoints` is also accepted.
- Call `list_objects` with the configured prefix instead of the impossible empty root prefix.
- Treat a listing error as a startup error, including the requested prefix in the error message. The mount is never created in this state.
- Keep a successful zero-object listing valid, but emit an explicit warning so operators can distinguish an intentionally empty prefix from a failed listing.
- Update source, Docker, and getting-started examples to include the required prefix and explain that startup listing requires a reachable object-store backend.
- Fix generated configuration docs to render Clap's actual kebab-case CLI flags (for example, `--block-size` instead of `--block_size`).

## Behavior

Before:

```text
list_objects("") -> error -> warning -> mount succeeds with an empty tree
```

After:

```text
list_objects("az/container") -> objects -> populate tree -> mount
list_objects("az/container") -> empty   -> warning -> mount an intentionally empty tree
list_objects("az/container") -> error   -> startup fails; no misleading mount
```

This is intentionally a single-prefix first version. Multiple roots and lazy population can be added separately without weakening the startup correctness guarantee here.

## Compatibility

`namespace_prefix` has no unsafe default because Talon cannot infer a user's backend or bucket. Existing FUSE invocations must provide it through the CLI, environment, or config file. Missing or structurally invalid values fail fast with an actionable configuration error.

## Tests

Added coverage for:

- required and malformed namespace prefixes;
- config precedence plus TOML/environment parsing;
- `--namespace-prefix` CLI parsing;
- fatal propagation of coordinator listing failures;
- successful namespace-tree population.

Verified locally:

- `cargo test -p talon-core -p talon-fuse --locked`
- `cargo clippy -p talon-core -p talon-fuse --all-targets --locked -- -D warnings`
- config reference regeneration/drift check with the `etcd,kubernetes` features
- `git diff --check`

The macOS host cannot compile Talon's Linux-only `fuser`/io_uring all-feature paths; those remain covered by Linux CI.

Built on the server-side `ListObjects` implementation merged in #367.

Closes #366
