### PR TITLE
fix(fuse): refuse hard links to object-backed files with EPERM

### DIFF
--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -898,7 +898,21 @@ impl fuser::Filesystem for TalonFuse {
         }
     }
 
-    /// Create a hard link by materializing the shared inode bytes at a new key.
+    /// Create a hard link, for node kinds that have no backend object.
+    ///
+    /// A link to a mount-local special node (FIFO, socket, device) is a pure
+    /// namespace operation: one inode gains a second dentry and no bytes move,
+    /// which is what a hard link actually means.
+    ///
+    /// A link to a regular file or symlink is **refused with `EPERM`**. Those
+    /// kinds are backed by an object, and the only representation available
+    /// without a metadata store is a copy per link path — N independent objects
+    /// that a write must fan out across. Object stores have no cross-key atomic
+    /// write, so any fan-out has a window where the copies disagree, and nothing
+    /// reconciles them afterwards (#363). Refusing is the honest answer until
+    /// the inode indirection in ADR 0003 §5 exists: an application can handle
+    /// `EPERM`, but it cannot detect two paths that POSIX says are one file
+    /// silently returning different bytes.
     fn link(
         &mut self,
         req: &fuser::Request<'_>,
@@ -924,38 +938,15 @@ impl fuser::Filesystem for TalonFuse {
                 Err(error) => reply.error(errno(error)),
             };
         }
