### PR TITLE
doc: lead the README with what makes Talon different

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,6 +10,14 @@ This document records the v1 architecture decisions. It is intentionally scoped:
 several harder problems (replication, coordinator HA, write-back) are explicitly
 deferred until workload data justifies them.
 
+> **Status note.** This is a historical record of the v1 decisions, not a
+> description of current behaviour. The FUSE client has since grown a write
+> path — `create`, `write`, `mkdir`, `rename`, `unlink`, `symlink`, `link`,
+> `setattr`, and `fsync` are all implemented (`crates/talon-fuse/src/mount.rs`)
+> — so the "read-only" framing below applies to v1 only. Write-back to the
+> backing store and POSIX locking remain unimplemented; see
+> [ADR 0002](docs/adr/) and [ADR 0003](docs/adr/) for where that work stands.
+
 ## Goals
 
 - Cache large, immutable objects (checkpoints, datasets) close to compute.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,58 @@
 # Talon
 
-**A distributed object-store cache written in Rust.**
+**An object-store cache whose metadata does not grow with your data — so there
+is no scaling ceiling and no single point of failure.**
 
-Talon sits between compute clients and a durable blob store (S3, GCS, Azure
-Blob), caching large immutable objects on local NVMe across a fleet of worker
-nodes and serving them through a read-only FUSE filesystem — high sequential
-read throughput, horizontal cache scale-out, and POSIX access for unmodified
-applications.
+Most caching filesystems put a metadata database in front of your object store,
+with a row per file. That database decides how many files you can have, and it
+decides what happens when it goes down.
+
+Talon's rule is the opposite: **if a fact can be rebuilt by listing the object
+store, it is not stored anywhere.** The namespace, file sizes, mtimes, and
+directory structure are all derived from the object store's own key listing.
+An ordinary file costs **zero** metadata records. Three things follow:
+
+- **S3 sets your scale limit, not us.** No per-object rows to shard, no inode
+  ceiling, no rebalance when the namespace grows.
+- **There is little state to protect.** Coordinators are stateless and run
+  active-active; restart one and there is nothing to recover. Lose a worker and
+  you lose cache, not data — the next read is a miss, not an outage.
+- **A plain S3 client can read anything Talon writes.** No proprietary on-disk
+  format, no lock-in, no migration to get back out.
+
+Advanced features that genuinely cannot derive their state — hard links, POSIX
+locking, write-back — are moving to an **optional**, deliberately sparse
+metadata store ([ADR 0003](docs/adr/0003-optional-metadata-store.md), proposed).
+Even then the rule holds: a singly-linked, unlocked file still costs zero
+records, so the store stays bounded by the features you actually use rather
+than by how much data you keep.
+
+Reads never copy: `sendfile` from NVMe to socket, `splice` from socket to NVMe
+on fill, driven by io_uring. At 1024 concurrent connections that measures **26%
+more throughput and 17× lower p50 latency — on comparable CPU and 19% less
+memory** — than the same server on Tokio. Per-core throughput stays flat from 1
+to 16 rings, so 8 cores serve **108K rps** and adding cores adds throughput
+with nothing to tune
+([measurements](docs/explanation/data-plane-runtime.md)).
+
+Read it through a FUSE mount, or use the [Python](docs/clients/python.md) /
+[Java](docs/clients/java.md) SDKs when a mount isn't the right fit.
+
+<!-- TODO(posix): POSIX compatibility is deliberately NOT claimed here yet.
+     Measured 2026-07-29 against a real kernel FUSE mount (pjdfstest, 238
+     files / 8798 assertions): roughly 2,540 assertions fail, i.e. ~71% pass.
+     Failures are dominated by two chmod/permission files (1284/2353 and
+     1106/2099); the rest are unlink/11 (90/270), rmdir/11 (15/47),
+     truncate/05, utimensat/07, rename/21+23, symlink/05+06.
+     The chmod concentration suggests a single root cause (mount options /
+     mode propagation) rather than 2,390 independent bugs — worth diagnosing
+     before publishing any number, since one fix may move the rate a lot.
+     Reproduce:
+       sudo TALON_REQUIRE_FUSE=1 TALON_RUN_PJDFSTEST=1 \
+         cargo test -p talon-fuse --features mount --test mount_e2e \
+         mount_pjdfstest_compatibility_suite -- --ignored --nocapture
+     When publishing: state the real rate and name the gaps. Hard links are
+     known-broken (ADR 0003 / #363 / #359); POSIX locking is unimplemented. -->
 
 [![CI](https://github.com/milvus-io/talon/actions/workflows/ci.yml/badge.svg)](https://github.com/milvus-io/talon/actions/workflows/ci.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)


### PR DESCRIPTION
## Why

The README opened with goals that any object-store cache would claim — *high
sequential read throughput, horizontal cache scale-out, POSIX access for
unmodified applications*. Swap in Alluxio or JuiceFS and every sentence still
reads true, so the reader has no way to tell what Talon actually does
differently.

## What changed

**Lead with the differentiator: metadata does not grow with the data.** Per
ADR 0003's admission rule — *if a fact can be rebuilt by listing the object
store, it does not go in TMS* — an ordinary file costs **zero** metadata
records. That is the real contrast with a per-file metadata database, and
unlike "no metadata server" it stays true once the optional sparse store
lands.

**Replace adjectives with the measured numbers** from
`docs/explanation/data-plane-runtime.md`: +26% throughput, 17× lower p50, 19%
less memory at 1024 connections, and 108K rps on 8 cores with per-core
throughput flat from 1→16 rings.

**Drop an unsupported claim.** The old text promised *"POSIX access for
unmodified applications"*. Running pjdfstest against a real kernel FUSE mount
(238 files / 8798 assertions) currently passes **~71%** — failures dominated by
two chmod files (1284/2353 and 1106/2099). The claim is removed and the
measurement recorded in a comment with the reproduce command. No pass rate is
published yet: the chmod concentration looks like one root cause rather than
2,390 independent bugs, and that is worth diagnosing before putting a number in
the README.

**DESIGN.md** gets a status note: its read-only framing is a v1 historical
record — the FUSE client has since grown `create`/`write`/`mkdir`/`rename`/
`unlink`/`symlink`/`link`/`setattr`/`fsync` — while write-back and POSIX
locking remain unimplemented.

## Verification

- Every number traced to `docs/explanation/data-plane-runtime.md`
  (51,668/41,060 = +26%; 19,905/1,175 = 17×; 8 rings = 107,993 rps).
- pjdfstest run on a 16-core privileged pod with a real kernel mount.
- `lychee --offline` clean: 21 OK, 0 errors.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)