### PR TITLE
feat(coordinator): advertise TMS capabilities with their own revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2537,6 +2537,7 @@ dependencies = [
  "serde",
  "serde_json",
  "talon-core",
+ "talon-metadata",
  "talon-transport",
  "thiserror 2.0.19",
  "tokio",

--- a/crates/talon-coordinator/Cargo.toml
+++ b/crates/talon-coordinator/Cargo.toml
@@ -33,6 +33,7 @@ etcd = ["dep:etcd-client", "dep:tonic"]
 
 [dependencies]
 talon-core.workspace = true
+talon-metadata.workspace = true
 talon-transport.workspace = true
 anyhow.workspace = true
 tokio.workspace = true

--- a/crates/talon-coordinator/src/api.rs
+++ b/crates/talon-coordinator/src/api.rs
@@ -57,6 +57,38 @@ pub struct ResponseMeta {
     pub backend: String,
 }
 
+/// What this cluster offers, and whether it can serve it right now.
+///
+/// ADR 0003 §4 requires capabilities to be discoverable without attempting an
+/// operation, and to be understood as a property of the *cluster*:
+///
+/// > two Talon clusters may legitimately offer different POSIX semantics. That
+/// > is a product-level fact and must be documented as such, not buried in a
+/// > config reference.
+#[derive(Debug, Clone, Serialize)]
+pub struct CapabilitiesView {
+    /// Capabilities this cluster advertises, e.g. `["hard_links"]`.
+    ///
+    /// Empty for a cluster with no metadata store, which §1 keeps a complete,
+    /// supported deployment offering today's feature set.
+    pub advertised: Vec<String>,
+    /// Revision of the advertised set.
+    ///
+    /// Distinct from the placement epoch and from §9's write-routing revision.
+    /// It advances on configuration change, never on membership change, so a
+    /// worker joining or leaving must not move it.
+    pub revision: u64,
+    /// Whether the metadata store is currently reachable.
+    ///
+    /// Always `true` when nothing is configured: an empty set is always
+    /// serviceable. §6 requires "not configured" and "configured but
+    /// unreachable" to stay separable during an incident, which is why this is
+    /// reported alongside the set rather than folded into it.
+    pub store_reachable: bool,
+    /// Response metadata.
+    pub meta: ResponseMeta,
+}
+
 /// Cluster-level summary counts.
 #[derive(Debug, Clone, Serialize)]
 pub struct ClusterSummary {
@@ -225,6 +257,7 @@ pub fn router(state: Arc<CoordinatorObservability>) -> Router {
         .route("/api/v1/nodes", get(nodes_handler))
         .route("/api/v1/nodes/{node_id}", get(node_detail_handler))
         .route("/api/v1/backend", get(backend_handler))
+        .route("/api/v1/capabilities", get(capabilities_handler))
         .route("/api/v1/openapi.json", get(openapi_handler))
         .with_state(state)
 }
@@ -432,6 +465,34 @@ async fn backend_handler(State(state): State<Arc<CoordinatorObservability>>) -> 
     (cache_headers(&snapshot.revision.to_string()), Json(body)).into_response()
 }
 
+async fn capabilities_handler(State(state): State<Arc<CoordinatorObservability>>) -> Response {
+    let snapshot = match snapshot_or_error(&state).await {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+    let capabilities = state.capabilities();
+    let body = CapabilitiesView {
+        advertised: capabilities
+            .advertised
+            .iter()
+            .map(|capability| capability.as_str().to_owned())
+            .collect(),
+        revision: capabilities.revision.get(),
+        store_reachable: capabilities.store_reachable,
+        meta: build_meta(&state, &snapshot),
+    };
+    // The ETag is the capability revision, not the snapshot revision. Reusing
+    // the snapshot revision would make this response appear to change on every
+    // membership change and appear unchanged across an actual capability
+    // change -- exactly the conflation ADR 0003 §4 forbids by giving
+    // capabilities their own revision.
+    (
+        cache_headers(&capabilities.revision.to_string()),
+        Json(body),
+    )
+        .into_response()
+}
+
 async fn openapi_handler() -> Response {
     ([(header::CONTENT_TYPE, "application/json")], OPENAPI_JSON).into_response()
 }
@@ -476,6 +537,36 @@ mod tests {
             },
             labels: BTreeMap::new(),
         }
+    }
+
+    use talon_metadata::{Capability, CapabilityRevision, CapabilitySet, ClusterCapabilities};
+
+    /// Observability state carrying an explicit capability set.
+    async fn state_with_capabilities(
+        capabilities: ClusterCapabilities,
+    ) -> Arc<CoordinatorObservability> {
+        let store: Arc<dyn crate::ClusterStateStore> = Arc::new(MemoryStateStore::new());
+        store
+            .upsert_node(worker("w00", 1000, 100, 10), Duration::from_secs(30))
+            .await
+            .unwrap();
+        let obs = Arc::new(
+            CoordinatorObservability::new(
+                "c".into(),
+                NodeInfo {
+                    id: NodeId::new("coord"),
+                    address: "coord:7000".into(),
+                    role: NodeRole::Coordinator,
+                },
+                "coord:8000".into(),
+                Duration::from_secs(1),
+                store,
+            )
+            .unwrap()
+            .with_capabilities(capabilities),
+        );
+        obs.check_ready().await.unwrap();
+        obs
     }
 
     async fn state_with_workers(n: usize) -> Arc<CoordinatorObservability> {
@@ -568,6 +659,68 @@ mod tests {
             .map(|n| n["node_id"].as_str().unwrap().to_string())
             .collect();
         assert_eq!(ids2, vec!["w02", "w03"]);
+    }
+
+    #[tokio::test]
+    async fn a_cluster_without_a_metadata_store_advertises_nothing() {
+        // ADR 0003 §1 keeps such a cluster "a complete, supported Talon
+        // deployment offering exactly today's feature set", so an empty set is
+        // the correct answer here -- not an error and not an omitted field.
+        let state = state_with_workers(1).await;
+        let (status, body) = get(state, "/api/v1/capabilities").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["advertised"].as_array().expect("array").len(), 0);
+        assert_eq!(body["revision"], 0);
+        assert_eq!(
+            body["store_reachable"], true,
+            "an empty capability set is always serviceable"
+        );
+    }
+
+    #[tokio::test]
+    async fn advertised_capabilities_are_listed_with_their_own_revision() {
+        let state = state_with_capabilities(ClusterCapabilities {
+            advertised: CapabilitySet::none().with(Capability::HardLinks),
+            revision: CapabilityRevision::new(7),
+            store_reachable: true,
+        })
+        .await;
+        let (status, body) = get(state, "/api/v1/capabilities").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["advertised"][0], "hard_links");
+        assert_eq!(body["revision"], 7);
+    }
+
+    #[tokio::test]
+    async fn an_unreachable_store_still_advertises_its_capabilities() {
+        // §6 requires "not configured" and "configured but unreachable" to be
+        // separable during an incident. If an unreachable store dropped its
+        // capabilities from this list, the two would look identical here and an
+        // operator could not tell an outage from a deployment choice.
+        let state = state_with_capabilities(ClusterCapabilities {
+            advertised: CapabilitySet::none().with(Capability::HardLinks),
+            revision: CapabilityRevision::new(2),
+            store_reachable: false,
+        })
+        .await;
+        let (_, body) = get(state, "/api/v1/capabilities").await;
+        assert_eq!(body["advertised"][0], "hard_links");
+        assert_eq!(body["store_reachable"], false);
+    }
+
+    #[tokio::test]
+    async fn the_capability_etag_tracks_the_capability_revision_not_membership() {
+        // §4 gives capabilities their own revision precisely so the two cannot
+        // be conflated. Two clusters differing only in worker count must return
+        // the same capability ETag.
+        let one = state_with_workers(1).await;
+        let many = state_with_workers(5).await;
+        let (_, first) = get(one, "/api/v1/capabilities").await;
+        let (_, second) = get(many, "/api/v1/capabilities").await;
+        assert_eq!(
+            first["revision"], second["revision"],
+            "membership changes must not advance the capability revision"
+        );
     }
 
     #[tokio::test]

