### PR TITLE
feat(worker): cache fine-grained pages in L1

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -186,18 +186,21 @@ today; only the data-plane TCP scheduling layer diverges.
 
 ### Data-plane paths
 
-**L1 memory hit** (optional, default off; for very hot small blocks): decode
-header + key → `mem_cache` lookup → send header → plain async socket write from
-a shared `Bytes` buffer. L1 is inclusive: every DRAM entry also has an L2 copy,
-and an L2 eviction/delete/version replacement invalidates the L1 entry. No disk,
-no `sendfile`; capacity and maximum entry size are independently bounded.
+**L1 memory hit** (optional, default off; for hot regions inside large blocks):
+decode header + key → look up every `(block_id, page_index)` touched by the
+range → send header → plain async socket write from shared `Bytes` pages. L1 is
+inclusive: every DRAM page has a whole-block L2 parent, and an L2
+eviction/delete/version replacement invalidates all child pages. No disk and no
+`sendfile` on an L1 hit; capacity is byte-bounded independently from page size.
 
 **L2 NVMe hit** (primary large-block path): decode header + key → `BlockIndex`
 lookup → open cached `.blk` fd → write response header →
 `sendfile(cached_fd → socket)` in the blocking helper. Large blocks are never
 read into a `Vec<u8>`, avoiding NVMe→userspace and userspace→socket copies, heap
-pressure, and buffer bloat. An L1-eligible small block is read once from L2 and
-promoted instead. Large-block path: `NVMe/page-cache → kernel → TCP socket`.
+pressure, and buffer bloat. When L1 is enabled, an L2 range hit reads and
+promotes only the aligned L1 pages touched by the request, never the whole block.
+With L1 disabled the large-block path remains
+`NVMe/page-cache → kernel → TCP socket`.
 
 **GET_RANGE hit:** identical to L2 hit but `sendfile` uses `(offset, length)` —
 suited to Lance / checkpoint footer / partial reads.
