### PR TITLE
fix(bench): select loadgen backend so k8s L1/L2 bench hits s3

### DIFF
--- a/crates/talon-worker/src/bin/loadgen.rs
+++ b/crates/talon-worker/src/bin/loadgen.rs
@@ -64,12 +64,24 @@ struct Args {
     /// Container or bucket the object lives in.
     #[arg(long, default_value = "c")]
     container: String,
+    /// Backend the object lives in (`s3`, `gcs`, or `az`).
+    ///
+    /// A worker rejects every request whose backend does not match the one it
+    /// was configured for, so a wrong value here produces zero samples rather
+    /// than a slow run: the benchmark must name the fleet's actual backend.
+    #[arg(long, default_value = "az", value_parser = parse_backend)]
+    backend: Backend,
     /// Worker PID to sample CPU and RSS from. Skipped when unset.
     #[arg(long)]
     server_pid: Option<u32>,
     /// Emit JSON Lines instead of a table, for scripted comparison.
     #[arg(long)]
     json: bool,
+}
+
+/// Parse a backend name for clap, mapping the core error to a CLI message.
+fn parse_backend(s: &str) -> Result<Backend, String> {
+    s.parse::<Backend>().map_err(|e| e.to_string())
 }
 
 /// One connection count's result.
@@ -192,7 +204,7 @@ async fn drive_one(
 }
 
 async fn run_one(args: &Args, conns: usize) -> Run {
-    let object = ObjectId::new(Backend::Azure, &args.container, &args.object);
+    let object = ObjectId::new(args.backend, &args.container, &args.object);
     let stop = Arc::new(AtomicBool::new(false));
     let errors = Arc::new(AtomicU64::new(0));
     let warmup = Duration::from_secs(args.warmup);

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -590,7 +590,7 @@ start_worker_forward "$TARGET_POD"
     --path "/s3/$BUCKET/bench" --len 65536 --out "$ARTIFACT_DIR/bench-warm.out"
 } 2>&1 | tee "$ARTIFACT_DIR/cold-warm.txt"
 target/release/talon-loadgen --addr "127.0.0.1:$WORKER_PORT" \
-  --container "$BUCKET" --object bench --range 65536 \
+  --backend s3 --container "$BUCKET" --object bench --range 65536 \
   --conns 1,32,128 --seconds "$BENCH_SECONDS" --warmup 2 --json |
   tee "$ARTIFACT_DIR/l1-benchmark.jsonl"
 [[ "$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l1"}')" -gt 0 ]] ||
@@ -602,7 +602,7 @@ start_coordinator_forward
 TARGET_POD="$(first_worker)"
 start_worker_forward "$TARGET_POD"
 target/release/talon-loadgen --addr "127.0.0.1:$WORKER_PORT" \
-  --container "$BUCKET" --object bench --range 65536 \
+  --backend s3 --container "$BUCKET" --object bench --range 65536 \
   --conns 1,32,128 --seconds "$BENCH_SECONDS" --warmup 2 --json |
   tee "$ARTIFACT_DIR/l2-benchmark.jsonl"
 [[ "$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l2"}')" -gt 0 ]] ||


### PR DESCRIPTION
The `3-worker L1/L2 E2E and benchmark` job fails at the benchmark stage:

```
first error response: request selects backend az, but this worker is configured for s3; route the request to a az worker
warning: 14115 errored requests at 1 connections
Error: no samples recorded at 1 connections; is the worker serving?
```

`talon-loadgen` hardcoded `Backend::Azure` when building the ObjectId, but the k8s fleet runs `TALON_WORKER_BACKEND=s3` against MinIO, so the worker rejected every request.

- add `--backend` to `talon-loadgen` (default `az`, preserving existing manual usage)
- pass `--backend s3` from `scripts/k8s_l1_l2_e2e.sh` for both the L1 and L2 sweeps

🤖 Generated with [Claude Code](https://claude.com/claude-code)