--- a/crates/talon-coordinator/src/main.rs
+++ b/crates/talon-coordinator/src/main.rs
@@ -91,6 +91,11 @@ struct Args {
 }
 
 impl Args {
+    // With neither `etcd` nor `kubernetes` enabled, every remaining field is
+    // listed explicitly below and the struct update becomes a no-op that clippy
+    // rejects under -D warnings. It is still required when either feature is
+    // on, so it cannot simply be deleted -- hence the allow rather than a fix.
+    #[allow(clippy::needless_update)]
     fn into_patch(self) -> CoordinatorConfigPatch {
         CoordinatorConfigPatch {
             listen: self.listen,

--- a/crates/talon-coordinator/src/observability.rs
+++ b/crates/talon-coordinator/src/observability.rs
@@ -13,6 +13,8 @@ use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
+use talon_metadata::ClusterCapabilities;
+
 use talon_core::metrics::labels;
 use talon_core::{
     Counter, Gauge, Histogram, Metrics, NodeHealth, NodeInfo, NodeMetricsSnapshot, NodeRole,
@@ -421,6 +423,7 @@ pub struct CoordinatorObservability {
     request_timeout: Duration,
     metrics: CoordinatorMetrics,
     store: Arc<dyn ClusterStateStore>,
+    capabilities: ClusterCapabilities,
 }
 
 impl CoordinatorObservability {
@@ -445,7 +448,30 @@ impl CoordinatorObservability {
             request_timeout,
             metrics: CoordinatorMetrics::new(),
             store,
+            // A coordinator with no metadata store advertises nothing. ADR 0003
+            // §1 keeps that a complete, supported deployment rather than a
+            // degraded one, so this is the correct default and not a
+            // placeholder.
+            capabilities: ClusterCapabilities::none(),
         })
+    }
+
+    /// Attach the capability set this cluster advertises.
+    ///
+    /// Builder-style so a coordinator without a metadata store needs no change:
+    /// omitting this leaves the empty set from [`ClusterCapabilities::none`].
+    #[must_use]
+    pub fn with_capabilities(mut self, capabilities: ClusterCapabilities) -> Self {
+        self.capabilities = capabilities;
+        self
+    }
+
+    /// Capabilities this cluster advertises.
+    ///
+    /// ADR 0003 §4 requires these to be discoverable "without attempting an
+    /// operation", which is what the management API endpoint is for.
+    pub fn capabilities(&self) -> &ClusterCapabilities {
+        &self.capabilities
     }
 
     /// Coordinator metric handles.

--- a/crates/talon-coordinator/src/openapi.json
+++ b/crates/talon-coordinator/src/openapi.json
@@ -77,6 +77,19 @@
         }
       }
     },
