### PR TITLE
fix(worker): configure loadgen backend

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -102,9 +102,10 @@ Notes on running it:
 - **Warmup is excluded** from recorded samples, so the numbers describe the
   serve path rather than the first-fetch miss path.
 - **`talon-loadgen` can drive an existing worker** directly:
-  `talon-loadgen --addr host:7001 --conns 1024 --server-pid <pid>`. With
-  `--server-pid` it samples the worker's CPU and RSS from `/proc` across the
-  measured window; `--json` emits JSON Lines for scripted comparison.
+  `talon-loadgen --addr host:7001 --backend s3 --conns 1024 --server-pid <pid>`.
+  Set `--backend` to the backend configured on the target worker (the default is
+  `az`). With `--server-pid` it samples the worker's CPU and RSS from `/proc`
+  across the measured window; `--json` emits JSON Lines for scripted comparison.
 - A run that reports **no samples** is a failed run, not a fast one — the tool
   refuses to turn error frames into latency numbers and prints the first error
   verbatim.

--- a/crates/talon-worker/src/bin/loadgen.rs
+++ b/crates/talon-worker/src/bin/loadgen.rs
@@ -61,6 +61,9 @@ struct Args {
     /// Object key to read.
     #[arg(long, default_value = "bench")]
     object: String,
+    /// Object-store backend serving the target object.
+    #[arg(long, default_value = "az")]
+    backend: Backend,
     /// Container or bucket the object lives in.
     #[arg(long, default_value = "c")]
     container: String,
@@ -192,7 +195,7 @@ async fn drive_one(
 }
 
 async fn run_one(args: &Args, conns: usize) -> Run {
-    let object = ObjectId::new(Backend::Azure, &args.container, &args.object);
+    let object = ObjectId::new(args.backend, &args.container, &args.object);
     let stop = Arc::new(AtomicBool::new(false));
     let errors = Arc::new(AtomicU64::new(0));
     let warmup = Duration::from_secs(args.warmup);
@@ -321,4 +324,23 @@ async fn main() -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_azure_backend() {
+        let args = Args::try_parse_from(["talon-loadgen"]).unwrap();
+
+        assert_eq!(args.backend, Backend::Azure);
+    }
+
+    #[test]
+    fn accepts_explicit_s3_backend() {
+        let args = Args::try_parse_from(["talon-loadgen", "--backend", "s3"]).unwrap();
+
+        assert_eq!(args.backend, Backend::S3);
+    }
 }

--- a/docs/explanation/data-plane-runtime.md
+++ b/docs/explanation/data-plane-runtime.md
@@ -255,7 +255,7 @@ CONNS=1,512,2048 SECONDS_PER=30 scripts/dataplane_loadtest.sh
 cargo bench -p talon-worker --bench dataplane_benches
 
 # Drive an already-running worker, sampling its CPU and RSS
-talon-loadgen --addr 127.0.0.1:7001 --conns 1024 --server-pid "$(pgrep -x talon-worker)"
+talon-loadgen --addr 127.0.0.1:7001 --backend az --conns 1024 --server-pid "$(pgrep -x talon-worker)"
 
 # Confirm SO_REUSEPORT: N listeners on one port
 talon-worker --data-plane-rings 2 --listen 127.0.0.1:7001

--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -590,7 +590,7 @@ start_worker_forward "$TARGET_POD"
     --path "/s3/$BUCKET/bench" --len 65536 --out "$ARTIFACT_DIR/bench-warm.out"
 } 2>&1 | tee "$ARTIFACT_DIR/cold-warm.txt"
 target/release/talon-loadgen --addr "127.0.0.1:$WORKER_PORT" \
-  --container "$BUCKET" --object bench --range 65536 \
+  --backend s3 --container "$BUCKET" --object bench --range 65536 \
   --conns 1,32,128 --seconds "$BENCH_SECONDS" --warmup 2 --json |
   tee "$ARTIFACT_DIR/l1-benchmark.jsonl"
 [[ "$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l1"}')" -gt 0 ]] ||
@@ -602,7 +602,7 @@ start_coordinator_forward
 TARGET_POD="$(first_worker)"
 start_worker_forward "$TARGET_POD"
 target/release/talon-loadgen --addr "127.0.0.1:$WORKER_PORT" \
-  --container "$BUCKET" --object bench --range 65536 \
+  --backend s3 --container "$BUCKET" --object bench --range 65536 \
   --conns 1,32,128 --seconds "$BENCH_SECONDS" --warmup 2 --json |
   tee "$ARTIFACT_DIR/l2-benchmark.jsonl"
 [[ "$(metric_value "$TARGET_POD" 'talon_worker_cache_tier_hits_total{tier="l2"}')" -gt 0 ]] ||


### PR DESCRIPTION
## Summary

Follow-up to #375. The backend-consistency guard added there correctly rejects requests whose `ObjectId` selects a different object store from the worker configuration. That exposed a latent mismatch in the Kubernetes L1/L2 benchmark: the worker and fixtures use S3, while `talon-loadgen` always constructed Azure object IDs.

This change:

- adds a `--backend` option to `talon-loadgen` and uses it when constructing the target `ObjectId`;
- keeps `az` as the default so the existing Azure-based manual dataplane load test remains backward compatible;
- passes `--backend s3` from both the L1 and L2 phases of the Kubernetes benchmark;
- adds parser regression tests for the default and an explicit S3 selection; and
- documents that the load generator backend must match the target worker.

## Root cause

Before #375, the S3 backend happened to ignore the backend tag carried by an `ObjectId`, so an Azure-tagged load-generator request could still reach the S3 bucket and appear to work. The stricter worker validation intentionally closed that unsafe behavior. In run 30402180278, every functional Kubernetes E2E phase passed, but the benchmark then sent Azure-tagged requests to an S3 worker, producing 14,115 rejected requests and zero latency samples.

The fix is in the benchmark client and its invocation; the worker guard remains strict.

## Validation

- `cargo fmt --all -- --check`
- `bash -n scripts/k8s_l1_l2_e2e.sh`
- `git diff --check`
- two new `talon-loadgen` CLI parser tests (run by Linux CI)

The worker crate cannot compile on macOS because of its existing Linux-only splice, sendfile, CPU-affinity, and io_uring paths, so the worker tests and full Kubernetes reproduction are left to Linux CI.

Failed run that exposed the mismatch: https://github.com/milvus-io/talon/actions/runs/30402180278