-        let contents = match &plan.buffered_contents {
-            Some(contents) => contents.clone(),
-            None => match self.read_committed_object(&plan.source_path, plan.source_size) {
-                Ok(contents) => WritebackSource::Memory(contents),
-                Err(error) => return reply.error(error),
-            },
-        };
-        if let Err(error) = self.writeback_object_source(&plan.target_path, contents) {
-            tracing::warn!(
-                source = %plan.source_path,
-                target = %plan.target_path,
-                %error,
-                "hard-link destination writeback failed"
-            );
-            return reply.error(libc::EIO);
-        }
-        match self.fs.commit_hard_link(&plan) {
-            Ok(attr) => {
-                let file_attr = to_file_attr(attr, req.uid(), req.gid());
-                reply.entry(&ATTR_TTL, &file_attr, 0);
-            }
-            Err(error) => {
-                if let Err(rollback_error) = self.delete_backend_object(&plan.target_path) {
-                    tracing::error!(
-                        target = %plan.target_path,
-                        %rollback_error,
-                        "hard-link destination rollback failed"
-                    );
-                }
-                reply.error(errno(error));
-            }
-        }
+        // Object-backed kinds would need a copy per link path. See the method
+        // doc and #363: divergence is inherent to that representation, not a
+        // bug in the fan-out, so this refuses rather than approximating.
+        tracing::debug!(
+            source = %plan.source_path,
+            target = %plan.target_path,
+            "refusing hard link to an object-backed file; requires inode indirection (#363)"
+        );
+        reply.error(libc::EPERM);
     }
 
     /// Create a regular file or mount-local POSIX special node.

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -258,7 +258,6 @@ pub struct HardLinkPlan {
     pub(crate) source_ino: u64,
     pub(crate) source_path: String,
     pub(crate) source_size: u64,
-    pub(crate) buffered_contents: Option<WritebackSource>,
     pub(crate) target_parent: u64,
     pub(crate) target_name: String,
     pub(crate) target_path: String,
@@ -1528,12 +1527,6 @@ impl ReadOnlyFs {
             source_ino,
             source_path: source.path.clone(),
             source_size: source.size,
-            buffered_contents: g
-                .dirty
-                .iter()
-                .filter(|(_, dirty)| dirty.ino == source_ino)
-                .max_by_key(|(fh, _)| *fh)
-                .map(|(_, dirty)| dirty.contents.snapshot()),
             target_parent,
             target_name: target_name.to_string(),
             target_path,
@@ -2646,6 +2639,47 @@ mod tests {
         assert_eq!(
             fs.new_symlink_path(parent.ino, &"x".repeat(256), b"target"),
             Err(FsError::NameTooLong)
+        );
+    }
+
+    #[test]
+    fn hard_link_plan_marks_object_backed_kinds_for_refusal() {
+        // The mount layer refuses a link whose plan reports `backend_object`
+        // (#363): those kinds would need one backend copy per link path, and
+        // object stores have no cross-key atomic write to keep the copies
+        // equal. Mount-local special nodes carry no object and stay linkable,
+        // so this pins which side of that branch each kind falls on.
+        let fs = fs();
+        let parent = data_dir(&fs);
+
+        let file = fs.lookup(parent.ino, "a.bin").unwrap();
+        let file_plan = fs
+            .hard_link_plan(file.ino, parent.ino, "file-link.bin")
+            .unwrap();
+        assert!(
+            file_plan.backend_object,
+            "a regular file is object-backed, so link() must refuse it"
+        );
+
+        let symlink = fs
+            .symlink(parent.ino, "sym", b"a.bin".to_vec())
+            .expect("create symlink");
+        let symlink_plan = fs
+            .hard_link_plan(symlink.ino, parent.ino, "sym-link")
+            .unwrap();
+        assert!(
+            symlink_plan.backend_object,
+            "a symlink stores its target in an object, so link() must refuse it too"
+        );
+
+        let fifo_plan = fs.mknod_plan(parent.ino, "fifo", MODE_NAMED_PIPE | 0o644, 0, 0, 0, 0);
+        let fifo = fs.commit_mknod(&fifo_plan.unwrap()).unwrap();
+        let fifo_link = fs
+            .hard_link_plan(fifo.ino, parent.ino, "fifo-link")
+            .unwrap();
+        assert!(
+            !fifo_link.backend_object,
+            "a mount-local special node has no object; linking it is a pure namespace op"
         );
     }
 

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -1262,10 +1262,18 @@ async fn mount_symbolic_links_are_written_through() {
     result.expect("exercise symbolic links through mount");
 }
 
-/// Keep hard-link dentries on one inode while writing every linked blob key.
+/// Refuse hard links to object-backed files, and keep the rest of the
+/// link-adjacent lifecycle intact.
+///
+/// `link()` on a regular file returns `EPERM` (#363): the only representation
+/// available without a metadata store is one backend copy per link path, and
+/// object stores offer no cross-key atomic write to keep those copies equal.
+/// This asserts the refusal is clean — no partial object is created, and the
+/// namespace is untouched — and that unrelated behaviour (cross-bucket
+/// rejection, rename, unlink-while-open) still works.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "requires /dev/fuse; run with --features mount -- --ignored"]
-async fn mount_hard_links_share_inode_and_backend_contents() {
+async fn mount_hard_links_to_objects_are_refused() {
     use fuser::MountOption;
 
     let block_size: u32 = 4 * 1024 * 1024;
@@ -1319,59 +1327,34 @@ async fn mount_hard_links_share_inode_and_backend_contents() {
     let cross_bucket = mountpoint.join("gcs").join("other").join("linked.bin");
     let operation_store = Arc::clone(&store);
     let result = tokio::task::spawn_blocking(move || {
-        std::fs::hard_link(&source, &linked)?;
-        let source_metadata = std::fs::metadata(&source)?;
-        let linked_metadata = std::fs::metadata(&linked)?;
-        assert_eq!(source_metadata.ino(), linked_metadata.ino());
-        assert_eq!(source_metadata.nlink(), 2);
-        assert_eq!(linked_metadata.nlink(), 2);
+        // A link to an object-backed file is refused, not approximated.
+        assert_eq!(
+            std::fs::hard_link(&source, &linked)
+                .unwrap_err()
+                .raw_os_error(),
+            Some(libc::EPERM),
+            "hard link to a regular file must be refused (#363)"
+        );
+
+        // The refusal leaves nothing behind: no dentry, no partial object, and
+        // the source is untouched.
+        assert!(!linked.exists(), "refused link must not create a name");
+        assert_eq!(std::fs::metadata(&source)?.nlink(), 1);
         {
             let committed = operation_store.lock().unwrap();
-            assert_eq!(
-                committed.get("/s3/bucket/source.bin"),
-                Some(&b"seed".to_vec())
+            assert!(
+                !committed.contains_key("/s3/bucket/linked.bin"),
+                "refused link must not write a backend object"
             );
             assert_eq!(
-                committed.get("/s3/bucket/linked.bin"),
-                Some(&b"seed".to_vec())
+                committed.get("/s3/bucket/source.bin"),
+                Some(&b"seed".to_vec()),
+                "refused link must not disturb the source object"
             );
         }
 
-        let mut writer = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(&linked)?;
-        writer.seek(SeekFrom::Start(0))?;
-        writer.write_all(b"next")?;
-        writer.sync_all()?;
-        {
-            let committed = operation_store.lock().unwrap();
-            assert_eq!(
-                committed.get("/s3/bucket/source.bin"),
-                Some(&b"next".to_vec())
-            );
-            assert_eq!(
-                committed.get("/s3/bucket/linked.bin"),
-                Some(&b"next".to_vec())
-            );
-        }
-
-        writer.set_len(2)?;
-        writer.sync_all()?;
-        assert_eq!(std::fs::read(&source)?, b"ne");
-        {
-            let committed = operation_store.lock().unwrap();
-            assert_eq!(
-                committed.get("/s3/bucket/source.bin"),
-                Some(&b"ne".to_vec())
-            );
-            assert_eq!(
-                committed.get("/s3/bucket/linked.bin"),
-                Some(&b"ne".to_vec())
-            );
-        }
-        drop(writer);
-
+        // A cross-bucket link is rejected before the kind check, so it keeps
+        // reporting EXDEV rather than EPERM.
         assert_eq!(
             std::fs::hard_link(&source, &cross_bucket)
                 .unwrap_err()
@@ -1379,25 +1362,38 @@ async fn mount_hard_links_share_inode_and_backend_contents() {
             Some(libc::EXDEV)
         );
 
-        std::fs::rename(&linked, &moved)?;
-        assert_eq!(std::fs::metadata(&source)?.nlink(), 2);
-        assert_eq!(std::fs::metadata(&moved)?.nlink(), 2);
+        // Writes to the single-linked file still work end to end.
+        let mut writer = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&source)?;
+        writer.seek(SeekFrom::Start(0))?;
+        writer.write_all(b"next")?;
+        writer.sync_all()?;
+        writer.set_len(2)?;
+        writer.sync_all()?;
+        drop(writer);
+        assert_eq!(std::fs::read(&source)?, b"ne");
         {
             let committed = operation_store.lock().unwrap();
-            assert!(!committed.contains_key("/s3/bucket/linked.bin"));
+            assert_eq!(
+                committed.get("/s3/bucket/source.bin"),
+                Some(&b"ne".to_vec())
+            );
+        }
+
+        // Rename still moves the object.
+        std::fs::rename(&source, &moved)?;
+        assert!(!source.exists());
+        assert_eq!(std::fs::metadata(&moved)?.nlink(), 1);
+        {
+            let committed = operation_store.lock().unwrap();
+            assert!(!committed.contains_key("/s3/bucket/source.bin"));
             assert_eq!(committed.get("/s3/bucket/moved.bin"), Some(&b"ne".to_vec()));
         }
 
-        std::fs::rename(&source, &moved)?;
-        assert!(source.exists());
-        assert!(moved.exists());
-        assert_eq!(std::fs::metadata(&source)?.nlink(), 2);
-
-        std::fs::remove_file(&source)?;
-        assert!(!source.exists());
-        assert_eq!(std::fs::metadata(&moved)?.nlink(), 1);
-        assert_eq!(std::fs::read(&moved)?, b"ne");
-
+        // Unlink-while-open still retains the inode on an orphan object and
+        // reclaims it on final release.
         let mut final_handle = std::fs::File::open(&moved)?;
         std::fs::remove_file(&moved)?;
         assert_eq!(final_handle.metadata()?.nlink(), 0);
@@ -1432,7 +1428,7 @@ async fn mount_hard_links_share_inode_and_backend_contents() {
 
     drop(session);
     std::fs::remove_dir_all(&mountpoint).ok();
-    result.expect("exercise hard links through mount");
+    result.expect("exercise hard-link refusal through mount");
 }
 
 /// Apply explicit, omitted, and current timestamps through kernel setattr.


### PR DESCRIPTION
Fixes #363. Implements ADR 0003 §5's immediate half — the part explicitly recorded as *"should land independently and first"*, since it corrects shipped behaviour and depends on nothing else in that ADR.

## The problem

`link()` on a regular file or symlink materialized a **full backend copy** at the new key. One inode became N independent objects, and every subsequent write had to fan out across all of them (`writeback_object_source_paths`, reached from `setattr`/truncate, `flush`, and `fsync`).

Object stores have no cross-key atomic write. So the fan-out always has a window where the copies disagree, and #359 is what that looks like in practice: link 1 of 3 succeeds, link 2 fails, the loop keeps going, link 3 succeeds, and the caller gets `EIO` — told the write failed while two copies are already durable with the new bytes and one holds the old.

The key point is that **this is a property of the representation, not of the loop.** Fail-fast, rollback, retry — each narrows the window; none closes it. There is no transaction spanning two keys to close it with.

## The change

Refuse with `EPERM` when the plan reports `backend_object`.

**Special nodes are unaffected.** FIFOs, sockets and device nodes carry no backend object, so linking them is a pure namespace operation — one inode gains a dentry, zero bytes move — which is what a hard link actually *is*. That branch is untouched and still commits. The split is `FileKind::has_backend_object()`: `File | Symlink` refuse, the rest proceed. Symlinks are included because they store their target in an object and diverge the same way.

Cross-bucket links are rejected earlier in `hard_link_plan`, so they keep reporting `EXDEV` rather than `EPERM`. The e2e asserts this ordering explicitly.

Also removes `HardLinkPlan::buffered_contents`, which lost its only reader when the copy path went. (`UnlinkPlan` has an identically-named field; that one is live and stays. Worth flagging since the names collide.)

## Why refuse rather than improve

From ADR 0003 §4: an application can handle `EPERM`. It cannot detect two paths that POSIX says are one file silently returning different bytes. The current behaviour appears to succeed, diverges under partial failure, cannot self-repair, and `first_error` discards *which* paths went stale so an operator cannot even enumerate the damage.

`st_nlink` already reports a link count (`ops.rs`, counted from the in-memory dentry index) that the backend has no way to honour — so the longer this stands, the more it reads as a guarantee.

ADR 0003 §5 records the real fix: inode-addressed storage with visible paths as references, which makes `link()` O(1), keeps writes touching exactly one object, and makes divergence structurally impossible. That needs the metadata store, which is Proposed and has open questions. This PR is the honest interim state, not a substitute.

## Tests

**`mount_hard_links_share_inode_and_backend_contents` → `mount_hard_links_to_objects_are_refused`.** The old test asserted the copy semantics worked end to end, so it had to be rewritten rather than kept. The new one asserts the refusal is *clean*:

- `EPERM`, not some other errno
- no dentry created — `linked.exists()` is false
- **no partial backend object written** — the store has no `linked.bin` key
- the source object is untouched, `nlink` stays 1

and keeps the coverage that still applies: cross-bucket still `EXDEV`, writes to a single-linked file still work end to end, rename still moves the object, unlink-while-open still retains the inode on an orphan and reclaims it on final release.

**`hard_link_plan_marks_object_backed_kinds_for_refusal`** (new unit test) pins which kinds land on which side of the branch — file and symlink object-backed, FIFO not. That flag is what the mount layer switches on, and unlike the e2e this one runs everywhere, not only where `/dev/fuse` exists.

## Verification

```
$ cargo test --workspace --all-features      # green
$ just clippy                                 # clean
$ RUSTDOCFLAGS="-D warnings" cargo doc ...    # clean
```

The mount e2e is `#[ignore]`-gated on `/dev/fuse`, which this sandbox lacks — I confirmed it compiles and takes its skip path here, and CI's `fuse-mount` job sets `TALON_REQUIRE_FUSE=1` so it genuinely executes there rather than passing vacuously.