+    "/api/v1/capabilities": {
+      "get": {
+        "summary": "Cluster capabilities",
+        "description": "Optional metadata-store capabilities this cluster offers, with their own revision. Capability is a property of the cluster, not of a mount: two Talon clusters may legitimately offer different POSIX semantics. The revision advances on configuration change and never on membership change, so it is distinct from the placement epoch.",
+        "responses": {
+          "200": {
+            "description": "Advertised capabilities.",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CapabilitiesView" } } }
+          },
+          "503": { "$ref": "#/components/responses/BackendUnavailable" }
+        }
+      }
+    },
     "/api/v1/openapi.json": {
       "get": {
         "summary": "This OpenAPI document",
@@ -163,6 +176,27 @@
           "ready": { "type": "boolean" },
           "revision": { "type": "string" },
           "snapshot_age_ms": { "type": "integer", "format": "int64" },
+          "meta": { "$ref": "#/components/schemas/ResponseMeta" }
+        }
+      },
+      "CapabilitiesView": {
+        "type": "object",
+        "required": ["advertised", "revision", "store_reachable", "meta"],
+        "properties": {
+          "advertised": {
+            "type": "array",
+            "description": "Capabilities this cluster offers. Empty when no metadata store is configured, which remains a complete, supported deployment.",
+            "items": { "type": "string", "enum": ["locks", "hard_links", "write_back"] }
+          },
+          "revision": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Revision of the advertised set. Advances on configuration change, never on membership change."
+          },
+          "store_reachable": {
+            "type": "boolean",
+            "description": "Whether the metadata store is currently reachable. Always true when nothing is configured. Reported separately from the set so that 'not configured' and 'configured but unreachable' remain distinguishable."
+          },
           "meta": { "$ref": "#/components/schemas/ResponseMeta" }
         }
       },

