### PR TITLE
feat(fuse): implement lock callbacks and the capability errno contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2575,6 +2575,7 @@ dependencies = [
  "fuser",
  "libc",
  "talon-core",
+ "talon-metadata",
  "talon-transport",
  "tempfile",
  "thiserror 2.0.19",

--- a/crates/talon-fuse/Cargo.toml
+++ b/crates/talon-fuse/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 talon-core.workspace = true
+talon-metadata.workspace = true
 talon-transport.workspace = true
 anyhow.workspace = true
 tokio.workspace = true

--- a/crates/talon-fuse/src/capability.rs
+++ b/crates/talon-fuse/src/capability.rs
@@ -1,0 +1,173 @@
+//! Mapping cluster capabilities onto POSIX errnos.
+//!
+//! ADR 0003 §4 calls itself "the load-bearing clause", and the reason is #363:
+//!
+//! > Silent degradation is precisely the defect in #363: `link()` currently
+//! > appears to succeed, produces copies that can diverge, cannot self-repair,
+//! > and does not report which copies went stale. A feature that looks supported
+//! > and is subtly wrong is worse than one that plainly refuses, because
+//! > applications build on the former.
+//!
+//! So every operation needing a capability the cluster lacks fails with a
+//! *distinct* errno, and the distinction an application can act on is between a
+//! permanent property of the deployment and a transient outage:
+//!
+//! | Operation or condition | Result |
+//! |---|---|
+//! | `link()` without TMS | `EPERM` |
+//! | `link()` capability configured but TMS unavailable | `EAGAIN` |
+//! | `fcntl`/`flock` without the TMS locking capability | `EOPNOTSUPP` |
+//! | TMS locking configured but unavailable | `ENOLCK` |
+//!
+//! > `EOPNOTSUPP` means that this cluster does not implement distributed
+//! > locking. `ENOLCK` is reserved for the distinct case where the cluster
+//! > offers locking but cannot currently reach or use the lock service. Talon
+//! > never turns either case into a successful mount-local lock.
+//!
+//! The pairing is what makes the errnos useful: `EPERM` and `EOPNOTSUPP` tell an
+//! application to stop asking, while `EAGAIN` and `ENOLCK` tell it to retry.
+//! Collapsing them would make an outage look like a deployment choice.
+
+use talon_metadata::{Capability, CapabilityState, ClusterCapabilities};
+
+/// Errno values from §4's table.
+///
+/// Defined here rather than taken from `libc` so this contract is testable in
+/// the default build: `libc` is an optional dependency behind the `mount`
+/// feature, and the errno mapping is exactly the part that most needs a test
+/// which always runs. `mount.rs` asserts these agree with `libc`.
+pub mod errno {
+    /// Operation not permitted. The cluster does not offer hard links.
+    pub const EPERM: i32 = 1;
+    /// Try again. The capability exists but its store is unreachable.
+    pub const EAGAIN: i32 = 11;
+    /// No locks available. The cluster offers locking but cannot reach it.
+    pub const ENOLCK: i32 = 37;
+    /// Operation not supported. This cluster does not implement locking.
+    pub const EOPNOTSUPP: i32 = 95;
+}
+
+/// The errno for a `link()` that requires inode indirection.
+///
+/// `EPERM` when the cluster does not offer hard links, `EAGAIN` when it does but
+/// the metadata store is unreachable. Returns `None` when the operation may
+/// proceed.
+///
+/// The `EPERM` case preserves today's shipped behaviour (`mount.rs:949`), which
+/// §5 singles out as the one part of the ADR that should exist before TMS does:
+///
+/// > Without TMS, `link()` returns `EPERM`. This is the only part of this ADR
+/// > that should be implemented before TMS exists, because it is a correctness
+/// > fix for shipped behaviour (#363).
+pub fn hard_link_errno(capabilities: &ClusterCapabilities) -> Option<i32> {
+    match capabilities.state_of(Capability::HardLinks) {
+        CapabilityState::Available => None,
+        CapabilityState::NotOffered => Some(errno::EPERM),
+        CapabilityState::Unreachable => Some(errno::EAGAIN),
+    }
+}
+
+/// The errno for a lock operation.
+///
+/// `EOPNOTSUPP` when the cluster does not implement distributed locking,
+/// `ENOLCK` when it does but the lock service is unreachable. Returns `None`
+/// when the operation may proceed.
+///
+/// Note that `None` is currently unreachable in practice: no backend advertises
+/// [`Capability::Locks`], because shipping POSIX locks needs its own ADR
+/// defining "the bounded byte-range representation, blocking and fairness rules,
+/// waiter recovery, and cross-file deadlock detection". The branch exists so
+/// that wiring the lock path later is a change to one call site rather than a
+/// change to this contract.
+pub fn lock_errno(capabilities: &ClusterCapabilities) -> Option<i32> {
+    match capabilities.state_of(Capability::Locks) {
+        CapabilityState::Available => None,
+        CapabilityState::NotOffered => Some(errno::EOPNOTSUPP),
+        CapabilityState::Unreachable => Some(errno::ENOLCK),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use talon_metadata::{CapabilityRevision, CapabilitySet};
+
+    fn offering(capability: Capability, reachable: bool) -> ClusterCapabilities {
+        ClusterCapabilities {
+            advertised: CapabilitySet::none().with(capability),
+            revision: CapabilityRevision::new(1),
+            store_reachable: reachable,
+        }
+    }
+
+    #[test]
+    fn a_cluster_without_tms_refuses_hard_links_with_eperm() {
+        // Today's shipped behaviour, which §5 keeps as the correct answer for an
+        // unconfigured cluster.
+        assert_eq!(
+            hard_link_errno(&ClusterCapabilities::none()),
+            Some(errno::EPERM)
+        );
+    }
+
+    #[test]
+    fn an_unreachable_store_makes_hard_links_retryable_not_forbidden() {
+        // EPERM would tell the application to stop asking, which is wrong when
+        // the capability exists and the store is merely down. §4 pairs the two
+        // errnos precisely so this case is distinguishable.
+        assert_eq!(
+            hard_link_errno(&offering(Capability::HardLinks, false)),
+            Some(errno::EAGAIN)
+        );
+    }
+
+    #[test]
+    fn hard_links_proceed_when_offered_and_reachable() {
+        assert_eq!(
+            hard_link_errno(&offering(Capability::HardLinks, true)),
+            None
+        );
+    }
+
+    #[test]
+    fn a_cluster_without_locking_reports_eopnotsupp_never_success() {
+        // The critical case. §4: "Talon never turns either case into a
+        // successful mount-local lock." A successful return here would let an
+        // application believe it holds cluster-wide exclusion while only
+        // coordinating processes on one mount.
+        let errno = lock_errno(&ClusterCapabilities::none());
+        assert_eq!(errno, Some(errno::EOPNOTSUPP));
+        assert_ne!(errno, None, "a lock request must never silently succeed");
+    }
+
+    #[test]
+    fn an_unreachable_lock_service_reports_enolck_not_eopnotsupp() {
+        // §4: "ENOLCK is reserved for the distinct case where the cluster offers
+        // locking but cannot currently reach or use the lock service."
+        assert_eq!(
+            lock_errno(&offering(Capability::Locks, false)),
+            Some(errno::ENOLCK)
+        );
+    }
+
+    #[test]
+    fn the_two_lock_errnos_are_never_interchangeable() {
+        // Guards the pairing itself: one says stop, the other says retry.
+        assert_ne!(errno::EOPNOTSUPP, errno::ENOLCK);
+        assert_ne!(
+            lock_errno(&ClusterCapabilities::none()),
+            lock_errno(&offering(Capability::Locks, false))
+        );
+    }
+
+    #[test]
+    fn an_unreachable_store_does_not_change_an_unoffered_capability() {
+        // A cluster that offers hard links but not locks, with its store down,
+        // must still report locks as unsupported rather than unreachable --
+        // otherwise an application would retry forever against a feature the
+        // cluster will never provide.
+        let capabilities = offering(Capability::HardLinks, false);
+        assert_eq!(lock_errno(&capabilities), Some(errno::EOPNOTSUPP));
+        assert_eq!(hard_link_errno(&capabilities), Some(errno::EAGAIN));
+    }
+}

--- a/crates/talon-fuse/src/lib.rs
+++ b/crates/talon-fuse/src/lib.rs
@@ -5,6 +5,7 @@
 //! into object store operations against the cluster.
 
 pub mod block_reader;
+pub mod capability;
 pub mod coordinator_client;
 pub(crate) mod lock;
 pub mod mapping;

--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -30,6 +30,7 @@ use crate::ops::{
 use crate::prefetch::Prefetcher;
 use crate::readahead::ReadaheadConfig;
 use talon_core::ObjectId;
+use talon_metadata::ClusterCapabilities;
 
 /// How long the kernel may cache a metadata reply before re-asking.
 ///
@@ -209,6 +210,12 @@ pub struct TalonFuse {
     /// Shared pool for write/delete connections to workers (mirrors the read
     /// pool). Reused across write handles.
     write_pool: Arc<crate::pool::ConnectionPool>,
+    /// What this cluster offers, as discovered from a coordinator.
+    ///
+    /// Defaults to [`ClusterCapabilities::none`], which is the honest answer for
+    /// a cluster with no metadata store and keeps today's behaviour exactly
+    /// (ADR 0003 §1). Set via [`with_capabilities`](Self::with_capabilities).
+    capabilities: ClusterCapabilities,
 }
 
 impl TalonFuse {
@@ -237,7 +244,44 @@ impl TalonFuse {
             prefetchers: Mutex::new(HashMap::new()),
             read_write: false,
             write_pool: Arc::new(crate::pool::ConnectionPool::new()),
+            capabilities: ClusterCapabilities::none(),
         }
+    }
+
+    /// The errno for a lock request, and the log line that explains it.
+    ///
+    /// `EOPNOTSUPP` when the cluster does not implement distributed locking,
+    /// `ENOLCK` when it offers locking but the store is unreachable. Never a
+    /// success: §4 requires that "Talon never turns either case into a
+    /// successful mount-local lock".
+    fn lock_refusal(&self, operation: &'static str) -> i32 {
+        let code = crate::capability::lock_errno(&self.capabilities).unwrap_or({
+            // The cluster advertises locking, but the distributed lock path does
+            // not exist yet -- it needs its own ADR defining byte-range
+            // representation, fairness, waiter recovery, and deadlock detection.
+            // Refusing is the only honest answer until then.
+            crate::capability::errno::EOPNOTSUPP
+        });
+        tracing::debug!(
+            operation,
+            errno = code,
+            capability_revision = self.capabilities.revision.get(),
+            store_reachable = self.capabilities.store_reachable,
+            "refusing lock request; distributed locking is not available"
+        );
+        code
+    }
+
+    /// Record the capabilities discovered from a coordinator.
+    ///
+    /// Capability is a property of the *cluster*, not of this mount. ADR 0003
+    /// §4 is explicit that a mount flag "cannot silently opt into a weaker
+    /// contract", so this exists to carry what the cluster reported -- never to
+    /// let an operator enable something the cluster does not offer.
+    #[must_use]
+    pub fn with_capabilities(mut self, capabilities: ClusterCapabilities) -> Self {
+        self.capabilities = capabilities;
+        self
     }
 
     /// Enable the write path (create/write/setattr/unlink/flush). When disabled
@@ -938,15 +982,101 @@ impl fuser::Filesystem for TalonFuse {
                 Err(error) => reply.error(errno(error)),
             };
         }
-        // Object-backed kinds would need a copy per link path. See the method
-        // doc and #363: divergence is inherent to that representation, not a
-        // bug in the fan-out, so this refuses rather than approximating.
-        tracing::debug!(
-            source = %plan.source_path,
-            target = %plan.target_path,
-            "refusing hard link to an object-backed file; requires inode indirection (#363)"
-        );
-        reply.error(libc::EPERM);
+        // Object-backed kinds need inode indirection (ADR 0003 §5); without it,
+        // a copy per link path can diverge and nothing reconciles it (#363).
+        //
+        // The errno distinguishes two cases §4 requires an application to be
+        // able to tell apart: EPERM when the cluster does not offer hard links
+        // at all, EAGAIN when it does but the metadata store is unreachable.
+        // One says stop asking, the other says retry.
+        match crate::capability::hard_link_errno(&self.capabilities) {
+            Some(code) => {
+                tracing::debug!(
+                    source = %plan.source_path,
+                    target = %plan.target_path,
+                    errno = code,
+                    capability_revision = self.capabilities.revision.get(),
+                    store_reachable = self.capabilities.store_reachable,
+                    "refusing hard link to an object-backed file; requires inode indirection (#363)"
+                );
+                reply.error(code);
+            }
+            None => {
+                // The cluster advertises hard links, but the inode indirection
+                // state machine (§5) is not implemented yet. Refusing is
+                // correct: committing the copy-per-path fan-out here is exactly
+                // the divergence #363 reports.
+                tracing::warn!(
+                    source = %plan.source_path,
+                    target = %plan.target_path,
+                    "cluster advertises hard links but inode indirection is not implemented; refusing"
+                );
+                reply.error(libc::EOPNOTSUPP);
+            }
+        }
+    }
+
+    /// Test a POSIX byte-range lock.
+    ///
+    /// Implemented deliberately, even though it can only refuse today. ADR 0003
+    /// §4:
+    ///
+    /// > The FUSE implementation must explicitly implement the `getlk`, `setlk`,
+    /// > and `flock` callbacks and forward them to the distributed lock path. It
+    /// > must not omit those callbacks and rely on a kernel or libfuse fallback,
+    /// > because such a fallback can make locks appear to work while only
+    /// > coordinating processes on one mount.
+    ///
+    /// That fallback is the danger: an application taking a lock on a shared
+    /// mount would believe it holds cluster-wide exclusion while actually
+    /// coordinating only with processes on the same host. It is the shape of
+    /// defect #363 reports for `link()`, in a different syscall, and it is worse
+    /// than a plain refusal because applications build on it.
+    ///
+    /// `fuser`'s own documentation confirms the mechanism: "if the locking
+    /// methods are not implemented, the kernel will still allow file locking to
+    /// work locally. Hence these are only interesting for network filesystems
+    /// and similar." Talon is such a filesystem.
+    ///
+    /// `flock` is not covered here: the `Filesystem` trait only gains that
+    /// callback at `abi-7-17`, and this crate targets `abi-7-9`. BSD advisory
+    /// locks on a Talon mount therefore still fall back to kernel-local
+    /// behaviour. Raising the ABI level changes the mount protocol for every
+    /// callback, so it is deliberately left to a follow-up rather than smuggled
+    /// in here (tracked in #392).
+    fn getlk(
+        &mut self,
+        _req: &fuser::Request<'_>,
+        _ino: u64,
+        _fh: u64,
+        _lock_owner: u64,
+        _start: u64,
+        _end: u64,
+        _typ: i32,
+        _pid: u32,
+        reply: fuser::ReplyLock,
+    ) {
+        reply.error(self.lock_refusal("getlk"));
+    }
+
+    /// Acquire or release a POSIX byte-range lock.
+    ///
+    /// See `getlk` above for why this refuses rather than falling back to the
+    /// kernel.
+    fn setlk(
+        &mut self,
+        _req: &fuser::Request<'_>,
+        _ino: u64,
+        _fh: u64,
+        _lock_owner: u64,
+        _start: u64,
+        _end: u64,
+        _typ: i32,
+        _pid: u32,
+        _sleep: bool,
+        reply: fuser::ReplyEmpty,
+    ) {
+        reply.error(self.lock_refusal("setlk"));
     }
 
     /// Create a regular file or mount-local POSIX special node.
@@ -1799,5 +1929,59 @@ mod tests {
         assert!(!ro.read_write, "adapter must default to read-only");
         let rw = adapter_with_readahead(4).with_read_write(true);
         assert!(rw.read_write, "with_read_write(true) enables writes");
+    }
+
+    #[test]
+    fn capability_errnos_match_libc() {
+        // crate::capability defines these itself so the mapping is testable in
+        // the default build, where libc is not a dependency. This is the check
+        // that keeps the two definitions honest.
+        use crate::capability::errno;
+        assert_eq!(errno::EPERM, libc::EPERM);
+        assert_eq!(errno::EAGAIN, libc::EAGAIN);
+        assert_eq!(errno::ENOLCK, libc::ENOLCK);
+        assert_eq!(errno::EOPNOTSUPP, libc::EOPNOTSUPP);
+    }
+
+    #[tokio::test]
+    async fn a_mount_defaults_to_advertising_nothing() {
+        // ADR 0003 §1: a cluster with no metadata store is a complete, supported
+        // deployment. The mount must not assume capabilities it was never told
+        // about.
+        let adapter = adapter_with_readahead(4);
+        assert!(adapter.capabilities.advertised.is_empty());
+        assert!(adapter.capabilities.store_reachable);
+    }
+
+    #[tokio::test]
+    async fn lock_requests_are_refused_and_never_silently_succeed() {
+        // The load-bearing assertion of ADR 0003 §4. A None here would mean the
+        // callback returns success, letting an application believe it holds
+        // cluster-wide exclusion while the kernel coordinates only local
+        // processes -- the #363 defect in a different syscall.
+        let adapter = adapter_with_readahead(4);
+        assert_eq!(adapter.lock_refusal("getlk"), libc::EOPNOTSUPP);
+
+        let offering_but_down = adapter_with_readahead(4).with_capabilities(ClusterCapabilities {
+            advertised: talon_metadata::CapabilitySet::none()
+                .with(talon_metadata::Capability::Locks),
+            revision: talon_metadata::CapabilityRevision::new(4),
+            store_reachable: false,
+        });
+        assert_eq!(
+            offering_but_down.lock_refusal("setlk"),
+            libc::ENOLCK,
+            "an unreachable lock service is ENOLCK, not EOPNOTSUPP"
+        );
+
+        // Advertised and reachable still refuses: the distributed lock path does
+        // not exist yet, and inventing a local approximation is what §4 forbids.
+        let offering = adapter_with_readahead(4).with_capabilities(ClusterCapabilities {
+            advertised: talon_metadata::CapabilitySet::none()
+                .with(talon_metadata::Capability::Locks),
+            revision: talon_metadata::CapabilityRevision::new(5),
+            store_reachable: true,
+        });
+        assert_eq!(offering.lock_refusal("getlk"), libc::EOPNOTSUPP);
     }
 }


