### PR TITLE
feat(metadata): add MetadataStore trait, error model, and capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2583,6 +2583,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "talon-metadata"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "serde",
+ "thiserror 2.0.19",
+ "tracing",
+]
+
+[[package]]
 name = "talon-observability"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/talon-client",
     "clients/python",
     "crates/talon-observability",
+    "crates/talon-metadata",
 ]
 
 [workspace.package]
@@ -22,6 +23,7 @@ rust-version = "1.80"
 [workspace.dependencies]
 talon-core = { path = "crates/talon-core" }
 talon-transport = { path = "crates/talon-transport" }
+talon-metadata = { path = "crates/talon-metadata" }
 
 # Common third-party dependencies shared across crates
 anyhow = "1"

--- a/crates/talon-metadata/Cargo.toml
+++ b/crates/talon-metadata/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "talon-metadata"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Optional Metadata Store (TMS) for facts that cannot be derived from the object store"
+
+[dependencies]
+thiserror.workspace = true
+serde.workspace = true
+async-trait.workspace = true
+tracing.workspace = true

--- a/crates/talon-metadata/src/capability.rs
+++ b/crates/talon-metadata/src/capability.rs
@@ -1,0 +1,221 @@
+//! Per-backend capability declaration.
+//!
+//! ADR 0003 §7 requires capabilities to be *declared* by each backend rather
+//! than inferred from the presence of a generic compare-and-swap call:
+//!
+//! > Capabilities are advertised per TMS backend, not inferred from the
+//! > existence of a generic compare-and-swap call.
+//!
+//! The distinction matters because the underlying primitives look similar while
+//! the guarantees differ. A store offering single-key compare-and-swap can back
+//! a lock, but hard links need one transaction to span the transition record,
+//! the inode record, and every path index entry. A backend that cannot do that
+//! must refuse the capability rather than approximate it with a sequence of
+//! single-key writes that a crash can interleave.
+//!
+//! This is why the ADR names a backend that must not claim the richer
+//! capabilities:
+//!
+//! > In particular, the Kubernetes Lease representation from ADR 0001 is not a
+//! > multi-record transaction service and cannot provide hard links or
+//! > write-back by itself.
+
+use core::fmt;
+
+/// A capability a [`MetadataStore`](crate::MetadataStore) backend may advertise.
+///
+/// Each variant names the guarantees ADR 0003 §7 requires of a backend before
+/// it may claim support. A backend advertises only what it can honour; callers
+/// check with [`CapabilitySet::supports`] before attempting an operation, and
+/// the store rejects unsupported operations with
+/// [`MetadataError::CapabilityUnsupported`](crate::MetadataError::CapabilityUnsupported).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum Capability {
+    /// Distributed locking.
+    ///
+    /// Requires server-observed expiring sessions and atomic compare-and-swap.
+    /// "Server-observed" is the load-bearing word: expiry must be judged by the
+    /// store, not by a client comparing wall-clock timestamps, because a
+    /// partitioned client cannot be trusted to notice that it lost its session.
+    ///
+    /// Advertising this capability does not make POSIX locks available. Per the
+    /// ADR's validation gates, a separate locking ADR must first define the
+    /// bounded byte-range representation, blocking and fairness rules, waiter
+    /// recovery, and cross-file deadlock detection.
+    Locks,
+
+    /// Hard links through inode indirection (ADR 0003 §5).
+    ///
+    /// Requires atomic transactions across transition, inode, and path index
+    /// records. A backend limited to single-record compare-and-swap must not
+    /// advertise this: the promotion commit in §5 updates two path indexes, one
+    /// inode record, and removes a transition record, and a crash partway
+    /// through a non-atomic emulation leaves exactly the divergence that #363
+    /// is about.
+    HardLinks,
+
+    /// Write-back shard ownership (ADR 0003 §9).
+    ///
+    /// Requires everything [`Capability::Locks`] does, plus persistent fencing
+    /// terms and atomic shard-state transitions. "Persistent" excludes stores
+    /// where the term lives only in an ephemeral session key, because §9.3
+    /// requires the last committed term to outlive owner lease expiry:
+    ///
+    /// > `term` is a monotonically increasing fencing number. It must survive
+    /// > owner lease expiry.
+    ///
+    /// Advertising this capability does **not** enable write-back. ADR 0003
+    /// §9.11 keeps write-back unreachable until a superseding ADR is accepted;
+    /// this capability only says the store *could* back it.
+    WriteBack,
+}
+
+impl Capability {
+    /// Every capability, in declaration order.
+    pub const ALL: [Self; 3] = [Self::Locks, Self::HardLinks, Self::WriteBack];
+
+    /// Stable lowercase identifier for logs, metrics, and the management API.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Locks => "locks",
+            Self::HardLinks => "hard_links",
+            Self::WriteBack => "write_back",
+        }
+    }
+}
+
+impl fmt::Display for Capability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The set of capabilities a backend advertises.
+///
+/// Stored as a bitmask so that it is `Copy` and cheap to pass alongside every
+/// operation. Construct with [`CapabilitySet::none`] and add only what the
+/// backend can actually honour — the default is deliberately empty so that a
+/// new backend advertises nothing until someone states otherwise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CapabilitySet(u8);
+
+impl CapabilitySet {
+    /// A backend that advertises nothing.
+    ///
+    /// This is the correct starting point for every backend. A store with no
+    /// capabilities is still useful: it can hold records for features that need
+    /// no cross-record atomicity, and it keeps the "cluster without TMS"
+    /// behaviour testable.
+    pub const fn none() -> Self {
+        Self(0)
+    }
+
+    /// Add a capability.
+    #[must_use]
+    pub const fn with(self, capability: Capability) -> Self {
+        Self(self.0 | Self::bit(capability))
+    }
+
+    /// Whether the backend advertises `capability`.
+    pub const fn supports(self, capability: Capability) -> bool {
+        self.0 & Self::bit(capability) != 0
+    }
+
+    /// Whether the backend advertises nothing at all.
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Iterate the advertised capabilities in [`Capability::ALL`] order.
+    pub fn iter(self) -> impl Iterator<Item = Capability> {
+        Capability::ALL
+            .into_iter()
+            .filter(move |capability| self.supports(*capability))
+    }
+
+    const fn bit(capability: Capability) -> u8 {
+        match capability {
+            Capability::Locks => 1 << 0,
+            Capability::HardLinks => 1 << 1,
+            Capability::WriteBack => 1 << 2,
+        }
+    }
+}
+
+impl FromIterator<Capability> for CapabilitySet {
+    fn from_iter<I: IntoIterator<Item = Capability>>(iter: I) -> Self {
+        iter.into_iter()
+            .fold(Self::none(), |set, capability| set.with(capability))
+    }
+}
+
+impl fmt::Display for CapabilitySet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_empty() {
+            return f.write_str("none");
+        }
+        let mut first = true;
+        for capability in self.iter() {
+            if !first {
+                f.write_str(",")?;
+            }
+            f.write_str(capability.as_str())?;
+            first = false;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_new_capability_set_advertises_nothing() {
+        let set = CapabilitySet::none();
+        assert!(set.is_empty());
+        for capability in Capability::ALL {
+            assert!(
+                !set.supports(capability),
+                "{capability} must not be advertised by default"
+            );
+        }
+    }
+
+    #[test]
+    fn adding_one_capability_does_not_imply_another() {
+        // Guards ADR 0003 §7: a store with single-key compare-and-swap can back
+        // locks without being able to back hard links. Nothing here may infer
+        // one capability from another.
+        let set = CapabilitySet::none().with(Capability::Locks);
+        assert!(set.supports(Capability::Locks));
+        assert!(!set.supports(Capability::HardLinks));
+        assert!(!set.supports(Capability::WriteBack));
+    }
+
+    #[test]
+    fn capabilities_round_trip_through_iteration() {
+        let set = CapabilitySet::none()
+            .with(Capability::WriteBack)
+            .with(Capability::Locks);
+        let collected: CapabilitySet = set.iter().collect();
+        assert_eq!(set, collected);
+        assert_eq!(
+            set.iter().collect::<Vec<_>>(),
+            [Capability::Locks, Capability::WriteBack]
+        );
+    }
+
+    #[test]
+    fn display_lists_capabilities_and_names_the_empty_set() {
+        assert_eq!(CapabilitySet::none().to_string(), "none");
+        assert_eq!(
+            CapabilitySet::none()
+                .with(Capability::Locks)
+                .with(Capability::HardLinks)
+                .to_string(),
+            "locks,hard_links"
+        );
+    }
+}

