### PR TITLE
fix(fuse): fail closed on incomplete or invalid namespace listings

### DIFF
--- a/clients/java/src/main/java/io/milvus/talon/TalonClient.java
+++ b/clients/java/src/main/java/io/milvus/talon/TalonClient.java
@@ -146,12 +146,13 @@ public final class TalonClient implements AutoCloseable {
      * List objects beneath a mount-relative prefix.
      *
      * <p>The prefix names a backend and bucket ({@code az/container}),
-     * optionally followed by a key prefix. Returned paths are in the same
-     * namespace, so they can be passed straight to {@link #read}.
+     * optionally followed by a key prefix. Returned paths are mount-relative;
+     * convert, for example, {@code az/container/key} to
+     * {@code az://container/key} before passing it to {@link #read}.
      *
-     * <p>Large listings are truncated rather than paginated: the control
-     * protocol has no cursor, so the server caps both the object count and the
-     * number of backend round trips.
+     * <p>The control protocol carries one bounded response. If a prefix exceeds
+     * the server's object, page, or payload limit, the call fails explicitly
+     * instead of returning an incomplete list; use a narrower prefix.
      */
     public List<ObjectEntry> list(String prefix) throws IOException {
         int id = requestIds.getAndIncrement();

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -245,9 +245,9 @@ impl Client {
     /// they can be passed straight to [`read`](Self::read) after converting to
     /// a URI.
     ///
-    /// Large listings are truncated rather than paginated: the control protocol
-    /// has no cursor, so the server caps both the object count and the number
-    /// of backend round trips.
+    /// The control protocol carries one bounded response. If a prefix exceeds
+    /// the server's object, page, or payload limit, the call fails explicitly
+    /// instead of returning an incomplete list; use a narrower prefix.
     fn list(&self, py: Python<'_>, prefix: &str) -> PyResult<Vec<ObjectEntry>> {
         let runtime = Arc::clone(&self.runtime);
         let coordinator = self.coordinator.clone();

--- a/crates/talon-coordinator/Cargo.toml
+++ b/crates/talon-coordinator/Cargo.toml
@@ -54,7 +54,7 @@ tonic = { workspace = true, optional = true }
 
 [dev-dependencies]
 divan.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 tower = { version = "0.5", features = ["util"] }
 
 [[bench]]

--- a/crates/talon-coordinator/src/main.rs
+++ b/crates/talon-coordinator/src/main.rs
@@ -20,9 +20,31 @@ use tokio::net::{TcpListener, TcpStream};
 /// this, new peers wait for an in-flight connection to finish.
 const MAX_CONTROL_CONNECTIONS: usize = 1024;
 
-/// Bound on a proxied worker round trip (#318). Short: a client is blocked on
-/// this, and trying the next worker beats waiting on an unresponsive one.
-const PROXY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+/// Bound on establishing a proxied worker connection (#318). Keep this short:
+/// trying the next worker beats waiting on an unreachable one.
+const PROXY_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Default total budget for trying all workers for one proxied request.
+const PROXY_REQUEST_BUDGET: Duration = Duration::from_secs(5);
+
+/// Total budget for trying all workers for a listing. Listing drains multiple
+/// backend pages, so it needs more time than single-operation RPCs. This is one
+/// shared deadline across retries—not 25 seconds per worker—and leaves headroom
+/// inside the FUSE client's default 30-second coordinator exchange deadline.
+const LIST_OBJECTS_PROXY_BUDGET: Duration = Duration::from_secs(25);
+
+/// Minimum time preserved for each worker that has not yet been attempted.
+/// When the request budget cannot cover this reserve, attempts share the
+/// remaining time evenly instead.
+const MIN_PROXY_RETRY_RESERVE: Duration = Duration::from_secs(1);
+
+/// Keep aggregated worker diagnostics comfortably below the 1 MiB control
+/// payload cap even when a worker returns an unusually large rejection detail.
+const MAX_PROXY_ATTEMPT_ERRORS_BYTES: usize = 8 * 1024;
+
+/// Prevent one oversized worker rejection from consuming the whole aggregate
+/// and hiding diagnostics from workers attempted afterward.
+const MAX_PROXY_ATTEMPT_ERROR_BYTES: usize = 1024;
 
 #[derive(Debug, Parser)]
 #[command(name = "talon-coordinator", version, about)]
@@ -96,6 +118,58 @@ struct Coordinator {
     lease_ttl: Duration,
 }
 
+fn proxy_request_budget(message: &ControlMessage) -> Duration {
+    match message {
+        ControlMessage::ListObjects { .. } => LIST_OBJECTS_PROXY_BUDGET,
+        _ => PROXY_REQUEST_BUDGET,
+    }
+}
+
+/// Give one serial attempt most of the time still available while preserving a
+/// minimum retry window for every worker that follows.
+///
+/// This lets a listing use nearly all of its 25-second budget to drain backend
+/// pages: with two workers the first gets up to 24 seconds, rather than an even
+/// 12.5-second split. A silent worker still cannot consume the one-second retry
+/// reserve. Fast failures donate all unused time to later workers. When the
+/// remaining budget is tight, clamp each reservation to the current fair share;
+/// this degrades smoothly to an even split without starving the current worker.
+fn proxy_attempt_budget(remaining: Duration, workers_remaining: usize) -> Duration {
+    debug_assert!(workers_remaining > 0);
+    let divisor = u32::try_from(workers_remaining).unwrap_or(u32::MAX);
+    let later_workers = divisor.saturating_sub(1);
+    let fair_share = remaining / divisor;
+    let reserve_per_later = MIN_PROXY_RETRY_RESERVE.min(fair_share);
+    let retry_reserve = reserve_per_later.saturating_mul(later_workers);
+    remaining.saturating_sub(retry_reserve)
+}
+
+fn append_proxy_attempt_error(errors: &mut String, error: &str) {
+    let separator = if errors.is_empty() { "" } else { "; " };
+    let remaining = MAX_PROXY_ATTEMPT_ERRORS_BYTES.saturating_sub(errors.len());
+    if remaining <= separator.len() {
+        return;
+    }
+    errors.push_str(separator);
+
+    let remaining =
+        (MAX_PROXY_ATTEMPT_ERRORS_BYTES - errors.len()).min(MAX_PROXY_ATTEMPT_ERROR_BYTES);
+    if error.len() <= remaining {
+        errors.push_str(error);
+        return;
+    }
+
+    const TRUNCATED: &str = "...";
+    let mut end = remaining.saturating_sub(TRUNCATED.len()).min(error.len());
+    while !error.is_char_boundary(end) {
+        end -= 1;
+    }
+    errors.push_str(&error[..end]);
+    if remaining >= TRUNCATED.len() {
+        errors.push_str(TRUNCATED);
+    }
+}
+
 impl Coordinator {
     fn new(observability: Arc<CoordinatorObservability>, lease_ttl: Duration) -> Arc<Self> {
         Arc::new(Self {
@@ -132,19 +206,84 @@ impl Coordinator {
             };
         }
 
-        let mut last_error = None;
-        for worker in &workers {
-            match Self::round_trip_worker(&worker.address, &message).await {
-                Ok(reply) => return reply,
-                Err(e) => last_error = Some(format!("{}: {e}", worker.address)),
+        Self::proxy_to_workers(&workers, message).await
+    }
+
+    /// Try workers in order, treating both transport errors and explicit worker
+    /// rejections as retryable. A worker can be ready enough to advertise but
+    /// still reject a request that a later healthy worker can serve.
+    async fn proxy_to_workers(workers: &[NodeInfo], message: ControlMessage) -> ControlMessage {
+        let budget = proxy_request_budget(&message);
+        Self::proxy_to_workers_with_budget(workers, message, budget).await
+    }
+
+    /// Proxy under one deadline shared by every serial worker attempt.
+    ///
+    /// Each attempt receives the remaining total budget minus a small reserve
+    /// for every later worker. This prevents a silent first worker from
+    /// consuming the whole request while leaving long-running listings most of
+    /// their 25-second budget.
+    async fn proxy_to_workers_with_budget(
+        workers: &[NodeInfo],
+        message: ControlMessage,
+        budget: Duration,
+    ) -> ControlMessage {
+        let deadline = tokio::time::Instant::now() + budget;
+        let mut attempt_errors = String::new();
+        let mut tried = 0;
+        for (index, worker) in workers.iter().enumerate() {
+            let now = tokio::time::Instant::now();
+            let remaining = deadline.saturating_duration_since(now);
+            if remaining.is_zero() {
+                break;
+            }
+            let workers_remaining = workers.len() - index;
+            let attempt_budget = proxy_attempt_budget(remaining, workers_remaining);
+            let attempt_deadline = now + attempt_budget;
+            tried += 1;
+            let attempt = tokio::time::timeout_at(
+                attempt_deadline,
+                Self::round_trip_worker(&worker.address, &message, attempt_deadline),
+            )
+            .await;
+            match attempt {
+                Err(_) => append_proxy_attempt_error(
+                    &mut attempt_errors,
+                    &format!(
+                        "{}: worker attempt timed out after {attempt_budget:?}",
+                        worker.address
+                    ),
+                ),
+                Ok(Ok(ControlMessage::Ack { ok: false, detail })) => {
+                    append_proxy_attempt_error(
+                        &mut attempt_errors,
+                        &format!(
+                            "{}: worker rejected request: {}",
+                            worker.address,
+                            detail.unwrap_or_else(|| "no detail provided".into())
+                        ),
+                    );
+                }
+                Ok(Ok(reply)) => return reply,
+                Ok(Err(e)) => append_proxy_attempt_error(
+                    &mut attempt_errors,
+                    &format!("{}: {e}", worker.address),
+                ),
+            }
+            if tokio::time::Instant::now() >= deadline {
+                break;
             }
         }
         ControlMessage::Ack {
             ok: false,
             detail: Some(format!(
-                "no worker served the request ({} tried); last error: {}",
+                "no worker served the request ({tried}/{} tried within {budget:?}); attempt errors: {}",
                 workers.len(),
-                last_error.unwrap_or_else(|| "unknown".into())
+                if attempt_errors.is_empty() {
+                    "unknown"
+                } else {
+                    &attempt_errors
+                }
             )),
         }
     }
@@ -153,17 +292,30 @@ impl Coordinator {
     async fn round_trip_worker(
         address: &str,
         message: &ControlMessage,
+        attempt_deadline: tokio::time::Instant,
     ) -> anyhow::Result<ControlMessage> {
-        let mut stream = tokio::time::timeout(PROXY_TIMEOUT, TcpStream::connect(address)).await??;
+        let remaining = attempt_deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            anyhow::bail!("worker attempt budget exhausted before connecting");
+        }
+        let connect_timeout = PROXY_CONNECT_TIMEOUT.min(remaining);
+        let mut stream = tokio::time::timeout(connect_timeout, TcpStream::connect(address))
+            .await
+            .map_err(|_| anyhow::anyhow!("connect timed out after {connect_timeout:?}"))??;
         let buf = codec::encode(0, message)?;
         stream.write_all(&buf).await?;
         stream.flush().await?;
 
+        let remaining = attempt_deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            anyhow::bail!("worker attempt budget exhausted before reading response");
+        }
         let (header, payload) = tokio::time::timeout(
-            PROXY_TIMEOUT,
-            talon_transport::read_frame(&mut stream, PROXY_TIMEOUT),
+            remaining,
+            talon_transport::read_frame(&mut stream, remaining),
         )
-        .await?
+        .await
+        .map_err(|_| anyhow::anyhow!("worker response did not arrive within its attempt budget"))?
         .map_err(|e| anyhow::anyhow!("{e}"))?;
         let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
         full.extend_from_slice(&header.encode());
@@ -707,6 +859,302 @@ mod tests {
             )
             .unwrap(),
         )
+    }
+
+    #[test]
+    fn listings_use_one_dedicated_total_proxy_budget() {
+        let listing = ControlMessage::ListObjects {
+            prefix: "s3/bucket".into(),
+        };
+        let stat = ControlMessage::StatObject {
+            object: talon_core::ObjectId::new(talon_core::Backend::S3, "bucket", "object"),
+        };
+
+        assert_eq!(proxy_request_budget(&listing), Duration::from_secs(25));
+        assert_eq!(proxy_request_budget(&stat), Duration::from_secs(5));
+        assert!(proxy_request_budget(&listing) > proxy_request_budget(&stat));
+        assert!(
+            proxy_request_budget(&listing) < Duration::from_secs(30),
+            "listing proxy must leave headroom inside the FUSE client deadline"
+        );
+        assert_eq!(
+            proxy_attempt_budget(proxy_request_budget(&listing), 2),
+            Duration::from_secs(24),
+            "listing keeps most of its long-running budget while reserving a retry"
+        );
+        assert_eq!(
+            proxy_attempt_budget(proxy_request_budget(&listing), 1),
+            Duration::from_secs(25),
+            "a sole listing worker keeps the full long-running budget"
+        );
+        assert_eq!(
+            proxy_attempt_budget(Duration::from_millis(2_100), 3),
+            Duration::from_millis(700),
+            "a tight budget degrades to an even split"
+        );
+        assert_eq!(
+            proxy_attempt_budget(Duration::from_millis(3_001), 3),
+            Duration::from_millis(1_001),
+            "crossing the one-second reserve threshold must be continuous"
+        );
+    }
+
+    #[test]
+    fn proxy_attempt_errors_are_bounded_without_hiding_the_next_worker() {
+        let mut errors = String::new();
+        let oversized = format!(
+            "worker-a: actionable listing limit; narrow the namespace prefix: {}",
+            "x".repeat(MAX_PROXY_ATTEMPT_ERRORS_BYTES)
+        );
+
+        append_proxy_attempt_error(&mut errors, &oversized);
+        append_proxy_attempt_error(&mut errors, "worker-b: backend mismatch");
+
+        assert!(errors.len() <= MAX_PROXY_ATTEMPT_ERRORS_BYTES);
+        assert!(errors.contains("worker-a: actionable listing limit"));
+        assert!(errors.contains("worker-b: backend mismatch"));
+    }
+
+    #[tokio::test]
+    async fn proxy_retries_after_a_worker_rejects_the_request() {
+        let rejecting_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let rejecting_address = rejecting_listener.local_addr().unwrap().to_string();
+        let rejecting_server = tokio::spawn(async move {
+            let (mut stream, _) = rejecting_listener.accept().await.unwrap();
+            let (_, request) = read_control(&mut stream).await.unwrap().unwrap();
+            assert!(matches!(request, ControlMessage::ListObjects { .. }));
+            let reply = codec::encode(
+                0,
+                &ControlMessage::Ack {
+                    ok: false,
+                    detail: Some("worker backend mismatch".into()),
+                },
+            )
+            .unwrap();
+            stream.write_all(&reply).await.unwrap();
+            stream.flush().await.unwrap();
+        });
+
+        let serving_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let serving_address = serving_listener.local_addr().unwrap().to_string();
+        let serving_server = tokio::spawn(async move {
+            let (mut stream, _) = serving_listener.accept().await.unwrap();
+            let (_, request) = read_control(&mut stream).await.unwrap().unwrap();
+            assert!(matches!(request, ControlMessage::ListObjects { .. }));
+            let reply = codec::encode(
+                0,
+                &ControlMessage::ObjectList {
+                    entries: vec![talon_transport::ObjectEntry {
+                        path: "s3/bucket/object".into(),
+                        size: 42,
+                    }],
+                },
+            )
+            .unwrap();
+            stream.write_all(&reply).await.unwrap();
+            stream.flush().await.unwrap();
+        });
+
+        let workers = vec![
+            NodeInfo {
+                id: NodeId::new("worker-rejects"),
+                address: rejecting_address,
+                role: NodeRole::Worker,
+            },
+            NodeInfo {
+                id: NodeId::new("worker-serves"),
+                address: serving_address,
+                role: NodeRole::Worker,
+            },
+        ];
+        let reply = Coordinator::proxy_to_workers(
+            &workers,
+            ControlMessage::ListObjects {
+                prefix: "s3/bucket".into(),
+            },
+        )
+        .await;
+
+        assert!(matches!(
+            reply,
+            ControlMessage::ObjectList { entries }
+                if entries == vec![talon_transport::ObjectEntry {
+                    path: "s3/bucket/object".into(),
+                    size: 42,
+                }]
+        ));
+        rejecting_server.await.unwrap();
+        serving_server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn proxy_retries_a_healthy_worker_after_a_silent_worker_times_out() {
+        let stalled_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let stalled_address = stalled_listener.local_addr().unwrap().to_string();
+        let (stalled_request_tx, stalled_request_rx) = tokio::sync::oneshot::channel();
+        let stalled_server = tokio::spawn(async move {
+            let (mut stream, _) = stalled_listener.accept().await.unwrap();
+            let (_, request) = read_control(&mut stream).await.unwrap().unwrap();
+            assert!(matches!(request, ControlMessage::ListObjects { .. }));
+            stalled_request_tx.send(()).unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        let serving_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let serving_address = serving_listener.local_addr().unwrap().to_string();
+        let serving_server = tokio::spawn(async move {
+            let (mut stream, _) = serving_listener.accept().await.unwrap();
+            let (_, request) = read_control(&mut stream).await.unwrap().unwrap();
+            assert!(matches!(request, ControlMessage::ListObjects { .. }));
+            let reply = codec::encode(
+                0,
+                &ControlMessage::ObjectList {
+                    entries: vec![talon_transport::ObjectEntry {
+                        path: "s3/bucket/object".into(),
+                        size: 42,
+                    }],
+                },
+            )
+            .unwrap();
+            stream.write_all(&reply).await.unwrap();
+            stream.flush().await.unwrap();
+        });
+
+        let workers = vec![
+            NodeInfo {
+                id: NodeId::new("worker-stalls"),
+                address: stalled_address,
+                role: NodeRole::Worker,
+            },
+            NodeInfo {
+                id: NodeId::new("worker-serves"),
+                address: serving_address,
+                role: NodeRole::Worker,
+            },
+        ];
+        let budget = Duration::from_secs(4);
+        let proxy = tokio::spawn(async move {
+            Coordinator::proxy_to_workers_with_budget(
+                &workers,
+                ControlMessage::ListObjects {
+                    prefix: "s3/bucket".into(),
+                },
+                budget,
+            )
+            .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), stalled_request_rx)
+            .await
+            .expect("coordinator did not reach the stalled worker")
+            .expect("stalled worker exited before receiving the request");
+        tokio::time::pause();
+        tokio::time::advance(Duration::from_secs(3)).await;
+        tokio::time::resume();
+
+        let reply = tokio::time::timeout(Duration::from_secs(3), proxy)
+            .await
+            .expect("coordinator did not retry the healthy worker")
+            .unwrap();
+        assert!(matches!(
+            reply,
+            ControlMessage::ObjectList { entries }
+                if entries == vec![talon_transport::ObjectEntry {
+                    path: "s3/bucket/object".into(),
+                    size: 42,
+                }]
+        ));
+
+        stalled_server.abort();
+        serving_server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn proxy_attempt_timeouts_do_not_reset_the_shared_total_budget() {
+        let first_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let first_address = first_listener.local_addr().unwrap().to_string();
+        let (first_request_tx, first_request_rx) = tokio::sync::oneshot::channel();
+        let first_server = tokio::spawn(async move {
+            let (mut stream, _) = first_listener.accept().await.unwrap();
+            let (_, request) = read_control(&mut stream).await.unwrap().unwrap();
+            assert!(matches!(request, ControlMessage::ListObjects { .. }));
+            first_request_tx.send(()).unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        let second_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let second_address = second_listener.local_addr().unwrap().to_string();
+        let (second_request_tx, second_request_rx) = tokio::sync::oneshot::channel();
+        let second_server = tokio::spawn(async move {
+            let (mut stream, _) = second_listener.accept().await.unwrap();
+            let (_, request) = read_control(&mut stream).await.unwrap().unwrap();
+            assert!(matches!(request, ControlMessage::ListObjects { .. }));
+            second_request_tx.send(()).unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        let workers = vec![
+            NodeInfo {
+                id: NodeId::new("worker-stalls-first"),
+                address: first_address.clone(),
+                role: NodeRole::Worker,
+            },
+            NodeInfo {
+                id: NodeId::new("worker-stalls-second"),
+                address: second_address.clone(),
+                role: NodeRole::Worker,
+            },
+        ];
+        let budget = Duration::from_secs(6);
+        let started = tokio::time::Instant::now();
+        let proxy = tokio::spawn(async move {
+            Coordinator::proxy_to_workers_with_budget(
+                &workers,
+                ControlMessage::ListObjects {
+                    prefix: "s3/bucket".into(),
+                },
+                budget,
+            )
+            .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), first_request_rx)
+            .await
+            .expect("coordinator did not reach the first worker")
+            .expect("first worker exited before receiving the request");
+        tokio::time::pause();
+        tokio::time::advance(Duration::from_secs(5)).await;
+        tokio::time::resume();
+        tokio::time::timeout(Duration::from_secs(1), second_request_rx)
+            .await
+            .expect("coordinator did not spend a separate slice on the second worker")
+            .expect("second worker exited before receiving the request");
+        tokio::time::pause();
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::time::resume();
+
+        let reply = tokio::time::timeout(Duration::from_secs(1), proxy)
+            .await
+            .expect("second worker received a fresh total budget")
+            .unwrap();
+        assert!(
+            started.elapsed() < budget + Duration::from_secs(2),
+            "shared {budget:?} budget took {:?}",
+            started.elapsed()
+        );
+        let detail = match reply {
+            ControlMessage::Ack {
+                ok: false,
+                detail: Some(detail),
+            } => detail,
+            other => panic!("expected aggregate proxy failure, got {other:?}"),
+        };
+        assert!(detail.contains("2/2 tried within 6s"), "{detail}");
+        assert!(detail.contains(&first_address), "{detail}");
+        assert!(detail.contains(&second_address), "{detail}");
+
+        first_server.abort();
+        second_server.abort();
     }
 
     #[tokio::test]

--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -1152,18 +1152,52 @@ impl FuseConfig {
         if self.coordinator.is_empty() {
             return Err(Error::Other("coordinator address must not be empty".into()));
         }
-        let trimmed = self.namespace_prefix.trim_start_matches('/');
-        let mut parts = trimmed.split('/');
-        let backend = parts.next().unwrap_or_default();
-        if backend.parse::<crate::Backend>().is_err() {
+        // Accept the historical absolute-looking spelling (`/s3/bucket`), but
+        // otherwise require a canonical namespace path. Empty, `.` and `..`
+        // components are ambiguous once the prefix is mapped into the FUSE
+        // tree and can cause the mounted path to address a different object.
+        // One trailing slash is meaningful after a non-empty key prefix (for
+        // example, `s3/bucket/dir/` must not also match `dir2`) and is retained.
+        let trimmed = self
+            .namespace_prefix
+            .strip_prefix('/')
+            .unwrap_or(&self.namespace_prefix);
+        if trimmed.starts_with('/') {
+            return Err(Error::Other(format!(
+                "namespace_prefix must not contain multiple leading slashes: {:?}",
+                self.namespace_prefix
+            )));
+        }
+        let parts: Vec<&str> = trimmed.split('/').collect();
+        let backend = parts.first().copied().unwrap_or_default();
+        if !matches!(
+            backend.parse::<crate::Backend>(),
+            Ok(parsed) if parsed.prefix() == backend
+        ) {
             return Err(Error::Other(format!(
                 "namespace_prefix must start with a supported backend (s3, gcs, or az): {:?}",
                 self.namespace_prefix
             )));
         }
-        if !matches!(parts.next(), Some(bucket) if !bucket.is_empty()) {
+        let bucket = parts.get(1).copied().unwrap_or_default();
+        if matches!(bucket, "" | "." | "..") {
             return Err(Error::Other(format!(
                 "namespace_prefix must name a bucket/container (for example, az/container): {:?}",
+                self.namespace_prefix
+            )));
+        }
+        const MAX_FUSE_COMPONENT_BYTES: usize = 255;
+        let invalid_component = parts.iter().enumerate().any(|(index, component)| {
+            let is_key_trailing_slash =
+                index + 1 == parts.len() && index >= 3 && component.is_empty();
+            matches!(*component, "." | "..")
+                || (component.is_empty() && !is_key_trailing_slash)
+                || component.as_bytes().contains(&0)
+                || component.len() > MAX_FUSE_COMPONENT_BYTES
+        });
+        if invalid_component {
+            return Err(Error::Other(format!(
+                "namespace_prefix contains an empty, `.` or `..` component, a NUL byte, or a component longer than {MAX_FUSE_COMPONENT_BYTES} bytes: {:?}",
                 self.namespace_prefix
             )));
         }
@@ -1568,7 +1602,22 @@ mod tests {
 
     #[test]
     fn fuse_namespace_prefix_requires_backend_and_bucket() {
-        for invalid in ["", "unknown/bucket", "s3", "gcs/"] {
+        for invalid in [
+            "",
+            "unknown/bucket",
+            "azure/container",
+            "s3",
+            "gcs/",
+            "//az/container",
+            "s3/./key",
+            "s3/../key",
+            "s3/bucket/",
+            "s3/bucket//dir",
+            "s3/bucket/./dir",
+            "s3/bucket/../dir",
+            "s3/bucket/dir//",
+            "s3/buck\0et/dir",
+        ] {
             let cli = FuseConfigPatch {
                 namespace_prefix: Some(invalid.into()),
                 ..Default::default()
@@ -1583,8 +1632,10 @@ mod tests {
         for valid in [
             "s3/bucket",
             "gcs/bucket/dir",
+            "gcs/bucket/dir/",
             "az/container",
             "/az/container/prefix",
+            "/az/container/prefix/",
         ] {
             let cli = FuseConfigPatch {
                 namespace_prefix: Some(valid.into()),
@@ -1593,5 +1644,13 @@ mod tests {
             let cfg = FuseConfig::resolve(Default::default(), Default::default(), cli).unwrap();
             assert_eq!(cfg.namespace_prefix, valid);
         }
+
+        let too_long = format!("s3/bucket/{}", "x".repeat(256));
+        let cli = FuseConfigPatch {
+            namespace_prefix: Some(too_long),
+            ..Default::default()
+        };
+        let err = FuseConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
+        assert!(err.to_string().contains("255"), "{err}");
     }
 }

--- a/crates/talon-fuse/src/main.rs
+++ b/crates/talon-fuse/src/main.rs
@@ -10,12 +10,13 @@
 //! but prints a clear message instead of mounting, so it still builds and runs
 //! in environments without `/dev/fuse` or libfuse.
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::Parser;
 use talon_core::{FuseConfig, FuseConfigPatch};
-use talon_fuse::{BlockReader, CoordinatorClient, PlacementCache, ReadOnlyFs};
+use talon_fuse::{path_to_object, BlockReader, CoordinatorClient, PlacementCache, ReadOnlyFs};
 use talon_transport::ObjectEntry;
 
 /// Command-line arguments for the Talon FUSE mount.
@@ -108,16 +109,146 @@ where
     let entries = listing.map_err(|error| {
         anyhow::anyhow!("failed to list namespace prefix {namespace_prefix:?}: {error}")
     })?;
-    if entries.is_empty() {
-        tracing::warn!(namespace_prefix, "namespace listing returned zero objects");
-    }
+
+    // Validate the entire response before mutating the tree.  Object-store keys
+    // may legally contain empty, `.` or `..` components, but those cannot be
+    // represented reversibly in a POSIX namespace.  Failing the mount is safer
+    // than silently mapping (for example) `foo//bar` to the different key
+    // `foo/bar`.  A single trailing slash is retained as a directory marker.
+    validate_listing_paths(namespace_prefix, &entries)?;
+
     let n = fs.populate_from_listing(entries.iter().map(|e| (e.path.as_str(), e.size)));
+    if n == 0 {
+        tracing::warn!(
+            namespace_prefix,
+            "namespace listing returned zero visible objects"
+        );
+    }
     tracing::info!(
         objects = n,
         namespace_prefix,
         "populated namespace from coordinator listing"
     );
     Ok(n)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ListingPathKind {
+    File,
+    DirectoryMarker,
+}
+
+const MAX_FUSE_COMPONENT_BYTES: usize = 255;
+
+/// Validate individual paths, requested scope, and relationships across the
+/// whole listing.
+///
+/// Object stores permit a key such as `foo` to coexist with `foo/bar`, but a
+/// POSIX node cannot be both a file and a directory. Detect those collisions
+/// before populating so the result does not depend on backend listing order.
+fn validate_listing_paths(namespace_prefix: &str, entries: &[ObjectEntry]) -> anyhow::Result<()> {
+    let namespace_prefix = namespace_prefix
+        .strip_prefix('/')
+        .unwrap_or(namespace_prefix);
+    let mut scope_parts = namespace_prefix.splitn(3, '/');
+    let backend = scope_parts.next().unwrap_or_default();
+    let bucket = scope_parts.next().unwrap_or_default();
+    if backend.is_empty() || bucket.is_empty() {
+        anyhow::bail!("invalid namespace prefix {namespace_prefix:?}");
+    }
+    let key_prefix = scope_parts.next().unwrap_or_default();
+    let namespace_root = format!("{backend}/{bucket}/");
+
+    let mut paths = BTreeMap::new();
+    for entry in entries {
+        validate_listing_path(&entry.path)?;
+        let entry_key = entry.path.strip_prefix(&namespace_root).ok_or_else(|| {
+            anyhow::anyhow!(
+                "namespace listing for {namespace_prefix:?} returned out-of-scope object path {:?}",
+                entry.path
+            )
+        })?;
+        if !entry_key.starts_with(key_prefix) {
+            anyhow::bail!(
+                "namespace listing for {namespace_prefix:?} returned out-of-scope object path {:?}",
+                entry.path
+            );
+        }
+        let (path, kind) = match entry.path.strip_suffix('/') {
+            Some(path) => {
+                if entry.size != 0 {
+                    anyhow::bail!(
+                        "namespace listing contains non-empty trailing-slash object {:?} ({} bytes); only zero-byte directory markers can be represented safely",
+                        entry.path,
+                        entry.size
+                    );
+                }
+                (path, ListingPathKind::DirectoryMarker)
+            }
+            None => (entry.path.as_str(), ListingPathKind::File),
+        };
+
+        if let Some(existing) = paths.insert(path, kind) {
+            if existing == kind {
+                anyhow::bail!(
+                    "namespace listing contains duplicate object path {:?}",
+                    entry.path
+                );
+            }
+            anyhow::bail!(
+                "namespace listing contains conflicting file and directory marker for {path:?}"
+            );
+        }
+    }
+
+    for path in paths.keys().copied() {
+        for (slash, _) in path.match_indices('/') {
+            let ancestor = &path[..slash];
+            if paths.get(ancestor) == Some(&ListingPathKind::File) {
+                anyhow::bail!(
+                    "namespace listing cannot represent file {ancestor:?} alongside descendant {path:?}"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Require the coordinator's mount-relative path to round-trip exactly through
+/// Talon's object-path mapping. Directory markers use one trailing slash,
+/// which is intentionally outside [`path_to_object`]'s file-path grammar.
+fn validate_listing_path(path: &str) -> anyhow::Result<()> {
+    let object_path = path.strip_suffix('/').unwrap_or(path);
+    if path.starts_with('/') {
+        anyhow::bail!("namespace listing returned non-canonical object path {path:?}");
+    }
+    for component in object_path.split('/') {
+        if matches!(component, "" | "." | "..") {
+            anyhow::bail!("namespace listing returned non-canonical object path {path:?}");
+        }
+        if component.as_bytes().contains(&0) {
+            anyhow::bail!("namespace listing returned object path {path:?} containing a NUL byte");
+        }
+        if component.len() > MAX_FUSE_COMPONENT_BYTES {
+            anyhow::bail!(
+                "namespace listing returned object path {path:?} with a component longer than {MAX_FUSE_COMPONENT_BYTES} bytes"
+            );
+        }
+    }
+
+    let object = path_to_object(object_path).map_err(|error| {
+        anyhow::anyhow!("namespace listing returned invalid object path {path:?}: {error}")
+    })?;
+    let canonical = object.to_path();
+    let canonical = canonical
+        .strip_prefix('/')
+        .expect("ObjectId::to_path always starts with a slash");
+    if canonical != object_path {
+        anyhow::bail!(
+            "namespace listing returned non-canonical object path {path:?}; expected {canonical:?}"
+        );
+    }
+    Ok(())
 }
 
 #[cfg(feature = "mount")]
@@ -244,5 +375,272 @@ mod tests {
         let gcs = fs.lookup(talon_fuse::ops::ROOT_INO, "gcs").unwrap();
         let models = fs.lookup(gcs.ino, "models").unwrap();
         assert!(fs.lookup(models.ino, "checkpoint.bin").is_ok());
+    }
+
+    #[test]
+    fn namespace_listing_rejects_ambiguous_paths_before_populating() {
+        for invalid in [
+            "/s3/bucket/file.bin",
+            "azure/container/file.bin",
+            "s3/bucket/a//b",
+            "s3/bucket/./file.bin",
+            "s3/bucket/../file.bin",
+            "s3/./file.bin",
+            "s3/../file.bin",
+            "s3/bucket/dir//",
+        ] {
+            let fs = ReadOnlyFs::new();
+            let error = populate_namespace::<&str>(
+                &fs,
+                "s3/bucket",
+                Ok(vec![
+                    ObjectEntry {
+                        path: "s3/bucket/valid.bin".into(),
+                        size: 1,
+                    },
+                    ObjectEntry {
+                        path: invalid.into(),
+                        size: 2,
+                    },
+                ]),
+            )
+            .unwrap_err();
+
+            assert!(error.to_string().contains(invalid), "{error:#}");
+            assert!(
+                fs.lookup(talon_fuse::ops::ROOT_INO, "s3").is_err(),
+                "{invalid:?} left a partially populated namespace"
+            );
+        }
+    }
+
+    #[test]
+    fn namespace_listing_accepts_directory_markers() {
+        let entries = vec![
+            ObjectEntry {
+                path: "s3/bucket/empty/".into(),
+                size: 0,
+            },
+            ObjectEntry {
+                path: "s3/bucket/empty/file.bin".into(),
+                size: 3,
+            },
+        ];
+
+        for reverse in [false, true] {
+            let fs = ReadOnlyFs::new();
+            let mut ordered = entries.clone();
+            if reverse {
+                ordered.reverse();
+            }
+            let count = populate_namespace::<&str>(&fs, "s3/bucket", Ok(ordered)).unwrap();
+
+            assert_eq!(count, 2);
+            let s3 = fs.lookup(talon_fuse::ops::ROOT_INO, "s3").unwrap();
+            let bucket = fs.lookup(s3.ino, "bucket").unwrap();
+            let empty = fs.lookup(bucket.ino, "empty").unwrap();
+            assert_eq!(empty.kind, talon_fuse::FileKind::Directory);
+            assert!(fs.lookup(empty.ino, "file.bin").is_ok());
+        }
+    }
+
+    #[test]
+    fn namespace_listing_rejects_unrepresentable_components_before_populating() {
+        let invalid = [
+            "s3/bucket/nul\0name".to_string(),
+            format!("s3/bucket/{}", "x".repeat(MAX_FUSE_COMPONENT_BYTES + 1)),
+        ];
+
+        for path in invalid {
+            let fs = ReadOnlyFs::new();
+            let error = populate_namespace::<&str>(
+                &fs,
+                "s3/bucket",
+                Ok(vec![ObjectEntry { path, size: 1 }]),
+            )
+            .unwrap_err();
+
+            assert!(error.to_string().contains("namespace listing"), "{error:#}");
+            assert!(
+                fs.lookup(talon_fuse::ops::ROOT_INO, "s3").is_err(),
+                "invalid listing left a partially populated namespace"
+            );
+        }
+    }
+
+    #[test]
+    fn namespace_listing_rejects_nonempty_trailing_slash_objects() {
+        let fs = ReadOnlyFs::new();
+        let error = populate_namespace::<&str>(
+            &fs,
+            "s3/bucket",
+            Ok(vec![ObjectEntry {
+                path: "s3/bucket/not-a-marker/".into(),
+                size: 7,
+            }]),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("non-empty trailing-slash"));
+        assert!(fs.lookup(talon_fuse::ops::ROOT_INO, "s3").is_err());
+    }
+
+    #[test]
+    fn namespace_listing_enforces_backend_bucket_and_raw_key_scope() {
+        for (namespace_prefix, in_scope, out_of_scope) in [
+            ("s3/bucket", "s3/bucket/file.bin", "gcs/bucket/file.bin"),
+            ("s3/bucket", "s3/bucket/file.bin", "s3/other/file.bin"),
+            (
+                "s3/bucket/wanted",
+                "s3/bucket/wanted.bin",
+                "s3/bucket/other.bin",
+            ),
+            (
+                "s3/bucket/dir/",
+                "s3/bucket/dir/file.bin",
+                "s3/bucket/dir2/file.bin",
+            ),
+        ] {
+            let fs = ReadOnlyFs::new();
+            let error = populate_namespace::<&str>(
+                &fs,
+                namespace_prefix,
+                Ok(vec![
+                    ObjectEntry {
+                        path: in_scope.into(),
+                        size: 1,
+                    },
+                    ObjectEntry {
+                        path: out_of_scope.into(),
+                        size: 2,
+                    },
+                ]),
+            )
+            .unwrap_err();
+
+            assert!(error.to_string().contains("out-of-scope"), "{error:#}");
+            assert!(
+                fs.lookup(talon_fuse::ops::ROOT_INO, "s3").is_err(),
+                "out-of-scope listing left a partially populated namespace"
+            );
+        }
+    }
+
+    #[test]
+    fn namespace_listing_preserves_raw_prefix_semantics() {
+        let fs = ReadOnlyFs::new();
+        let count = populate_namespace::<&str>(
+            &fs,
+            "/s3/bucket/dir",
+            Ok(vec![
+                ObjectEntry {
+                    path: "s3/bucket/dir2/file.bin".into(),
+                    size: 1,
+                },
+                ObjectEntry {
+                    path: "s3/bucket/directory/file.bin".into(),
+                    size: 2,
+                },
+            ]),
+        )
+        .unwrap();
+        assert_eq!(count, 2);
+
+        let fs = ReadOnlyFs::new();
+        let count = populate_namespace::<&str>(
+            &fs,
+            "s3/bucket/dir/",
+            Ok(vec![
+                ObjectEntry {
+                    path: "s3/bucket/dir/".into(),
+                    size: 0,
+                },
+                ObjectEntry {
+                    path: "s3/bucket/dir/file.bin".into(),
+                    size: 3,
+                },
+            ]),
+        )
+        .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn namespace_listing_rejects_tree_conflicts_in_any_order() {
+        let conflicts = [
+            vec![
+                ObjectEntry {
+                    path: "s3/bucket/foo".into(),
+                    size: 1,
+                },
+                ObjectEntry {
+                    path: "s3/bucket/foo/bar".into(),
+                    size: 2,
+                },
+            ],
+            vec![
+                ObjectEntry {
+                    path: "s3/bucket/foo".into(),
+                    size: 1,
+                },
+                ObjectEntry {
+                    path: "s3/bucket/foo/".into(),
+                    size: 0,
+                },
+            ],
+            vec![
+                ObjectEntry {
+                    path: "s3/bucket/foo".into(),
+                    size: 1,
+                },
+                ObjectEntry {
+                    path: "s3/bucket/foo/bar/".into(),
+                    size: 0,
+                },
+            ],
+            vec![
+                ObjectEntry {
+                    path: "s3/bucket/foo".into(),
+                    size: 1,
+                },
+                ObjectEntry {
+                    path: "s3/bucket/foo".into(),
+                    size: 2,
+                },
+            ],
+        ];
+
+        for entries in conflicts {
+            for reverse in [false, true] {
+                let fs = ReadOnlyFs::new();
+                let mut ordered = entries.clone();
+                if reverse {
+                    ordered.reverse();
+                }
+                let error = populate_namespace::<&str>(&fs, "s3/bucket", Ok(ordered)).unwrap_err();
+
+                assert!(error.to_string().contains("namespace listing"), "{error:#}");
+                assert!(
+                    fs.lookup(talon_fuse::ops::ROOT_INO, "s3").is_err(),
+                    "conflicting listing left a partially populated namespace"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn internal_only_listing_has_zero_visible_objects() {
+        let fs = ReadOnlyFs::new();
+        let count = populate_namespace::<&str>(
+            &fs,
+            "s3/bucket",
+            Ok(vec![ObjectEntry {
+                path: "s3/bucket/.__talon_internal/unlinked/stale/1".into(),
+                size: 7,
+            }]),
+        )
+        .unwrap();
+
+        assert_eq!(count, 0);
     }
 }

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -32,7 +32,7 @@ use talon_backend::{
 };
 use talon_core::{
     azure_sas_from_env, gcs_bearer_from_env, s3_secret_key_from_env, s3_session_token_from_env,
-    BackendStore, NodeId, NodeInfo, NodeRole, WorkerConfig, WorkerConfigPatch,
+    Backend, BackendStore, NodeId, NodeInfo, NodeRole, WorkerConfig, WorkerConfigPatch,
 };
 use talon_transport::{codec, ControlMessage};
 use talon_worker::tokio_conn::{handle_conn, read_control};
@@ -309,6 +309,11 @@ async fn main() -> anyhow::Result<()> {
     }
     let inflight = Arc::new(InFlightLoads::new());
     let backend_kind = cfg.backend.as_deref().unwrap_or("azure");
+    let configured_backend: Backend = backend_kind.parse().map_err(|error| {
+        anyhow::anyhow!(
+            "unknown TALON_WORKER_BACKEND {backend_kind:?}; expected azure, s3, or gcs: {error}"
+        )
+    })?;
     let node = NodeInfo {
         id: NodeId::new(
             cfg.node_id
@@ -420,17 +425,20 @@ async fn main() -> anyhow::Result<()> {
     };
     tracing::info!(backend = backend_kind, "object-store backend ready");
 
-    let worker = Arc::new(WorkerRuntime::new_with_l1(
-        store,
-        index,
-        inflight,
-        backend,
-        cfg.block_size,
-        cfg.capacity_bytes,
-        cfg.l1_capacity_bytes,
-        cfg.l1_max_entry_bytes,
-        observability.metrics().clone(),
-    ));
+    let worker = Arc::new(
+        WorkerRuntime::new_with_l1(
+            store,
+            index,
+            inflight,
+            backend,
+            cfg.block_size,
+            cfg.capacity_bytes,
+            cfg.l1_capacity_bytes,
+            cfg.l1_max_entry_bytes,
+            observability.metrics().clone(),
+        )
+        .with_backend_kind(configured_backend),
+    );
 
     let admin_listener = TcpListener::bind(&cfg.admin_listen).await?;
     tracing::info!(listen = %cfg.admin_listen, "worker serving administration API");

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -10,6 +10,8 @@ use talon_core::{
     ObjectStore, PageIndex, Version,
 };
 use talon_transport::data::RangeRequest;
+use talon_transport::frame::HEADER_LEN;
+use talon_transport::{codec, ControlMessage, ObjectEntry, MAX_CONTROL_PAYLOAD_LEN};
 
 use crate::{
     BlockIndex, CacheUnit, InFlightLoads, LoadKey, Lru, MemoryInsert, MemoryStore, Presence,
@@ -23,6 +25,16 @@ use crate::{
 /// read path; the conditional GET (`If-Match`) is the hard correctness guard
 /// that catches an overwrite inside the window (issue #163).
 const DEFAULT_VERSION_TTL: Duration = Duration::from_secs(3);
+
+/// Maximum number of objects that can be returned by one non-paginated
+/// `ListObjects` control request.
+const MAX_LIST_OBJECTS: usize = 10_000;
+
+/// Maximum backend pages drained by one non-paginated `ListObjects` request.
+const MAX_LIST_PAGES: usize = 20;
+
+/// Objects requested per backend page.
+const LIST_PAGE_SIZE: u32 = 1000;
 
 /// A per-object resolved version with the instant it was resolved.
 struct CachedVersion {
@@ -55,6 +67,10 @@ pub struct WorkerRuntime {
     index: Arc<BlockIndex>,
     inflight: Arc<InFlightLoads>,
     backend: Arc<dyn BackendStore>,
+    /// Backend selected by the worker process. Optional only so unit-test
+    /// runtimes that do not exercise backend routing retain their compact
+    /// constructors.
+    configured_backend: Option<Backend>,
     block_size: u32,
     metrics: WorkerMetrics,
     /// Byte-accounted LRU driving capacity enforcement/eviction (issue #159).
@@ -127,6 +143,7 @@ impl WorkerRuntime {
             index,
             inflight,
             backend,
+            configured_backend: None,
             block_size,
             metrics,
             lru,
@@ -134,6 +151,32 @@ impl WorkerRuntime {
             version_cache: Mutex::new(HashMap::new()),
             version_ttl: DEFAULT_VERSION_TTL,
         }
+    }
+
+    /// Record the backend selected by the worker process.
+    ///
+    /// Requests carry a backend either directly in their [`ObjectId`] or in a
+    /// namespace prefix (`s3`, `gcs`, or `az`). A worker has exactly one
+    /// configured backend, so retaining that selection lets it reject a request
+    /// routed to the wrong worker instead of addressing the same bucket/key on
+    /// a different object store.
+    pub fn with_backend_kind(mut self, backend: Backend) -> Self {
+        self.configured_backend = Some(backend);
+        self
+    }
+
+    /// Reject an operation routed to a worker for another object-store backend.
+    fn ensure_configured_backend(&self, requested: Backend) -> anyhow::Result<()> {
+        let Some(configured) = self.configured_backend else {
+            return Ok(());
+        };
+        if requested != configured {
+            anyhow::bail!(
+                "request selects backend {requested}, but this worker is configured for \
+                 {configured}; route the request to a {requested} worker"
+            );
+        }
+        Ok(())
     }
 
     /// Override the resolved-version cache TTL (test hook).
@@ -178,6 +221,7 @@ impl WorkerRuntime {
     /// invalidated and the request is retried once against the freshly-resolved
     /// version (issue #163).
     pub async fn serve_range(&self, request: &RangeRequest) -> anyhow::Result<bytes::Bytes> {
+        self.ensure_configured_backend(request.object.backend)?;
         if request.len == 0 {
             return Ok(bytes::Bytes::new());
         }
@@ -211,6 +255,7 @@ impl WorkerRuntime {
     /// blocks are keyed by the resolved ETag, and a `412`/`VersionMismatch` inside
     /// the version-cache window re-resolves once (issues #119, #163).
     pub async fn serve(&self, request: &RangeRequest) -> anyhow::Result<ServeOutcome> {
+        self.ensure_configured_backend(request.object.backend)?;
         if request.len == 0 {
             return Ok(ServeOutcome::Bytes(bytes::Bytes::new()));
         }
@@ -378,21 +423,11 @@ impl WorkerRuntime {
     /// feed them straight back to `read`.
     ///
     /// Pages are drained here rather than exposed to the client: the control
-    /// protocol has no cursor, and adding one would be a wire change. To keep
-    /// that bounded, both the object count and the number of backend round
-    /// trips are capped — an unbounded listing of a large bucket would
-    /// otherwise hold the whole result set in memory and block the caller for
-    /// an unbounded time. A truncated listing is better than an unbounded one,
-    /// and the cap is high enough that a namespace hitting it is already past
-    /// what a single control message should carry.
+    /// protocol has no cursor, and adding one would be a wire change. Object,
+    /// page, and encoded-response limits bound the operation. Hitting any limit
+    /// is an error: returning a partial success would mount an apparently
+    /// healthy but incomplete namespace.
     pub async fn list_objects(&self, prefix: &str) -> anyhow::Result<Vec<(String, u64)>> {
-        /// Objects returned before truncating.
-        const MAX_OBJECTS: usize = 10_000;
-        /// Backend round trips before giving up, independent of page size.
-        const MAX_PAGES: usize = 20;
-        /// Objects requested per backend page.
-        const PAGE_SIZE: u32 = 1000;
-
         let trimmed = prefix.trim_start_matches('/');
         let mut parts = trimmed.splitn(3, '/');
         let backend_prefix = parts.next().unwrap_or("");
@@ -404,6 +439,7 @@ impl WorkerRuntime {
         let backend: Backend = backend_prefix.parse().map_err(|_| {
             anyhow::anyhow!("unknown backend {backend_prefix:?} in listing prefix {prefix:?}")
         })?;
+        self.ensure_configured_backend(backend)?;
         let bucket = parts.next().unwrap_or("");
         if bucket.is_empty() {
             anyhow::bail!(
@@ -414,27 +450,43 @@ impl WorkerRuntime {
 
         let mut out = Vec::new();
         let mut cursor: Option<String> = None;
-        for _ in 0..MAX_PAGES {
+        for page_number in 1..=MAX_LIST_PAGES {
             let page = self
                 .backend
-                .list_objects(bucket, key_prefix, cursor.as_deref(), PAGE_SIZE)
+                .list_objects(bucket, key_prefix, cursor.as_deref(), LIST_PAGE_SIZE)
                 .await
                 .map_err(|error| anyhow::anyhow!("list {prefix}: {error}"))?;
+
+            let page_len = page.objects.len();
+            let remaining = MAX_LIST_OBJECTS.saturating_sub(out.len());
+            if page_len > remaining || (page_len == remaining && page.next.is_some()) {
+                anyhow::bail!(
+                    "listing {prefix:?} exceeds the 10,000-object control-response \
+                     limit; narrow the namespace prefix"
+                );
+            }
             for object in page.objects {
                 out.push((
                     format!("{}/{}/{}", backend.prefix(), bucket, object.key),
                     object.size,
                 ));
-                if out.len() >= MAX_OBJECTS {
-                    return Ok(out);
-                }
             }
+
+            ensure_listing_fits_control_frame(prefix, &out)?;
+
             match page.next {
                 Some(next) => cursor = Some(next),
-                None => break,
+                None => return Ok(out),
+            }
+            if page_number == MAX_LIST_PAGES {
+                anyhow::bail!(
+                    "listing {prefix:?} did not complete within {MAX_LIST_PAGES} backend pages; \
+                     narrow the namespace prefix"
+                );
             }
         }
-        Ok(out)
+
+        unreachable!("the bounded listing loop always returns or reports its limit")
     }
 
     /// Return an object's size and current version (#318).
@@ -447,6 +499,7 @@ impl WorkerRuntime {
     /// maintains: a size can change under an overwrite, and serving a stale one
     /// would make a client read past the end of the new object.
     pub async fn stat_object(&self, object: &ObjectId) -> anyhow::Result<talon_core::ObjectStat> {
+        self.ensure_configured_backend(object.backend)?;
         let stat = self
             .backend
             .head(object)
@@ -740,6 +793,7 @@ impl WorkerRuntime {
         object: &ObjectId,
         body: bytes::Bytes,
     ) -> anyhow::Result<Version> {
+        self.ensure_configured_backend(object.backend)?;
         if body.len() as u64 > self.block_size as u64 {
             anyhow::bail!(
                 "object {} is {} bytes; v1 write supports at most one block ({} bytes)",
@@ -802,6 +856,7 @@ impl WorkerRuntime {
         path: &Path,
         len: u64,
     ) -> anyhow::Result<Version> {
+        self.ensure_configured_backend(object.backend)?;
         if len <= self.block_size as u64 {
             let body = tokio::fs::read(path).await?;
             if body.len() as u64 != len {
@@ -849,6 +904,7 @@ impl WorkerRuntime {
     /// cached version so a subsequent read re-resolves (and sees the object gone).
     /// Best-effort evicts the object's currently-cached block.
     pub async fn delete_object(&self, object: &ObjectId) -> anyhow::Result<()> {
+        self.ensure_configured_backend(object.backend)?;
         match self.backend.delete(object).await {
             Ok(()) => self.metrics.record_backend_delete_success(),
             Err(error) => {
@@ -923,6 +979,36 @@ impl WorkerRuntime {
     }
 }
 
+/// Ensure a successful listing reply can cross the control-plane transport.
+///
+/// The transport reader rejects control payloads above 1 MiB. Check the exact
+/// codec output here so the worker can return a small, actionable `Ack(false)`
+/// instead of writing a frame that every conforming client must reject.
+fn ensure_listing_fits_control_frame(
+    prefix: &str,
+    entries: &[(String, u64)],
+) -> anyhow::Result<()> {
+    let message = ControlMessage::ObjectList {
+        entries: entries
+            .iter()
+            .map(|(path, size)| ObjectEntry {
+                path: path.clone(),
+                size: *size,
+            })
+            .collect(),
+    };
+    let encoded = codec::encode(0, &message)
+        .map_err(|error| anyhow::anyhow!("encode listing response for {prefix:?}: {error}"))?;
+    let payload_len = encoded.len().saturating_sub(HEADER_LEN);
+    if payload_len > MAX_CONTROL_PAYLOAD_LEN as usize {
+        anyhow::bail!(
+            "listing {prefix:?} requires a {payload_len}-byte control response, exceeding the \
+             {MAX_CONTROL_PAYLOAD_LEN}-byte transport limit; narrow the namespace prefix"
+        );
+    }
+    Ok(())
+}
+
 fn slice(buffer: &bytes::Bytes, offset: u64, len: u64) -> anyhow::Result<bytes::Bytes> {
     let start = usize::try_from(offset).map_err(|_| anyhow::anyhow!("offset is too large"))?;
     if start > buffer.len() {
@@ -948,6 +1034,7 @@ fn is_version_mismatch(error: &anyhow::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use std::collections::hash_map::DefaultHasher;
+    use std::collections::VecDeque;
     use std::hash::{Hash, Hasher};
     use std::os::unix::fs::FileExt;
     use std::path::{Path, PathBuf};
@@ -956,7 +1043,7 @@ mod tests {
 
     use async_trait::async_trait;
     use bytes::Bytes;
-    use talon_core::{Backend, Error, ObjectStat, Result};
+    use talon_core::{Backend, Error, ListPage, ListedObject, ObjectStat, Result};
 
     use super::*;
 
@@ -983,6 +1070,46 @@ mod tests {
         }
     }
 
+    struct ListingBackend {
+        pages: Mutex<VecDeque<ListPage>>,
+        calls: AtomicUsize,
+    }
+
+    impl ListingBackend {
+        fn new(pages: impl IntoIterator<Item = ListPage>) -> Self {
+            Self {
+                pages: Mutex::new(pages.into_iter().collect()),
+                calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl BackendStore for ListingBackend {
+        async fn list_objects(
+            &self,
+            _bucket: &str,
+            _prefix: &str,
+            _cursor: Option<&str>,
+            _max_keys: u32,
+        ) -> Result<ListPage> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.pages
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| Error::Backend("unexpected extra listing page".into()))
+        }
+
+        async fn fetch_range(&self, _object: &ObjectId, _offset: u64, _len: u64) -> Result<Bytes> {
+            Err(Error::Backend("not used by listing tests".into()))
+        }
+
+        async fn head(&self, _object: &ObjectId) -> Result<ObjectStat> {
+            Err(Error::Backend("not used by listing tests".into()))
+        }
+    }
+
     fn request(path: &str) -> RangeRequest {
         RangeRequest {
             object: ObjectId::new(Backend::Azure, "container", path),
@@ -1004,6 +1131,158 @@ mod tests {
         // Most tests assert version-sensitivity per read; a zero TTL keeps the
         // resolved-version cache from masking a source overwrite between reads.
         .with_version_ttl(Duration::ZERO)
+    }
+
+    fn listing_runtime(backend: Arc<ListingBackend>, root: &Path) -> WorkerRuntime {
+        WorkerRuntime::new(
+            WholeBlockStore::open(root).unwrap(),
+            Arc::new(BlockIndex::new()),
+            Arc::new(InFlightLoads::new()),
+            backend,
+            8,
+            0,
+            WorkerMetrics::new(1024),
+        )
+        .with_backend_kind(Backend::Azure)
+    }
+
+    fn listing_page(page: usize, count: usize, has_next: bool) -> ListPage {
+        ListPage {
+            objects: (0..count)
+                .map(|index| ListedObject {
+                    key: format!("dir/object-{page}-{index}"),
+                    size: index as u64,
+                })
+                .collect(),
+            next: has_next.then(|| format!("cursor-{page}")),
+        }
+    }
+
+    #[tokio::test]
+    async fn listing_rejects_a_backend_prefix_for_another_worker() {
+        let root = tmp_root();
+        let backend = Arc::new(ListingBackend::new([listing_page(0, 1, false)]));
+        let runtime = listing_runtime(Arc::clone(&backend), &root);
+
+        let error = runtime.list_objects("s3/bucket/dir").await.unwrap_err();
+
+        assert!(error.to_string().contains("configured for az"));
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 0);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    fn assert_backend_mismatch(error: anyhow::Error) {
+        let detail = error.to_string();
+        assert!(detail.contains("selects backend s3"), "{detail}");
+        assert!(detail.contains("configured for az"), "{detail}");
+    }
+
+    #[tokio::test]
+    async fn object_operations_reject_a_backend_for_another_worker() {
+        let root = tmp_root();
+        let backend = Arc::new(ListingBackend::new([]));
+        let runtime = listing_runtime(Arc::clone(&backend), &root);
+        let object = ObjectId::new(Backend::S3, "bucket", "object");
+        let request = RangeRequest {
+            object: object.clone(),
+            offset: 0,
+            len: 0,
+        };
+
+        assert_backend_mismatch(runtime.serve_range(&request).await.unwrap_err());
+        let serve_error = match runtime.serve(&request).await {
+            Ok(_) => panic!("serve accepted an object for another backend"),
+            Err(error) => error,
+        };
+        assert_backend_mismatch(serve_error);
+        assert_backend_mismatch(runtime.stat_object(&object).await.unwrap_err());
+        assert_backend_mismatch(
+            runtime
+                .write_object(&object, Bytes::from_static(b"x"))
+                .await
+                .unwrap_err(),
+        );
+        assert_backend_mismatch(
+            runtime
+                .write_object_file(&object, Path::new("unused-mismatched-backend-file"), 9)
+                .await
+                .unwrap_err(),
+        );
+        assert_backend_mismatch(runtime.delete_object(&object).await.unwrap_err());
+
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 0);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn listing_reports_object_limit_instead_of_returning_a_partial_success() {
+        let root = tmp_root();
+        let pages = (0..10).map(|page| listing_page(page, 1000, true));
+        let backend = Arc::new(ListingBackend::new(pages));
+        let runtime = listing_runtime(Arc::clone(&backend), &root);
+
+        let error = runtime.list_objects("az/bucket/dir").await.unwrap_err();
+
+        assert!(error.to_string().contains("10,000-object"));
+        assert!(error.to_string().contains("narrow the namespace prefix"));
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 10);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn listing_reports_page_limit_instead_of_returning_a_partial_success() {
+        let root = tmp_root();
+        let pages = (0..MAX_LIST_PAGES).map(|page| listing_page(page, 1, true));
+        let backend = Arc::new(ListingBackend::new(pages));
+        let runtime = listing_runtime(Arc::clone(&backend), &root);
+
+        let error = runtime.list_objects("az/bucket/dir").await.unwrap_err();
+
+        assert!(error.to_string().contains("20 backend pages"));
+        assert!(error.to_string().contains("narrow the namespace prefix"));
+        assert_eq!(backend.calls.load(Ordering::SeqCst), MAX_LIST_PAGES);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn listing_accepts_exact_object_and_page_boundaries_when_complete() {
+        let root = tmp_root();
+        let pages = (0..MAX_LIST_PAGES).map(|page| {
+            listing_page(
+                page,
+                MAX_LIST_OBJECTS / MAX_LIST_PAGES,
+                page + 1 < MAX_LIST_PAGES,
+            )
+        });
+        let backend = Arc::new(ListingBackend::new(pages));
+        let runtime = listing_runtime(Arc::clone(&backend), &root);
+
+        let entries = runtime.list_objects("az/bucket/dir").await.unwrap();
+
+        assert_eq!(entries.len(), MAX_LIST_OBJECTS);
+        assert_eq!(backend.calls.load(Ordering::SeqCst), MAX_LIST_PAGES);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn listing_reports_transport_limit_before_writing_an_oversized_frame() {
+        let root = tmp_root();
+        let page = ListPage {
+            objects: vec![ListedObject {
+                key: "x".repeat(MAX_CONTROL_PAYLOAD_LEN as usize),
+                size: 1,
+            }],
+            next: None,
+        };
+        let backend = Arc::new(ListingBackend::new([page]));
+        let runtime = listing_runtime(Arc::clone(&backend), &root);
+
+        let error = runtime.list_objects("az/bucket").await.unwrap_err();
+
+        assert!(error.to_string().contains("transport limit"));
+        assert!(error.to_string().contains("narrow the namespace prefix"));
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+        std::fs::remove_dir_all(root).ok();
     }
 
     fn runtime_l1(

--- a/deploy/docker/fuse.Dockerfile
+++ b/deploy/docker/fuse.Dockerfile
@@ -7,7 +7,8 @@
 # Mounting talks to the kernel, so a container running this image needs
 # `/dev/fuse` and the SYS_ADMIN capability, e.g.:
 #   docker run --rm --device /dev/fuse --cap-add SYS_ADMIN \
-#     -e TALON_FUSE_COORDINATOR=coordinator:7000 talon-fuse \
+#     -e TALON_FUSE_COORDINATOR=coordinator:7000 \
+#     -e TALON_FUSE_NAMESPACE_PREFIX=az/container talon-fuse \
 #     --mountpoint /mnt/talon
 #
 # Build from the repository root:


### PR DESCRIPTION
## Summary

Follow-up to #369. Requiring a namespace prefix fixed the empty-root startup request, but the mount could still report success with a partial, out-of-scope, or POSIX-unrepresentable listing.

This change makes startup listing fail closed end to end:

- Worker listing now returns an actionable error instead of partial success when it reaches 10,000 objects, 20 backend pages, or the 1 MiB control payload limit.
- Worker runtime records its configured object-store backend and rejects mismatched list, stat, read, write, staged-write, and delete requests before they touch the backend or cache.
- Coordinator retries explicit worker rejections and transport failures under one shared deadline. Listings receive a 25-second total budget, while each attempt preserves a bounded retry window for later workers. Aggregated diagnostics are UTF-8 safe and size bounded.
- FUSE validates the complete response before mutating the namespace tree. It rejects entries outside the requested raw prefix, non-canonical paths, NUL or over-255-byte components, duplicates, file-directory collisions, file-as-ancestor conflicts, and non-empty trailing-slash objects.
- FUSE configuration rejects ambiguous prefixes while preserving a meaningful trailing slash such as s3/bucket/dir/, which prevents raw prefix dir from also matching dir2.
- The empty-visible-namespace warning now uses the final populated count, so listings containing only hidden internal objects are reported correctly.
- The Docker example now includes the required namespace prefix, and Java/Python API docs describe bounded listing failures. The Java docs also clarify conversion from mount-relative paths to read URIs.

## Correctness model

The control protocol remains schema v2 and intentionally does not add pagination in this follow-up. Because there is no continuation token on the wire, crossing any server-side listing limit is an explicit failure rather than an apparently successful truncated mount.

The coordinator uses one absolute deadline across all worker attempts. A silent worker cannot reset or consume the complete request budget: with a 25-second listing budget and two workers, the first can use up to 24 seconds while one second remains for failover. When the remaining budget is smaller, attempts share it evenly.

All listing paths are validated as one transaction before populate_from_listing runs, so a single invalid entry cannot leave a partially built mount.

## Tests

- cargo test -p talon-core -p talon-fuse --locked
- cargo test -p talon-coordinator --locked
- cargo test -p talon-python --locked
- cargo clippy -p talon-core -p talon-coordinator -p talon-python --all-targets --all-features --locked -- -D warnings
- cargo clippy -p talon-fuse --all-targets --locked -- -D warnings
- cargo fmt --all -- --check
- git diff --check

The full worker crate cannot compile on this macOS host because its existing splice, sendfile, CPU-affinity, and io_uring paths are Linux-only. The new worker regression tests are included for Linux CI. Java changes are Javadoc-only; Java CI will run the Maven suite.