### PR DESCRIPTION
Closes #392. Part of #380.

## The lock callbacks are a live correctness problem, not a missing feature

`getlk` and `setlk` were not implemented at all. `fuser`'s own documentation
says what that means:

> **if the locking methods are not implemented, the kernel will still allow file
> locking to work locally.** Hence these are only interesting for network
> filesystems and similar.

Talon is such a filesystem. So an application taking a lock on a shared Talon
mount could believe it held cluster-wide exclusion while actually coordinating
only with processes on the same host — #363's defect in a different syscall, and
§4 calls out this exact fallback:

> It must not omit those callbacks and rely on a kernel or libfuse fallback,
> because such a fallback can make locks appear to work while only coordinating
> processes on one mount.

Implementing them to refuse is strictly better than leaving them absent, and
does not depend on distributed locking existing.

### `flock` is not covered — deliberately

The `Filesystem` trait only gains that callback at `abi-7-17`; this crate
targets `abi-7-9` (`Cargo.toml:32`). BSD advisory locks on a Talon mount
therefore **still fall back to kernel-local behaviour**. Raising the ABI level
changes the mount protocol for every callback, so it belongs in its own change
rather than smuggled into this one. Called out in the `getlk` rustdoc so it
cannot be mistaken for covered.

## The errno pairs