@@ -310,11 +313,11 @@ dedup (a correctness requirement — per-shard dedup would refetch the same
 
 ## 3. Worker storage
 
-- **Tiering:** optional byte-bounded **L1 DRAM** for small whole blocks over an
-  inclusive local **L2 NVMe SSD** store. L1 is empty after restart and promotes
-  eligible L2 hits; L2 remains persistent and authoritative for cache residency.
-  Large blocks bypass L1 and retain the `sendfile` path. No `mmap` as the default
-  abstraction.
+- **Tiering:** optional byte-bounded, page-granular **L1 DRAM** over an inclusive
+  local whole-block **L2 NVMe SSD** store. L1 is empty after restart and promotes
+  only pages touched by L2 hits; L2 remains persistent and authoritative for
+  cache residency. Disabling L1 retains the whole-block `sendfile` path. No
+  `mmap` as the default abstraction.
 - **Eviction:** byte-accounted **LRU / segmented-LRU** first. LFU risks pinning
   stale hotspots; TinyLFU is more complex — revisit with real workload data.
   Capacity is per-worker, with support for multiple cache dirs each with its own

--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -85,8 +85,8 @@ pub struct WorkerConfig {
     pub capacity_bytes: u64,
     /// L1 DRAM cache capacity in bytes. Zero disables L1.
     pub l1_capacity_bytes: u64,
-    /// Largest whole block eligible for admission into L1.
-    pub l1_max_entry_bytes: u64,
+    /// Fixed L1 DRAM page size in bytes.
+    pub l1_page_size_bytes: u64,
     /// Object-store backend selector: `azure` (default), `s3`, or `gcs`. The
     /// per-backend endpoint/credential fields below apply to the selected one.
     pub backend: Option<String>,
@@ -210,7 +210,7 @@ impl Default for WorkerConfig {
             cache_dirs: vec![PathBuf::from("/var/cache/talon")],
             capacity_bytes: 64 << 30,
             l1_capacity_bytes: 0,
-            l1_max_entry_bytes: 4 << 20,
+            l1_page_size_bytes: 256 << 10,
             backend: None,
             azure_account: None,
             azure_endpoint: None,
@@ -261,8 +261,8 @@ pub struct WorkerConfigPatch {
     pub capacity_bytes: Option<u64>,
     /// Override for [`WorkerConfig::l1_capacity_bytes`].
     pub l1_capacity_bytes: Option<u64>,
-    /// Override for [`WorkerConfig::l1_max_entry_bytes`].
-    pub l1_max_entry_bytes: Option<u64>,
+    /// Override for [`WorkerConfig::l1_page_size_bytes`].
+    pub l1_page_size_bytes: Option<u64>,
     /// Override for [`WorkerConfig::backend`].
     pub backend: Option<String>,
     /// Override for [`WorkerConfig::azure_account`].
@@ -313,7 +313,7 @@ impl Patch for WorkerConfigPatch {
             cache_dirs: self.cache_dirs.or(base.cache_dirs),
             capacity_bytes: self.capacity_bytes.or(base.capacity_bytes),
             l1_capacity_bytes: self.l1_capacity_bytes.or(base.l1_capacity_bytes),
-            l1_max_entry_bytes: self.l1_max_entry_bytes.or(base.l1_max_entry_bytes),
+            l1_page_size_bytes: self.l1_page_size_bytes.or(base.l1_page_size_bytes),
             backend: self.backend.or(base.backend),
             azure_account: self.azure_account.or(base.azure_account),
             azure_endpoint: self.azure_endpoint.or(base.azure_endpoint),
@@ -436,12 +436,12 @@ pub const WORKER_ENV_SCHEMA: &[ConfigVar] = &[
         help: "L1 DRAM cache capacity in bytes; 0 disables L1.",
     },
     ConfigVar {
-        env: "TALON_WORKER_L1_MAX_ENTRY_BYTES",
-        key: "l1_max_entry_bytes",
-        default: Some("4194304"),
+        env: "TALON_WORKER_L1_PAGE_SIZE_BYTES",
+        key: "l1_page_size_bytes",
+        default: Some("262144"),
         cli: false,
         secret: false,
-        help: "Largest whole block eligible for the L1 DRAM cache.",
+        help: "Fixed L1 DRAM page size in bytes.",
     },
     ConfigVar {
         env: "TALON_WORKER_BACKEND",
@@ -625,7 +625,7 @@ pub(crate) mod worker_env {
     pub const CACHE_DIRS: &str = "TALON_WORKER_CACHE_DIRS";
     pub const CAPACITY_BYTES: &str = "TALON_WORKER_CAPACITY_BYTES";
     pub const L1_CAPACITY_BYTES: &str = "TALON_WORKER_L1_CAPACITY_BYTES";
-    pub const L1_MAX_ENTRY_BYTES: &str = "TALON_WORKER_L1_MAX_ENTRY_BYTES";
+    pub const L1_PAGE_SIZE_BYTES: &str = "TALON_WORKER_L1_PAGE_SIZE_BYTES";
     pub const BACKEND: &str = "TALON_WORKER_BACKEND";
     pub const AZURE_ACCOUNT: &str = "TALON_WORKER_AZURE_ACCOUNT";
     pub const AZURE_ENDPOINT: &str = "TALON_WORKER_AZURE_ENDPOINT";
@@ -717,8 +717,8 @@ impl WorkerConfigPatch {
             l1_capacity_bytes: get(worker_env::L1_CAPACITY_BYTES)
                 .map(|v| parse_u64(v, worker_env::L1_CAPACITY_BYTES))
                 .transpose()?,
-            l1_max_entry_bytes: get(worker_env::L1_MAX_ENTRY_BYTES)
-                .map(|v| parse_u64(v, worker_env::L1_MAX_ENTRY_BYTES))
+            l1_page_size_bytes: get(worker_env::L1_PAGE_SIZE_BYTES)
+                .map(|v| parse_u64(v, worker_env::L1_PAGE_SIZE_BYTES))
                 .transpose()?,
             azure_account: get(worker_env::AZURE_ACCOUNT),
             azure_endpoint: get(worker_env::AZURE_ENDPOINT),
@@ -796,7 +796,7 @@ impl WorkerConfig {
             cache_dirs: merged.cache_dirs.unwrap_or(d.cache_dirs),
             capacity_bytes: merged.capacity_bytes.unwrap_or(d.capacity_bytes),
             l1_capacity_bytes: merged.l1_capacity_bytes.unwrap_or(d.l1_capacity_bytes),
-            l1_max_entry_bytes: merged.l1_max_entry_bytes.unwrap_or(d.l1_max_entry_bytes),
+            l1_page_size_bytes: merged.l1_page_size_bytes.unwrap_or(d.l1_page_size_bytes),
             azure_account: merged.azure_account.or(d.azure_account),
             azure_endpoint: merged.azure_endpoint.or(d.azure_endpoint),
             backend: merged.backend.or(d.backend),
@@ -905,15 +905,27 @@ impl WorkerConfig {
             )));
         }
         if self.l1_capacity_bytes > 0 {
-            if self.l1_max_entry_bytes == 0 {
+            if self.l1_page_size_bytes == 0 {
                 return Err(Error::Other(
-                    "l1_max_entry_bytes must be > 0 when L1 is enabled".into(),
+                    "l1_page_size_bytes must be > 0 when L1 is enabled".into(),
                 ));
             }
-            if self.l1_max_entry_bytes > self.l1_capacity_bytes {
+            if self.l1_page_size_bytes > self.l1_capacity_bytes {
                 return Err(Error::Other(format!(
-                    "l1_max_entry_bytes ({}) must be <= l1_capacity_bytes ({})",
-                    self.l1_max_entry_bytes, self.l1_capacity_bytes
+                    "l1_page_size_bytes ({}) must be <= l1_capacity_bytes ({})",
+                    self.l1_page_size_bytes, self.l1_capacity_bytes
+                )));
+            }
+            if self.l1_page_size_bytes > self.block_size as u64 {
+                return Err(Error::Other(format!(
+                    "l1_page_size_bytes ({}) must be <= block_size ({})",
+                    self.l1_page_size_bytes, self.block_size
+                )));
+            }
+            if u64::from(self.block_size) % self.l1_page_size_bytes != 0 {
+                return Err(Error::Other(format!(
+                    "block_size ({}) must be divisible by l1_page_size_bytes ({})",
+                    self.block_size, self.l1_page_size_bytes
                 )));
             }
         }
@@ -1290,12 +1302,12 @@ mod tests {
     fn l1_config_respects_layer_precedence() {
         let file = WorkerConfigPatch {
             l1_capacity_bytes: Some(16 << 20),
-            l1_max_entry_bytes: Some(1 << 20),
+            l1_page_size_bytes: Some(1 << 20),
             ..Default::default()
         };
         let env = WorkerConfigPatch {
             l1_capacity_bytes: Some(32 << 20),
-            l1_max_entry_bytes: Some(2 << 20),
+            l1_page_size_bytes: Some(2 << 20),
             ..Default::default()
         };
         let cli = WorkerConfigPatch {
@@ -1305,20 +1317,20 @@ mod tests {
 
         let cfg = WorkerConfig::resolve(file, env, cli).unwrap();
         assert_eq!(cfg.l1_capacity_bytes, 64 << 20);
-        assert_eq!(cfg.l1_max_entry_bytes, 2 << 20);
+        assert_eq!(cfg.l1_page_size_bytes, 2 << 20);
     }
 
     #[test]
     fn from_toml_parses_and_rejects_unknown() {
         let patch = WorkerConfigPatch::from_toml(
             "listen = \"0.0.0.0:9000\"\ncache_dirs = [\"/a\", \"/b\"]\n\
-             l1_capacity_bytes = 67108864\nl1_max_entry_bytes = 1048576\n",
+             l1_capacity_bytes = 67108864\nl1_page_size_bytes = 1048576\n",
         )
         .unwrap();
         assert_eq!(patch.listen.as_deref(), Some("0.0.0.0:9000"));
         assert_eq!(patch.cache_dirs.unwrap().len(), 2);
         assert_eq!(patch.l1_capacity_bytes, Some(64 << 20));
-        assert_eq!(patch.l1_max_entry_bytes, Some(1 << 20));
+        assert_eq!(patch.l1_page_size_bytes, Some(1 << 20));
         assert!(WorkerConfigPatch::from_toml("bogus_key = 1").is_err());
     }
 
@@ -1334,7 +1346,7 @@ mod tests {
             "TALON_WORKER_BACKEND_JITTER_MS" => Some("50".to_string()),
             "TALON_WORKER_BACKEND_THROUGHPUT_BYTES" => Some("1048576".to_string()),
             "TALON_WORKER_L1_CAPACITY_BYTES" => Some("67108864".to_string()),
-            "TALON_WORKER_L1_MAX_ENTRY_BYTES" => Some("1048576".to_string()),
+            "TALON_WORKER_L1_PAGE_SIZE_BYTES" => Some("1048576".to_string()),
             "TALON_WORKER_BACKEND" => Some("s3".to_string()),
             "TALON_WORKER_S3_REGION" => Some("us-east-1".to_string()),
             "TALON_WORKER_S3_PATH_STYLE" => Some("true".to_string()),
@@ -1354,7 +1366,7 @@ mod tests {
         assert_eq!(patch.backend_jitter_ms, Some(50));
         assert_eq!(patch.backend_throughput_bytes, Some(1 << 20));
         assert_eq!(patch.l1_capacity_bytes, Some(64 << 20));
-        assert_eq!(patch.l1_max_entry_bytes, Some(1 << 20));
+        assert_eq!(patch.l1_page_size_bytes, Some(1 << 20));
         assert_eq!(patch.backend.as_deref(), Some("s3"));
         assert_eq!(patch.s3_region.as_deref(), Some("us-east-1"));
         assert_eq!(patch.s3_path_style, Some(true));
@@ -1400,19 +1412,39 @@ mod tests {
 
         let cli = WorkerConfigPatch {
             l1_capacity_bytes: Some(1024),
-            l1_max_entry_bytes: Some(2048),
+            l1_page_size_bytes: Some(2048),
             ..Default::default()
         };
         let err = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
-        assert!(err.to_string().contains("l1_max_entry_bytes"));
+        assert!(err.to_string().contains("l1_page_size_bytes"));
 
         let cli = WorkerConfigPatch {
             l1_capacity_bytes: Some(1024),
-            l1_max_entry_bytes: Some(0),
+            l1_page_size_bytes: Some(0),
             ..Default::default()
         };
         let err = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
         assert!(err.to_string().contains("must be > 0"));
+
+        let cli = WorkerConfigPatch {
+            block_size: Some(1024),
+            capacity_bytes: Some(1024),
+            l1_capacity_bytes: Some(4096),
+            l1_page_size_bytes: Some(2048),
+            ..Default::default()
+        };
+        let err = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
+        assert!(err.to_string().contains("must be <= block_size"));
+
+        let cli = WorkerConfigPatch {
+            block_size: Some(1024),
+            capacity_bytes: Some(1024),
+            l1_capacity_bytes: Some(4096),
+            l1_page_size_bytes: Some(300),
+            ..Default::default()
+        };
+        let err = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
+        assert!(err.to_string().contains("must be divisible"));
     }
 
     #[test]

--- a/crates/talon-worker/benches/serve_path_benches.rs
+++ b/crates/talon-worker/benches/serve_path_benches.rs
@@ -4,11 +4,9 @@
 //! **real loopback TCP** through the worker's serve logic, so they measure the
 //! actual wins from the epic:
 //!
-//! - `serve_whole_block_read` vs `serve_sendfile`: delivering a small sub-range
-//!   of a large *resident* block. The old byte path (`serve_range`) reads the
-//!   entire block into memory and writes the slice; the new path (`serve` →
-//!   `ServeOutcome::Sendfile`) streams exactly the requested window from the
-//!   block file's fd with `sendfile(2)`, never touching the whole block (#179).
+//! - `serve_userspace_range_read`, `serve_l1_page`, and `serve_sendfile`:
+//!   delivering a small sub-range of a large resident block through L2
+//!   userspace I/O, the fine-grained L1 page cache, or zero-copy L2 sendfile.
 //! - `fetch_unpooled` vs `fetch_pooled`: N sequential small round-trips to a
 //!   worker, dialing a fresh TCP connection each time vs reusing one pooled
 //!   connection — the handshake cost the client pool removes (#181).
@@ -97,10 +95,29 @@ async fn warm_runtime(root: &PathBuf) -> Arc<WorkerRuntime> {
     runtime
 }
 
-/// Spawn a server that, per connection, reads one RangeRequest and serves it
-/// with the OLD byte path: `serve_range` reads the whole block into memory, then
-/// we write header + bytes.
-async fn spawn_old_server(runtime: Arc<WorkerRuntime>) -> String {
+async fn warm_l1_runtime(root: &PathBuf) -> Arc<WorkerRuntime> {
+    let runtime = Arc::new(WorkerRuntime::new_with_l1(
+        WholeBlockStore::open(root).unwrap(),
+        Arc::new(BlockIndex::new()),
+        Arc::new(InFlightLoads::new()),
+        Arc::new(RampBackend) as Arc<dyn BackendStore>,
+        BLOCK_BYTES,
+        0,
+        8 << 20,
+        256 << 10,
+        WorkerMetrics::new(1 << 30),
+    ));
+    let warm = RangeRequest {
+        object: obj(),
+        offset: 0,
+        len: RANGE_LEN,
+    };
+    let _ = runtime.serve(&warm).await.unwrap();
+    runtime
+}
+
+/// Spawn a server that serves a request through the userspace byte path.
+async fn spawn_bytes_server(runtime: Arc<WorkerRuntime>) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap().to_string();
     tokio::spawn(async move {
@@ -209,10 +226,9 @@ async fn client_fetch(addr: &str, req: &RangeRequest) -> usize {
     body.len()
 }
 
-/// Deliver a 64 KiB sub-range of a 32 MiB resident block via the OLD path (whole
-/// block read into memory), over real loopback TCP.
+/// Deliver a 64 KiB sub-range with a block-relative userspace L2 read.
 #[divan::bench]
-fn serve_whole_block_read(bencher: divan::Bencher) {
+fn serve_userspace_range_read(bencher: divan::Bencher) {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(2)
         .enable_all()
@@ -221,7 +237,33 @@ fn serve_whole_block_read(bencher: divan::Bencher) {
     let root = tmp_root("old");
     let (addr, req) = rt.block_on(async {
         let runtime = warm_runtime(&root).await;
-        let addr = spawn_old_server(runtime).await;
+        let addr = spawn_bytes_server(runtime).await;
+        let req = RangeRequest {
+            object: obj(),
+            offset: 4096,
+            len: RANGE_LEN,
+        };
+        (addr, req)
+    });
+    bencher.bench(|| {
+        let n = rt.block_on(client_fetch(&addr, &req));
+        assert_eq!(n, RANGE_LEN as usize);
+    });
+    std::fs::remove_dir_all(&root).ok();
+}
+
+/// Deliver the same range from one resident 256 KiB L1 page.
+#[divan::bench]
+fn serve_l1_page(bencher: divan::Bencher) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    let root = tmp_root("l1-page");
+    let (addr, req) = rt.block_on(async {
+        let runtime = warm_l1_runtime(&root).await;
+        let addr = spawn_bytes_server(runtime).await;
         let req = RangeRequest {
             object: obj(),
             offset: 4096,

--- a/crates/talon-worker/src/bin/loadgen.rs
+++ b/crates/talon-worker/src/bin/loadgen.rs
@@ -67,24 +67,12 @@ struct Args {
     /// Container or bucket the object lives in.
     #[arg(long, default_value = "c")]
     container: String,
-    /// Backend the object lives in (`s3`, `gcs`, or `az`).
-    ///
-    /// A worker rejects every request whose backend does not match the one it
-    /// was configured for, so a wrong value here produces zero samples rather
-    /// than a slow run: the benchmark must name the fleet's actual backend.
-    #[arg(long, default_value = "az", value_parser = parse_backend)]
-    backend: Backend,
     /// Worker PID to sample CPU and RSS from. Skipped when unset.
     #[arg(long)]
     server_pid: Option<u32>,
     /// Emit JSON Lines instead of a table, for scripted comparison.
     #[arg(long)]
     json: bool,
-}
-
-/// Parse a backend name for clap, mapping the core error to a CLI message.
-fn parse_backend(s: &str) -> Result<Backend, String> {
-    s.parse::<Backend>().map_err(|e| e.to_string())
 }
 
 /// One connection count's result.

--- a/crates/talon-worker/src/block_store.rs
+++ b/crates/talon-worker/src/block_store.rs
@@ -22,6 +22,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::io::{Read, Write};
 use std::os::fd::OwnedFd;
+use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use talon_core::{
@@ -145,6 +146,36 @@ impl WholeBlockStore {
             }
             Err(e) => Err(e.into()),
         }
+    }
+
+    /// Read exactly one block-relative byte window into userspace.
+    ///
+    /// This is used to promote touched L2 regions into the finer-grained L1
+    /// page cache without reading the entire (256 MiB by default) block.
+    pub async fn get_range_bytes(&self, id: &BlockId, offset: u64, len: u64) -> Result<Bytes> {
+        let path = self.path_for(id);
+        let id = id.clone();
+        spawn_blocking_io(move || {
+            let file = match std::fs::File::open(&path) {
+                Ok(file) => file,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    return Err(Error::NotFound(id.to_string()));
+                }
+                Err(error) => return Err(error.into()),
+            };
+            let file_len = file.metadata()?.len();
+            if offset.checked_add(len).map_or(true, |end| end > file_len) {
+                return Err(Error::Other(format!(
+                    "range {offset}+{len} out of bounds for block of {file_len} bytes"
+                )));
+            }
+            let size = usize::try_from(len)
+                .map_err(|_| Error::Other(format!("range length {len} exceeds usize")))?;
+            let mut buffer = vec![0_u8; size];
+            file.read_exact_at(&mut buffer, offset)?;
+            Ok(Bytes::from(buffer))
+        })
+        .await
     }
 }
 
@@ -473,6 +504,24 @@ mod tests {
         ));
 
         std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[tokio::test]
+    async fn get_range_bytes_reads_only_the_requested_window() {
+        let root = tmp_root();
+        let store = WholeBlockStore::open(&root).unwrap();
+        let id = block(42);
+        store
+            .put(&id, Bytes::from_static(b"0123456789abcdef"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store.get_range_bytes(&id, 5, 6).await.unwrap(),
+            Bytes::from_static(b"56789a")
+        );
+        assert!(store.get_range_bytes(&id, 15, 2).await.is_err());
+        std::fs::remove_dir_all(root).ok();
     }
 
     #[tokio::test]

--- a/crates/talon-worker/src/lib.rs
+++ b/crates/talon-worker/src/lib.rs
@@ -29,7 +29,7 @@ pub use eviction::{CacheUnit, Lru};
 pub use flusher::{FlushOutcome, FlushPolicy, FlushStats, Flusher};
 pub use index::{BlockIndex, Presence};
 pub use loader::{LoadOutcome, LoadTask, LoaderPool};
-pub use memory_store::{MemoryInsert, MemoryStore};
+pub use memory_store::{MemoryInsert, MemoryPageKey, MemoryStore};
 pub use miss::{touched_pages, Admission, InFlightGuard, InFlightLoads, LoadKey};
 pub use observability::{serve_admin, WorkerMetrics, WorkerObservability, WorkerReadiness};
 pub use paged_store::PagedBlockStore;

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -135,7 +135,7 @@ impl Args {
             cache_dirs: None,
             capacity_bytes: None,
             l1_capacity_bytes: None,
-            l1_max_entry_bytes: None,
+            l1_page_size_bytes: None,
             backend: None,
             azure_account: None,
             azure_endpoint: None,
@@ -271,7 +271,7 @@ async fn main() -> anyhow::Result<()> {
         cache_dirs = ?cfg.cache_dirs,
         capacity_bytes = cfg.capacity_bytes,
         l1_capacity_bytes = cfg.l1_capacity_bytes,
-        l1_max_entry_bytes = cfg.l1_max_entry_bytes,
+        l1_page_size_bytes = cfg.l1_page_size_bytes,
         azure_account = ?cfg.azure_account,
         azure_endpoint = ?cfg.azure_endpoint,
         "starting talon-worker"
@@ -434,7 +434,7 @@ async fn main() -> anyhow::Result<()> {
             cfg.block_size,
             cfg.capacity_bytes,
             cfg.l1_capacity_bytes,
-            cfg.l1_max_entry_bytes,
+            cfg.l1_page_size_bytes,
             observability.metrics().clone(),
         )
         .with_backend_kind(configured_backend),

--- a/crates/talon-worker/src/memory_store.rs
+++ b/crates/talon-worker/src/memory_store.rs
@@ -1,27 +1,32 @@
-//! Byte-accounted in-memory L1 block store.
+//! Byte-accounted in-memory L1 page cache.
 //!
-//! The store is intentionally scoped to small whole blocks. Large blocks stay in
-//! the NVMe-backed L2 where the data plane can serve them with `sendfile(2)`.
-//! Reads clone [`Bytes`], which is reference-counted and does not copy payload
-//! bytes, and atomically mark the entry most-recently-used.
+//! L2 stores large whole blocks on local disk. L1 independently caches fixed
+//! size pages addressed by `(BlockId, PageIndex)`, so a small hot region of a
+//! large block can stay in DRAM without promoting the whole block.
 
-use async_trait::async_trait;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use std::collections::HashMap;
 use std::sync::Mutex;
-use talon_core::{BlockHandle, BlockId, Error, ObjectStore, PageIndex, Result};
+use talon_core::{BlockId, PageIndex};
 
-/// Outcome of attempting to admit a block into L1.
+/// Identity of one L1 page.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MemoryPageKey {
+    pub block: BlockId,
+    pub page: PageIndex,
+}
+
+/// Outcome of attempting to admit a page into L1.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MemoryInsert {
-    /// L1 is disabled (`capacity_bytes == 0`).
+    /// L1 is disabled (`capacity_bytes == 0` or `page_size_bytes == 0`).
     Disabled,
-    /// The block exceeds the configured per-entry limit or total L1 capacity.
+    /// The value is empty, larger than one page, or cannot fit in L1.
     TooLarge,
-    /// The block was admitted; these colder entries were evicted to make room.
+    /// The page was admitted; these colder pages were evicted to make room.
     Inserted {
-        /// Evicted L1 block identities, coldest first.
-        evicted: Vec<BlockId>,
+        /// Evicted L1 page identities, coldest first.
+        evicted: Vec<MemoryPageKey>,
     },
 }
 
@@ -31,26 +36,22 @@ struct Entry {
 }
 
 struct Inner {
-    entries: HashMap<BlockId, Entry>,
+    entries: HashMap<MemoryPageKey, Entry>,
     resident_bytes: u64,
     clock: u64,
 }
 
-/// An in-memory L1 store with byte capacity and LRU eviction.
+/// An in-memory, byte-capacity LRU over fixed-size block pages.
 pub struct MemoryStore {
     inner: Mutex<Inner>,
     capacity_bytes: u64,
-    max_entry_bytes: u64,
+    page_size_bytes: u64,
 }
 
 impl MemoryStore {
-    /// Create an empty store without a practical payload limit.
-    ///
-    /// This preserves the original `MemoryStore::new()` behavior for callers
-    /// using it as a standalone in-memory [`ObjectStore`]. Worker L1 instances
-    /// should use [`MemoryStore::with_limits`].
+    /// Create an empty disabled store.
     pub fn new() -> Self {
-        Self::with_limits(u64::MAX, u64::MAX)
+        Self::disabled()
     }
 
     /// Create a store with L1 admission disabled.
@@ -58,11 +59,8 @@ impl MemoryStore {
         Self::with_limits(0, 0)
     }
 
-    /// Create an L1 store bounded by total and per-entry byte limits.
-    ///
-    /// A zero capacity disables admission. `max_entry_bytes` is clamped to the
-    /// total capacity so an entry can never evict the cache and then fail to fit.
-    pub fn with_limits(capacity_bytes: u64, max_entry_bytes: u64) -> Self {
+    /// Create an L1 store bounded by total bytes with fixed-size pages.
+    pub fn with_limits(capacity_bytes: u64, page_size_bytes: u64) -> Self {
         Self {
             inner: Mutex::new(Inner {
                 entries: HashMap::new(),
@@ -70,13 +68,15 @@ impl MemoryStore {
                 clock: 0,
             }),
             capacity_bytes,
-            max_entry_bytes: max_entry_bytes.min(capacity_bytes),
+            page_size_bytes,
         }
     }
 
     /// Whether L1 admission is enabled.
     pub fn is_enabled(&self) -> bool {
-        self.capacity_bytes > 0 && self.max_entry_bytes > 0
+        self.capacity_bytes > 0
+            && self.page_size_bytes > 0
+            && self.page_size_bytes <= self.capacity_bytes
     }
 
     /// Configured total L1 capacity.
@@ -84,22 +84,17 @@ impl MemoryStore {
         self.capacity_bytes
     }
 
-    /// Maximum size of one admitted L1 entry.
-    pub fn max_entry_bytes(&self) -> u64 {
-        self.max_entry_bytes
+    /// Configured L1 page size.
+    pub fn page_size_bytes(&self) -> u64 {
+        self.page_size_bytes
     }
 
-    /// Whether a block of `len` bytes is eligible for L1.
-    pub fn is_eligible(&self, len: u64) -> bool {
-        self.is_enabled() && len <= self.max_entry_bytes && len <= self.capacity_bytes
-    }
-
-    /// Return the number of resident L1 blocks.
+    /// Return the number of resident L1 pages.
     pub fn len(&self) -> usize {
         self.inner.lock().unwrap().entries.len()
     }
 
-    /// Return whether L1 contains no blocks.
+    /// Return whether L1 contains no pages.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -109,37 +104,106 @@ impl MemoryStore {
         self.inner.lock().unwrap().resident_bytes
     }
 
-    /// Fetch and mark a block most-recently-used.
-    pub fn get(&self, id: &BlockId) -> Option<Bytes> {
+    /// Fetch one page and mark it most-recently-used.
+    pub fn get_page(&self, block: &BlockId, page: PageIndex) -> Option<Bytes> {
         let mut inner = self.inner.lock().unwrap();
         inner.clock = inner.clock.saturating_add(1);
         let tick = inner.clock;
-        let entry = inner.entries.get_mut(id)?;
+        let entry = inner.entries.get_mut(&MemoryPageKey {
+            block: block.clone(),
+            page,
+        })?;
         entry.last_used = tick;
         Some(entry.value.clone())
     }
 
-    /// Admit or replace a block and enforce the configured L1 capacity.
-    pub fn insert(&self, id: BlockId, value: Bytes) -> MemoryInsert {
+    /// Fetch an exact block-relative range when every covering page is present.
+    ///
+    /// A range within one page returns a zero-copy `Bytes::slice`. Multi-page
+    /// ranges are stitched into one contiguous buffer.
+    pub fn get_range(&self, block: &BlockId, offset: u64, len: u64) -> Option<Bytes> {
+        if len == 0 {
+            return Some(Bytes::new());
+        }
+        let end = offset.checked_add(len)?;
+        let page_size = self.page_size_bytes;
+        if !self.is_enabled() || end > block.block_size as u64 {
+            return None;
+        }
+        let first = offset / page_size;
+        let last = (end - 1) / page_size;
+
+        let mut inner = self.inner.lock().unwrap();
+        for page in first..=last {
+            let page = PageIndex(u32::try_from(page).ok()?);
+            let entry = inner.entries.get(&MemoryPageKey {
+                block: block.clone(),
+                page,
+            })?;
+            let page_start = u64::from(page.0) * page_size;
+            let required_end = end.min(page_start + page_size) - page_start;
+            if entry.value.len() < usize::try_from(required_end).ok()? {
+                return None;
+            }
+        }
+
+        inner.clock = inner.clock.saturating_add(1);
+        let tick = inner.clock;
+        if first == last {
+            let page = PageIndex(u32::try_from(first).ok()?);
+            let entry = inner.entries.get_mut(&MemoryPageKey {
+                block: block.clone(),
+                page,
+            })?;
+            entry.last_used = tick;
+            let start = usize::try_from(offset % page_size).ok()?;
+            return Some(entry.value.slice(start..start + usize::try_from(len).ok()?));
+        }
+
+        let mut out = BytesMut::with_capacity(usize::try_from(len).ok()?);
+        for page_number in first..=last {
+            let page = PageIndex(u32::try_from(page_number).ok()?);
+            let entry = inner.entries.get_mut(&MemoryPageKey {
+                block: block.clone(),
+                page,
+            })?;
+            entry.last_used = tick;
+            let page_start = page_number * page_size;
+            let start = usize::try_from(offset.saturating_sub(page_start)).ok()?;
+            let take_end = end.min(page_start + page_size) - page_start;
+            let take_end = usize::try_from(take_end).ok()?;
+            out.extend_from_slice(&entry.value[start..take_end]);
+        }
+        Some(out.freeze())
+    }
+
+    /// Admit or replace one page and enforce the configured L1 capacity.
+    pub fn insert_page(&self, block: BlockId, page: PageIndex, value: Bytes) -> MemoryInsert {
         let len = value.len() as u64;
         if !self.is_enabled() {
             return MemoryInsert::Disabled;
         }
-        if !self.is_eligible(len) {
+        let page_start = u64::from(page.0).saturating_mul(self.page_size_bytes);
+        if len == 0
+            || len > self.page_size_bytes
+            || len > self.capacity_bytes
+            || page_start >= block.block_size as u64
+        {
             return MemoryInsert::TooLarge;
         }
 
+        let key = MemoryPageKey { block, page };
         let mut inner = self.inner.lock().unwrap();
         inner.clock = inner.clock.saturating_add(1);
         let tick = inner.clock;
-        if let Some(previous) = inner.entries.remove(&id) {
+        if let Some(previous) = inner.entries.remove(&key) {
             inner.resident_bytes = inner
                 .resident_bytes
                 .saturating_sub(previous.value.len() as u64);
         }
         inner.resident_bytes = inner.resident_bytes.saturating_add(len);
         inner.entries.insert(
-            id,
+            key,
             Entry {
                 value,
                 last_used: tick,
@@ -152,7 +216,7 @@ impl MemoryStore {
                 .entries
                 .iter()
                 .min_by_key(|(_, entry)| entry.last_used)
-                .map(|(id, _)| id.clone());
+                .map(|(key, _)| key.clone());
             let Some(victim) = victim else {
                 break;
             };
@@ -166,25 +230,33 @@ impl MemoryStore {
         MemoryInsert::Inserted { evicted }
     }
 
-    /// Remove one block, returning whether it was resident.
-    pub fn remove(&self, id: &BlockId) -> bool {
+    /// Remove every page belonging to one block.
+    pub fn remove_block(&self, block: &BlockId) -> Vec<MemoryPageKey> {
         let mut inner = self.inner.lock().unwrap();
-        let Some(entry) = inner.entries.remove(id) else {
-            return false;
-        };
-        inner.resident_bytes = inner
-            .resident_bytes
-            .saturating_sub(entry.value.len() as u64);
-        true
-    }
-
-    /// Remove every old version of the same logical block as `keep`.
-    pub fn remove_superseded(&self, keep: &BlockId) -> Vec<BlockId> {
-        let mut inner = self.inner.lock().unwrap();
-        let victims: Vec<BlockId> = inner
+        let victims: Vec<_> = inner
             .entries
             .keys()
-            .filter(|id| {
+            .filter(|key| &key.block == block)
+            .cloned()
+            .collect();
+        for victim in &victims {
+            if let Some(entry) = inner.entries.remove(victim) {
+                inner.resident_bytes = inner
+                    .resident_bytes
+                    .saturating_sub(entry.value.len() as u64);
+            }
+        }
+        victims
+    }
+
+    /// Remove all pages for old versions of the same logical block as `keep`.
+    pub fn remove_superseded(&self, keep: &BlockId) -> Vec<MemoryPageKey> {
+        let mut inner = self.inner.lock().unwrap();
+        let victims: Vec<_> = inner
+            .entries
+            .keys()
+            .filter(|key| {
+                let id = &key.block;
                 id.object == keep.object
                     && id.offset == keep.offset
                     && id.block_size == keep.block_size
@@ -209,41 +281,6 @@ impl Default for MemoryStore {
     }
 }
 
-#[async_trait]
-impl ObjectStore for MemoryStore {
-    async fn get_block(&self, id: &BlockId) -> Result<BlockHandle> {
-        // A DRAM entry has no file descriptor; callers use `get_bytes`.
-        Err(Error::NotFound(id.to_string()))
-    }
-
-    async fn get_page(&self, id: &BlockId, page: PageIndex) -> Result<BlockHandle> {
-        Err(Error::NotFound(format!("{id} page {}", page.0)))
-    }
-
-    async fn get_range(&self, id: &BlockId, _offset: u64, _len: u64) -> Result<Vec<BlockHandle>> {
-        Err(Error::NotFound(id.to_string()))
-    }
-
-    async fn get_bytes(&self, id: &BlockId) -> Result<Bytes> {
-        self.get(id).ok_or_else(|| Error::NotFound(id.to_string()))
-    }
-
-    async fn put(&self, id: &BlockId, value: Bytes) -> Result<()> {
-        match self.insert(id.clone(), value) {
-            MemoryInsert::Inserted { .. } => Ok(()),
-            MemoryInsert::Disabled => Err(Error::Other("L1 memory store is disabled".into())),
-            MemoryInsert::TooLarge => Err(Error::Other(format!(
-                "block {id} exceeds L1 entry/capacity limit"
-            ))),
-        }
-    }
-
-    async fn delete(&self, id: &BlockId) -> Result<()> {
-        self.remove(id);
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -253,147 +290,136 @@ mod tests {
         BlockId::new(
             ObjectId::new(Backend::S3, "bucket", name),
             0,
-            256 * 1024 * 1024,
+            16,
             Version::new(version),
         )
     }
 
-    #[tokio::test]
-    async fn put_get_delete_roundtrip() {
-        let store = MemoryStore::with_limits(64, 64);
-        let id = block("hello", "v1");
+    #[test]
+    fn pages_are_independent_and_ranges_require_all_pages() {
+        let store = MemoryStore::with_limits(16, 4);
+        let id = block("hot", "v1");
+        store.insert_page(id.clone(), PageIndex(0), Bytes::from_static(b"abcd"));
+        store.insert_page(id.clone(), PageIndex(2), Bytes::from_static(b"ijkl"));
 
-        store.put(&id, Bytes::from_static(b"world")).await.unwrap();
+        assert_eq!(store.get_range(&id, 1, 2), Some(Bytes::from_static(b"bc")));
         assert_eq!(
-            store.get_bytes(&id).await.unwrap(),
-            Bytes::from_static(b"world")
+            store.get_range(&id, 8, 4),
+            Some(Bytes::from_static(b"ijkl"))
         );
-        assert!(store.contains(&id).await.unwrap());
-        assert_eq!(store.resident_bytes(), 5);
-
-        store.delete(&id).await.unwrap();
-        assert!(!store.contains(&id).await.unwrap());
-        assert_eq!(store.resident_bytes(), 0);
+        assert_eq!(store.get_range(&id, 3, 6), None);
     }
 
     #[test]
-    fn disabled_and_oversized_entries_are_not_admitted() {
-        let disabled = MemoryStore::disabled();
+    fn multi_page_range_is_stitched_exactly() {
+        let store = MemoryStore::with_limits(16, 4);
+        let id = block("range", "v1");
+        for (page, bytes) in [b"abcd", b"efgh", b"ijkl"].into_iter().enumerate() {
+            store.insert_page(
+                id.clone(),
+                PageIndex(page as u32),
+                Bytes::copy_from_slice(bytes),
+            );
+        }
         assert_eq!(
-            disabled.insert(block("a", "v1"), Bytes::from_static(b"a")),
-            MemoryInsert::Disabled
+            store.get_range(&id, 2, 9),
+            Some(Bytes::from_static(b"cdefghijk"))
         );
-        assert!(disabled.is_empty());
+    }
 
+    #[test]
+    fn short_final_page_supports_in_bounds_ranges_only() {
         let store = MemoryStore::with_limits(8, 4);
-        assert_eq!(
-            store.insert(block("a", "v1"), Bytes::from_static(b"12345")),
-            MemoryInsert::TooLarge
-        );
-        assert!(store.is_empty());
-    }
-
-    #[tokio::test]
-    async fn default_store_remains_writable_and_disabled_put_is_an_error() {
-        let store = MemoryStore::new();
-        let id = block("default", "v1");
-        store
-            .put(&id, Bytes::from_static(b"payload"))
-            .await
-            .unwrap();
-        assert_eq!(
-            store.get_bytes(&id).await.unwrap(),
-            Bytes::from_static(b"payload")
-        );
-
-        let disabled = MemoryStore::disabled();
-        let error = disabled
-            .put(&id, Bytes::from_static(b"payload"))
-            .await
-            .unwrap_err();
-        assert!(error.to_string().contains("disabled"));
-        assert!(disabled.is_empty());
+        let id = block("tail", "v1");
+        store.insert_page(id.clone(), PageIndex(3), Bytes::from_static(b"xy"));
+        assert_eq!(store.get_range(&id, 12, 2), Some(Bytes::from_static(b"xy")));
+        assert_eq!(store.get_range(&id, 12, 3), None);
     }
 
     #[test]
-    fn max_entry_limit_is_clamped_to_capacity() {
-        let store = MemoryStore::with_limits(4, 8);
-        assert_eq!(store.capacity_bytes(), 4);
-        assert_eq!(store.max_entry_bytes(), 4);
-        assert!(store.is_eligible(4));
-        assert!(!store.is_eligible(5));
-    }
-
-    #[test]
-    fn lru_eviction_is_byte_accounted_and_touch_sensitive() {
+    fn lru_eviction_is_page_granular_and_touch_sensitive() {
         let store = MemoryStore::with_limits(8, 4);
-        let a = block("a", "v1");
-        let b = block("b", "v1");
-        let c = block("c", "v1");
-        assert_eq!(
-            store.insert(a.clone(), Bytes::from_static(b"aaaa")),
-            MemoryInsert::Inserted { evicted: vec![] }
-        );
-        assert_eq!(
-            store.insert(b.clone(), Bytes::from_static(b"bbbb")),
-            MemoryInsert::Inserted { evicted: vec![] }
-        );
-        assert_eq!(store.get(&a), Some(Bytes::from_static(b"aaaa")));
+        let id = block("lru", "v1");
+        store.insert_page(id.clone(), PageIndex(0), Bytes::from_static(b"aaaa"));
+        store.insert_page(id.clone(), PageIndex(1), Bytes::from_static(b"bbbb"));
+        assert!(store.get_page(&id, PageIndex(0)).is_some());
 
         assert_eq!(
-            store.insert(c.clone(), Bytes::from_static(b"cccc")),
+            store.insert_page(id.clone(), PageIndex(2), Bytes::from_static(b"cccc")),
             MemoryInsert::Inserted {
-                evicted: vec![b.clone()]
+                evicted: vec![MemoryPageKey {
+                    block: id.clone(),
+                    page: PageIndex(1),
+                }]
             }
         );
-        assert!(store.get(&b).is_none());
-        assert!(store.get(&a).is_some());
-        assert!(store.get(&c).is_some());
+        assert!(store.get_page(&id, PageIndex(0)).is_some());
+        assert!(store.get_page(&id, PageIndex(1)).is_none());
+        assert!(store.get_page(&id, PageIndex(2)).is_some());
         assert_eq!(store.resident_bytes(), 8);
     }
 
     #[test]
-    fn replacing_an_entry_updates_accounting_without_self_eviction() {
-        let store = MemoryStore::with_limits(8, 8);
-        let id = block("a", "v1");
-        store.insert(id.clone(), Bytes::from_static(b"123456"));
-        assert_eq!(store.resident_bytes(), 6);
-        assert_eq!(
-            store.insert(id.clone(), Bytes::from_static(b"xy")),
-            MemoryInsert::Inserted { evicted: vec![] }
-        );
+    fn replacing_page_updates_byte_accounting() {
+        let store = MemoryStore::with_limits(8, 4);
+        let id = block("replace", "v1");
+        store.insert_page(id.clone(), PageIndex(0), Bytes::from_static(b"abcd"));
+        store.insert_page(id.clone(), PageIndex(0), Bytes::from_static(b"xy"));
         assert_eq!(store.resident_bytes(), 2);
-        assert_eq!(store.get(&id), Some(Bytes::from_static(b"xy")));
+        assert_eq!(
+            store.get_page(&id, PageIndex(0)),
+            Some(Bytes::from_static(b"xy"))
+        );
     }
 
     #[test]
-    fn superseded_versions_are_removed_without_touching_other_blocks() {
-        let store = MemoryStore::with_limits(64, 16);
+    fn block_and_version_invalidation_remove_all_matching_pages() {
+        let store = MemoryStore::with_limits(32, 4);
         let old = block("same", "v1");
         let keep = block("same", "v2");
         let other = block("other", "v1");
-        for id in [&old, &keep, &other] {
-            store.insert(id.clone(), Bytes::from_static(b"data"));
+        for page in 0..2 {
+            store.insert_page(old.clone(), PageIndex(page), Bytes::from_static(b"old!"));
+            store.insert_page(keep.clone(), PageIndex(page), Bytes::from_static(b"keep"));
         }
+        store.insert_page(other.clone(), PageIndex(0), Bytes::from_static(b"data"));
 
-        assert_eq!(store.remove_superseded(&keep), vec![old.clone()]);
-        assert!(store.get(&old).is_none());
-        assert!(store.get(&keep).is_some());
-        assert!(store.get(&other).is_some());
-        assert_eq!(store.resident_bytes(), 8);
+        assert_eq!(store.remove_superseded(&keep).len(), 2);
+        assert!(store.get_page(&old, PageIndex(0)).is_none());
+        assert!(store.get_page(&keep, PageIndex(0)).is_some());
+        assert_eq!(store.remove_block(&keep).len(), 2);
+        assert!(store.get_page(&other, PageIndex(0)).is_some());
+    }
+
+    #[test]
+    fn disabled_and_invalid_pages_are_rejected() {
+        let id = block("invalid", "v1");
+        assert_eq!(
+            MemoryStore::disabled().insert_page(id.clone(), PageIndex(0), Bytes::from_static(b"a")),
+            MemoryInsert::Disabled
+        );
+        let store = MemoryStore::with_limits(4, 4);
+        assert_eq!(
+            store.insert_page(id.clone(), PageIndex(0), Bytes::from_static(b"12345")),
+            MemoryInsert::TooLarge
+        );
+        assert_eq!(
+            store.insert_page(id, PageIndex(4), Bytes::from_static(b"x")),
+            MemoryInsert::TooLarge
+        );
     }
 
     #[test]
     fn concurrent_reads_and_inserts_stay_within_capacity() {
-        let store = std::sync::Arc::new(MemoryStore::with_limits(1024, 32));
+        let store = std::sync::Arc::new(MemoryStore::with_limits(1024, 16));
         let mut threads = Vec::new();
         for worker in 0..8 {
             let store = std::sync::Arc::clone(&store);
             threads.push(std::thread::spawn(move || {
                 for n in 0..500 {
                     let id = block(&format!("{worker}-{n}"), "v1");
-                    store.insert(id.clone(), Bytes::from(vec![worker as u8; 16]));
-                    let _ = store.get(&id);
+                    store.insert_page(id.clone(), PageIndex(0), Bytes::from(vec![worker; 16]));
+                    let _ = store.get_page(&id, PageIndex(0));
                 }
             }));
         }

--- a/crates/talon-worker/src/observability.rs
+++ b/crates/talon-worker/src/observability.rs
@@ -57,7 +57,7 @@ pub struct WorkerMetrics {
     block_count: Gauge,
     page_count: Gauge,
     resident_bytes: Gauge,
-    l1_blocks: Gauge,
+    l1_pages: Gauge,
     l1_resident_bytes: Gauge,
     l1_capacity_bytes: Gauge,
     ready: Gauge,
@@ -140,12 +140,12 @@ impl WorkerMetrics {
         );
         let l1_admissions_total = registry.counter(
             "talon_worker_l1_admissions_total",
-            "Blocks admitted or promoted into the L1 DRAM cache.",
+            "Pages admitted or promoted into the L1 DRAM cache.",
             BTreeMap::new(),
         );
         let l1_evictions_total = registry.counter(
             "talon_worker_l1_evictions_total",
-            "Blocks evicted from the L1 DRAM cache.",
+            "Pages evicted from the L1 DRAM cache.",
             BTreeMap::new(),
         );
         let backend_fetch_bytes_total = registry.counter(
@@ -238,9 +238,9 @@ impl WorkerMetrics {
             "Bytes currently resident in the worker cache.",
             BTreeMap::new(),
         );
-        let l1_blocks = registry.gauge(
-            "talon_worker_l1_blocks",
-            "Blocks currently resident in the L1 DRAM cache.",
+        let l1_pages = registry.gauge(
+            "talon_worker_l1_pages",
+            "Pages currently resident in the L1 DRAM cache.",
             BTreeMap::new(),
         );
         let l1_resident_bytes = registry.gauge(
@@ -303,7 +303,7 @@ impl WorkerMetrics {
             block_count,
             page_count,
             resident_bytes,
-            l1_blocks,
+            l1_pages,
             l1_resident_bytes,
             l1_capacity_bytes,
             ready,
@@ -355,7 +355,7 @@ impl WorkerMetrics {
         self.l2_misses_total.inc();
     }
 
-    /// Record a block admitted or promoted into L1.
+    /// Record a page admitted or promoted into L1.
     pub fn record_l1_admission(&self) {
         self.l1_admissions_total.inc();
     }
@@ -371,8 +371,8 @@ impl WorkerMetrics {
     }
 
     /// Publish current L1 entry and byte residency.
-    pub fn update_l1_residency(&self, blocks: u64, resident_bytes: u64) {
-        self.l1_blocks.set(blocks as f64);
+    pub fn update_l1_residency(&self, pages: u64, resident_bytes: u64) {
+        self.l1_pages.set(pages as f64);
         self.l1_resident_bytes.set(resident_bytes as f64);
     }
 

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -60,7 +60,8 @@ pub enum ServeOutcome {
 
 /// Shared state required to serve instrumented data-plane range requests.
 pub struct WorkerRuntime {
-    /// Small-block DRAM cache. L1 is inclusive: every entry also exists in L2.
+    /// Fine-grained DRAM page cache. L1 is inclusive: every page has an L2
+    /// whole-block parent.
     l1: Arc<MemoryStore>,
     /// Persistent local-NVMe cache.
     store: WholeBlockStore,
@@ -124,7 +125,7 @@ impl WorkerRuntime {
         block_size: u32,
         capacity_bytes: u64,
         l1_capacity_bytes: u64,
-        l1_max_entry_bytes: u64,
+        l1_page_size_bytes: u64,
         metrics: WorkerMetrics,
     ) -> Self {
         let lru = Arc::new(Lru::new());
@@ -133,7 +134,7 @@ impl WorkerRuntime {
         }
         let l1 = Arc::new(MemoryStore::with_limits(
             l1_capacity_bytes,
-            l1_max_entry_bytes,
+            l1_page_size_bytes,
         ));
         metrics.set_l1_capacity(l1_capacity_bytes);
         metrics.update_l1_residency(0, 0);
@@ -289,43 +290,21 @@ impl WorkerRuntime {
             .ok_or_else(|| anyhow::anyhow!("range offset+len overflows u64"))?;
         let start_block = (request.offset / block_size) * block_size;
 
-        // Single-block fast paths: L1 bytes first, then an L2 sendfile handle.
+        // With L1 enabled, use the page-granular byte path. With L1 disabled,
+        // preserve the whole-block L2 sendfile fast path.
         if end <= start_block + block_size {
             let block = self.block_for(&request.object, request.offset, version);
             let offset_in_block = request.offset - block.offset;
-            if let Some(bytes) = self.l1_get(&block) {
-                return Ok(ServeOutcome::Bytes(slice(
-                    &bytes,
-                    offset_in_block,
-                    request.len,
-                )?));
+            if self.l1.is_enabled() {
+                return Ok(ServeOutcome::Bytes(
+                    self.block_range_bytes(request, &block, offset_in_block, request.len)
+                        .await?,
+                ));
             }
             if matches!(
                 self.index.presence(&block, PageIndex(0), PageIndex(1)),
                 Presence::Whole
             ) {
-                // Small blocks are promoted into L1 on their first post-restart L2
-                // hit. Large blocks preserve the zero-copy sendfile path.
-                if self
-                    .index
-                    .get(&block)
-                    .is_some_and(|meta| self.l1.is_eligible(meta.len))
-                {
-                    match self.store.get_bytes(&block).await {
-                        Ok(bytes) => {
-                            self.record_l2_hit(&block);
-                            self.admit_l1(&block, bytes.clone());
-                            return Ok(ServeOutcome::Bytes(slice(
-                                &bytes,
-                                offset_in_block,
-                                request.len,
-                            )?));
-                        }
-                        Err(error) => {
-                            tracing::debug!(%block, %error, "L2 promotion read lost an eviction race");
-                        }
-                    }
-                }
                 // Open an fd over exactly the requested window. This can fail if
                 // the block was evicted between the presence check and the open
                 // (a benign race); fall through to the byte path in that case.
@@ -350,14 +329,10 @@ impl WorkerRuntime {
                 }
             }
 
-            self.metrics.record_l2_miss();
-            self.metrics.record_cache_miss();
-            let bytes = self.load_block_bytes(request, &block).await?;
-            return Ok(ServeOutcome::Bytes(slice(
-                &bytes,
-                offset_in_block,
-                request.len,
-            )?));
+            return Ok(ServeOutcome::Bytes(
+                self.block_range_bytes(request, &block, offset_in_block, request.len)
+                    .await?,
+            ));
         }
 
         // Fallback: miss or boundary-spanning read → in-memory bytes.
@@ -389,8 +364,9 @@ impl WorkerRuntime {
         if end <= start_block + block_size {
             let block = self.block_for(&request.object, request.offset, version);
             let offset_in_block = request.offset - block.offset;
-            let bytes = self.block_bytes(request, &block).await?;
-            return slice(&bytes, offset_in_block, request.len);
+            return self
+                .block_range_bytes(request, &block, offset_in_block, request.len)
+                .await;
         }
 
         // Slow path: stitch across blocks.
@@ -401,8 +377,9 @@ impl WorkerRuntime {
             let offset_in_block = cursor - block.offset;
             let block_end = block.offset + block_size;
             let take = block_end.min(end) - cursor;
-            let bytes = self.block_bytes(request, &block).await?;
-            let piece = slice(&bytes, offset_in_block, take)?;
+            let piece = self
+                .block_range_bytes(request, &block, offset_in_block, take)
+                .await?;
             // A block that returned fewer bytes than its share means the object
             // ends inside it; stop rather than silently returning a short read.
             let short = piece.len() < take as usize;
@@ -571,8 +548,8 @@ impl WorkerRuntime {
         self.version_cache.lock().unwrap().remove(object);
     }
 
-    /// Return the full committed/fetched bytes of a single block, using the
-    /// cache-hit path when resident and the backend-miss path otherwise.
+    /// Return one block-relative range, using L1 pages, then an aligned L2 read,
+    /// then a whole-block origin fill.
     ///
     /// Concurrent misses for the same block are deduplicated: the first caller
     /// (the leader, holding an `InFlightGuard`) performs the backend fetch; the
@@ -580,24 +557,28 @@ impl WorkerRuntime {
     /// misses trigger a single backend fetch instead of N (issue #113). The
     /// guard clears the in-flight marker on drop, so a cancelled or panicking
     /// leader can never orphan the key and hang the waiters (issue #162).
-    async fn block_bytes(
+    async fn block_range_bytes(
         &self,
         request: &RangeRequest,
         block: &BlockId,
+        offset: u64,
+        len: u64,
     ) -> anyhow::Result<bytes::Bytes> {
-        if let Some(bytes) = self.cached_block(block).await? {
+        if let Some(bytes) = self.cached_block_range(block, offset, len).await? {
             return Ok(bytes);
         }
 
         self.metrics.record_cache_miss();
-        self.load_block_bytes(request, block).await
+        self.load_block_range(request, block, offset, len).await
     }
 
     /// Load one block after both L1 and L2 have missed.
-    async fn load_block_bytes(
+    async fn load_block_range(
         &self,
         request: &RangeRequest,
         block: &BlockId,
+        offset: u64,
+        len: u64,
     ) -> anyhow::Result<bytes::Bytes> {
         let key = LoadKey::Whole(block.clone());
         match self.inflight.admit_owned(key.clone()) {
@@ -606,13 +587,14 @@ impl WorkerRuntime {
                 // (including on cancellation/panic).
                 let result = self.fetch_and_commit(request, block).await;
                 drop(guard);
-                result
+                let bytes = result?;
+                self.range_from_fetched(block, bytes, offset, len)
             }
             None => {
                 // A peer is already fetching this block; wait for it and serve
                 // from cache rather than issuing a duplicate backend fetch.
                 self.inflight.wait(&key).await;
-                if let Some(bytes) = self.cached_block(block).await? {
+                if let Some(bytes) = self.cached_block_range(block, offset, len).await? {
                     return Ok(bytes);
                 }
                 // The leader's load failed (marker cleared, block still absent).
@@ -621,65 +603,98 @@ impl WorkerRuntime {
                     Some(guard) => {
                         let result = self.fetch_and_commit(request, block).await;
                         drop(guard);
-                        result
+                        let bytes = result?;
+                        self.range_from_fetched(block, bytes, offset, len)
                     }
                     None => {
                         // Another peer already restarted the load; wait once
                         // more, then, if still absent, fetch without holding
                         // admission to avoid an unbounded wait loop.
                         self.inflight.wait(&key).await;
-                        if let Some(bytes) = self.cached_block(block).await? {
+                        if let Some(bytes) = self.cached_block_range(block, offset, len).await? {
                             return Ok(bytes);
                         }
-                        self.fetch_and_commit(request, block).await
+                        let bytes = self.fetch_and_commit(request, block).await?;
+                        self.range_from_fetched(block, bytes, offset, len)
                     }
                 }
             }
         }
     }
 
-    /// Return a block's bytes from the local cache if resident, else `None`.
-    async fn cached_block(&self, block: &BlockId) -> anyhow::Result<Option<bytes::Bytes>> {
-        if let Some(bytes) = self.l1_get(block) {
+    /// Return a block range from the local cache if its L2 parent is resident.
+    async fn cached_block_range(
+        &self,
+        block: &BlockId,
+        offset: u64,
+        len: u64,
+    ) -> anyhow::Result<Option<bytes::Bytes>> {
+        let Some(meta) = self.index.get(block) else {
+            if self.l1.is_enabled() {
+                self.metrics.record_l1_miss();
+            }
+            self.metrics.record_l2_miss();
+            return Ok(None);
+        };
+        if !matches!(meta.form, BlockForm::Whole) {
+            self.metrics.record_l2_miss();
+            return Ok(None);
+        }
+        let len = available_range_len(meta.len, offset, len)?;
+        if self.l1.is_enabled() {
+            match self.l1.get_range(block, offset, len) {
+                Some(bytes) => {
+                    self.metrics.record_l1_hit();
+                    self.metrics.record_cache_hit();
+                    self.lru.touch(&CacheUnit::Whole(block.clone()));
+                    tracing::debug!(block = %block, offset, len, tier = "l1", "HIT");
+                    return Ok(Some(bytes));
+                }
+                None => {
+                    self.metrics.record_l1_miss();
+                }
+            }
+        }
+
+        self.record_l2_hit(block);
+        tracing::debug!(block = %block, offset, len, tier = "l2", "HIT");
+        if !self.l1.is_enabled() {
+            let bytes = match self.store.get_range_bytes(block, offset, len).await {
+                Ok(bytes) => bytes,
+                Err(Error::NotFound(_)) => {
+                    self.forget_missing_l2_parent(block);
+                    return Ok(None);
+                }
+                Err(error) => {
+                    return Err(anyhow::anyhow!("read committed block range: {error}"));
+                }
+            };
             return Ok(Some(bytes));
         }
-        if matches!(
-            self.index.presence(block, PageIndex(0), PageIndex(1)),
-            Presence::Whole
-        ) {
-            self.record_l2_hit(block);
-            tracing::info!(block = %block, tier = "l2", "HIT");
-            let bytes = self
-                .store
-                .get_bytes(block)
-                .await
-                .map_err(|error| anyhow::anyhow!("read committed block: {error}"))?;
-            self.admit_l1(block, bytes.clone());
-            Ok(Some(bytes))
-        } else {
-            self.metrics.record_l2_miss();
-            Ok(None)
-        }
+
+        let (page_start, page_len) = self.page_window(offset, len, meta.len)?;
+        let pages = match self
+            .store
+            .get_range_bytes(block, page_start, page_len)
+            .await
+        {
+            Ok(bytes) => bytes,
+            Err(Error::NotFound(_)) => {
+                self.forget_missing_l2_parent(block);
+                return Ok(None);
+            }
+            Err(error) => return Err(anyhow::anyhow!("read committed L2 pages: {error}")),
+        };
+        self.admit_l1_pages(block, page_start, pages.clone());
+        Ok(Some(slice(&pages, offset - page_start, len)?))
     }
 
-    /// Read L1 and keep the inclusive L2 parent hot when present.
-    fn l1_get(&self, block: &BlockId) -> Option<bytes::Bytes> {
-        if !self.l1.is_enabled() {
-            return None;
-        }
-        match self.l1.get(block) {
-            Some(bytes) => {
-                self.metrics.record_l1_hit();
-                self.metrics.record_cache_hit();
-                self.lru.touch(&CacheUnit::Whole(block.clone()));
-                tracing::info!(block = %block, tier = "l1", "HIT");
-                Some(bytes)
-            }
-            None => {
-                self.metrics.record_l1_miss();
-                None
-            }
-        }
+    /// Drop stale metadata after an index-hit/file-miss eviction race.
+    fn forget_missing_l2_parent(&self, block: &BlockId) {
+        self.invalidate_l1(block);
+        self.index.remove(block);
+        self.lru.remove(&CacheUnit::Whole(block.clone()));
+        tracing::debug!(%block, "discarded stale L2 index entry after file miss");
     }
 
     /// Record an L2 hit and touch its capacity LRU.
@@ -689,23 +704,84 @@ impl WorkerRuntime {
         self.lru.touch(&CacheUnit::Whole(block.clone()));
     }
 
-    /// Admit eligible bytes into L1 and publish resulting residency/evictions.
-    fn admit_l1(&self, block: &BlockId, bytes: bytes::Bytes) {
-        match self.l1.insert(block.clone(), bytes) {
-            MemoryInsert::Inserted { evicted } => {
-                self.metrics.record_l1_admission();
-                for victim in evicted {
-                    self.metrics.record_l1_eviction();
-                    tracing::debug!(block = %victim, tier = "l1", "evicted block");
-                }
-                self.refresh_l1_metrics();
-            }
-            MemoryInsert::Disabled | MemoryInsert::TooLarge => {}
+    fn page_window(&self, offset: u64, len: u64, block_len: u64) -> anyhow::Result<(u64, u64)> {
+        if len == 0 {
+            return Ok((offset, 0));
         }
+        let page_size = self.l1.page_size_bytes();
+        let end = offset
+            .checked_add(len)
+            .ok_or_else(|| anyhow::anyhow!("range offset+len overflows u64"))?;
+        let start = (offset / page_size) * page_size;
+        let aligned_end = end
+            .div_ceil(page_size)
+            .saturating_mul(page_size)
+            .min(block_len);
+        Ok((start, aligned_end.saturating_sub(start)))
+    }
+
+    /// Split an aligned byte window into pages and publish L1 residency changes.
+    fn admit_l1_pages(&self, block: &BlockId, start: u64, bytes: bytes::Bytes) {
+        if !self.l1.is_enabled() || bytes.is_empty() {
+            return;
+        }
+        let page_size = self.l1.page_size_bytes();
+        debug_assert_eq!(start % page_size, 0);
+        let first_page = start / page_size;
+        let mut chunk_start = 0_usize;
+        let Ok(page_size_usize) = usize::try_from(page_size) else {
+            return;
+        };
+        let mut relative = 0_u64;
+        while chunk_start < bytes.len() {
+            let chunk_end = (chunk_start + page_size_usize).min(bytes.len());
+            let page_number = first_page + relative;
+            let Ok(page_number) = u32::try_from(page_number) else {
+                break;
+            };
+            match self.l1.insert_page(
+                block.clone(),
+                PageIndex(page_number),
+                bytes.slice(chunk_start..chunk_end),
+            ) {
+                MemoryInsert::Inserted { evicted } => {
+                    self.metrics.record_l1_admission();
+                    for victim in evicted {
+                        self.metrics.record_l1_eviction();
+                        tracing::debug!(
+                            block = %victim.block,
+                            page = victim.page.0,
+                            tier = "l1",
+                            "evicted page"
+                        );
+                    }
+                }
+                MemoryInsert::Disabled | MemoryInsert::TooLarge => {}
+            }
+            chunk_start = chunk_end;
+            relative += 1;
+        }
+        self.refresh_l1_metrics();
+    }
+
+    fn range_from_fetched(
+        &self,
+        block: &BlockId,
+        bytes: bytes::Bytes,
+        offset: u64,
+        len: u64,
+    ) -> anyhow::Result<bytes::Bytes> {
+        let len = available_range_len(bytes.len() as u64, offset, len)?;
+        if self.l1.is_enabled() && len > 0 {
+            let (page_start, page_len) = self.page_window(offset, len, bytes.len() as u64)?;
+            let pages = slice(&bytes, page_start, page_len)?;
+            self.admit_l1_pages(block, page_start, pages);
+        }
+        slice(&bytes, offset, len)
     }
 
     fn invalidate_l1(&self, block: &BlockId) {
-        if self.l1.remove(block) {
+        if !self.l1.remove_block(block).is_empty() {
             self.refresh_l1_metrics();
         }
     }
@@ -772,7 +848,6 @@ impl WorkerRuntime {
         if !self.l1.remove_superseded(block).is_empty() {
             self.refresh_l1_metrics();
         }
-        self.admit_l1(block, bytes.clone());
         tracing::info!(block = %block, bytes = len, "committed block");
         Ok(bytes)
     }
@@ -840,7 +915,7 @@ impl WorkerRuntime {
         if !self.l1.remove_superseded(&block).is_empty() {
             self.refresh_l1_metrics();
         }
-        self.admit_l1(&block, body);
+        self.admit_l1_pages(&block, 0, body);
         tracing::info!(object = %object.to_path(), bytes = len, version = %version, "wrote object");
         Ok(version)
     }
@@ -963,8 +1038,8 @@ impl WorkerRuntime {
         self.index.resident_bytes()
     }
 
-    /// Number of blocks resident in L1.
-    pub fn l1_block_count(&self) -> u64 {
+    /// Number of pages resident in L1.
+    pub fn l1_page_count(&self) -> u64 {
         self.l1.len() as u64
     }
 
@@ -1017,6 +1092,13 @@ fn slice(buffer: &bytes::Bytes, offset: u64, len: u64) -> anyhow::Result<bytes::
     let requested = usize::try_from(len).unwrap_or(usize::MAX);
     let end = start.saturating_add(requested).min(buffer.len());
     Ok(buffer.slice(start..end))
+}
+
+fn available_range_len(block_len: u64, offset: u64, requested: u64) -> anyhow::Result<u64> {
+    if offset > block_len {
+        anyhow::bail!("offset {offset} beyond block length {block_len} bytes");
+    }
+    Ok(requested.min(block_len - offset))
 }
 
 /// Whether an error chain carries a backend [`Error::VersionMismatch`], i.e. an
@@ -1291,7 +1373,7 @@ mod tests {
         root: &PathBuf,
         l2_capacity: u64,
         l1_capacity: u64,
-        l1_max_entry: u64,
+        l1_page_size: u64,
     ) -> WorkerRuntime {
         WorkerRuntime::new_with_l1(
             WholeBlockStore::open(root).unwrap(),
@@ -1301,7 +1383,7 @@ mod tests {
             8,
             l2_capacity,
             l1_capacity,
-            l1_max_entry,
+            l1_page_size,
             metrics,
         )
         .with_version_ttl(Duration::ZERO)
@@ -1347,7 +1429,7 @@ mod tests {
             ServeOutcome::Bytes(bytes) => assert_eq!(bytes, Bytes::from_static(b"abcd")),
             ServeOutcome::Sendfile(_) => panic!("origin miss must return fetched bytes"),
         }
-        assert_eq!(runtime.l1_block_count(), 1);
+        assert_eq!(runtime.l1_page_count(), 1);
         assert_eq!(runtime.l1_resident_bytes(), 8);
 
         match runtime.serve(&request("l1")).await.unwrap() {
@@ -1360,7 +1442,7 @@ mod tests {
         assert!(rendered.contains("talon_worker_cache_tier_misses_total{tier=\"l1\"} 1"));
         assert!(rendered.contains("talon_worker_cache_tier_misses_total{tier=\"l2\"} 1"));
         assert!(rendered.contains("talon_worker_l1_admissions_total 1"));
-        assert!(rendered.contains("talon_worker_l1_blocks 1"));
+        assert!(rendered.contains("talon_worker_l1_pages 1"));
         assert!(rendered.contains("talon_worker_l1_resident_bytes 8"));
         assert!(rendered.contains("talon_worker_l1_capacity_bytes 16"));
         std::fs::remove_dir_all(root).ok();
@@ -1381,7 +1463,7 @@ mod tests {
             b"abcd"
         );
         assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
-        assert_eq!(runtime.l1_block_count(), 0);
+        assert_eq!(runtime.l1_page_count(), 0);
         assert_eq!(runtime.l1_resident_bytes(), 0);
         let rendered = metrics.render();
         assert!(rendered.contains("talon_worker_cache_tier_hits_total{tier=\"l2\"} 1"));
@@ -1405,7 +1487,7 @@ mod tests {
         );
 
         let _ = runtime.serve(&request("boundary")).await.unwrap();
-        assert_eq!(runtime.l1_block_count(), 1);
+        assert_eq!(runtime.l1_page_count(), 1);
         assert_eq!(runtime.l1_resident_bytes(), 8);
         match runtime.serve(&request("boundary")).await.unwrap() {
             ServeOutcome::Bytes(bytes) => assert_eq!(bytes, Bytes::from_static(b"abcd")),
@@ -1416,7 +1498,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn oversized_block_stays_on_l2_sendfile_path() {
+    async fn block_larger_than_l1_still_caches_its_hot_page() {
         let root = tmp_root();
         let backend = Arc::new(MockBackend {
             calls: AtomicUsize::new(0),
@@ -1425,15 +1507,154 @@ mod tests {
         let runtime = runtime_l1(Arc::clone(&backend), metrics.clone(), &root, 1024, 16, 4);
 
         let _ = runtime.serve(&request("large")).await.unwrap();
-        assert_eq!(runtime.l1_block_count(), 0);
-        assert_eq!(
-            read_handle(runtime.serve(&request("large")).await.unwrap()),
-            b"abcd"
-        );
+        assert_eq!(runtime.l1_page_count(), 1);
+        match runtime.serve(&request("large")).await.unwrap() {
+            ServeOutcome::Bytes(bytes) => assert_eq!(bytes, Bytes::from_static(b"abcd")),
+            ServeOutcome::Sendfile(_) => panic!("hot page must be served from L1"),
+        }
         assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
         assert!(metrics
             .render()
-            .contains("talon_worker_cache_tier_hits_total{tier=\"l2\"} 1"));
+            .contains("talon_worker_cache_tier_hits_total{tier=\"l1\"} 1"));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn different_ranges_of_one_block_admit_only_their_touched_pages() {
+        let root = tmp_root();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let backend = Arc::new(CountingRampBackend {
+            block_size: 16,
+            calls: Arc::clone(&calls),
+        });
+        let runtime = WorkerRuntime::new_with_l1(
+            WholeBlockStore::open(&root).unwrap(),
+            Arc::new(BlockIndex::new()),
+            Arc::new(InFlightLoads::new()),
+            backend,
+            16,
+            1024,
+            8,
+            4,
+            WorkerMetrics::new(1024),
+        )
+        .with_version_ttl(Duration::ZERO);
+        let object = ObjectId::new(Backend::Azure, "container", "page-hotness");
+
+        let first = RangeRequest {
+            object: object.clone(),
+            offset: 1,
+            len: 2,
+        };
+        assert_eq!(runtime.serve_range(&first).await.unwrap(), expected(1, 2));
+        let block = BlockId::new(object.clone(), 0, 16, Version::new("v1"));
+        assert!(runtime.l1.get_page(&block, PageIndex(0)).is_some());
+        assert!(runtime.l1.get_page(&block, PageIndex(1)).is_none());
+        assert!(runtime.l1.get_page(&block, PageIndex(2)).is_none());
+        assert_eq!(runtime.l1_page_count(), 1);
+
+        let second = RangeRequest {
+            object,
+            offset: 9,
+            len: 2,
+        };
+        assert_eq!(runtime.serve_range(&second).await.unwrap(), expected(9, 2));
+        assert!(runtime.l1.get_page(&block, PageIndex(0)).is_some());
+        assert!(runtime.l1.get_page(&block, PageIndex(1)).is_none());
+        assert!(runtime.l1.get_page(&block, PageIndex(2)).is_some());
+        assert!(runtime.l1.get_page(&block, PageIndex(3)).is_none());
+        assert_eq!(runtime.l1_page_count(), 2);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn range_crossing_page_boundaries_admits_and_hits_all_touched_pages() {
+        let root = tmp_root();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let backend = Arc::new(CountingRampBackend {
+            block_size: 16,
+            calls: Arc::clone(&calls),
+        });
+        let metrics = WorkerMetrics::new(1024);
+        let runtime = WorkerRuntime::new_with_l1(
+            WholeBlockStore::open(&root).unwrap(),
+            Arc::new(BlockIndex::new()),
+            Arc::new(InFlightLoads::new()),
+            backend,
+            16,
+            1024,
+            16,
+            4,
+            metrics.clone(),
+        )
+        .with_version_ttl(Duration::ZERO);
+        let request = RangeRequest {
+            object: ObjectId::new(Backend::Azure, "container", "cross-pages"),
+            offset: 3,
+            len: 10,
+        };
+
+        assert_eq!(
+            runtime.serve_range(&request).await.unwrap(),
+            expected(3, 10)
+        );
+        assert_eq!(runtime.l1_page_count(), 4);
+        assert_eq!(
+            runtime.serve_range(&request).await.unwrap(),
+            expected(3, 10)
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(metrics
+            .render()
+            .contains("talon_worker_cache_tier_hits_total{tier=\"l1\"} 1"));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn default_large_block_can_cache_one_small_hot_page() {
+        const BLOCK_SIZE: u32 = 256 << 20;
+        const PAGE_SIZE: u64 = 256 << 10;
+
+        let root = tmp_root();
+        let store = WholeBlockStore::open(&root).unwrap();
+        let object = ObjectId::new(Backend::Azure, "container", "large-block");
+        let block = BlockId::new(object.clone(), 0, BLOCK_SIZE, Version::new("v1"));
+        let bytes = Bytes::from(vec![7_u8; (PAGE_SIZE * 2) as usize]);
+        store.put(&block, bytes.clone()).await.unwrap();
+        let index = Arc::new(BlockIndex::new());
+        index.commit(BlockMeta {
+            id: block.clone(),
+            form: BlockForm::Whole,
+            len: bytes.len() as u64,
+        });
+        let runtime = WorkerRuntime::new_with_l1(
+            store,
+            index,
+            Arc::new(InFlightLoads::new()),
+            Arc::new(RampBackend {
+                block_size: BLOCK_SIZE as u64,
+            }),
+            BLOCK_SIZE,
+            BLOCK_SIZE as u64,
+            PAGE_SIZE * 2,
+            PAGE_SIZE,
+            WorkerMetrics::new(BLOCK_SIZE as u64),
+        );
+        runtime.store_version(&object, &Version::new("v1"));
+        let request = RangeRequest {
+            object,
+            offset: PAGE_SIZE + 17,
+            len: 64,
+        };
+
+        assert_eq!(
+            runtime.serve_range(&request).await.unwrap(),
+            Bytes::from(vec![7_u8; 64])
+        );
+        assert_eq!(runtime.l1_page_count(), 1);
+        assert!(runtime.l1.get_page(&block, PageIndex(0)).is_none());
+        assert!(runtime.l1.get_page(&block, PageIndex(1)).is_some());
         std::fs::remove_dir_all(root).ok();
     }
 
@@ -1449,7 +1670,7 @@ mod tests {
         let _ = runtime.serve(&request("a")).await.unwrap();
         let _ = runtime.serve(&request("b")).await.unwrap();
         assert_eq!(runtime.block_count(), 2, "both parents remain in L2");
-        assert_eq!(runtime.l1_block_count(), 1, "L1 holds only the MRU block");
+        assert_eq!(runtime.l1_page_count(), 1, "L1 holds only the MRU block");
         assert_eq!(backend.calls.load(Ordering::SeqCst), 2);
 
         match runtime.serve(&request("a")).await.unwrap() {
@@ -1462,7 +1683,7 @@ mod tests {
             "L1 eviction must degrade to L2, not origin"
         );
         assert_eq!(runtime.block_count(), 2);
-        assert_eq!(runtime.l1_block_count(), 1);
+        assert_eq!(runtime.l1_page_count(), 1);
         assert!(metrics
             .render()
             .contains("talon_worker_l1_evictions_total 2"));
@@ -1475,25 +1696,31 @@ mod tests {
         let backend = Arc::new(MockBackend {
             calls: AtomicUsize::new(0),
         });
-        let runtime = runtime_l1(Arc::clone(&backend), WorkerMetrics::new(8), &root, 8, 16, 8);
+        let runtime = runtime_l1(Arc::clone(&backend), WorkerMetrics::new(8), &root, 8, 16, 4);
+        let full = |name| RangeRequest {
+            object: ObjectId::new(Backend::Azure, "container", name),
+            offset: 0,
+            len: 8,
+        };
 
-        let _ = runtime.serve(&request("a")).await.unwrap();
-        let _ = runtime.serve(&request("b")).await.unwrap();
+        let _ = runtime.serve(&full("a")).await.unwrap();
+        assert_eq!(runtime.l1_page_count(), 2);
+        let _ = runtime.serve(&full("b")).await.unwrap();
         assert_eq!(runtime.block_count(), 1, "L2 capacity keeps one block");
         assert_eq!(
-            runtime.l1_block_count(),
-            1,
-            "evicted L2 parent must not leave an orphan L1 copy"
+            runtime.l1_page_count(),
+            2,
+            "evicted L2 parent must remove all of its child pages"
         );
 
-        let _ = runtime.serve(&request("a")).await.unwrap();
+        let _ = runtime.serve(&full("a")).await.unwrap();
         assert_eq!(
             backend.calls.load(Ordering::SeqCst),
             3,
             "reading the L2-evicted block must fetch origin again"
         );
         assert_eq!(runtime.block_count(), 1);
-        assert_eq!(runtime.l1_block_count(), 1);
+        assert_eq!(runtime.l1_page_count(), 2);
         std::fs::remove_dir_all(root).ok();
     }
 
@@ -1509,7 +1736,7 @@ mod tests {
             &root,
             1024,
             16,
-            8,
+            4,
         );
         let _ = first.serve(&request("restart")).await.unwrap();
         assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
@@ -1528,11 +1755,11 @@ mod tests {
             8,
             1024,
             16,
-            8,
+            4,
             WorkerMetrics::new(1024),
         )
         .with_version_ttl(Duration::ZERO);
-        assert_eq!(restarted.l1_block_count(), 0);
+        assert_eq!(restarted.l1_page_count(), 0);
         assert_eq!(restarted.block_count(), 1);
 
         match restarted.serve(&request("restart")).await.unwrap() {
@@ -1544,7 +1771,52 @@ mod tests {
             1,
             "restart promotion must not refetch object bytes"
         );
-        assert_eq!(restarted.l1_block_count(), 1);
+        assert_eq!(restarted.l1_page_count(), 1);
+        let block = restarted.block_for(
+            &ObjectId::new(Backend::Azure, "container", "restart"),
+            0,
+            &Version::new("v1"),
+        );
+        assert!(restarted.l1.get_page(&block, PageIndex(0)).is_some());
+        assert!(restarted.l1.get_page(&block, PageIndex(1)).is_none());
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn stale_l2_index_entry_refetches_after_file_disappears() {
+        let root = tmp_root();
+        let backend = Arc::new(MockBackend {
+            calls: AtomicUsize::new(0),
+        });
+        let runtime = runtime_l1(
+            Arc::clone(&backend),
+            WorkerMetrics::new(1024),
+            &root,
+            1024,
+            16,
+            4,
+        );
+        let req = request("lost-file");
+        assert_eq!(
+            runtime.serve_range(&req).await.unwrap(),
+            Bytes::from_static(b"abcd")
+        );
+
+        let block = runtime.block_for(&req.object, req.offset, &Version::new("v1"));
+        runtime.l1.remove_block(&block);
+        runtime.store.delete(&block).await.unwrap();
+        assert!(
+            runtime.index.get(&block).is_some(),
+            "test must leave stale metadata behind"
+        );
+
+        assert_eq!(
+            runtime.serve_range(&req).await.unwrap(),
+            Bytes::from_static(b"abcd")
+        );
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 2);
+        assert!(runtime.index.get(&block).is_some());
+        assert_eq!(runtime.l1_page_count(), 1);
         std::fs::remove_dir_all(root).ok();
     }
 
@@ -1561,7 +1833,7 @@ mod tests {
             &root,
             1024,
             16,
-            8,
+            4,
         ));
         let _ = runtime.serve(&request("hot")).await.unwrap();
 
@@ -1599,7 +1871,7 @@ mod tests {
             8,
             1024,
             16,
-            8,
+            4,
             metrics.clone(),
         )
         .with_version_ttl(Duration::ZERO);
@@ -1611,8 +1883,8 @@ mod tests {
 
         assert_eq!(runtime.serve_range(&req).await.unwrap(), expected(6, 8));
         assert_eq!(calls.load(Ordering::SeqCst), 2);
-        assert_eq!(runtime.l1_block_count(), 2);
-        assert_eq!(runtime.l1_resident_bytes(), 16);
+        assert_eq!(runtime.l1_page_count(), 3);
+        assert_eq!(runtime.l1_resident_bytes(), 12);
 
         assert_eq!(runtime.serve_range(&req).await.unwrap(), expected(6, 8));
         assert_eq!(
@@ -1638,14 +1910,14 @@ mod tests {
             &root,
             1024,
             16,
-            8,
+            4,
         );
 
         assert!(runtime.serve(&request("failure")).await.is_err());
         assert_eq!(runtime.inflight_loads(), 0);
         assert_eq!(runtime.block_count(), 0);
         assert_eq!(runtime.resident_bytes(), 0);
-        assert_eq!(runtime.l1_block_count(), 0);
+        assert_eq!(runtime.l1_page_count(), 0);
         assert_eq!(runtime.l1_resident_bytes(), 0);
         std::fs::remove_dir_all(root).ok();
     }
@@ -2085,30 +2357,31 @@ mod tests {
             8,
             1024,
             16,
-            8,
+            4,
             WorkerMetrics::new(1024),
         )
         .with_version_ttl(Duration::ZERO);
 
+        let full_request = RangeRequest {
+            object: ObjectId::new(Backend::Azure, "container", "versioned"),
+            offset: 0,
+            len: 8,
+        };
         assert_eq!(
-            runtime.serve_range(&request("versioned")).await.unwrap(),
-            Bytes::from_static(b"old-")
+            runtime.serve_range(&full_request).await.unwrap(),
+            Bytes::from_static(b"old-data")
         );
         assert_eq!(runtime.block_count(), 1);
-        assert_eq!(runtime.l1_block_count(), 1);
+        assert_eq!(runtime.l1_page_count(), 2);
 
         *backend.version.lock().unwrap() = "v2".into();
         *backend.body.lock().unwrap() = Bytes::from_static(b"new-data");
         assert_eq!(
-            runtime.serve_range(&request("versioned")).await.unwrap(),
-            Bytes::from_static(b"new-")
+            runtime.serve_range(&full_request).await.unwrap(),
+            Bytes::from_static(b"new-data")
         );
         assert_eq!(runtime.block_count(), 1, "old L2 version must be removed");
-        assert_eq!(
-            runtime.l1_block_count(),
-            1,
-            "old L1 version must be removed"
-        );
+        assert_eq!(runtime.l1_page_count(), 2, "old L1 pages must be removed");
         assert_eq!(runtime.l1_resident_bytes(), 8);
         std::fs::remove_dir_all(root).ok();
     }
@@ -2175,7 +2448,7 @@ mod tests {
             8,
             1024,
             16,
-            8,
+            4,
             WorkerMetrics::new(1024),
         );
         let object = ObjectId::new(Backend::Azure, "container", "mutable");
@@ -2189,7 +2462,7 @@ mod tests {
         );
         assert_eq!(backend.puts.load(Ordering::SeqCst), 1);
         assert_eq!(runtime.block_count(), 1);
-        assert_eq!(runtime.l1_block_count(), 1);
+        assert_eq!(runtime.l1_page_count(), 2);
 
         assert_eq!(
             runtime
@@ -2211,7 +2484,7 @@ mod tests {
         runtime.delete_object(&object).await.unwrap();
         assert_eq!(backend.deletes.load(Ordering::SeqCst), 1);
         assert_eq!(runtime.block_count(), 0);
-        assert_eq!(runtime.l1_block_count(), 0);
+        assert_eq!(runtime.l1_page_count(), 0);
         assert_eq!(runtime.l1_resident_bytes(), 0);
         std::fs::remove_dir_all(root).ok();
     }

--- a/deploy/helm/talon/README.md
+++ b/deploy/helm/talon/README.md
@@ -55,7 +55,7 @@ SSD) instead of an `emptyDir`. Disable workers entirely with
 | `worker.blockSizeBytes` | `268435456` | Cache block size in bytes |
 | `worker.capacityBytes` | `8589934592` | Per-worker cache capacity |
 | `worker.l1CapacityBytes` | `0` | L1 DRAM capacity; zero disables L1 |
-| `worker.l1MaxEntryBytes` | `4194304` | Largest block admitted to L1 |
+| `worker.l1PageSizeBytes` | `262144` | Fixed L1 DRAM page size |
 | `image.registry` / `image.tag` | `ghcr.io/milvus-io` / chart appVersion | Image source |
 | `serviceMonitor.enabled` | `false` | Prometheus Operator ServiceMonitor |
 

--- a/deploy/helm/talon/templates/worker.yaml
+++ b/deploy/helm/talon/templates/worker.yaml
@@ -102,8 +102,8 @@ spec:
               value: {{ .Values.worker.capacityBytes | quote }}
             - name: TALON_WORKER_L1_CAPACITY_BYTES
               value: {{ .Values.worker.l1CapacityBytes | quote }}
-            - name: TALON_WORKER_L1_MAX_ENTRY_BYTES
-              value: {{ .Values.worker.l1MaxEntryBytes | quote }}
+            - name: TALON_WORKER_L1_PAGE_SIZE_BYTES
+              value: {{ .Values.worker.l1PageSizeBytes | quote }}
             - name: TALON_WORKER_AZURE_ACCOUNT
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/talon/values.yaml
+++ b/deploy/helm/talon/values.yaml
@@ -64,8 +64,8 @@ worker:
   capacityBytes: 8589934592
   # -- L1 DRAM cache capacity in bytes. Zero keeps L1 disabled.
   l1CapacityBytes: 0
-  # -- Largest whole block eligible for L1 admission.
-  l1MaxEntryBytes: 4194304
+  # -- Fixed L1 DRAM page size.
+  l1PageSizeBytes: 262144
   # -- Object-store credentials. Reference a Secret you create out-of-band (see
   # deploy/kubernetes/worker-secret.example.yaml).
   backend:

--- a/deploy/kubernetes/worker.yaml
+++ b/deploy/kubernetes/worker.yaml
@@ -110,8 +110,8 @@ spec:
             # includes this capacity plus the worker's normal heap/runtime use.
             - name: TALON_WORKER_L1_CAPACITY_BYTES
               value: "0"
-            - name: TALON_WORKER_L1_MAX_ENTRY_BYTES
-              value: "4194304"
+            - name: TALON_WORKER_L1_PAGE_SIZE_BYTES
+              value: "262144"
             # Object-store backend credentials from the Secret — never logged.
             - name: TALON_WORKER_AZURE_ACCOUNT
               valueFrom:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -119,6 +119,63 @@ Honor X-Forwarded-For for audit attribution behind a trusted proxy.
 - **Default:** `false`
 - **CLI flag:** not settable via CLI (config file or environment only)
 
+### `etcd.endpoints`
+
+Comma-separated etcd host:port endpoints.
+
+- **Environment variable:** `TALON_COORDINATOR_ETCD_ENDPOINTS`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `etcd.username`
+
+etcd username (requires password).
+
+- **Environment variable:** `TALON_COORDINATOR_ETCD_USERNAME`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `etcd.password` 🔒
+
+etcd password; keep in a Secret, not the config file.
+
+- **Environment variable:** `TALON_COORDINATOR_ETCD_PASSWORD`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+- **Secret:** read only from the environment; never written to a config file or logged
+
+### `etcd.tls.ca_cert_path`
+
+PEM CA certificate path; enables TLS.
+
+- **Environment variable:** `TALON_COORDINATOR_ETCD_CA_CERT_PATH`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `etcd.tls.client_cert_path`
+
+PEM client certificate path; mutual TLS.
+
+- **Environment variable:** `TALON_COORDINATOR_ETCD_CLIENT_CERT_PATH`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `etcd.tls.client_key_path`
+
+PEM client key path; mutual TLS.
+
+- **Environment variable:** `TALON_COORDINATOR_ETCD_CLIENT_KEY_PATH`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `kubernetes.namespace`
+
+Namespace holding Talon Lease objects.
+
+- **Environment variable:** `TALON_COORDINATOR_K8S_NAMESPACE`
+- **Default:** `talon`
+- **CLI flag:** not settable via CLI (config file or environment only)
+
 ## Worker
 
 ### `listen`

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -119,63 +119,6 @@ Honor X-Forwarded-For for audit attribution behind a trusted proxy.
 - **Default:** `false`
 - **CLI flag:** not settable via CLI (config file or environment only)
 
-### `etcd.endpoints`
-
-Comma-separated etcd host:port endpoints.
-
-- **Environment variable:** `TALON_COORDINATOR_ETCD_ENDPOINTS`
-- **Default:** none
-- **CLI flag:** not settable via CLI (config file or environment only)
-
-### `etcd.username`
-
-etcd username (requires password).
-
-- **Environment variable:** `TALON_COORDINATOR_ETCD_USERNAME`
-- **Default:** none
-- **CLI flag:** not settable via CLI (config file or environment only)
-
-### `etcd.password` 🔒
-
-etcd password; keep in a Secret, not the config file.
-
-- **Environment variable:** `TALON_COORDINATOR_ETCD_PASSWORD`
-- **Default:** none
-- **CLI flag:** not settable via CLI (config file or environment only)
-- **Secret:** read only from the environment; never written to a config file or logged
-
-### `etcd.tls.ca_cert_path`
-
-PEM CA certificate path; enables TLS.
-
-- **Environment variable:** `TALON_COORDINATOR_ETCD_CA_CERT_PATH`
-- **Default:** none
-- **CLI flag:** not settable via CLI (config file or environment only)
-
-### `etcd.tls.client_cert_path`
-
-PEM client certificate path; mutual TLS.
-
-- **Environment variable:** `TALON_COORDINATOR_ETCD_CLIENT_CERT_PATH`
-- **Default:** none
-- **CLI flag:** not settable via CLI (config file or environment only)
-
-### `etcd.tls.client_key_path`
-
-PEM client key path; mutual TLS.
-
-- **Environment variable:** `TALON_COORDINATOR_ETCD_CLIENT_KEY_PATH`
-- **Default:** none
-- **CLI flag:** not settable via CLI (config file or environment only)
-
-### `kubernetes.namespace`
-
-Namespace holding Talon Lease objects.
-
-- **Environment variable:** `TALON_COORDINATOR_K8S_NAMESPACE`
-- **Default:** `talon`
-- **CLI flag:** not settable via CLI (config file or environment only)
-
 ## Worker
 
 ### `listen`
@@ -266,12 +209,12 @@ L1 DRAM cache capacity in bytes; 0 disables L1.
 - **Default:** `0`
 - **CLI flag:** not settable via CLI (config file or environment only)
 
-### `l1_max_entry_bytes`
+### `l1_page_size_bytes`
 
-Largest whole block eligible for the L1 DRAM cache.
+Fixed L1 DRAM page size in bytes.
 
-- **Environment variable:** `TALON_WORKER_L1_MAX_ENTRY_BYTES`
-- **Default:** `4194304`
+- **Environment variable:** `TALON_WORKER_L1_PAGE_SIZE_BYTES`
+- **Default:** `262144`
 - **CLI flag:** not settable via CLI (config file or environment only)
 
 ### `backend`

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -15,7 +15,8 @@ BENCH_SECONDS="${BENCH_SECONDS:-5}"
 ARTIFACT_DIR="${ARTIFACT_DIR:-$ROOT/.artifacts/k8s-l1-l2}"
 COORD_PORT="${COORD_PORT:-17000}"
 WORKER_PORT="${WORKER_PORT:-17001}"
-BLOCK_SIZE=$((1024 * 1024))
+BLOCK_SIZE="${BLOCK_SIZE:-$((16 * 1024 * 1024))}"
+PAGE_SIZE="${PAGE_SIZE:-$((256 * 1024))}"
 MINIO_ACCESS_KEY="minioadmin"
 MINIO_SECRET_KEY="minioadmin"
 BUCKET="talon-e2e"
@@ -150,6 +151,28 @@ first_worker() {
   worker_pods | sort | head -1
 }
 
+second_worker() {
+  worker_pods | sort | sed -n '2p'
+}
+
+cluster_loadgen() {
+  local target_pod="$1"
+  local output="$2"
+  local bench_pod target_ip
+  bench_pod="$(second_worker)"
+  target_ip="$(kubectl -n "$NAMESPACE" get pod "$target_pod" -o jsonpath='{.status.podIP}')"
+  [[ -n "$bench_pod" && "$bench_pod" != "$target_pod" && -n "$target_ip" ]] ||
+    fail "cannot select a separate in-cluster load-generator pod"
+  kubectl -n "$NAMESPACE" exec -i "$bench_pod" -- \
+    sh -c 'cat >/tmp/talon-loadgen && chmod 755 /tmp/talon-loadgen' \
+    <target/release/talon-loadgen
+  kubectl -n "$NAMESPACE" exec "$bench_pod" -- \
+    /tmp/talon-loadgen --addr "$target_ip:7001" \
+    --backend s3 --container "$BUCKET" --object bench --range 65536 \
+    --conns 1,32,128 --seconds "$BENCH_SECONDS" --warmup 2 --json |
+    tee "$output"
+}
+
 assert_workers_spread() {
   local ready=0 nodes pod
   for _ in $(seq 1 60); do
@@ -200,7 +223,7 @@ set_cache_limits() {
   local l2="$2"
   kubectl -n "$NAMESPACE" set env "deployment/$RELEASE-worker" \
     "TALON_WORKER_L1_CAPACITY_BYTES=$l1" \
-    "TALON_WORKER_L1_MAX_ENTRY_BYTES=$BLOCK_SIZE" \
+    "TALON_WORKER_L1_PAGE_SIZE_BYTES=$PAGE_SIZE" \
     "TALON_WORKER_CAPACITY_BYTES=$l2" >/dev/null
   rollout_workers
 }
@@ -364,10 +387,10 @@ helm upgrade --install "$RELEASE" deploy/helm/talon -n "$NAMESPACE" \
   --set coordinator.clusterId=e2e \
   --set worker.replicas=3 \
   --set worker.topologySpreadWhenUnsatisfiable=DoNotSchedule \
-  --set worker.blockSizeBytes=$BLOCK_SIZE \
+  --set worker.blockSizeBytes="$BLOCK_SIZE" \
   --set worker.capacityBytes=$((64 * BLOCK_SIZE)) \
-  --set worker.l1CapacityBytes=$((32 * BLOCK_SIZE)) \
-  --set worker.l1MaxEntryBytes=$BLOCK_SIZE \
+  --set worker.l1CapacityBytes=$((32 * PAGE_SIZE)) \
+  --set worker.l1PageSizeBytes="$PAGE_SIZE" \
   --set worker.resources.requests.cpu=100m \
   --set worker.resources.requests.memory=128Mi \
   --set worker.resources.limits.cpu=2 \
@@ -435,14 +458,24 @@ start_coordinator_forward
 TARGET_POD="$(first_worker)"
 start_worker_forward "$TARGET_POD"
 head -c 65536 "$ARTIFACT_DIR/hot.bin" >"$ARTIFACT_DIR/hot.expected"
+hot_pages_before="$(metric_value "$TARGET_POD" talon_worker_l1_pages)"
 direct_read hot.bin 0 65536 "$ARTIFACT_DIR/hot-cold.out" |
   tee "$ARTIFACT_DIR/hot-cold.log"
+[[ "$(metric_value "$TARGET_POD" talon_worker_l1_pages)" -eq $((hot_pages_before + 1)) ]] ||
+  fail "first hot range admitted more than its single touched page"
 direct_read hot.bin 0 65536 "$ARTIFACT_DIR/hot-warm.out" |
   tee "$ARTIFACT_DIR/hot-warm.log"
 cmp "$ARTIFACT_DIR/hot.expected" "$ARTIFACT_DIR/hot-cold.out"
 cmp "$ARTIFACT_DIR/hot.expected" "$ARTIFACT_DIR/hot-warm.out"
 [[ "$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l1"}')" -ge 1 ]] ||
   fail "warm read did not register an L1 hit"
+HOT_SECOND_OFFSET=$((4 * PAGE_SIZE + 4096))
+dd if="$ARTIFACT_DIR/hot.bin" of="$ARTIFACT_DIR/hot-second.expected" \
+  bs=1 skip="$HOT_SECOND_OFFSET" count=65536 status=none
+direct_read hot.bin "$HOT_SECOND_OFFSET" 65536 "$ARTIFACT_DIR/hot-second.out" >/dev/null
+cmp "$ARTIFACT_DIR/hot-second.expected" "$ARTIFACT_DIR/hot-second.out"
+[[ "$(metric_value "$TARGET_POD" talon_worker_l1_pages)" -eq $((hot_pages_before + 2)) ]] ||
+  fail "a second range in the same block did not admit exactly one independent page"
 
 CROSS_OFFSET=$((BLOCK_SIZE - 32768))
 CROSS_LEN=65536
@@ -453,7 +486,7 @@ cmp "$ARTIFACT_DIR/cross.expected" "$ARTIFACT_DIR/cross.out"
 
 log "verifying L1 eviction falls back to L2 and L2 eviction invalidates L1"
 stop_port_forwards
-set_cache_limits $((2 * BLOCK_SIZE)) $((4 * BLOCK_SIZE))
+set_cache_limits $((2 * PAGE_SIZE)) $((4 * BLOCK_SIZE))
 start_coordinator_forward
 TARGET_POD="$(first_worker)"
 start_worker_forward "$TARGET_POD"
@@ -487,12 +520,12 @@ l1_hits_after="$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{
   fail "L2 eviction left an orphan L1 copy instead of refetching origin"
 [[ "$l1_hits_after" -eq "$l1_hits_before" ]] ||
   fail "L2-evicted block was incorrectly served from an orphan L1 copy"
-[[ "$(metric_value "$TARGET_POD" talon_worker_l1_blocks)" -le 2 ]] ||
-  fail "L1 exceeded its configured block capacity"
+[[ "$(metric_value "$TARGET_POD" talon_worker_l1_pages)" -le 2 ]] ||
+  fail "L1 exceeded its configured page capacity"
 
 log "verifying container restart rebuilds L2 and promotes into an empty L1"
 stop_port_forwards
-set_cache_limits $((32 * BLOCK_SIZE)) $((64 * BLOCK_SIZE))
+set_cache_limits $((32 * PAGE_SIZE)) $((64 * BLOCK_SIZE))
 start_coordinator_forward
 TARGET_POD="$(first_worker)"
 start_worker_forward "$TARGET_POD"
@@ -514,7 +547,7 @@ done
 stop_port_forwards
 start_coordinator_forward
 start_worker_forward "$TARGET_POD"
-[[ "$(metric_value "$TARGET_POD" talon_worker_l1_blocks)" -eq 0 ]] ||
+[[ "$(metric_value "$TARGET_POD" talon_worker_l1_pages)" -eq 0 ]] ||
   fail "L1 was not empty after process restart"
 direct_read restart.bin 0 4096 "$ARTIFACT_DIR/restart-after.out" >/dev/null
 cmp "$ARTIFACT_DIR/restart-before.out" "$ARTIFACT_DIR/restart-after.out"
@@ -522,7 +555,7 @@ cmp "$ARTIFACT_DIR/restart-before.out" "$ARTIFACT_DIR/restart-after.out"
   fail "restart promotion refetched the object body"
 [[ "$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l2"}')" -ge 1 ]] ||
   fail "restart read did not hit rebuilt L2"
-[[ "$(metric_value "$TARGET_POD" talon_worker_l1_blocks)" -eq 1 ]] ||
+[[ "$(metric_value "$TARGET_POD" talon_worker_l1_pages)" -eq 1 ]] ||
   fail "rebuilt L2 block was not promoted into L1"
 
 log "verifying concurrent cold misses collapse to one backend body fetch"
@@ -577,7 +610,7 @@ done
 
 log "benchmarking cold, warm L1, and warm L2 paths"
 stop_port_forwards
-set_cache_limits $((32 * BLOCK_SIZE)) $((64 * BLOCK_SIZE))
+set_cache_limits $((64 * PAGE_SIZE)) $((64 * BLOCK_SIZE))
 start_coordinator_forward
 TARGET_POD="$(first_worker)"
 start_worker_forward "$TARGET_POD"
@@ -589,10 +622,7 @@ start_worker_forward "$TARGET_POD"
     target/release/talon-client --worker "127.0.0.1:$WORKER_PORT" \
     --path "/s3/$BUCKET/bench" --len 65536 --out "$ARTIFACT_DIR/bench-warm.out"
 } 2>&1 | tee "$ARTIFACT_DIR/cold-warm.txt"
-target/release/talon-loadgen --addr "127.0.0.1:$WORKER_PORT" \
-  --backend s3 --container "$BUCKET" --object bench --range 65536 \
-  --conns 1,32,128 --seconds "$BENCH_SECONDS" --warmup 2 --json |
-  tee "$ARTIFACT_DIR/l1-benchmark.jsonl"
+cluster_loadgen "$TARGET_POD" "$ARTIFACT_DIR/l1-benchmark.jsonl"
 [[ "$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l1"}')" -gt 0 ]] ||
   fail "L1 benchmark produced no L1 hits"
 
@@ -601,10 +631,7 @@ set_cache_limits 0 $((64 * BLOCK_SIZE))
 start_coordinator_forward
 TARGET_POD="$(first_worker)"
 start_worker_forward "$TARGET_POD"
-target/release/talon-loadgen --addr "127.0.0.1:$WORKER_PORT" \
-  --backend s3 --container "$BUCKET" --object bench --range 65536 \
-  --conns 1,32,128 --seconds "$BENCH_SECONDS" --warmup 2 --json |
-  tee "$ARTIFACT_DIR/l2-benchmark.jsonl"
+cluster_loadgen "$TARGET_POD" "$ARTIFACT_DIR/l2-benchmark.jsonl"
 [[ "$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l2"}')" -gt 0 ]] ||
   fail "L2 benchmark produced no L2 hits"
 


### PR DESCRIPTION
## Summary

- replace whole-block L1 entries with `(BlockId, PageIndex)` pages while keeping whole blocks authoritative in L2
- promote only pages touched by a range; L2 promotion uses positional range reads instead of loading the whole block
- invalidate all child pages on L2 eviction, delete, version replacement, restart, or stale-index/file races
- replace `l1_max_entry_bytes` with `l1_page_size_bytes` (256 KiB default) across config, metrics, Helm, Kubernetes, and docs
- keep the L2 `sendfile` path unchanged when L1 is disabled

## Tests

- `cargo test -p talon-worker -p talon-core` (147 worker tests, 36 core tests)
- `cargo clippy -p talon-worker -p talon-core --all-targets -- -D warnings`
- `shellcheck scripts/k8s_l1_l2_e2e.sh`
- generated configuration reference matches the committed document
- GitHub Actions `Kubernetes L1/L2 E2E` run `30402300756`: passed on a Kind cluster with 1 control plane and 3 worker nodes

Kubernetes coverage includes three workers spread across three nodes, independent hot/cold pages in one block, multi-page and cross-block reads, L1 and L2 eviction, parent-child invalidation, process restart with L2 rebuild, 32-way cold-miss single-flight, source version replacement, coordinator replacement, worker replacement, and direct Pod-to-Pod load generation.

## Benchmark

Real loopback TCP, 64 KiB range, 100 samples:

| path | median | mean |
|---|---:|---:|
| L1 page | 233.9 us | 241.9 us |
| L2 sendfile | 276.3 us | 291.1 us |
| L2 userspace range read | 284.7 us | 292.6 us |

Three-node Kind, loadgen in a separate worker pod connected directly to the target Pod IP, 64 KiB ranges, 2 s warmup + 3 s measured:

| tier | conns | RPS | throughput | p50 | p99 | p999 |
|---|---:|---:|---:|---:|---:|---:|
| L1 | 1 | 7,584 | 474 MiB/s | 126 us | 195 us | 291 us |
| L1 | 32 | 29,605 | 1,850 MiB/s | 1.02 ms | 2.36 ms | 4.04 ms |
| L1 | 128 | 28,190 | 1,762 MiB/s | 4.33 ms | 9.33 ms | 97.0 ms |
| L2 | 1 | 4,392 | 275 MiB/s | 217 us | 357 us | 690 us |
| L2 | 32 | 11,727 | 733 MiB/s | 2.60 ms | 5.56 ms | 8.61 ms |
| L2 | 128 | 10,852 | 678 MiB/s | 11.18 ms | 23.87 ms | 105.8 ms |

The sweep shows saturation by 32 connections: raising concurrency to 128 reduces throughput by 4.8% for L1 and 7.5% for L2 while sharply increasing tail latency. L1 is 2.5-2.6x faster than L2 at high concurrency. These absolute numbers are diagnostic rather than production capacity figures: Kind forces the Tokio data plane in this workflow, L2 therefore pays the per-request blocking-pool/socket-mode handoff around `sendfile`, and the current in-cluster loadgen cannot sample the target container CPU/RSS.

A further comparison caveat is that the L2 sendfile hot path currently emits one `INFO` log per hit while the L1 hot path logs only at `DEBUG`. That logging asymmetry can materially depress L2 throughput and inflate its tail, so the L1/L2 ratio should not be treated as a clean storage-tier comparison until hot-hit logging is removed or disabled.