### PR TITLE
feat(metadata): add memory backend and shared contract suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2589,6 +2589,7 @@ dependencies = [
  "async-trait",
  "serde",
  "thiserror 2.0.19",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/talon-metadata/Cargo.toml
+++ b/crates/talon-metadata/Cargo.toml
@@ -12,3 +12,6 @@ thiserror.workspace = true
 serde.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/talon-metadata/src/contract.rs
+++ b/crates/talon-metadata/src/contract.rs
@@ -1,0 +1,282 @@
+//! Shared contract suite for [`MetadataStore`](crate::MetadataStore) backends.
+//!
+//! Every backend runs these identical cases. The point is that ADR 0003's
+//! correctness arguments rest on *contract* properties, not on any one
+//! implementation — so a backend that quietly weakens one must fail here rather
+//! than surface later as a hard-link divergence in production.
+//!
+//! The suite covers the refusal paths as deliberately as the happy paths. §7
+//! requires a backend that cannot honour a capability to reject the operation,
+//! and §4 calls approximating it "precisely the defect in #363". A backend that
+//! silently half-applied a transaction would pass a happy-path-only suite.
+//!
+//! Exported rather than `#[cfg(test)]`-private so the etcd backend can run the
+//! same cases against a real server.
+
+use crate::capability::Capability;
+use crate::error::MetadataError;
+use crate::memory::MemoryMetadataStore;
+use crate::record::{InodeRecord, LinkCount, NamespaceId, PathIndexEntry};
+use crate::revision::MappingRevision;
+use crate::transaction::{Operation, Precondition, Transaction};
+use crate::{InodeNumber, MetadataStore};
+
+fn namespace() -> NamespaceId {
+    NamespaceId::new("contract-ns").expect("valid namespace")
+}
+
+fn inode(value: u64) -> InodeNumber {
+    InodeNumber::new(value).expect("non-zero inode")
+}
+
+/// A promotion commit, as specified by ADR 0003 §5.
+///
+/// Mirrors the four changes the ADR requires to apply together:
+///
+/// ```text
+/// source_path -> inode
+/// new_path    -> inode
+/// inode.link_count = 2
+/// remove LinkTransition
+/// ```
+fn promotion(
+    ns: &NamespaceId,
+    source_path: &str,
+    new_path: &str,
+    ino: InodeNumber,
+    expected_revision: MappingRevision,
+) -> Transaction {
+    Transaction::new()
+        .when(Precondition::MappingRevisionIs {
+            namespace: ns.clone(),
+            expected: expected_revision,
+        })
+        .then(Operation::PutPathIndex(PathIndexEntry {
+            namespace: ns.clone(),
+            path: source_path.to_owned(),
+            inode: ino,
+        }))
+        .then(Operation::PutPathIndex(PathIndexEntry {
+            namespace: ns.clone(),
+            path: new_path.to_owned(),
+            inode: ino,
+        }))
+        .then(Operation::PutInode(InodeRecord {
+            namespace: ns.clone(),
+            inode: ino,
+            link_count: LinkCount::PROMOTED,
+            corrupt: false,
+        }))
+        .then(Operation::AdvanceMappingRevision {
+            namespace: ns.clone(),
+        })
+}
+
+/// An ordinary single-path file has no TMS record.
+///
+/// This is §3's sparsity claim at the store boundary, and it is what makes an
+/// etcd-class backend viable: per-object records for a billion-object bucket
+/// would exceed etcd's in-memory keyspace. `resolve_path` returning `None` is
+/// the normal case, not an error.
+pub async fn unmapped_paths_resolve_to_nothing(store: &impl MetadataStore) {
+    let ns = namespace();
+    let resolved = store
+        .resolve_path(&ns, "ordinary/file.bin")
+        .await
+        .expect("resolving an unmapped path is not an error");
+    assert_eq!(
+        resolved, None,
+        "a single-path file must occupy zero records (ADR 0003 §3)"
+    );
+}
+
+/// A namespace with no transitions reports the initial mapping revision.
+///
+/// Sparsity covers the mapping guard too: an untouched namespace stores nothing.
+pub async fn untouched_namespaces_report_the_initial_revision(store: &impl MetadataStore) {
+    let ns = NamespaceId::new("never-touched").expect("valid namespace");
+    let revision = store
+        .mapping_revision(&ns)
+        .await
+        .expect("an untouched namespace has a revision without storing one");
+    assert_eq!(revision, MappingRevision::INITIAL);
+}
+
+/// A backend refuses operations whose capability it does not advertise.
+///
+/// §7: "A backend that cannot satisfy one of these contracts must not advertise
+/// that capability." The refusal must be a capability gap, not a transient
+/// error, so callers can map it to the errno for "this cluster does not offer
+/// the feature" rather than retrying.
+pub async fn unsupported_capabilities_are_refused_not_approximated(store: &impl MetadataStore) {
+    if store.supports(Capability::HardLinks) {
+        return;
+    }
+    let ns = namespace();
+    let error = store
+        .resolve_path(&ns, "a.bin")
+        .await
+        .expect_err("a backend without hard links must refuse to resolve paths");
+    assert!(
+        error.is_capability_gap(),
+        "refusal must be a capability gap, got {error}"
+    );
+    assert!(
+        !error.is_retryable(),
+        "a missing capability is permanent; retrying would spin"
+    );
+}
+
+/// A failed precondition applies none of the transaction's operations.
+///
+/// The property §5's promotion commit depends on. A partially applied promotion
+/// would leave one path resolving to an inode and the other to a path-addressed
+/// object that cleanup is about to delete — reintroducing #363's divergence one
+/// layer down.
+pub fn a_failed_precondition_applies_nothing(store: &MemoryMetadataStore) {
+    let ns = namespace();
+    let ino = inode(42);
+
+    let stale = promotion(&ns, "a.bin", "b.bin", ino, MappingRevision::new(99));
+    let error = store
+        .commit(&stale)
+        .expect_err("a stale mapping revision must not commit");
+    assert!(matches!(error, MetadataError::CompareAndSwapFailed { .. }));
+
+    let state = store.state_snapshot(&ns);
+    assert!(
+        state.paths.is_empty(),
+        "no path index entry may survive a failed transaction"
+    );
+    assert!(
+        state.inodes.is_empty(),
+        "no inode record may survive a failed transaction"
+    );
+    assert_eq!(
+        state.mapping_revision,
+        MappingRevision::INITIAL,
+        "the mapping revision must not advance on a failed transaction"
+    );
+}
+
+/// A promotion commit applies all four changes together.
+pub fn a_promotion_commits_atomically(store: &MemoryMetadataStore) {
+    let ns = namespace();
+    let ino = inode(7);
+
+    let outcome = store
+        .commit(&promotion(
+            &ns,
+            "data/a.bin",
+            "data/b.bin",
+            ino,
+            MappingRevision::INITIAL,
+        ))
+        .expect("promotion commits against the current revision");
+
+    assert_eq!(
+        outcome.mapping_revision,
+        Some(MappingRevision::new(1)),
+        "creating a transition advances the namespace revision (§5)"
+    );
+
+    let state = store.state_snapshot(&ns);
+    assert_eq!(state.paths.get("data/a.bin"), Some(&ino));
+    assert_eq!(
+        state.paths.get("data/b.bin"),
+        Some(&ino),
+        "both names must resolve to the inode after the linearization point"
+    );
+    assert_eq!(
+        state.inodes.get(&ino.get()).map(|record| record.link_count),
+        Some(LinkCount::PROMOTED)
+    );
+}
+
+/// A second commit against a consumed revision fails.
+///
+/// The race §5's mapping revision exists to close: a transition prepared
+/// against one view of the namespace must not commit after a concurrent
+/// transition already moved the same path.
+pub fn a_consumed_mapping_revision_cannot_commit_twice(store: &MemoryMetadataStore) {
+    let ns = namespace();
+
+    store
+        .commit(&promotion(
+            &ns,
+            "x.bin",
+            "y.bin",
+            inode(1),
+            MappingRevision::INITIAL,
+        ))
+        .expect("first promotion commits");
+
+    let error = store
+        .commit(&promotion(
+            &ns,
+            "x.bin",
+            "z.bin",
+            inode(2),
+            MappingRevision::INITIAL,
+        ))
+        .expect_err("a replayed revision must not commit");
+    assert!(matches!(error, MetadataError::CompareAndSwapFailed { .. }));
+}
+
+/// A negative mapping precondition rejects an already-mapped path.
+///
+/// §5: "A current negative mapping proves that an ordinary unlinked object
+/// still uses its visible path."
+pub fn an_already_mapped_path_fails_the_unmapped_precondition(store: &MemoryMetadataStore) {
+    let ns = namespace();
+    let ino = inode(5);
+
+    store
+        .commit(&promotion(
+            &ns,
+            "p.bin",
+            "q.bin",
+            ino,
+            MappingRevision::INITIAL,
+        ))
+        .expect("promotion commits");
+
+    let transaction = Transaction::new()
+        .when(Precondition::PathIsUnmapped {
+            namespace: ns.clone(),
+            path: "p.bin".to_owned(),
+        })
+        .then(Operation::AdvanceMappingRevision {
+            namespace: ns.clone(),
+        });
+
+    store
+        .commit(&transaction)
+        .expect_err("a mapped path must fail the unmapped precondition");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn memory_backend_satisfies_the_async_contract() {
+        let store = MemoryMetadataStore::new();
+        unmapped_paths_resolve_to_nothing(&store).await;
+        untouched_namespaces_report_the_initial_revision(&store).await;
+    }
+
+    #[tokio::test]
+    async fn a_store_without_capabilities_refuses_rather_than_approximating() {
+        let store = MemoryMetadataStore::without_capabilities();
+        unsupported_capabilities_are_refused_not_approximated(&store).await;
+    }
+
+    #[test]
+    fn memory_backend_satisfies_the_transaction_contract() {
+        a_failed_precondition_applies_nothing(&MemoryMetadataStore::new());
+        a_promotion_commits_atomically(&MemoryMetadataStore::new());
+        a_consumed_mapping_revision_cannot_commit_twice(&MemoryMetadataStore::new());
+        an_already_mapped_path_fails_the_unmapped_precondition(&MemoryMetadataStore::new());
+    }
+}

--- a/crates/talon-metadata/src/contract.rs
+++ b/crates/talon-metadata/src/contract.rs
@@ -1,4 +1,4 @@
-//! Shared contract suite for [`MetadataStore`](crate::MetadataStore) backends.
+//! Shared contract suite for [`MetadataStore`] backends.
 //!
 //! Every backend runs these identical cases. The point is that ADR 0003's
 //! correctness arguments rest on *contract* properties, not on any one

--- a/crates/talon-metadata/src/lib.rs
+++ b/crates/talon-metadata/src/lib.rs
@@ -59,17 +59,22 @@
 #![warn(missing_docs)]
 
 mod capability;
+pub mod contract;
 mod error;
+mod memory;
 mod record;
 mod revision;
+mod transaction;
 
 pub use capability::{Capability, CapabilitySet};
 pub use error::{MetadataBackend, MetadataError, MetadataResult};
+pub use memory::{MemoryMetadataStore, NamespaceSnapshot};
 pub use record::{
     InodeNumber, InodeRecord, LinkCount, LinkTransition, LinkTransitionState, NamespaceId,
     PathIndexEntry,
 };
 pub use revision::{MappingRevision, StoreRevision};
+pub use transaction::{Operation, Precondition, Transaction, TransactionOutcome};
 
 use async_trait::async_trait;
 

--- a/crates/talon-metadata/src/memory.rs
+++ b/crates/talon-metadata/src/memory.rs
@@ -1,0 +1,373 @@
+//! In-process [`MetadataStore`] for tests and single-node development.
+//!
+//! Advertises [`Capability::HardLinks`] because it does provide real atomic
+//! multi-record transactions — everything happens under one mutex, so a
+//! transaction either applies fully or not at all.
+//!
+//! It does **not** advertise [`Capability::Locks`] or
+//! [`Capability::WriteBack`]. Both require server-observed expiring sessions,
+//! and §9's write-back additionally requires fencing terms that "must survive
+//! owner lease expiry". A single-process store cannot observe the expiry of a
+//! session belonging to a client in another process, and its records do not
+//! survive the process at all. Claiming either would be exactly the silent
+//! over-promise §7 forbids:
+//!
+//! > A backend that cannot satisfy one of these contracts must not advertise
+//! > that capability.
+//!
+//! This store is for tests. Nothing in production should depend on it.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use crate::capability::{Capability, CapabilitySet};
+use crate::error::{MetadataBackend, MetadataError, MetadataResult};
+use crate::record::{InodeNumber, InodeRecord, LinkTransition, NamespaceId, PathIndexEntry};
+use crate::revision::{MappingRevision, StoreRevision};
+use crate::transaction::{Operation, Precondition, Transaction, TransactionOutcome};
+use crate::{BackendHealth, MetadataStore};
+
+#[derive(Debug, Default)]
+struct NamespaceState {
+    mapping_revision: MappingRevision,
+    paths: BTreeMap<String, InodeNumber>,
+    inodes: BTreeMap<u64, InodeRecord>,
+    transitions: BTreeMap<String, LinkTransition>,
+}
+
+/// A point-in-time view of one namespace, for contract assertions.
+#[derive(Debug, Default)]
+pub struct NamespaceSnapshot {
+    /// Current mapping revision.
+    pub mapping_revision: MappingRevision,
+    /// Path index entries, keyed by visible path.
+    pub paths: BTreeMap<String, InodeNumber>,
+    /// Inode records, keyed by inode number.
+    pub inodes: BTreeMap<u64, InodeRecord>,
+    /// In-flight link transitions, keyed by operation id.
+    pub transitions: BTreeMap<String, LinkTransition>,
+}
+
+#[derive(Debug, Default)]
+struct State {
+    namespaces: BTreeMap<String, NamespaceState>,
+    revision: u64,
+}
+
+/// An in-process metadata store.
+#[derive(Debug)]
+pub struct MemoryMetadataStore {
+    state: Mutex<State>,
+    capabilities: CapabilitySet,
+}
+
+impl MemoryMetadataStore {
+    /// A store advertising hard links.
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(State::default()),
+            capabilities: CapabilitySet::none().with(Capability::HardLinks),
+        }
+    }
+
+    /// A store advertising nothing.
+    ///
+    /// Used to exercise the refusal paths: callers must return the errno for
+    /// "this cluster does not offer the feature" without falling back to a
+    /// local approximation (§4).
+    pub fn without_capabilities() -> Self {
+        Self {
+            state: Mutex::new(State::default()),
+            capabilities: CapabilitySet::none(),
+        }
+    }
+
+    fn require(&self, capability: Capability) -> MetadataResult<()> {
+        if self.capabilities.supports(capability) {
+            return Ok(());
+        }
+        Err(MetadataError::CapabilityUnsupported {
+            backend: MetadataBackend::Memory,
+            capability,
+        })
+    }
+
+    /// Apply a transaction atomically.
+    ///
+    /// Every precondition is evaluated against one view before any operation is
+    /// applied, so a failure leaves the store untouched. This is the property
+    /// §5's promotion commit depends on.
+    ///
+    /// # Errors
+    ///
+    /// [`MetadataError::CompareAndSwapFailed`] when a precondition does not
+    /// hold, or [`MetadataError::CapabilityUnsupported`] when hard links are not
+    /// advertised.
+    pub fn commit(&self, transaction: &Transaction) -> MetadataResult<TransactionOutcome> {
+        self.require(Capability::HardLinks)?;
+        let mut state = self.state.lock().expect("metadata state mutex poisoned");
+
+        for precondition in transaction.preconditions() {
+            Self::check(&state, precondition)?;
+        }
+
+        let mut mapping_revision = None;
+        for operation in transaction.operations() {
+            mapping_revision = Self::apply(&mut state, operation).or(mapping_revision);
+        }
+
+        state.revision += 1;
+        let revision = StoreRevision::new(state.revision.to_string())?;
+        Ok(TransactionOutcome {
+            revision,
+            mapping_revision,
+        })
+    }
+
+    fn check(state: &State, precondition: &Precondition) -> MetadataResult<()> {
+        let fail =
+            |detail: String| Err(MetadataError::InvalidRecord { detail }) as MetadataResult<()>;
+        match precondition {
+            Precondition::MappingRevisionIs {
+                namespace,
+                expected,
+            } => {
+                let actual = state
+                    .namespaces
+                    .get(namespace.as_str())
+                    .map_or(MappingRevision::INITIAL, |ns| ns.mapping_revision);
+                if actual != *expected {
+                    return Err(MetadataError::CompareAndSwapFailed {
+                        expected: StoreRevision::new(expected.to_string())?,
+                        observed: StoreRevision::new(actual.to_string())?,
+                    });
+                }
+                Ok(())
+            }
+            Precondition::PathIsUnmapped { namespace, path } => {
+                let mapped = state
+                    .namespaces
+                    .get(namespace.as_str())
+                    .is_some_and(|ns| ns.paths.contains_key(path));
+                if mapped {
+                    return fail(format!("path {path} is already mapped to an inode"));
+                }
+                Ok(())
+            }
+            Precondition::PathResolvesTo {
+                namespace,
+                path,
+                inode,
+            } => {
+                let actual = state
+                    .namespaces
+                    .get(namespace.as_str())
+                    .and_then(|ns| ns.paths.get(path));
+                if actual != Some(inode) {
+                    return fail(format!("path {path} does not resolve to inode {inode}"));
+                }
+                Ok(())
+            }
+            Precondition::TransitionExists {
+                namespace,
+                operation_id,
+            } => {
+                let present = state
+                    .namespaces
+                    .get(namespace.as_str())
+                    .is_some_and(|ns| ns.transitions.contains_key(operation_id));
+                if !present {
+                    return Err(MetadataError::NotFound {
+                        key: format!("transition/{operation_id}"),
+                    });
+                }
+                Ok(())
+            }
+            Precondition::TransitionAbsent {
+                namespace,
+                operation_id,
+            } => {
+                let present = state
+                    .namespaces
+                    .get(namespace.as_str())
+                    .is_some_and(|ns| ns.transitions.contains_key(operation_id));
+                if present {
+                    return Err(MetadataError::AlreadyExists {
+                        key: format!("transition/{operation_id}"),
+                    });
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn apply(state: &mut State, operation: &Operation) -> Option<MappingRevision> {
+        match operation {
+            Operation::PutPathIndex(entry) => {
+                state
+                    .namespaces
+                    .entry(entry.namespace.as_str().to_owned())
+                    .or_default()
+                    .paths
+                    .insert(entry.path.clone(), entry.inode);
+                None
+            }
+            Operation::RemovePathIndex { namespace, path } => {
+                if let Some(ns) = state.namespaces.get_mut(namespace.as_str()) {
+                    ns.paths.remove(path);
+                }
+                None
+            }
+            Operation::PutInode(record) => {
+                state
+                    .namespaces
+                    .entry(record.namespace.as_str().to_owned())
+                    .or_default()
+                    .inodes
+                    .insert(record.inode.get(), record.clone());
+                None
+            }
+            Operation::RemoveInode { namespace, inode } => {
+                if let Some(ns) = state.namespaces.get_mut(namespace.as_str()) {
+                    ns.inodes.remove(&inode.get());
+                }
+                None
+            }
+            Operation::PutTransition(transition) => {
+                state
+                    .namespaces
+                    .entry(transition.namespace.as_str().to_owned())
+                    .or_default()
+                    .transitions
+                    .insert(transition.operation_id.clone(), transition.clone());
+                None
+            }
+            Operation::RemoveTransition {
+                namespace,
+                operation_id,
+            } => {
+                if let Some(ns) = state.namespaces.get_mut(namespace.as_str()) {
+                    ns.transitions.remove(operation_id);
+                }
+                None
+            }
+            Operation::AdvanceMappingRevision { namespace } => {
+                let ns = state
+                    .namespaces
+                    .entry(namespace.as_str().to_owned())
+                    .or_default();
+                ns.mapping_revision = ns.mapping_revision.next();
+                Some(ns.mapping_revision)
+            }
+        }
+    }
+
+    /// A snapshot of one namespace, for contract assertions.
+    ///
+    /// Exposes internal state so the shared suite can prove that a failed
+    /// transaction left *nothing* behind — a claim that cannot be made from the
+    /// public read API alone, since it must also cover records the caller never
+    /// asked for.
+    pub fn state_snapshot(&self, namespace: &NamespaceId) -> NamespaceSnapshot {
+        let state = self.state.lock().expect("metadata state mutex poisoned");
+        state
+            .namespaces
+            .get(namespace.as_str())
+            .map_or_else(NamespaceSnapshot::default, |ns| NamespaceSnapshot {
+                mapping_revision: ns.mapping_revision,
+                paths: ns.paths.clone(),
+                inodes: ns.inodes.clone(),
+                transitions: ns.transitions.clone(),
+            })
+    }
+
+    /// Load a link transition, if present.
+    ///
+    /// # Errors
+    ///
+    /// [`MetadataError::CapabilityUnsupported`] when hard links are not
+    /// advertised.
+    pub fn load_transition(
+        &self,
+        namespace: &NamespaceId,
+        operation_id: &str,
+    ) -> MetadataResult<Option<LinkTransition>> {
+        self.require(Capability::HardLinks)?;
+        let state = self.state.lock().expect("metadata state mutex poisoned");
+        Ok(state
+            .namespaces
+            .get(namespace.as_str())
+            .and_then(|ns| ns.transitions.get(operation_id))
+            .cloned())
+    }
+}
+
+impl Default for MemoryMetadataStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl MetadataStore for MemoryMetadataStore {
+    fn backend(&self) -> MetadataBackend {
+        MetadataBackend::Memory
+    }
+
+    fn capabilities(&self) -> CapabilitySet {
+        self.capabilities
+    }
+
+    async fn check_ready(&self) -> MetadataResult<BackendHealth> {
+        Ok(BackendHealth {
+            ready: true,
+            detail: "in-process metadata store".to_owned(),
+        })
+    }
+
+    async fn mapping_revision(&self, namespace: &NamespaceId) -> MetadataResult<MappingRevision> {
+        self.require(Capability::HardLinks)?;
+        let state = self.state.lock().expect("metadata state mutex poisoned");
+        Ok(state
+            .namespaces
+            .get(namespace.as_str())
+            .map_or(MappingRevision::INITIAL, |ns| ns.mapping_revision))
+    }
+
+    async fn resolve_path(
+        &self,
+        namespace: &NamespaceId,
+        path: &str,
+    ) -> MetadataResult<Option<PathIndexEntry>> {
+        self.require(Capability::HardLinks)?;
+        let state = self.state.lock().expect("metadata state mutex poisoned");
+        Ok(state
+            .namespaces
+            .get(namespace.as_str())
+            .and_then(|ns| ns.paths.get(path))
+            .map(|inode| PathIndexEntry {
+                namespace: namespace.clone(),
+                path: path.to_owned(),
+                inode: *inode,
+            }))
+    }
+
+    async fn load_inode(
+        &self,
+        namespace: &NamespaceId,
+        inode: InodeNumber,
+    ) -> MetadataResult<InodeRecord> {
+        self.require(Capability::HardLinks)?;
+        let state = self.state.lock().expect("metadata state mutex poisoned");
+        state
+            .namespaces
+            .get(namespace.as_str())
+            .and_then(|ns| ns.inodes.get(&inode.get()))
+            .cloned()
+            .ok_or_else(|| MetadataError::NotFound {
+                key: format!("inode/{inode}"),
+            })
+    }
+}

--- a/crates/talon-metadata/src/revision.rs
+++ b/crates/talon-metadata/src/revision.rs
@@ -73,7 +73,7 @@ impl fmt::Display for StoreRevision {
 /// stops a client holding a cached path mapping from writing to an object that
 /// a concurrent hard-link promotion has already moved to inode-addressed
 /// storage.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
 pub struct MappingRevision(u64);
 
 impl MappingRevision {

--- a/crates/talon-metadata/src/transaction.rs
+++ b/crates/talon-metadata/src/transaction.rs
@@ -1,0 +1,233 @@
+//! Atomic multi-record transactions.
+//!
+//! ADR 0003 §5's promotion commit is a single compare-and-swap that must apply
+//! four changes together:
+//!
+//! ```text
+//! source_path -> inode
+//! new_path    -> inode
+//! inode.link_count = 2
+//! remove LinkTransition
+//! ```
+//!
+//! > That TMS transaction is the linearization point of `link()`. Before it,
+//! > `source_path` is authoritative and `new_path` does not exist. After it, the
+//! > inode object is authoritative for both paths.
+//!
+//! Partial application has no valid interpretation. A crash between the two path
+//! writes leaves one name resolving to an inode and the other to a
+//! path-addressed object that post-commit cleanup is about to delete — the
+//! divergence #363 is about, reintroduced one layer down.
+//!
+//! This is also why the capability exists. §7 requires hard links to have
+//! "atomic transactions across transition, inode, and path index records", and a
+//! backend that can only do single-key compare-and-swap must refuse
+//! [`Capability::HardLinks`](crate::Capability::HardLinks) rather than emulate
+//! the transaction with a sequence of writes.
+
+use crate::record::{InodeNumber, InodeRecord, NamespaceId, PathIndexEntry};
+use crate::revision::MappingRevision;
+
+/// A precondition evaluated atomically before a transaction applies.
+///
+/// All conditions are checked against one linearizable view. If any fails, no
+/// operation in the transaction is applied.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Precondition {
+    /// The namespace's mapping revision equals this value.
+    ///
+    /// §5 requires the promotion commit to verify the mapping revision it was
+    /// formed against. Without this, a transition prepared against one view of
+    /// the namespace could commit after a concurrent transition already moved
+    /// the same path.
+    MappingRevisionIs {
+        /// Namespace being fenced.
+        namespace: NamespaceId,
+        /// Revision the caller resolved against.
+        expected: MappingRevision,
+    },
+    /// The path has no index entry — it is an ordinary single-path file.
+    ///
+    /// §5: "A current negative mapping proves that an ordinary unlinked object
+    /// still uses its visible path."
+    PathIsUnmapped {
+        /// Namespace owning the path.
+        namespace: NamespaceId,
+        /// Path that must not resolve to an inode.
+        path: String,
+    },
+    /// The path resolves to this inode.
+    PathResolvesTo {
+        /// Namespace owning the path.
+        namespace: NamespaceId,
+        /// Path being checked.
+        path: String,
+        /// Inode the path must resolve to.
+        inode: InodeNumber,
+    },
+    /// A link transition with this operation id exists and is unchanged.
+    ///
+    /// Fences a resumed transition against its own predecessor: a recovering
+    /// coordinator must not commit a transition that another has already
+    /// aborted.
+    TransitionExists {
+        /// Namespace owning the transition.
+        namespace: NamespaceId,
+        /// Operation identifier.
+        operation_id: String,
+    },
+    /// No link transition exists for this operation id.
+    TransitionAbsent {
+        /// Namespace owning the transition.
+        namespace: NamespaceId,
+        /// Operation identifier.
+        operation_id: String,
+    },
+}
+
+/// A single record mutation within a transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Operation {
+    /// Create or replace a path index entry.
+    PutPathIndex(PathIndexEntry),
+    /// Remove a path index entry.
+    RemovePathIndex {
+        /// Namespace owning the path.
+        namespace: NamespaceId,
+        /// Path to unmap.
+        path: String,
+    },
+    /// Create or replace an inode record.
+    PutInode(InodeRecord),
+    /// Remove an inode record.
+    ///
+    /// Used by demotion, which §5 requires as "the required inverse of
+    /// promotion, not an optional space optimization" — leaving the record
+    /// behind would violate §3's sparsity claim.
+    RemoveInode {
+        /// Namespace owning the inode.
+        namespace: NamespaceId,
+        /// Inode to remove.
+        inode: InodeNumber,
+    },
+    /// Create or replace a link transition record.
+    PutTransition(crate::record::LinkTransition),
+    /// Remove a link transition record.
+    RemoveTransition {
+        /// Namespace owning the transition.
+        namespace: NamespaceId,
+        /// Operation identifier.
+        operation_id: String,
+    },
+    /// Advance the namespace mapping revision.
+    ///
+    /// §5: "Creating a transition advances the revision." Clients carrying an
+    /// older revision are rejected with a stale-mapping error and refresh,
+    /// which is what closes the race where a client holding a stale negative
+    /// mapping writes to a visible path after promotion moved it.
+    AdvanceMappingRevision {
+        /// Namespace whose revision advances.
+        namespace: NamespaceId,
+    },
+}
+
+/// An all-or-nothing set of preconditions and operations.
+///
+/// Build with [`Transaction::new`], add preconditions with
+/// [`Transaction::when`], and operations with [`Transaction::then`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Transaction {
+    preconditions: Vec<Precondition>,
+    operations: Vec<Operation>,
+}
+
+impl Transaction {
+    /// An empty transaction.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a precondition.
+    #[must_use]
+    pub fn when(mut self, precondition: Precondition) -> Self {
+        self.preconditions.push(precondition);
+        self
+    }
+
+    /// Add an operation.
+    #[must_use]
+    pub fn then(mut self, operation: Operation) -> Self {
+        self.operations.push(operation);
+        self
+    }
+
+    /// Preconditions, in declaration order.
+    pub fn preconditions(&self) -> &[Precondition] {
+        &self.preconditions
+    }
+
+    /// Operations, in declaration order.
+    pub fn operations(&self) -> &[Operation] {
+        &self.operations
+    }
+
+    /// Whether the transaction would change nothing.
+    pub fn is_empty(&self) -> bool {
+        self.operations.is_empty()
+    }
+}
+
+/// Outcome of a committed transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransactionOutcome {
+    /// Revision at which the transaction committed.
+    pub revision: crate::revision::StoreRevision,
+    /// Namespace mapping revision after any advance, when one was requested.
+    pub mapping_revision: Option<MappingRevision>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn namespace() -> NamespaceId {
+        NamespaceId::new("ns").expect("valid namespace")
+    }
+
+    #[test]
+    fn an_empty_transaction_changes_nothing() {
+        assert!(Transaction::new().is_empty());
+    }
+
+    #[test]
+    fn preconditions_and_operations_keep_declaration_order() {
+        // Order matters for diagnostics: when a commit fails, the first failing
+        // precondition is the one worth reporting.
+        let transaction = Transaction::new()
+            .when(Precondition::MappingRevisionIs {
+                namespace: namespace(),
+                expected: MappingRevision::INITIAL,
+            })
+            .when(Precondition::PathIsUnmapped {
+                namespace: namespace(),
+                path: "b.bin".to_owned(),
+            })
+            .then(Operation::AdvanceMappingRevision {
+                namespace: namespace(),
+            });
+
+        assert_eq!(transaction.preconditions().len(), 2);
+        assert!(matches!(
+            transaction.preconditions()[0],
+            Precondition::MappingRevisionIs { .. }
+        ));
+        assert!(matches!(
+            transaction.preconditions()[1],
+            Precondition::PathIsUnmapped { .. }
+        ));
+        assert_eq!(transaction.operations().len(), 1);
+        assert!(!transaction.is_empty());
+    }
+}


### PR DESCRIPTION
Closes #385. Part of #380. Builds on #388.

## The suite is the point, not the backend

ADR 0003's correctness arguments rest on *contract* properties — atomic
multi-record transactions, linearizable preconditions, honest capability
refusal. Those need testing against the contract rather than one
implementation, otherwise the etcd backend (#386) can weaken a property
silently and it surfaces later as a hard-link divergence in production.

The suite is exported (`pub mod contract`) rather than `#[cfg(test)]`-private
so #386 runs the identical cases against a real server.

## Why transactions are all-or-nothing

§5's promotion commit applies four changes at once:

```text
source_path -> inode
new_path    -> inode
inode.link_count = 2
remove LinkTransition
```

> That TMS transaction is the linearization point of `link()`.

A partial application has no valid interpretation. One name resolving to an
inode while the other still resolves to a path-addressed object that cleanup is
about to delete is exactly the divergence #363 is about, one layer down.

`a_failed_precondition_applies_nothing` asserts this. It needs a state snapshot
rather than the public read API, because proving *absence* has to cover records
the caller never asked for.

## Capability honesty

The memory store advertises `HardLinks` — it genuinely provides atomic
transactions, since everything happens under one mutex.

It does **not** advertise `Locks` or `WriteBack`. Both need server-observed
session expiry, which a single-process store cannot do for a client in another
process. Write-back additionally needs fencing terms that §9.3 requires to
"survive owner lease expiry" — impossible for state that cannot outlive the
process holding it. Claiming either would be the silent over-promise §7 forbids:

> A backend that cannot satisfy one of these contracts must not advertise that
> capability.

`MemoryMetadataStore::without_capabilities()` exists to exercise the refusal
path, which is covered as deliberately as the happy paths — a backend that
half-applied a transaction, or approximated a missing capability, would pass a
happy-path-only suite.

## Coverage

| Case | Property |
|---|---|
| `unmapped_paths_resolve_to_nothing` | §3 sparsity: a single-path file has no record, and that is not an error |
| `untouched_namespaces_report_the_initial_revision` | sparsity covers the mapping guard too |
| `unsupported_capabilities_are_refused_not_approximated` | §7 refusal is a capability gap, not retryable |
| `a_failed_precondition_applies_nothing` | atomicity |
| `a_promotion_commits_atomically` | §5's four changes land together |
| `a_consumed_mapping_revision_cannot_commit_twice` | the race §5's revision closes |
| `an_already_mapped_path_fails_the_unmapped_precondition` | §5's negative-mapping proof |

## Scope

Still contract and test infrastructure only — no wiring, no runtime behaviour
change. Nothing here enables write-back (§9.11).

## Validation

- 26 unit tests
- `cargo clippy -p talon-metadata --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)