| Condition | Errno | Meaning to an application |
|---|---|---|
| No hard-link capability | `EPERM` | stop asking |
| Configured but store unreachable | `EAGAIN` | retry |
| No locking capability | `EOPNOTSUPP` | stop asking |
| Locking offered, store unreachable | `ENOLCK` | retry |

> `EOPNOTSUPP` means that this cluster does not implement distributed locking.
> `ENOLCK` is reserved for the distinct case where the cluster offers locking but
> cannot currently reach or use the lock service. Talon never turns either case
> into a successful mount-local lock.

Collapsing either pair would make an outage indistinguishable from a deployment
choice. `link()` previously returned a flat `EPERM` (`mount.rs:949`) — correct
for the unconfigured case, but unable to express the other.

Note the third case in `lock_refusal`: a cluster that advertises locking with a
reachable store **still** gets `EOPNOTSUPP`, because the distributed lock path
does not exist yet. Inventing a local approximation there is precisely what §4
forbids.

## Why the errno constants are not `libc`'s

`libc` is optional behind the `mount` feature, and the errno mapping is exactly
the part that most needs a test which always runs — so `capability.rs` defines
them and its 7 tests run in the default build. A test under `--features mount`
asserts the two definitions agree, so they cannot drift.

## Defaults

A mount advertises nothing until told otherwise, so a cluster with no metadata
store behaves exactly as today. `with_capabilities` carries what a coordinator
reported and never lets an operator enable more — §4 requires two mounts of the
same cluster to observe the same semantics, so a mount flag cannot opt into a
weaker contract.

## Validation

- 143 tests with `--features mount`, 130 in the default build
- clippy `-D warnings` clean in both configurations
- `RUSTDOCFLAGS="-D warnings" cargo doc --all-features` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)