### PR TITLE
feat(metadata): add etcd backend and run the contract suite against it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,14 @@ jobs:
           cargo test -p talon-coordinator
           --features etcd,state-store-testkit
           --test etcd_contract --locked
+      - name: Run etcd metadata-store contract tests
+        # Same ephemeral etcd, different store. ADR 0003 §7 keeps TMS and
+        # ClusterStateStore as separate abstractions under separate prefixes,
+        # and one of these tests asserts the two cannot collide.
+        run: >-
+          cargo test -p talon-metadata
+          --features etcd
+          --test etcd_backend --locked
 
   docker-build:
     name: docker image build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2587,9 +2587,11 @@ name = "talon-metadata"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "etcd-client",
  "serde",
  "thiserror 2.0.19",
  "tokio",
+ "tonic",
  "tracing",
 ]
 

--- a/crates/talon-metadata/Cargo.toml
+++ b/crates/talon-metadata/Cargo.toml
@@ -9,9 +9,17 @@ description = "Optional Metadata Store (TMS) for facts that cannot be derived fr
 
 [dependencies]
 thiserror.workspace = true
+etcd-client = { workspace = true, optional = true }
+tonic = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true, features = ["time"] }
 serde.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+
+[features]
+# Production etcd TMS backend. Off by default so non-etcd builds do not pull in
+# the gRPC/TLS stack, mirroring talon-coordinator's etcd feature.
+etcd = ["dep:etcd-client", "dep:tonic", "dep:tokio"]

--- a/crates/talon-metadata/src/contract.rs
+++ b/crates/talon-metadata/src/contract.rs
@@ -15,14 +15,23 @@
 
 use crate::capability::Capability;
 use crate::error::MetadataError;
-use crate::memory::MemoryMetadataStore;
 use crate::record::{InodeRecord, LinkCount, NamespaceId, PathIndexEntry};
 use crate::revision::MappingRevision;
 use crate::transaction::{Operation, Precondition, Transaction};
 use crate::{InodeNumber, MetadataStore};
 