--- a/crates/talon-metadata/src/error.rs
+++ b/crates/talon-metadata/src/error.rs
@@ -1,0 +1,279 @@
+//! Backend-neutral failures for [`MetadataStore`](crate::MetadataStore).
+//!
+//! ADR 0003 §7 requires the error model to mirror `ClusterStateStore`'s shape,
+//! with explicit `Compacted` / `WatchLagged` / `Timeout` / `Unavailable`
+//! variants. Two additions carry weight beyond diagnostics.
+//!
+//! [`MetadataError::CapabilityUnsupported`] is how a backend refuses rather
+//! than approximates. §4 calls silent degradation "precisely the defect in
+//! #363", so a store that cannot do multi-record transactions must fail here
+//! instead of emulating one with a sequence of single-key writes.
+//!
+//! [`MetadataError::Unavailable`] must stay distinguishable from
+//! `CapabilityUnsupported` all the way up to the errno the caller returns. §4
+//! maps them differently on purpose — `EOPNOTSUPP` for "this cluster does not
+//! implement locking" versus `ENOLCK` for "it does, but the lock service is
+//! unreachable" — and §6 requires "not configured" and "configured but
+//! unreachable" to be separable during an incident.
+
+use core::fmt;
+use core::time::Duration;
+
+use crate::capability::Capability;
+use crate::revision::StoreRevision;
+
+/// Result alias for metadata-store operations.
+pub type MetadataResult<T> = Result<T, MetadataError>;
+
+/// Identifies which backend produced an error, for logs and metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum MetadataBackend {
+    /// In-process store used by tests and single-node development.
+    Memory,
+    /// etcd-backed store.
+    Etcd,
+}
+
+impl MetadataBackend {
+    /// Stable lowercase identifier for logs, metrics, and configuration.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Memory => "memory",
+            Self::Etcd => "etcd",
+        }
+    }
+}
+
+impl fmt::Display for MetadataBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Backend-neutral metadata-store failures.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum MetadataError {
+    /// The backend does not advertise the capability this operation needs.
+    ///
+    /// This is a permanent property of the deployed backend, not a transient
+    /// condition: retrying cannot help, and the caller must surface a distinct
+    /// errno rather than falling back to an approximation (§4).
+    #[error("{backend} metadata backend does not support {capability}")]
+    CapabilityUnsupported {
+        /// Backend that refused.
+        backend: MetadataBackend,
+        /// Capability the operation required.
+        capability: Capability,
+    },
+
+    /// A compare-and-swap observed a different revision than the caller expected.
+    ///
+    /// The caller re-reads and decides whether its intent still applies. This is
+    /// the ordinary contention path, not a fault.
+    #[error("compare-and-swap failed: expected revision {expected}, found {observed}")]
+    CompareAndSwapFailed {
+        /// Revision the caller predicated the write on.
+        expected: StoreRevision,
+        /// Revision actually found.
+        observed: StoreRevision,
+    },
+
+    /// A record required by the operation does not exist.
+    #[error("metadata record not found: {key}")]
+    NotFound {
+        /// Sanitized record key. Must not carry credentials.
+        key: String,
+    },
+
+    /// A record already exists where the operation required none.
+    #[error("metadata record already exists: {key}")]
+    AlreadyExists {
+        /// Sanitized record key. Must not carry credentials.
+        key: String,
+    },
+
+    /// A record violated the shared schema contract.
+    #[error("invalid metadata record: {detail}")]
+    InvalidRecord {
+        /// Stable diagnostic detail without credentials.
+        detail: String,
+    },
+
+    /// A revision token was empty, malformed, or belonged to another backend.
+    #[error("invalid revision {revision:?}: {detail}")]
+    InvalidRevision {
+        /// Backend that rejected the token, when known.
+        backend: Option<MetadataBackend>,
+        /// Rejected opaque token.
+        revision: String,
+        /// Stable diagnostic detail without credentials.
+        detail: &'static str,
+    },
+
+    /// A lease duration was zero or could not be represented.
+    #[error("invalid lease TTL: {0:?}")]
+    InvalidLeaseTtl(Duration),
+
+    /// The session backing this operation has expired or was never valid.
+    ///
+    /// §7 is explicit about what a client must conclude: "If renewal fails, the
+    /// client must assume the session and all of its locks are lost." A caller
+    /// must not retry the operation as though the session still held.
+    #[error("metadata session {session} is no longer valid")]
+    SessionExpired {
+        /// Sanitized session identifier.
+        session: String,
+    },
+
+    /// A watch can no longer resume from the requested revision.
+    #[error("revision {requested} was compacted; oldest available is {oldest}")]
+    Compacted {
+        /// Requested resume revision.
+        requested: StoreRevision,
+        /// Oldest revision retained by the backend.
+        oldest: StoreRevision,
+    },
+
+    /// A live watch receiver fell behind its bounded event buffer.
+    #[error("metadata watch lagged by {skipped} events after revision {after}")]
+    WatchLagged {
+        /// Last revision delivered to the caller.
+        after: StoreRevision,
+        /// Number of skipped events reported by the backend.
+        skipped: u64,
+    },
+
+    /// Backend authentication failed.
+    #[error("{backend} metadata backend authentication failed")]
+    Authentication {
+        /// Selected backend.
+        backend: MetadataBackend,
+    },
+
+    /// Backend authorization denied the requested operation.
+    #[error("{backend} metadata backend permission denied")]
+    PermissionDenied {
+        /// Selected backend.
+        backend: MetadataBackend,
+    },
+
+    /// A backend operation exceeded its configured deadline.
+    #[error("{backend} metadata backend operation timed out")]
+    Timeout {
+        /// Selected backend.
+        backend: MetadataBackend,
+    },
+
+    /// The backend or watch transport is unavailable.
+    ///
+    /// Distinct from [`MetadataError::CapabilityUnsupported`]: the cluster does
+    /// offer the feature, it just cannot reach the store right now. §6 requires
+    /// callers to fail closed here — never to substitute a local approximation —
+    /// while keeping the two cases separable in logs and metrics.
+    #[error("{backend} metadata backend unavailable: {detail}")]
+    Unavailable {
+        /// Selected backend.
+        backend: MetadataBackend,
+        /// Sanitized diagnostic detail.
+        detail: String,
+    },
+}
+
+impl MetadataError {
+    /// Whether retrying after backoff, or relisting, can recover the operation.
+    ///
+    /// [`MetadataError::CapabilityUnsupported`] is deliberately **not**
+    /// retryable: the backend will never grow the capability at runtime, so a
+    /// retry loop would spin until a deadline instead of reporting the honest
+    /// answer to the application.
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::Compacted { .. }
+                | Self::WatchLagged { .. }
+                | Self::Timeout { .. }
+                | Self::Unavailable { .. }
+        )
+    }
+
+    /// Whether the failure reflects a permanent property of the deployment
+    /// rather than a transient condition.
+    ///
+    /// Callers use this to choose between §4's paired errnos: an unsupported
+    /// capability is reported as "this cluster does not offer the feature",
+    /// while an unavailable store is reported as "the feature exists but its
+    /// store is unreachable".
+    pub fn is_capability_gap(&self) -> bool {
+        matches!(self, Self::CapabilityUnsupported { .. })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_unsupported_capability_is_never_retryable() {
+        // ADR 0003 §4: a missing capability is a permanent property of the
+        // deployed backend. Retrying it would spin instead of reporting the
+        // honest answer, which is the silent-degradation failure mode #363 is
+        // about.
+        let error = MetadataError::CapabilityUnsupported {
+            backend: MetadataBackend::Memory,
+            capability: Capability::HardLinks,
+        };
+        assert!(!error.is_retryable());
+        assert!(error.is_capability_gap());
+    }
+
+    #[test]
+    fn an_unavailable_backend_is_retryable_and_not_a_capability_gap() {
+        // The pairing that §4 maps to EOPNOTSUPP vs ENOLCK and that §6 requires
+        // to stay separable during an incident.
+        let error = MetadataError::Unavailable {
+            backend: MetadataBackend::Etcd,
+            detail: "connection refused".to_owned(),
+        };
+        assert!(error.is_retryable());
+        assert!(!error.is_capability_gap());
+    }
+
+    #[test]
+    fn compare_and_swap_contention_is_not_retryable_without_re_reading() {
+        // A failed CAS is not a transport fault. Blind retry would re-apply an
+        // intent formed against a revision that no longer exists, so the caller
+        // must re-read first.
+        let error = MetadataError::CompareAndSwapFailed {
+            expected: StoreRevision::new("7").expect("non-empty token"),
+            observed: StoreRevision::new("9").expect("non-empty token"),
+        };
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn watch_recovery_paths_are_retryable() {
+        let compacted = MetadataError::Compacted {
+            requested: StoreRevision::new("3").expect("non-empty token"),
+            oldest: StoreRevision::new("11").expect("non-empty token"),
+        };
+        let lagged = MetadataError::WatchLagged {
+            after: StoreRevision::new("11").expect("non-empty token"),
+            skipped: 42,
+        };
+        assert!(compacted.is_retryable());
+        assert!(lagged.is_retryable());
+    }
+
+    #[test]
+    fn session_expiry_is_not_retryable() {
+        // §7: "If renewal fails, the client must assume the session and all of
+        // its locks are lost." Retrying under the dead session would act on
+        // ownership the store no longer grants.
+        let error = MetadataError::SessionExpired {
+            session: "session-1".to_owned(),
+        };
+        assert!(!error.is_retryable());
+    }
+}

--- a/crates/talon-metadata/src/lib.rs
+++ b/crates/talon-metadata/src/lib.rs
@@ -1,0 +1,265 @@
+//! Optional Metadata Store (TMS) for Talon.
+//!
+//! TMS holds ownership facts that **cannot be derived by listing the object
+//! store**. Everything else stays out, by rule (ADR 0003 §2):
+//!
+//! > If a fact can be rebuilt by listing the object store, it does not go in TMS.
+//!
+//! # Why this store exists at all
+//!
+//! Three features converged on the same missing primitive: hard links (#363),
+//! write-back (ADR 0002 §2), and POSIX locking. None of them needs "somewhere
+//! to put data" — they need **durable, strongly consistent ownership that
+//! outlives a single process and is visible to every client**.
+//!
+//! # Why it is optional
+//!
+//! Talon's namespace is derived, not stored: the object store's key list *is*
+//! the truth. ADR 0003 is blunt about what that buys and what would lose it:
+//!
+//! > That property — **path == data** — is why a plain S3 client can read what
+//! > Talon wrote, why a coordinator is disposable, and why there is no metadata
+//! > to recover after a restart. Any metadata store that dilutes it converts
+//! > Talon from a cache in front of an object store into an object-store-backed
+//! > filesystem (the JuiceFS model). That is a legitimate architecture and it is
+//! > not this one.
+//!
+//! So a cluster without TMS is a complete, supported deployment offering today's
+//! feature set. TMS is "the price of admission for a specific group of features,
+//! and clusters that do not need those features must not pay it" (§1).
+//!
+//! # Why sparsity is load-bearing
+//!
+//! §3 makes a quantity claim, not a style preference: a singly-linked file, an
+//! unlocked file, and a cluster without write-back each occupy **zero** records.
+//! That is what makes an etcd-class backend viable, since etcd holds its
+//! keyspace in memory with a practical ceiling in the single-digit GB. Per-object
+//! records for a billion-object bucket would not fit.
+//!
+//! [`LinkCount`] enforces the sharpest edge of this in the type system: it
+//! cannot represent 1, so a record for an ordinary single-path file is
+//! unrepresentable rather than merely discouraged.
+//!
+//! # Scope of this crate
+//!
+//! This crate defines the contract only. Per ADR 0003 §9.11, none of this
+//! enables write-back:
+//!
+//! > ADR 0002 §2 remains in force. [...] Write-back still requires bounded
+//! > production implementation, failure-injection evidence, observability,
+//! > operator procedures, and its own ADR superseding ADR 0002 before any
+//! > configuration can make this path reachable.
+//!
+//! Likewise, [`Capability::Locks`] says a backend *could* support distributed
+//! locking; shipping POSIX locks additionally requires a locking ADR defining
+//! byte-range representation, blocking and fairness rules, waiter recovery, and
+//! cross-file deadlock detection.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+mod capability;
+mod error;
+mod record;
+mod revision;
+
+pub use capability::{Capability, CapabilitySet};
+pub use error::{MetadataBackend, MetadataError, MetadataResult};
+pub use record::{
+    InodeNumber, InodeRecord, LinkCount, LinkTransition, LinkTransitionState, NamespaceId,
+    PathIndexEntry,
+};
+pub use revision::{MappingRevision, StoreRevision};
+
+use async_trait::async_trait;
+
+/// Health of a metadata backend, as reported by [`MetadataStore::check_ready`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendHealth {
+    /// Whether the backend can currently serve authoritative requests.
+    pub ready: bool,
+    /// Sanitized diagnostic detail. Must never carry credentials.
+    pub detail: String,
+}
+
+/// A durable, strongly consistent store for non-derivable ownership facts.
+///
+/// # Relationship to `ClusterStateStore`
+///
+/// This is deliberately a separate trait rather than new record types on
+/// `ClusterStateStore`, because the two have opposite durability invariants
+/// (§7):
+///
+/// > Cluster membership is ephemeral, bounded, and rebuildable from live
+/// > processes (ADR 0001 §2); TMS records are durable and *not* rebuildable.
+/// > Mixing them in one abstraction would make ADR 0001 §2's "bounded,
+/// > rebuildable" invariant untrue by construction.
+///
+/// Both may target the same physical etcd cluster under different prefixes.
+/// They remain separate abstractions with separate invariants.
+///
+/// # Capability checking
+///
+/// Implementations must reject an operation whose capability they do not
+/// advertise, returning [`MetadataError::CapabilityUnsupported`]. They must not
+/// emulate a missing guarantee with a weaker one — §4 identifies that as the
+/// defect behind #363, where an operation "appears to succeed, produces copies
+/// that can diverge, cannot self-repair, and does not report which copies went
+/// stale".
+///
+/// # Credential boundary
+///
+/// §7 places TMS access in the management tier: FUSE clients never receive TMS
+/// credentials or connect directly, and hard-link and lock operations are
+/// proxied through any active coordinator. A lock belongs to a renewable client
+/// session, not to the coordinator process that happened to proxy its
+/// acquisition, so a coordinator failure neither transfers nor drops it.
+#[async_trait]
+pub trait MetadataStore: Send + Sync {
+    /// Backend implementation represented by this store.
+    fn backend(&self) -> MetadataBackend;
+
+    /// Capabilities this backend advertises.
+    ///
+    /// Declared by the implementation, never inferred from the presence of a
+    /// generic compare-and-swap call (§7). A backend that cannot satisfy a
+    /// capability's contract must omit it here and reject the corresponding
+    /// operations.
+    fn capabilities(&self) -> CapabilitySet;
+
+    /// Whether this backend advertises `capability`.
+    fn supports(&self, capability: Capability) -> bool {
+        self.capabilities().supports(capability)
+    }
+
+    /// Verify the backend can serve authoritative requests.
+    ///
+    /// A failure here means "configured but unreachable", which §4 and §6
+    /// require callers to keep distinct from "not configured" — the two map to
+    /// different errnos and must be separable in an incident.
+    async fn check_ready(&self) -> MetadataResult<BackendHealth>;
+
+    /// Return the current revision of the namespace's hard-link mapping.
+    ///
+    /// A namespace that has never had a mapping transition reports
+    /// [`MappingRevision::INITIAL`], which requires no stored record: §3's
+    /// sparsity claim covers the mapping guard too, so an untouched namespace
+    /// occupies nothing.
+    ///
+    /// # Errors
+    ///
+    /// [`MetadataError::CapabilityUnsupported`] when the backend does not
+    /// advertise [`Capability::HardLinks`].
+    async fn mapping_revision(&self, namespace: &NamespaceId) -> MetadataResult<MappingRevision>;
+
+    /// Resolve a visible path to its inode, if the path is multiply linked.
+    ///
+    /// Returns `Ok(None)` for an ordinary single-path file. That is the common
+    /// case and it is not an error: such a file has no TMS record because its
+    /// path *is* its address in the object store.
+    ///
+    /// # Errors
+    ///
+    /// [`MetadataError::CapabilityUnsupported`] when the backend does not
+    /// advertise [`Capability::HardLinks`].
+    async fn resolve_path(
+        &self,
+        namespace: &NamespaceId,
+        path: &str,
+    ) -> MetadataResult<Option<PathIndexEntry>>;
+
+    /// Load an inode record.
+    ///
+    /// # Errors
+    ///
+    /// [`MetadataError::NotFound`] when no such inode exists, or
+    /// [`MetadataError::CapabilityUnsupported`] when the backend does not
+    /// advertise [`Capability::HardLinks`].
+    async fn load_inode(
+        &self,
+        namespace: &NamespaceId,
+        inode: InodeNumber,
+    ) -> MetadataResult<InodeRecord>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A store advertising nothing, used to pin the refusal contract.
+    struct UncapableStore;
+
+    #[async_trait]
+    impl MetadataStore for UncapableStore {
+        fn backend(&self) -> MetadataBackend {
+            MetadataBackend::Memory
+        }
+
+        fn capabilities(&self) -> CapabilitySet {
+            CapabilitySet::none()
+        }
+
+        async fn check_ready(&self) -> MetadataResult<BackendHealth> {
+            Ok(BackendHealth {
+                ready: true,
+                detail: "in-process".to_owned(),
+            })
+        }
+
+        async fn mapping_revision(
+            &self,
+            _namespace: &NamespaceId,
+        ) -> MetadataResult<MappingRevision> {
+            Err(MetadataError::CapabilityUnsupported {
+                backend: self.backend(),
+                capability: Capability::HardLinks,
+            })
+        }
+
+        async fn resolve_path(
+            &self,
+            _namespace: &NamespaceId,
+            _path: &str,
+        ) -> MetadataResult<Option<PathIndexEntry>> {
+            Err(MetadataError::CapabilityUnsupported {
+                backend: self.backend(),
+                capability: Capability::HardLinks,
+            })
+        }
+
+        async fn load_inode(
+            &self,
+            _namespace: &NamespaceId,
+            _inode: InodeNumber,
+        ) -> MetadataResult<InodeRecord> {
+            Err(MetadataError::CapabilityUnsupported {
+                backend: self.backend(),
+                capability: Capability::HardLinks,
+            })
+        }
+    }
+
+    #[test]
+    fn a_backend_advertises_nothing_until_it_says_otherwise() {
+        // §7: capabilities are declared per backend, never inferred. A store
+        // that has not claimed a capability must report that honestly.
+        let store = UncapableStore;
+        assert!(store.capabilities().is_empty());
+        for capability in Capability::ALL {
+            assert!(!store.supports(capability));
+        }
+    }
+
+    #[test]
+    fn refusal_is_reported_as_a_capability_gap_not_a_transient_fault() {
+        // The distinction §4 maps to EOPNOTSUPP vs ENOLCK: a caller must be able
+        // to tell "this cluster does not offer the feature" from "it does, but
+        // the store is unreachable", and must not retry the former.
+        let error = MetadataError::CapabilityUnsupported {
+            backend: MetadataBackend::Memory,
+            capability: Capability::HardLinks,
+        };
+        assert!(error.is_capability_gap());
+        assert!(!error.is_retryable());
+    }
+}