--- a/crates/talon-metadata/src/cluster.rs
+++ b/crates/talon-metadata/src/cluster.rs
@@ -1,0 +1,233 @@
+//! What a cluster advertises to clients and operators.
+//!
+//! ADR 0003 §4 requires capability discovery to be possible without attempting
+//! an operation:
+//!
+//! > A client must be able to discover cluster capabilities before relying on
+//! > them. Capabilities are reported by the coordinator with their own
+//! > capability revision and exposed through the management API so an operator
+//! > can see what a cluster offers without attempting an operation.
+//!
+//! Two distinctions in this module carry more weight than they might appear to.
+//!
+//! # The revision is its own thing
+//!
+//! > The capability revision and §9's write-routing revision are not ADR 0001's
+//! > membership-derived `PlacementVersion`.
+//!
+//! Three revisions that advance for unrelated reasons. `PlacementVersion` is a
+//! content hash of the node set, so it changes whenever a worker joins or
+//! leaves — which happens constantly and says nothing about what the cluster can
+//! do. A capability revision changes when the *configuration* changes, which is
+//! rare. Folding them together would make every membership change look like a
+//! capability change and hide the changes that matter.
+//!
+//! # Advertised is not the same as reachable
+//!
+//! [`ClusterCapabilities::advertised`] answers "what does this cluster offer",
+//! and [`ClusterCapabilities::store_reachable`] answers "can it serve that right
+//! now". §6 requires the two to stay separable:
+//!
+//! > Operations requiring TMS fail closed, with the same errno as an
+//! > unconfigured cluster plus a distinct log and metric so "not configured" and
+//! > "configured but unreachable" are separable in an incident.
+//!
+//! §4 then maps the pair to different errnos — `EOPNOTSUPP` for a cluster that
+//! does not implement locking, `ENOLCK` for one that does but cannot reach its
+//! lock service. Collapsing them would make an outage indistinguishable from a
+//! deployment choice, in both the logs and the application's error handling.
+
+use core::fmt;
+
+use crate::capability::{Capability, CapabilitySet};
+
+/// A monotonically increasing revision of a cluster's advertised capabilities.
+///
+/// Deliberately a distinct type from any placement or routing version so the
+/// three cannot be compared or assigned to one another by accident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+pub struct CapabilityRevision(u64);
+
+impl CapabilityRevision {
+    /// The revision of a cluster whose capabilities have never changed.
+    pub const INITIAL: Self = Self(0);
+
+    /// Construct from a raw counter value.
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// The raw counter value, for the wire protocol and the management API.
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// The next revision.
+    ///
+    /// # Panics
+    ///
+    /// Panics on overflow, which would make a newer revision compare as older
+    /// and leave clients pinned to a stale capability set.
+    #[must_use]
+    pub const fn next(self) -> Self {
+        match self.0.checked_add(1) {
+            Some(value) => Self(value),
+            None => panic!("capability revision overflowed"),
+        }
+    }
+}
+
+impl fmt::Display for CapabilityRevision {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// What a cluster advertises, and whether it can currently serve it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClusterCapabilities {
+    /// Capabilities this cluster offers.
+    ///
+    /// Empty for a cluster with no metadata store configured, which §1 keeps a
+    /// complete, supported deployment:
+    ///
+    /// > A cluster without one is a complete, supported Talon deployment
+    /// > offering exactly today's feature set.
+    pub advertised: CapabilitySet,
+
+    /// Revision of the advertised set.
+    ///
+    /// Advances on configuration change, never on membership change.
+    pub revision: CapabilityRevision,
+
+    /// Whether the metadata store is currently reachable.
+    ///
+    /// `true` when no store is configured: an empty capability set is always
+    /// serviceable, since there is nothing to fail. Distinguishing "offers
+    /// nothing" from "offers something it cannot reach" is the point of
+    /// [`ClusterCapabilities::state_of`].
+    pub store_reachable: bool,
+}
+
+/// Why an operation requiring a capability cannot proceed.
+///
+/// Maps directly onto §4's errno table. Kept as an enum rather than a bool so
+/// the two failure modes cannot collapse into one on the way to the caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilityState {
+    /// The cluster offers this capability and can serve it now.
+    Available,
+    /// The cluster does not offer this capability at all.
+    ///
+    /// A permanent property of the deployment. Retrying cannot help, and the
+    /// caller must report it as unsupported rather than as a transient fault.
+    NotOffered,
+    /// The cluster offers this capability but its store is unreachable.
+    ///
+    /// Transient. §6 requires the read path to be unaffected and the operation
+    /// to fail closed — never to fall back to a local approximation.
+    Unreachable,
+}
+
+impl ClusterCapabilities {
+    /// A cluster with no metadata store.
+    pub fn none() -> Self {
+        Self {
+            advertised: CapabilitySet::none(),
+            revision: CapabilityRevision::INITIAL,
+            store_reachable: true,
+        }
+    }
+
+    /// How an operation requiring `capability` should be answered.
+    pub fn state_of(&self, capability: Capability) -> CapabilityState {
+        if !self.advertised.supports(capability) {
+            return CapabilityState::NotOffered;
+        }
+        if self.store_reachable {
+            CapabilityState::Available
+        } else {
+            CapabilityState::Unreachable
+        }
+    }
+
+    /// Whether `capability` can be used right now.
+    pub fn is_available(&self, capability: Capability) -> bool {
+        self.state_of(capability) == CapabilityState::Available
+    }
+}
+
+impl Default for ClusterCapabilities {
+    fn default() -> Self {
+        Self::none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_cluster_without_a_metadata_store_offers_nothing_and_is_serviceable() {
+        // §1: such a cluster "is a complete, supported Talon deployment offering
+        // exactly today's feature set" -- not a degraded one.
+        let capabilities = ClusterCapabilities::none();
+        assert!(capabilities.advertised.is_empty());
+        assert!(capabilities.store_reachable);
+        assert_eq!(
+            capabilities.state_of(Capability::HardLinks),
+            CapabilityState::NotOffered
+        );
+    }
+
+    #[test]
+    fn not_offered_and_unreachable_are_distinct_states() {
+        // The distinction §4 maps to EOPNOTSUPP vs ENOLCK and §6 requires to
+        // stay separable in an incident. Collapsing them would make an outage
+        // indistinguishable from a deployment choice.
+        let offered_and_down = ClusterCapabilities {
+            advertised: CapabilitySet::none().with(Capability::Locks),
+            revision: CapabilityRevision::new(3),
+            store_reachable: false,
+        };
+        assert_eq!(
+            offered_and_down.state_of(Capability::Locks),
+            CapabilityState::Unreachable
+        );
+        assert_eq!(
+            offered_and_down.state_of(Capability::HardLinks),
+            CapabilityState::NotOffered,
+            "an unreachable store does not make an unoffered capability unreachable"
+        );
+        assert!(!offered_and_down.is_available(Capability::Locks));
+    }
+
+    #[test]
+    fn an_advertised_capability_with_a_reachable_store_is_available() {
+        let capabilities = ClusterCapabilities {
+            advertised: CapabilitySet::none().with(Capability::HardLinks),
+            revision: CapabilityRevision::new(1),
+            store_reachable: true,
+        };
+        assert_eq!(
+            capabilities.state_of(Capability::HardLinks),
+            CapabilityState::Available
+        );
+        assert!(capabilities.is_available(Capability::HardLinks));
+    }
+
+    #[test]
+    fn capability_revisions_advance_monotonically() {
+        let first = CapabilityRevision::INITIAL;
+        assert!(first.next() > first);
+        assert_eq!(first.next().next().get(), 2);
+    }
+
+    #[test]
+    fn capability_revision_ordering_is_numeric_not_lexicographic() {
+        // Guards against encoding the counter as a string on the wire or in the
+        // API: "10" sorts before "9" lexicographically, which would make a newer
+        // capability set look stale and pin clients to an old view.
+        assert!(CapabilityRevision::new(10) > CapabilityRevision::new(9));
+    }
+}

--- a/crates/talon-metadata/src/lib.rs
+++ b/crates/talon-metadata/src/lib.rs
@@ -59,6 +59,7 @@
 #![warn(missing_docs)]
 
 mod capability;
+mod cluster;
 pub mod contract;
 mod error;
 #[cfg(feature = "etcd")]
@@ -69,6 +70,7 @@ mod revision;
 mod transaction;
 
 pub use capability::{Capability, CapabilitySet};
+pub use cluster::{CapabilityRevision, CapabilityState, ClusterCapabilities};
 pub use error::{MetadataBackend, MetadataError, MetadataResult};
 pub use memory::{MemoryMetadataStore, NamespaceSnapshot};
 pub use record::{

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -19,6 +19,17 @@ Backend status
 | `200` | [`BackendStatus`](#backendstatus) | Backend status. |
 | `503` | — | (see BackendUnavailable) |
 
+### `GET /api/v1/capabilities`
+
+Cluster capabilities
+
+**Responses:**
+
+| Status | Body | Description |
+|--------|------|-------------|
+| `200` | [`CapabilitiesView`](#capabilitiesview) | Advertised capabilities. |
+| `503` | — | (see BackendUnavailable) |
+
 ### `GET /api/v1/cluster`
 
 Cluster summary
@@ -96,6 +107,15 @@ This OpenAPI document
 | `ready` | boolean | yes |
 | `revision` | string | yes |
 | `snapshot_age_ms` | integer (int64) | yes |
+
+### CapabilitiesView
+
+| Field | Type | Required |
+|-------|------|----------|
+| `advertised` | array of string | yes |
+| `meta` | [`ResponseMeta`](#responsemeta) | yes |
+| `revision` | integer (int64) | yes |
+| `store_reachable` | boolean | yes |
 
 ### ClusterSummary
 


### PR DESCRIPTION
Closes #391. Part of #380.

§4 requires a client to be able to discover what a cluster offers "without
attempting an operation". This is the coordinator half: a capability snapshot
type, `GET /api/v1/capabilities`, and the OpenAPI contract.

## The capability revision is not the placement epoch

§4 says so directly:

> The capability revision and §9's write-routing revision are not ADR 0001's
> membership-derived `PlacementVersion`.

They move for unrelated causes. The placement epoch is a content hash of the
node set (`placement_cache.rs:40`), so it changes whenever a worker joins or
leaves — which says nothing about what the cluster can do. A capability revision
changes when *configuration* changes, which is rare.

Conflating them would make every membership change look like a capability
change, and hide the changes that matter. So `CapabilityRevision` is its own
type, and **the endpoint's ETag is the capability revision**, not the snapshot
revision the other endpoints use. `the_capability_etag_tracks_the_capability_revision_not_membership`
pins this: two clusters differing only in worker count must return the same
revision.

## Advertised is not the same as reachable

§6:

> Operations requiring TMS fail closed, with the same errno as an unconfigured
> cluster plus a distinct log and metric so "not configured" and "configured but
> unreachable" are separable in an incident.

An unreachable store therefore **still advertises its capabilities** and reports
`store_reachable: false`, rather than dropping them from the list. Dropping them
would make an outage indistinguishable from a deployment choice — both to an
operator reading the API and to §4's errno mapping, which needs `EOPNOTSUPP` and
`ENOLCK` to stay distinct.

`CapabilityState` is an enum rather than a bool so the two cannot collapse on
the way to the caller.

## A cluster with no metadata store

Advertises an empty set, reports reachable (an empty set is always serviceable),
and behaves exactly as today. §1 keeps that a complete, supported deployment
rather than a degraded one, so it is the correct answer and not a placeholder.

`with_capabilities` is builder-style, so the five existing
`CoordinatorObservability::new` call sites need no change.

## Drive-by fix

`main.rs:110` had a pre-existing clippy failure visible only in the **default**
build: with neither `etcd` nor `kubernetes` enabled, every remaining patch field
is listed explicitly and `..Default::default()` becomes a no-op. Confirmed
present on `upstream/main` before my changes. It is still required when either
feature is on, so an `allow` is narrower than deleting it.

## Validation

- 4 new API tests; 72 coordinator lib tests, 31 metadata tests
- clippy `-D warnings` clean in **both** the default build and with
  `--features etcd,kubernetes,state-store-testkit`
- `RUSTDOCFLAGS="-D warnings" cargo doc --all-features` clean
- `docs/reference/rest-api.md` regenerated via `talon-gen-api-docs` so the drift
  gate passes

## Next

#392: client-side capability cache, `getlk`/`setlk`/`flock`, and the errno
contract. That one matters — those three callbacks are currently absent, so an
`flock` on a Talon mount may be getting mount-local coordination that looks
cluster-wide (§4 calls this out explicitly as unsafe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)