-fn namespace() -> NamespaceId {
-    NamespaceId::new("contract-ns").expect("valid namespace")
+/// A namespace unique to one case.
+///
+/// Cases must not assume a freshly constructed store: a backend under test may
+/// be a shared etcd server, and the suite has to be runnable twice against it.
+/// Scoping each case to its own namespace makes every case independent of
+/// execution order and of anything left behind by a previous run.
+fn namespace(case: &str) -> NamespaceId {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock after epoch")
+        .as_nanos();
+    NamespaceId::new(format!("contract-{case}-{nanos}")).expect("valid namespace")
 }
 
 fn inode(value: u64) -> InodeNumber {
@@ -79,7 +88,7 @@ fn promotion(
 /// would exceed etcd's in-memory keyspace. `resolve_path` returning `None` is
 /// the normal case, not an error.
 pub async fn unmapped_paths_resolve_to_nothing(store: &impl MetadataStore) {
-    let ns = namespace();
+    let ns = namespace("unmapped");
     let resolved = store
         .resolve_path(&ns, "ordinary/file.bin")
         .await
@@ -112,7 +121,7 @@ pub async fn unsupported_capabilities_are_refused_not_approximated(store: &impl 
     if store.supports(Capability::HardLinks) {
         return;
     }
-    let ns = namespace();
+    let ns = namespace("refusal");
     let error = store
         .resolve_path(&ns, "a.bin")
         .await
@@ -133,35 +142,43 @@ pub async fn unsupported_capabilities_are_refused_not_approximated(store: &impl 
 /// would leave one path resolving to an inode and the other to a path-addressed
 /// object that cleanup is about to delete — reintroducing #363's divergence one
 /// layer down.
-pub fn a_failed_precondition_applies_nothing(store: &MemoryMetadataStore) {
-    let ns = namespace();
+pub async fn a_failed_precondition_applies_nothing(store: &impl MetadataStore) {
+    let ns = namespace("atomicity");
     let ino = inode(42);
 
     let stale = promotion(&ns, "a.bin", "b.bin", ino, MappingRevision::new(99));
     let error = store
         .commit(&stale)
+        .await
         .expect_err("a stale mapping revision must not commit");
     assert!(matches!(error, MetadataError::CompareAndSwapFailed { .. }));
 
-    let state = store.state_snapshot(&ns);
-    assert!(
-        state.paths.is_empty(),
+    // Absence is the assertion. Every record the transaction would have written
+    // must be missing, including ones no caller asks for by name.
+    assert_eq!(
+        store.resolve_path(&ns, "a.bin").await.expect("resolve"),
+        None,
+        "no path index entry may survive a failed transaction"
+    );
+    assert_eq!(
+        store.resolve_path(&ns, "b.bin").await.expect("resolve"),
+        None,
         "no path index entry may survive a failed transaction"
     );
     assert!(
-        state.inodes.is_empty(),
+        store.load_inode(&ns, ino).await.is_err(),
         "no inode record may survive a failed transaction"
     );
     assert_eq!(
-        state.mapping_revision,
+        store.mapping_revision(&ns).await.expect("revision"),
         MappingRevision::INITIAL,
         "the mapping revision must not advance on a failed transaction"
     );
 }
 
 /// A promotion commit applies all four changes together.
-pub fn a_promotion_commits_atomically(store: &MemoryMetadataStore) {
-    let ns = namespace();
+pub async fn a_promotion_commits_atomically(store: &impl MetadataStore) {
+    let ns = namespace("promotion");
     let ino = inode(7);
 
     let outcome = store
@@ -172,6 +189,7 @@ pub fn a_promotion_commits_atomically(store: &MemoryMetadataStore) {
             ino,
             MappingRevision::INITIAL,
         ))
+        .await
         .expect("promotion commits against the current revision");
 
     assert_eq!(
@@ -180,16 +198,30 @@ pub fn a_promotion_commits_atomically(store: &MemoryMetadataStore) {
         "creating a transition advances the namespace revision (§5)"
     );
 
-    let state = store.state_snapshot(&ns);
-    assert_eq!(state.paths.get("data/a.bin"), Some(&ino));
     assert_eq!(
-        state.paths.get("data/b.bin"),
-        Some(&ino),
+        store
+            .resolve_path(&ns, "data/a.bin")
+            .await
+            .expect("resolve")
+            .map(|entry| entry.inode),
+        Some(ino)
+    );
+    assert_eq!(
+        store
+            .resolve_path(&ns, "data/b.bin")
+            .await
+            .expect("resolve")
+            .map(|entry| entry.inode),
+        Some(ino),
         "both names must resolve to the inode after the linearization point"
     );
     assert_eq!(
-        state.inodes.get(&ino.get()).map(|record| record.link_count),
-        Some(LinkCount::PROMOTED)
+        store
+            .load_inode(&ns, ino)
+            .await
+            .expect("inode record exists")
+            .link_count,
+        LinkCount::PROMOTED
     );
 }
 
@@ -198,8 +230,8 @@ pub fn a_promotion_commits_atomically(store: &MemoryMetadataStore) {
 /// The race §5's mapping revision exists to close: a transition prepared
 /// against one view of the namespace must not commit after a concurrent
 /// transition already moved the same path.
-pub fn a_consumed_mapping_revision_cannot_commit_twice(store: &MemoryMetadataStore) {
-    let ns = namespace();
+pub async fn a_consumed_mapping_revision_cannot_commit_twice(store: &impl MetadataStore) {
+    let ns = namespace("replay");
 
     store
         .commit(&promotion(
@@ -209,6 +241,7 @@ pub fn a_consumed_mapping_revision_cannot_commit_twice(store: &MemoryMetadataSto
             inode(1),
             MappingRevision::INITIAL,
         ))
+        .await
         .expect("first promotion commits");
 
     let error = store
@@ -219,6 +252,7 @@ pub fn a_consumed_mapping_revision_cannot_commit_twice(store: &MemoryMetadataSto
             inode(2),
             MappingRevision::INITIAL,
         ))
+        .await
         .expect_err("a replayed revision must not commit");
     assert!(matches!(error, MetadataError::CompareAndSwapFailed { .. }));
 }
@@ -227,8 +261,8 @@ pub fn a_consumed_mapping_revision_cannot_commit_twice(store: &MemoryMetadataSto
 ///
 /// §5: "A current negative mapping proves that an ordinary unlinked object
 /// still uses its visible path."
-pub fn an_already_mapped_path_fails_the_unmapped_precondition(store: &MemoryMetadataStore) {
-    let ns = namespace();
+pub async fn an_already_mapped_path_fails_the_unmapped_precondition(store: &impl MetadataStore) {
+    let ns = namespace("mapped");
     let ino = inode(5);
 
     store
@@ -239,6 +273,7 @@ pub fn an_already_mapped_path_fails_the_unmapped_precondition(store: &MemoryMeta
             ino,
             MappingRevision::INITIAL,
         ))
+        .await
         .expect("promotion commits");
 
     let transaction = Transaction::new()
@@ -252,7 +287,24 @@ pub fn an_already_mapped_path_fails_the_unmapped_precondition(store: &MemoryMeta
 
     store
         .commit(&transaction)
+        .await
         .expect_err("a mapped path must fail the unmapped precondition");
+}
+
+/// Run every contract case against one store.
+///
+/// Backends call this so a new case is picked up everywhere automatically
+/// rather than needing to be added to each backend's test module.
+pub async fn run_all(store: &impl MetadataStore) {
+    unmapped_paths_resolve_to_nothing(store).await;
+    untouched_namespaces_report_the_initial_revision(store).await;
+    unsupported_capabilities_are_refused_not_approximated(store).await;
+    if store.supports(Capability::HardLinks) {
+        a_failed_precondition_applies_nothing(store).await;
+        a_promotion_commits_atomically(store).await;
+        a_consumed_mapping_revision_cannot_commit_twice(store).await;
+        an_already_mapped_path_fails_the_unmapped_precondition(store).await;
+    }
 }
 
 #[cfg(test)]
@@ -261,6 +313,7 @@ mod tests {
 
     #[tokio::test]
     async fn memory_backend_satisfies_the_async_contract() {
+        use crate::memory::MemoryMetadataStore;
         let store = MemoryMetadataStore::new();
         unmapped_paths_resolve_to_nothing(&store).await;
         untouched_namespaces_report_the_initial_revision(&store).await;
@@ -268,15 +321,17 @@ mod tests {
 
     #[tokio::test]
     async fn a_store_without_capabilities_refuses_rather_than_approximating() {
+        use crate::memory::MemoryMetadataStore;
         let store = MemoryMetadataStore::without_capabilities();
         unsupported_capabilities_are_refused_not_approximated(&store).await;
     }
 
-    #[test]
-    fn memory_backend_satisfies_the_transaction_contract() {
-        a_failed_precondition_applies_nothing(&MemoryMetadataStore::new());
-        a_promotion_commits_atomically(&MemoryMetadataStore::new());
-        a_consumed_mapping_revision_cannot_commit_twice(&MemoryMetadataStore::new());
-        an_already_mapped_path_fails_the_unmapped_precondition(&MemoryMetadataStore::new());
+    #[tokio::test]
+    async fn memory_backend_satisfies_the_transaction_contract() {
+        use crate::memory::MemoryMetadataStore;
+        a_failed_precondition_applies_nothing(&MemoryMetadataStore::new()).await;
+        a_promotion_commits_atomically(&MemoryMetadataStore::new()).await;
+        a_consumed_mapping_revision_cannot_commit_twice(&MemoryMetadataStore::new()).await;
+        an_already_mapped_path_fails_the_unmapped_precondition(&MemoryMetadataStore::new()).await;
     }
 }

--- a/crates/talon-metadata/src/etcd.rs
+++ b/crates/talon-metadata/src/etcd.rs
@@ -1,0 +1,519 @@
+//! etcd-backed [`MetadataStore`].
+//!
+//! ADR 0003 §7 names etcd as the first backend able to carry the richer
+//! capabilities:
+//!
+//! > The first hard-link and write-back TMS implementation therefore targets
+//! > etcd; a lease-only backend may still provide locking if it meets the
+//! > locking contract.
+//!
+//! The reason is transactions. etcd's `Txn` evaluates every comparison against
+//! one revision and applies every operation atomically, which is what §5's
+//! promotion commit needs — the four changes it makes have no valid partial
+//! interpretation.
+//!
+//! # Why etcd is viable despite holding its keyspace in memory
+//!
+//! Only because of §3's sparsity. etcd has "a practical ceiling in the
+//! single-digit GB and a 1.5 MB per-value limit", so per-object records for a
+//! billion-object bucket would not fit. Per-*linked*-file and per-*locked*-file
+//! records are orders of magnitude smaller, and zero for workloads using
+//! neither feature.
+//!
+//! This backend is therefore safe **only while §2's admission rule holds**. If a
+//! per-object record for ordinary files ever lands here, etcd stops being a
+//! viable backend. `record_population_does_not_scale_with_object_count` guards
+//! that.
+//!
+//! # Prefix separation
+//!
+//! §7 permits sharing a physical etcd cluster with `ClusterStateStore` but
+//! requires the two to stay separate abstractions. They use disjoint prefixes,
+//! and `metadata_and_cluster_state_prefixes_do_not_collide` asserts it: mixing
+//! them would make ADR 0001 §2's "bounded, rebuildable" invariant untrue by
+//! construction, because TMS records are neither.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use etcd_client::{Client, Compare, CompareOp, GetOptions, Txn, TxnOp};
+use tokio::time::timeout;
+
+use crate::capability::{Capability, CapabilitySet};
+use crate::error::{MetadataBackend, MetadataError, MetadataResult};
+use crate::record::{InodeNumber, InodeRecord, LinkCount, NamespaceId, PathIndexEntry};
+use crate::revision::{MappingRevision, StoreRevision};
+use crate::transaction::{Operation, Precondition, Transaction, TransactionOutcome};
+use crate::{BackendHealth, MetadataStore};
+
+/// Default keyspace prefix for TMS records.
+///
+/// Deliberately distinct from `ClusterStateStore`'s `/talon`: §7 keeps the two
+/// stores separate even when they share an etcd cluster.
+pub const DEFAULT_METADATA_PREFIX: &str = "/talon-metadata";
+
+const OPERATION_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Configuration for the etcd metadata backend.
+#[derive(Debug, Clone)]
+pub struct EtcdMetadataConfig {
+    /// etcd endpoints.
+    pub endpoints: Vec<String>,
+    /// Keyspace prefix for TMS records.
+    pub prefix: String,
+}
+
+impl EtcdMetadataConfig {
+    /// Configuration for a single endpoint using the default prefix.
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoints: vec![endpoint.into()],
+            prefix: DEFAULT_METADATA_PREFIX.to_owned(),
+        }
+    }
+
+    fn normalized_prefix(&self) -> String {
+        self.prefix.trim_end_matches('/').to_owned()
+    }
+}
+
+/// An etcd-backed metadata store.
+#[derive(Clone)]
+pub struct EtcdMetadataStore {
+    client: Client,
+    prefix: String,
+}
+
+impl std::fmt::Debug for EtcdMetadataStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EtcdMetadataStore")
+            .field("prefix", &self.prefix)
+            .finish_non_exhaustive()
+    }
+}
+
+impl EtcdMetadataStore {
+    /// Connect to etcd.
+    ///
+    /// # Errors
+    ///
+    /// [`MetadataError::Unavailable`] when the cluster cannot be reached.
+    pub async fn connect(config: &EtcdMetadataConfig) -> MetadataResult<Self> {
+        let client = timeout(
+            OPERATION_TIMEOUT,
+            Client::connect(config.endpoints.clone(), None),
+        )
+        .await
+        .map_err(|_| MetadataError::Timeout {
+            backend: MetadataBackend::Etcd,
+        })?
+        .map_err(map_etcd_error)?;
+
+        Ok(Self {
+            client,
+            prefix: config.normalized_prefix(),
+        })
+    }
+
+    fn mapping_revision_key(&self, namespace: &NamespaceId) -> String {
+        format!("{}/ns/{}/mapping_revision", self.prefix, namespace)
+    }
+
+    fn path_key(&self, namespace: &NamespaceId, path: &str) -> String {
+        format!("{}/ns/{}/paths/{path}", self.prefix, namespace)
+    }
+
+    fn inode_key(&self, namespace: &NamespaceId, inode: InodeNumber) -> String {
+        format!("{}/ns/{}/inodes/{inode}", self.prefix, namespace)
+    }
+
+    fn transition_key(&self, namespace: &NamespaceId, operation_id: &str) -> String {
+        format!(
+            "{}/ns/{}/transitions/{operation_id}",
+            self.prefix, namespace
+        )
+    }
+
+    async fn get_raw(&self, key: &str) -> MetadataResult<Option<Vec<u8>>> {
+        let mut client = self.client.clone();
+        let response = timeout(OPERATION_TIMEOUT, client.get(key, None))
+            .await
+            .map_err(|_| MetadataError::Timeout {
+                backend: MetadataBackend::Etcd,
+            })?
+            .map_err(map_etcd_error)?;
+        Ok(response.kvs().first().map(|kv| kv.value().to_vec()))
+    }
+
+    async fn commit_txn(&self, transaction: &Transaction) -> MetadataResult<TransactionOutcome> {
+        let mut compares = Vec::new();
+        for precondition in transaction.preconditions() {
+            compares.push(self.compare_for(precondition).await?);
+        }
+
+        let mut ops = Vec::new();
+        let mut mapping_revision = None;
+        for operation in transaction.operations() {
+            let (op, revision) = self.op_for(operation).await?;
+            // A read-modify-write operation fences itself against the value it
+            // observed, so a concurrent advance between the read and the commit
+            // aborts this transaction rather than silently losing an increment.
+            if let Some(next) = revision {
+                if let Some(fence) = self.fence_for(operation, previous_of(next)) {
+                    compares.push(fence);
+                }
+            }
+            ops.push(op);
+            mapping_revision = revision.or(mapping_revision);
+        }
+
+        let txn = Txn::new().when(compares).and_then(ops);
+        let mut client = self.client.clone();
+        let response = timeout(OPERATION_TIMEOUT, client.txn(txn))
+            .await
+            .map_err(|_| MetadataError::Timeout {
+                backend: MetadataBackend::Etcd,
+            })?
+            .map_err(map_etcd_error)?;
+
+        if !response.succeeded() {
+            return Err(MetadataError::CompareAndSwapFailed {
+                expected: StoreRevision::new("precondition")?,
+                observed: StoreRevision::new("mismatch")?,
+            });
+        }
+
+        let revision = response
+            .header()
+            .map(|header| header.revision())
+            .unwrap_or_default();
+        Ok(TransactionOutcome {
+            revision: StoreRevision::new(revision.to_string())?,
+            mapping_revision,
+        })
+    }
+
+    async fn compare_for(&self, precondition: &Precondition) -> MetadataResult<Compare> {
+        Ok(match precondition {
+            Precondition::MappingRevisionIs {
+                namespace,
+                expected,
+            } => {
+                let key = self.mapping_revision_key(namespace);
+                if *expected == MappingRevision::INITIAL {
+                    // A namespace that has never had a transition stores no
+                    // revision key at all -- that is §3's sparsity claim applied
+                    // to the mapping guard. Comparing its value would evaluate
+                    // against a missing key and always fail, so the absence of
+                    // the key *is* the initial revision.
+                    Compare::create_revision(key, CompareOp::Equal, 0)
+                } else {
+                    Compare::value(key, CompareOp::Equal, expected.get().to_string())
+                }
+            }
+            Precondition::PathIsUnmapped { namespace, path } => {
+                Compare::create_revision(self.path_key(namespace, path), CompareOp::Equal, 0)
+            }
+            Precondition::PathResolvesTo {
+                namespace,
+                path,
+                inode,
+            } => Compare::value(
+                self.path_key(namespace, path),
+                CompareOp::Equal,
+                inode.get().to_string(),
+            ),
+            Precondition::TransitionExists {
+                namespace,
+                operation_id,
+            } => Compare::create_revision(
+                self.transition_key(namespace, operation_id),
+                CompareOp::Greater,
+                0,
+            ),
+            Precondition::TransitionAbsent {
+                namespace,
+                operation_id,
+            } => Compare::create_revision(
+                self.transition_key(namespace, operation_id),
+                CompareOp::Equal,
+                0,
+            ),
+        })
+    }
+
+    async fn op_for(
+        &self,
+        operation: &Operation,
+    ) -> MetadataResult<(TxnOp, Option<MappingRevision>)> {
+        Ok(match operation {
+            Operation::PutPathIndex(entry) => (
+                TxnOp::put(
+                    self.path_key(&entry.namespace, &entry.path),
+                    entry.inode.get().to_string(),
+                    None,
+                ),
+                None,
+            ),
+            Operation::RemovePathIndex { namespace, path } => {
+                (TxnOp::delete(self.path_key(namespace, path), None), None)
+            }
+            Operation::PutInode(record) => (
+                TxnOp::put(
+                    self.inode_key(&record.namespace, record.inode),
+                    encode_inode(record),
+                    None,
+                ),
+                None,
+            ),
+            Operation::RemoveInode { namespace, inode } => {
+                (TxnOp::delete(self.inode_key(namespace, *inode), None), None)
+            }
+            Operation::PutTransition(transition) => (
+                TxnOp::put(
+                    self.transition_key(&transition.namespace, &transition.operation_id),
+                    transition.source_path.clone(),
+                    None,
+                ),
+                None,
+            ),
+            Operation::RemoveTransition {
+                namespace,
+                operation_id,
+            } => (
+                TxnOp::delete(self.transition_key(namespace, operation_id), None),
+                None,
+            ),
+            Operation::AdvanceMappingRevision { namespace } => {
+                // Read-modify-write, so the value read here must be fenced or a
+                // concurrent transaction could advance the revision between the
+                // read and the commit and one increment would be lost. The
+                // caller usually supplies MappingRevisionIs, but correctness
+                // must not depend on the caller remembering: `fence_for` adds
+                // the matching comparison unconditionally, and a duplicate is
+                // harmless because etcd evaluates all comparisons against one
+                // revision.
+                let current = self.read_mapping_revision(namespace).await?;
+                let next = current.next();
+                (
+                    TxnOp::put(
+                        self.mapping_revision_key(namespace),
+                        next.get().to_string(),
+                        None,
+                    ),
+                    Some(next),
+                )
+            }
+        })
+    }
+
+    /// The comparison that fences a read-modify-write operation.
+    ///
+    /// Returns `None` for operations that write an absolute value and therefore
+    /// need no fence.
+    fn fence_for(&self, operation: &Operation, observed: MappingRevision) -> Option<Compare> {
+        match operation {
+            Operation::AdvanceMappingRevision { namespace } => {
+                let key = self.mapping_revision_key(namespace);
+                Some(if observed == MappingRevision::INITIAL {
+                    Compare::create_revision(key, CompareOp::Equal, 0)
+                } else {
+                    Compare::value(key, CompareOp::Equal, observed.get().to_string())
+                })
+            }
+            _ => None,
+        }
+    }
+
+    async fn read_mapping_revision(
+        &self,
+        namespace: &NamespaceId,
+    ) -> MetadataResult<MappingRevision> {
+        let key = self.mapping_revision_key(namespace);
+        let Some(raw) = self.get_raw(&key).await? else {
+            return Ok(MappingRevision::INITIAL);
+        };
+        decode_u64(&raw).map(MappingRevision::new)
+    }
+
+    /// Count stored keys under this store's prefix.
+    ///
+    /// Exists for the regression test that guards §2's admission rule: if the
+    /// record population ever starts tracking object count, etcd stops being a
+    /// viable backend (§3).
+    ///
+    /// # Errors
+    ///
+    /// [`MetadataError::Unavailable`] when etcd cannot be reached.
+    pub async fn record_count(&self) -> MetadataResult<i64> {
+        let mut client = self.client.clone();
+        let response = timeout(
+            OPERATION_TIMEOUT,
+            client.get(
+                self.prefix.clone(),
+                Some(GetOptions::new().with_prefix().with_count_only()),
+            ),
+        )
+        .await
+        .map_err(|_| MetadataError::Timeout {
+            backend: MetadataBackend::Etcd,
+        })?
+        .map_err(map_etcd_error)?;
+        Ok(response.count())
+    }
+}
+
+#[async_trait]
+impl MetadataStore for EtcdMetadataStore {
+    fn backend(&self) -> MetadataBackend {
+        MetadataBackend::Etcd
+    }
+
+    fn capabilities(&self) -> CapabilitySet {
+        // Hard links only. etcd can satisfy the write-back contract's
+        // transactional requirements, but §9.11 keeps write-back unreachable
+        // until an ADR superseding ADR 0002 is accepted, and locks await their
+        // own ADR defining byte-range representation, fairness, waiter
+        // recovery, and deadlock detection. Advertising either before the
+        // supporting mechanism exists would be the over-promise §7 forbids.
+        CapabilitySet::none().with(Capability::HardLinks)
+    }
+
+    async fn check_ready(&self) -> MetadataResult<BackendHealth> {
+        let mut client = self.client.clone();
+        match timeout(OPERATION_TIMEOUT, client.status()).await {
+            Ok(Ok(_)) => Ok(BackendHealth {
+                ready: true,
+                detail: "etcd reachable".to_owned(),
+            }),
+            Ok(Err(error)) => Ok(BackendHealth {
+                ready: false,
+                detail: sanitize(&error.to_string()),
+            }),
+            Err(_) => Ok(BackendHealth {
+                ready: false,
+                detail: "status request timed out".to_owned(),
+            }),
+        }
+    }
+
+    async fn mapping_revision(&self, namespace: &NamespaceId) -> MetadataResult<MappingRevision> {
+        self.read_mapping_revision(namespace).await
+    }
+
+    async fn resolve_path(
+        &self,
+        namespace: &NamespaceId,
+        path: &str,
+    ) -> MetadataResult<Option<PathIndexEntry>> {
+        let key = self.path_key(namespace, path);
+        let Some(raw) = self.get_raw(&key).await? else {
+            return Ok(None);
+        };
+        let inode = InodeNumber::new(decode_u64(&raw)?)?;
+        Ok(Some(PathIndexEntry {
+            namespace: namespace.clone(),
+            path: path.to_owned(),
+            inode,
+        }))
+    }
+
+    async fn commit(&self, transaction: &Transaction) -> MetadataResult<TransactionOutcome> {
+        self.commit_txn(transaction).await
+    }
+
+    async fn load_inode(
+        &self,
+        namespace: &NamespaceId,
+        inode: InodeNumber,
+    ) -> MetadataResult<InodeRecord> {
+        let key = self.inode_key(namespace, inode);
+        let raw = self
+            .get_raw(&key)
+            .await?
+            .ok_or_else(|| MetadataError::NotFound {
+                key: format!("inode/{inode}"),
+            })?;
+        decode_inode(namespace, inode, &raw)
+    }
+}
+
+fn encode_inode(record: &InodeRecord) -> String {
+    format!("{}:{}", record.link_count.get(), u8::from(record.corrupt))
+}
+
+fn decode_inode(
+    namespace: &NamespaceId,
+    inode: InodeNumber,
+    raw: &[u8],
+) -> MetadataResult<InodeRecord> {
+    let text = std::str::from_utf8(raw).map_err(|_| MetadataError::InvalidRecord {
+        detail: "inode record is not valid UTF-8".to_owned(),
+    })?;
+    let (count, corrupt) = text
+        .split_once(':')
+        .ok_or_else(|| MetadataError::InvalidRecord {
+            detail: "inode record must be <link_count>:<corrupt>".to_owned(),
+        })?;
+    let link_count =
+        LinkCount::new(
+            count
+                .parse::<u64>()
+                .map_err(|_| MetadataError::InvalidRecord {
+                    detail: "inode link count is not a number".to_owned(),
+                })?,
+        )?;
+    Ok(InodeRecord {
+        namespace: namespace.clone(),
+        inode,
+        link_count,
+        corrupt: corrupt != "0",
+    })
+}
+
+fn decode_u64(raw: &[u8]) -> MetadataResult<u64> {
+    std::str::from_utf8(raw)
+        .ok()
+        .and_then(|text| text.parse::<u64>().ok())
+        .ok_or_else(|| MetadataError::InvalidRecord {
+            detail: "value is not a base-10 integer".to_owned(),
+        })
+}
+
+fn sanitize(detail: &str) -> String {
+    detail.replace(['\n', '\r'], " ")
+}
+
+fn map_etcd_error(error: etcd_client::Error) -> MetadataError {
+    use etcd_client::Error;
+    match error {
+        Error::GRpcStatus(status) => match status.code() {
+            tonic::Code::Unauthenticated => MetadataError::Authentication {
+                backend: MetadataBackend::Etcd,
+            },
+            tonic::Code::PermissionDenied => MetadataError::PermissionDenied {
+                backend: MetadataBackend::Etcd,
+            },
+            tonic::Code::DeadlineExceeded => MetadataError::Timeout {
+                backend: MetadataBackend::Etcd,
+            },
+            _ => MetadataError::Unavailable {
+                backend: MetadataBackend::Etcd,
+                detail: sanitize(status.message()),
+            },
+        },
+        other => MetadataError::Unavailable {
+            backend: MetadataBackend::Etcd,
+            detail: sanitize(&other.to_string()),
+        },
+    }
+}
+
+/// The revision immediately before `next`.
+///
+/// `op_for` returns the value it will write; the fence has to compare against
+/// the value it read. Saturating at zero is correct because
+/// [`MappingRevision::INITIAL`] is the floor.
+fn previous_of(next: MappingRevision) -> MappingRevision {
+    MappingRevision::new(next.get().saturating_sub(1))
+}

--- a/crates/talon-metadata/src/lib.rs
+++ b/crates/talon-metadata/src/lib.rs
@@ -61,6 +61,8 @@
 mod capability;
 pub mod contract;
 mod error;
+#[cfg(feature = "etcd")]
+mod etcd;
 mod memory;
 mod record;
 mod revision;
@@ -75,6 +77,9 @@ pub use record::{
 };
 pub use revision::{MappingRevision, StoreRevision};
 pub use transaction::{Operation, Precondition, Transaction, TransactionOutcome};
+
+#[cfg(feature = "etcd")]
+pub use etcd::{EtcdMetadataConfig, EtcdMetadataStore, DEFAULT_METADATA_PREFIX};
 
 use async_trait::async_trait;
 
@@ -185,6 +190,24 @@ pub trait MetadataStore: Send + Sync {
         namespace: &NamespaceId,
         inode: InodeNumber,
     ) -> MetadataResult<InodeRecord>;
+
+    /// Apply a transaction atomically.
+    ///
+    /// Every precondition is evaluated against one linearizable view before any
+    /// operation applies. A failure leaves the store untouched.
+    ///
+    /// This is on the trait rather than each backend because §5's promotion
+    /// commit depends on the property, and the shared contract suite has to be
+    /// able to assert it for *every* backend. A backend that cannot provide
+    /// cross-record atomicity must not advertise [`Capability::HardLinks`] and
+    /// must reject this call, per §7.
+    ///
+    /// # Errors
+    ///
+    /// [`MetadataError::CompareAndSwapFailed`] when a precondition does not
+    /// hold, or [`MetadataError::CapabilityUnsupported`] when the backend does
+    /// not advertise the capability the transaction requires.
+    async fn commit(&self, transaction: &Transaction) -> MetadataResult<TransactionOutcome>;
 }
 
 #[cfg(test)]
@@ -237,6 +260,13 @@ mod tests {
             _namespace: &NamespaceId,
             _inode: InodeNumber,
         ) -> MetadataResult<InodeRecord> {
+            Err(MetadataError::CapabilityUnsupported {
+                backend: self.backend(),
+                capability: Capability::HardLinks,
+            })
+        }
+
+        async fn commit(&self, _transaction: &Transaction) -> MetadataResult<TransactionOutcome> {
             Err(MetadataError::CapabilityUnsupported {
                 backend: self.backend(),
                 capability: Capability::HardLinks,

--- a/crates/talon-metadata/src/memory.rs
+++ b/crates/talon-metadata/src/memory.rs
@@ -94,18 +94,7 @@ impl MemoryMetadataStore {
         })
     }
 
-    /// Apply a transaction atomically.
-    ///
-    /// Every precondition is evaluated against one view before any operation is
-    /// applied, so a failure leaves the store untouched. This is the property
-    /// §5's promotion commit depends on.
-    ///
-    /// # Errors
-    ///
-    /// [`MetadataError::CompareAndSwapFailed`] when a precondition does not
-    /// hold, or [`MetadataError::CapabilityUnsupported`] when hard links are not
-    /// advertised.
-    pub fn commit(&self, transaction: &Transaction) -> MetadataResult<TransactionOutcome> {
+    fn commit_locked(&self, transaction: &Transaction) -> MetadataResult<TransactionOutcome> {
         self.require(Capability::HardLinks)?;
         let mut state = self.state.lock().expect("metadata state mutex poisoned");
 
@@ -369,5 +358,9 @@ impl MetadataStore for MemoryMetadataStore {
             .ok_or_else(|| MetadataError::NotFound {
                 key: format!("inode/{inode}"),
             })
+    }
+
+    async fn commit(&self, transaction: &Transaction) -> MetadataResult<TransactionOutcome> {
+        self.commit_locked(transaction)
     }
 }

--- a/crates/talon-metadata/tests/etcd_backend.rs
+++ b/crates/talon-metadata/tests/etcd_backend.rs
@@ -1,0 +1,145 @@
+//! etcd metadata backend against a real server.
+//!
+//! Runs the shared contract suite, so the etcd backend is held to the identical
+//! cases as the memory backend. ADR 0003 §7 lists the properties TMS
+//! correctness rests on; testing them per-implementation would let this backend
+//! weaken one silently, and the symptom would be a hard-link divergence in
+//! production rather than a red test.
+//!
+//! Requires `TALON_ETCD_TEST_ENDPOINT`. Skips when unset so a local
+//! `cargo test` without etcd stays green.
+
+#![cfg(feature = "etcd")]
+
+use talon_metadata::{
+    contract, Capability, EtcdMetadataConfig, EtcdMetadataStore, InodeNumber, MappingRevision,
+    MetadataStore, NamespaceId, Operation, PathIndexEntry, Precondition, Transaction,
+};
+
+fn endpoint() -> Option<String> {
+    std::env::var("TALON_ETCD_TEST_ENDPOINT")
+        .ok()
+        .filter(|value| !value.is_empty())
+}
+
+/// A prefix unique to one test, so cases cannot interfere through shared etcd.
+fn unique_prefix(name: &str) -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock after epoch")
+        .as_nanos();
+    format!("/talon-metadata-test/{name}-{nanos}")
+}
+
+async fn store_for(name: &str) -> Option<EtcdMetadataStore> {
+    let endpoint = endpoint()?;
+    let mut config = EtcdMetadataConfig::new(endpoint);
+    config.prefix = unique_prefix(name);
+    Some(
+        EtcdMetadataStore::connect(&config)
+            .await
+            .expect("etcd is reachable at TALON_ETCD_TEST_ENDPOINT"),
+    )
+}
+
+#[tokio::test]
+async fn etcd_backend_satisfies_the_shared_contract() {
+    let Some(store) = store_for("contract").await else {
+        eprintln!("skipping: TALON_ETCD_TEST_ENDPOINT is not set");
+        return;
+    };
+    contract::run_all(&store).await;
+}
+
+#[tokio::test]
+async fn etcd_advertises_hard_links_and_withholds_the_rest() {
+    let Some(store) = store_for("capabilities").await else {
+        eprintln!("skipping: TALON_ETCD_TEST_ENDPOINT is not set");
+        return;
+    };
+
+    // etcd can satisfy the transactional part of every contract, but §9.11
+    // keeps write-back unreachable until an ADR superseding ADR 0002 is
+    // accepted, and locks await their own ADR. Advertising a capability whose
+    // supporting mechanism does not exist is the over-promise §7 forbids.
+    assert!(store.supports(Capability::HardLinks));
+    assert!(!store.supports(Capability::Locks));
+    assert!(!store.supports(Capability::WriteBack));
+}
+
+#[tokio::test]
+async fn metadata_and_cluster_state_prefixes_do_not_collide() {
+    let Some(endpoint) = endpoint() else {
+        eprintln!("skipping: TALON_ETCD_TEST_ENDPOINT is not set");
+        return;
+    };
+
+    // §7 permits sharing a physical etcd cluster but requires the two stores to
+    // stay separate abstractions. ClusterStateStore uses /talon; TMS must not
+    // land inside it, or ADR 0001 §2's "bounded, rebuildable" invariant would
+    // become untrue by construction -- TMS records are neither.
+    let config = EtcdMetadataConfig::new(endpoint);
+    assert!(
+        !config.prefix.starts_with("/talon/"),
+        "TMS prefix {} must not nest inside the cluster-state prefix",
+        config.prefix
+    );
+    assert_ne!(config.prefix, "/talon");
+}
+
+#[tokio::test]
+async fn record_population_does_not_scale_with_object_count() {
+    let Some(store) = store_for("sparsity").await else {
+        eprintln!("skipping: TALON_ETCD_TEST_ENDPOINT is not set");
+        return;
+    };
+
+    // §3's sparsity claim is what makes an etcd-class backend viable at all:
+    // etcd holds its keyspace in memory, so per-object records for a
+    // billion-object bucket would not fit. This asserts that reading many
+    // ordinary single-path files creates nothing.
+    let namespace = NamespaceId::new("sparsity-ns").expect("valid namespace");
+    let before = store.record_count().await.expect("count records");
+
+    for index in 0..500 {
+        let resolved = store
+            .resolve_path(&namespace, &format!("ordinary/file-{index}.bin"))
+            .await
+            .expect("resolving an unmapped path is not an error");
+        assert_eq!(resolved, None, "a single-path file must have no record");
+    }
+
+    let after = store.record_count().await.expect("count records");
+    assert_eq!(
+        before, after,
+        "500 ordinary files must add zero TMS records (ADR 0003 §3)"
+    );
+
+    // One promoted pair does create records -- sparsity is proportional to
+    // feature use, not to data volume.
+    let inode = InodeNumber::new(1).expect("non-zero inode");
+    store
+        .commit(
+            &Transaction::new()
+                .when(Precondition::MappingRevisionIs {
+                    namespace: namespace.clone(),
+                    expected: MappingRevision::INITIAL,
+                })
+                .then(Operation::PutPathIndex(PathIndexEntry {
+                    namespace: namespace.clone(),
+                    path: "linked/a.bin".to_owned(),
+                    inode,
+                }))
+                .then(Operation::AdvanceMappingRevision {
+                    namespace: namespace.clone(),
+                }),
+        )
+        .await
+        .expect("promotion commits");
+
+    let promoted = store.record_count().await.expect("count records");
+    assert!(
+        promoted > after,
+        "a multiply-linked file does occupy records"
+    );
+}


### PR DESCRIPTION
Closes #386. Part of #380.

§7 names etcd as the first backend able to carry hard links, because its `Txn`
evaluates every comparison against one revision and applies every operation
atomically — what §5's promotion commit needs, since its four changes have no
valid partial interpretation.

## Running the shared suite against a real server found two bugs

Neither is reachable through the memory backend. This is the argument #385 made
for a shared suite, and it paid immediately.

**A missing key is not a key holding zero.** `MappingRevisionIs` with the
initial revision compiled to a value comparison against `"0"` — but a namespace
that has never had a transition stores *no revision key at all*. That is §3's
sparsity claim applied to the mapping guard. etcd compares a missing key as
false, so **every first promotion in a namespace failed**. The absence of the
key is now what represents the initial revision.

**`AdvanceMappingRevision` was an unfenced read-modify-write.** A concurrent
transaction could advance the revision between the read and the commit, losing
one increment. Callers usually pass `MappingRevisionIs`, but correctness must
not depend on the caller remembering, so the comparison is now added
automatically. Duplicates are harmless — etcd evaluates all comparisons against
one revision.

## The suite had a latent defect too

Cases shared one store and assumed it was freshly constructed. The memory
backend hid this by being new per case; against a shared etcd server it made
them order-dependent and non-repeatable. Each case now scopes itself to a unique
namespace, so the suite can run twice against the same server — verified
locally.

## Capability scope

etcd advertises **hard links only**. It could satisfy the transactional
requirements of the other two, but:

- §9.11 keeps write-back unreachable until an ADR superseding ADR 0002 is
  accepted;
- locks await an ADR defining byte-range representation, fairness, waiter
  recovery, and deadlock detection.

Advertising a capability whose supporting mechanism does not exist is the
over-promise §7 forbids. Happy to flip this if you read the capability as "the
store could back it" rather than "the feature is reachable" — it is a one-line
change.

## Sparsity regression test

`record_population_does_not_scale_with_object_count` resolves 500 ordinary
single-path files and asserts the record count is unchanged, then commits one
promotion and asserts it grew. Sparsity is proportional to feature use, not data
volume — and it is the only reason an in-memory-keyspace backend is viable:

> etcd holds its keyspace in memory, with a practical ceiling in the
> single-digit GB and a 1.5 MB per-value limit. — §3

## Prefix separation

`/talon-metadata`, disjoint from `ClusterStateStore`'s `/talon`, with a test
asserting they cannot collide. §7 permits sharing a physical cluster but keeps
the abstractions separate: mixing them would make ADR 0001 §2's "bounded,
rebuildable" invariant untrue by construction, since TMS records are neither.

## Validation

- 4 etcd tests against a real etcd 3.5.16, run twice to prove repeatability
- 26 memory tests unchanged
- clippy `-D warnings` clean with `--features etcd`
- `RUSTDOCFLAGS="-D warnings" cargo doc --all-features` clean — this is the
  check I missed on #389, now part of my pre-push routine
- CI reuses the existing ephemeral etcd rather than starting a second one

🤖 Generated with [Claude Code](https://claude.com/claude-code)