--- a/crates/talon-metadata/src/record.rs
+++ b/crates/talon-metadata/src/record.rs
@@ -1,0 +1,360 @@
+//! Record types admitted to TMS.
+//!
+//! Every type here must satisfy ADR 0003 §2's admission rule:
+//!
+//! > If a fact can be rebuilt by listing the object store, it does not go in TMS.
+//!
+//! The rule is not advisory. §3 turns it into a quantity claim that decides
+//! whether an etcd-class backend is viable at all:
+//!
+//! > a file with a single link occupies zero TMS records; [...] an unlocked file
+//! > occupies zero.
+//!
+//! etcd holds its keyspace in memory with a practical ceiling in the
+//! single-digit GB, so per-object records for a billion-object bucket would not
+//! fit. Sparsity is what makes the backend choice work, which is why
+//! [`LinkCount`] cannot represent 1: a singly-linked file must be
+//! *unrepresentable* here, not merely absent by convention.
+//!
+//! Deliberately **not** modelled, because the object store is the truth:
+//! file existence, directory structure, size, mtime, ETag, desired shard
+//! placement, and per-object dirty inventory.
+
+use core::fmt;
+use core::num::NonZeroU64;
+
+use crate::error::{MetadataError, MetadataResult};
+use crate::revision::MappingRevision;
+
+/// Identifies a namespace within a cluster.
+///
+/// Namespaces scope mapping revisions and write shards. §9.1 includes the
+/// namespace in the shard hash so that two namespaces sharing a bucket do not
+/// contend for the same shard ownership.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct NamespaceId(String);
+
+impl NamespaceId {
+    /// Construct from a non-empty identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MetadataError::InvalidRecord`] when empty.
+    pub fn new(value: impl Into<String>) -> MetadataResult<Self> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(MetadataError::InvalidRecord {
+                detail: "namespace id must not be empty".to_owned(),
+            });
+        }
+        Ok(Self(value))
+    }
+
+    /// Borrow the identifier.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for NamespaceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// An inode number within a namespace.
+///
+/// Inode-addressed storage uses the `<ns>/<ino>` convention that already exists
+/// for unlink-while-open. §5 notes the convention is reusable but its
+/// persistence model is not: that mechanism's mapping "only has to survive
+/// inside one process for one open handle's lifetime, so in-memory state
+/// suffices", whereas hard links "must hold across processes, clients, and
+/// restarts".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct InodeNumber(NonZeroU64);
+
+impl InodeNumber {
+    /// Construct from a non-zero inode number.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MetadataError::InvalidRecord`] for zero, which POSIX reserves.
+    pub fn new(value: u64) -> MetadataResult<Self> {
+        NonZeroU64::new(value)
+            .map(Self)
+            .ok_or_else(|| MetadataError::InvalidRecord {
+                detail: "inode number must be non-zero".to_owned(),
+            })
+    }
+
+    /// The raw inode number.
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+impl fmt::Display for InodeNumber {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A link count of at least two.
+///
+/// This type is the admission rule expressed in Rust. §3 requires a singly
+/// linked file to occupy **zero** TMS records, and §5 confines indirection to
+/// files that actually use the feature:
+///
+/// > Indirection applies **only to multiply-linked files**. A file with one name
+/// > remains a plain object at its visible path, directly readable by any S3
+/// > client. When a link count returns to one, the object moves back.
+///
+/// Making 1 unrepresentable means a future change cannot quietly start writing
+/// a record per ordinary file — the code would not compile. That matters more
+/// than it might appear: per-object records are precisely what would make etcd
+/// non-viable (§3) and turn Talon into the object-store-backed filesystem that
+/// the ADR's context section rules out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct LinkCount(NonZeroU64);
+
+impl LinkCount {
+    /// The count at which a file first enters inode-addressed storage.
+    pub const PROMOTED: Self = match NonZeroU64::new(2) {
+        Some(value) => Self(value),
+        None => unreachable!(),
+    };
+
+    /// Construct from a count of at least two.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MetadataError::InvalidRecord`] for 0 or 1. A count of 1 is not
+    /// an error in the filesystem — it is the ordinary case — but it must not be
+    /// *stored*, because storing it would mean a record per ordinary file.
+    pub fn new(value: u64) -> MetadataResult<Self> {
+        if value < 2 {
+            return Err(MetadataError::InvalidRecord {
+                detail: format!(
+                    "link count {value} does not belong in TMS: a file with fewer than two links \
+                     occupies zero records (ADR 0003 §3)"
+                ),
+            });
+        }
+        NonZeroU64::new(value)
+            .map(Self)
+            .ok_or_else(|| MetadataError::InvalidRecord {
+                detail: "link count must be non-zero".to_owned(),
+            })
+    }
+
+    /// The raw count.
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+
+    /// One more link.
+    ///
+    /// § 5: adding a third or later link "needs no object copy: one TMS
+    /// transaction adds the new path index, increments the bounded link count,
+    /// and advances the mapping revision."
+    ///
+    /// # Panics
+    ///
+    /// Panics on overflow, which would otherwise wrap a large count to a small
+    /// one and make the inode look ready for demotion.
+    #[must_use]
+    pub fn increment(self) -> Self {
+        let raw = self.0.get().checked_add(1).expect("link count overflowed");
+        Self(NonZeroU64::new(raw).expect("incremented count is non-zero"))
+    }
+
+    /// One fewer link, or `None` when the file should demote to path-addressed
+    /// storage.
+    ///
+    /// Returning `None` at 1 rather than a `LinkCount` of 1 is what forces the
+    /// caller to handle demotion. §5 calls that "the required inverse of
+    /// promotion, not an optional space optimization" — leaving a
+    /// singly-referenced inode record behind would violate §3's sparsity claim
+    /// and strand an object outside its visible path.
+    #[must_use]
+    pub fn decrement(self) -> Option<Self> {
+        NonZeroU64::new(self.0.get() - 1)
+            .filter(|raw| raw.get() >= 2)
+            .map(Self)
+    }
+}
+
+impl fmt::Display for LinkCount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// An inode record for a multiply-linked file.
+///
+/// Admitted by §2 as "inode reference counts". Exists only while the file has
+/// two or more links; see [`LinkCount`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InodeRecord {
+    /// Namespace owning the inode.
+    pub namespace: NamespaceId,
+    /// Inode number, addressing the internal object.
+    pub inode: InodeNumber,
+    /// Number of visible paths referencing this inode.
+    pub link_count: LinkCount,
+    /// Set when the inode object is missing or failed verification.
+    ///
+    /// §5's repair policy is deliberately asymmetric: an unreferenced object is
+    /// quarantined and eventually deleted, but a reference to a *missing* object
+    /// is marked corrupt and alerted — "never fabricate data or delete the
+    /// references automatically".
+    pub corrupt: bool,
+}
+
+/// A visible path referencing an inode.
+///
+/// Admitted by §2 as "`path -> inode` for files with more than one link".
+/// Ordinary single-path files have no such record: their path *is* their
+/// address in the object store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathIndexEntry {
+    /// Namespace owning the path.
+    pub namespace: NamespaceId,
+    /// Visible path, as seen through the mount.
+    pub path: String,
+    /// Inode this path resolves to.
+    pub inode: InodeNumber,
+}
+
+/// State of a hard-link transition (ADR 0003 §5).
+///
+/// The transition record is what makes promotion crash-safe. It is durable
+/// before any object copy begins, so recovery can always tell which of the
+/// copy, the commit, and the cleanup have happened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum LinkTransitionState {
+    /// The copy to inode-addressed storage has not been committed.
+    ///
+    /// § 5: while `PREPARING` exists, reads may continue from the original
+    /// object, and writes receive a retryable error rather than landing on an
+    /// object that is about to stop being authoritative.
+    Preparing,
+    /// The TMS commit succeeded; obsolete path objects may still exist.
+    ///
+    /// The commit — not the cleanup — is the linearization point of `link()`.
+    /// A crash here loses nothing: the inode object is authoritative and the
+    /// stale path object is deleted on recovery.
+    Committed,
+    /// The transition was abandoned before commit.
+    Aborted,
+}
+
+impl LinkTransitionState {
+    /// Whether the original path object is still authoritative.
+    ///
+    /// Drives §5's crash-recovery table: before the commit the original object
+    /// holds the data, after it the inode object does.
+    pub const fn original_is_authoritative(self) -> bool {
+        matches!(self, Self::Preparing | Self::Aborted)
+    }
+}
+
+/// A durable hard-link transition record (ADR 0003 §5).
+///
+/// Admitted by §2 as an "active link and namespace transition record". Unlike
+/// the inode and path records, this one is short-lived: it exists only while a
+/// transition is in progress, and §3 notes that "an identity-changing operation
+/// occupies one transition record only while it is in progress".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkTransition {
+    /// Namespace owning the transition.
+    pub namespace: NamespaceId,
+    /// Unique operation identifier, used to fence a resumed transition.
+    pub operation_id: String,
+    /// Current state.
+    pub state: LinkTransitionState,
+    /// Path holding the data before promotion.
+    pub source_path: String,
+    /// Path being added as a second link.
+    pub new_path: String,
+    /// Object version captured before the copy.
+    ///
+    /// Used as a precondition for both the copy and the post-commit delete, so
+    /// a concurrent overwrite cannot be silently discarded.
+    pub source_version: String,
+    /// Mapping revision this transition was formed against.
+    pub expected_mapping_revision: MappingRevision,
+    /// Inode the paths will resolve to.
+    pub inode: InodeNumber,
+    /// Worker executing the object-store copy.
+    ///
+    /// §7: coordinators "do not receive object-store credentials solely for TMS
+    /// features and do not proxy payload bytes". The worker already authorized
+    /// for the namespace does the copy under a fenced operation token.
+    pub operation_worker: String,
+    /// Process incarnation of that worker, so a restarted worker cannot resume
+    /// a transition its predecessor owned.
+    pub operation_worker_incarnation: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_single_link_cannot_be_represented() {
+        // The admission rule as a compile-and-runtime boundary: §3 requires a
+        // singly-linked file to occupy zero TMS records, so a count of 1 must
+        // not be storable at all.
+        for value in [0, 1] {
+            let error = LinkCount::new(value).expect_err("counts below two must not construct");
+            assert!(matches!(error, MetadataError::InvalidRecord { .. }));
+        }
+        assert_eq!(LinkCount::new(2).expect("two links").get(), 2);
+    }
+
+    #[test]
+    fn decrementing_to_one_link_signals_demotion_rather_than_storing_one() {
+        // §5 calls demotion "the required inverse of promotion, not an optional
+        // space optimization". Returning None forces the caller to perform it
+        // instead of leaving a singly-referenced inode record behind.
+        assert_eq!(LinkCount::PROMOTED.decrement(), None);
+
+        let three = LinkCount::new(3).expect("three links");
+        assert_eq!(three.decrement(), Some(LinkCount::PROMOTED));
+    }
+
+    #[test]
+    fn link_counts_increment_for_additional_paths() {
+        let promoted = LinkCount::PROMOTED;
+        assert_eq!(promoted.increment().get(), 3);
+        assert_eq!(promoted.increment().increment().get(), 4);
+    }
+
+    #[test]
+    fn inode_zero_is_rejected() {
+        let error = InodeNumber::new(0).expect_err("zero is reserved");
+        assert!(matches!(error, MetadataError::InvalidRecord { .. }));
+        assert_eq!(InodeNumber::new(7).expect("non-zero").get(), 7);
+    }
+
+    #[test]
+    fn an_empty_namespace_id_is_rejected() {
+        assert!(NamespaceId::new("").is_err());
+        assert_eq!(
+            NamespaceId::new("ns-a").expect("non-empty").as_str(),
+            "ns-a"
+        );
+    }
+
+    #[test]
+    fn authority_follows_the_commit_not_the_cleanup() {
+        // §5's crash-recovery table: the TMS commit is the linearization point,
+        // so the original object stops being authoritative there — not when the
+        // obsolete object is finally deleted.
+        assert!(LinkTransitionState::Preparing.original_is_authoritative());
+        assert!(LinkTransitionState::Aborted.original_is_authoritative());
+        assert!(!LinkTransitionState::Committed.original_is_authoritative());
+    }
+}

--- a/crates/talon-metadata/src/revision.rs
+++ b/crates/talon-metadata/src/revision.rs
@@ -1,0 +1,153 @@
+//! Opaque revision tokens.
+//!
+//! A revision is a backend-issued token, never a number Talon computes. ADR
+//! 0003 §7 requires watch-from-revision with an explicit `Compacted` variant,
+//! which only works if the token round-trips through Talon unmodified.
+//!
+//! Treating it as opaque also keeps three unrelated revisions from being
+//! confused. §4 and §9.3 are explicit that they are distinct:
+//!
+//! > The capability revision and §9's write-routing revision are not ADR 0001's
+//! > membership-derived `PlacementVersion`.
+//!
+//! They advance for different reasons — membership changes immediately alter
+//! the desired HRW ranking, while effective write ownership changes only after
+//! a handoff or recovery commits — so a value from one is meaningless to the
+//! others.
+
+use core::fmt;
+
+use crate::error::{MetadataError, MetadataResult};
+
+/// An opaque, backend-issued revision token.
+///
+/// Talon compares these for equality and hands them back to the backend. It
+/// never parses, orders, or arithmetically advances one: etcd revisions are
+/// monotonic integers, but that is a backend detail and other backends need not
+/// share it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct StoreRevision(String);
+
+impl StoreRevision {
+    /// Construct a revision from a non-empty backend token.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MetadataError::InvalidRevision`] when the token is empty. An
+    /// empty token would silently behave like "from the beginning" in a
+    /// watch resume, which is exactly the case that must surface as an error
+    /// rather than a full replay.
+    pub fn new(value: impl Into<String>) -> MetadataResult<Self> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(MetadataError::InvalidRevision {
+                backend: None,
+                revision: value,
+                detail: "revision must not be empty",
+            });
+        }
+        Ok(Self(value))
+    }
+
+    /// Borrow the backend token without interpreting it.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for StoreRevision {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A namespace-scoped mapping revision (ADR 0003 §5).
+///
+/// Distinct from [`StoreRevision`]: this one Talon *does* own and advance.
+///
+/// > A namespace with the hard-link capability therefore has one monotonically
+/// > increasing `MappingRevision` and a TMS-backed mutation guard.
+///
+/// Every write and namespace mutation carries the revision it resolved against,
+/// and workers reject an older one with a stale-mapping error. That is what
+/// stops a client holding a cached path mapping from writing to an object that
+/// a concurrent hard-link promotion has already moved to inode-addressed
+/// storage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct MappingRevision(u64);
+
+impl MappingRevision {
+    /// The revision of a namespace that has never had a mapping transition.
+    pub const INITIAL: Self = Self(0);
+
+    /// Construct from a raw counter value.
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// The raw counter value, for durable encoding and the wire protocol.
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// The next revision.
+    ///
+    /// # Panics
+    ///
+    /// Panics on overflow. At one transition per nanosecond this would take
+    /// roughly 585 years; a wrap would silently make a stale mapping look
+    /// current, so aborting is the safer failure.
+    #[must_use]
+    pub const fn next(self) -> Self {
+        match self.0.checked_add(1) {
+            Some(value) => Self(value),
+            None => panic!("mapping revision overflowed"),
+        }
+    }
+}
+
+impl fmt::Display for MappingRevision {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_empty_revision_token_is_rejected() {
+        // An empty token would read as "resume from the beginning" instead of
+        // failing, turning a lost position into a silent full replay.
+        let error = StoreRevision::new("").expect_err("empty token must not construct");
+        assert!(matches!(error, MetadataError::InvalidRevision { .. }));
+    }
+
+    #[test]
+    fn a_revision_token_round_trips_unmodified() {
+        // The backend must get back exactly what it issued; Talon never
+        // normalises or reformats the token.
+        let token = "\"etcd-rev-9007199254740993\"";
+        let revision = StoreRevision::new(token).expect("non-empty token");
+        assert_eq!(revision.as_str(), token);
+        assert_eq!(revision.to_string(), token);
+    }
+
+    #[test]
+    fn mapping_revisions_advance_monotonically_from_initial() {
+        let first = MappingRevision::INITIAL;
+        let second = first.next();
+        assert!(second > first);
+        assert_eq!(second.get(), 1);
+        assert_eq!(second.next().get(), 2);
+    }
+
+    #[test]
+    fn mapping_revision_ordering_is_numeric_not_lexicographic() {
+        // Guards against encoding the counter as a string somewhere along the
+        // way: "10" sorts before "9" lexicographically, which would make a
+        // newer mapping look stale and admit a write that should be fenced.
+        assert!(MappingRevision::new(10) > MappingRevision::new(9));
+    }
+}


### PR DESCRIPTION
Closes #384. Part of #380.

Contract only — no backend, no wiring, no runtime behaviour change anywhere.

## Three things enforced by types rather than documented

**`LinkCount` cannot represent 1.** §3 requires a singly-linked file to occupy
zero TMS records, because etcd holds its keyspace in memory and per-object
records for a billion-object bucket would not fit. Making 1 unrepresentable
means a later change cannot quietly start writing a record per ordinary file —
it would not compile. `decrement()` returns `None` at one link rather than a
`LinkCount` of 1, forcing callers to perform the demotion §5 calls "the required
inverse of promotion, not an optional space optimization".

**Capabilities are declared, not inferred.** §7:

> Capabilities are advertised per TMS backend, not inferred from the existence
> of a generic compare-and-swap call.

A store with single-key CAS can back a lock but not hard links, which need one
transaction spanning the transition, inode, and path index records. The ADR
names the Kubernetes Lease representation as a backend that must not claim the
richer capabilities.

**`CapabilityUnsupported` is not retryable, and is distinct from `Unavailable`.**
§4 maps them to different errnos on purpose — `EOPNOTSUPP` for "this cluster does
not implement locking" versus `ENOLCK` for "it does, but the lock service is
unreachable" — and §6 requires the two to stay separable during an incident.
Retrying a missing capability would spin until a deadline instead of reporting
the honest answer, which is the silent-degradation defect behind #363.

## Admission rule

Modelled (§2's left column): `path -> inode` for multiply-linked files, inode
reference counts, `LinkTransition` records, namespace `MappingRevision`.

Deliberately absent (§2's right column): file existence, directory structure,
size, mtime, ETag, desired shard placement, per-object dirty inventory. The
object store is the truth for all of those.

## Separate from `ClusterStateStore`

Per §7, a distinct trait rather than new record types on the existing store:
membership is ephemeral and rebuildable, TMS records are durable and not. Mixing
them would make ADR 0001 §2's "bounded, rebuildable" invariant untrue by
construction. `ClusterStateStore` is untouched by this PR.

## Scope

Nothing here enables write-back — §9.11 keeps that unreachable until an ADR
superseding ADR 0002 is accepted. `Capability::Locks` says a backend *could*
support distributed locking; shipping POSIX locks additionally requires a
locking ADR defining byte-range representation, fairness, waiter recovery, and
deadlock detection.

## Validation

- 21 unit tests, each named for the invariant it pins
- `cargo clippy -p talon-metadata --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean
- `cargo build --workspace` unaffected

## Next

#385 (memory backend + shared contract suite) → #386 (etcd) → #387 (capability
negotiation and the errno contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)