### PR TITLE
feat(coordinator): connect a metadata store and report live capabilities

### DIFF
--- a/crates/talon-coordinator/Cargo.toml
+++ b/crates/talon-coordinator/Cargo.toml
@@ -29,7 +29,7 @@ state-store-testkit = []
 kubernetes = ["dep:kube", "dep:k8s-openapi", "dep:futures"]
 # Production etcd v3 ClusterStateStore backend. Kept off by default so
 # non-etcd builds do not pull in the gRPC/TLS stack.
-etcd = ["dep:etcd-client", "dep:tonic"]
+etcd = ["dep:etcd-client", "dep:tonic", "talon-metadata/etcd"]
 
 [dependencies]
 talon-core.workspace = true

--- a/crates/talon-coordinator/src/config.rs
+++ b/crates/talon-coordinator/src/config.rs
@@ -32,6 +32,14 @@ pub struct CoordinatorConfig {
     /// Kubernetes backend settings, required when `state.backend` is kubernetes.
     #[cfg(feature = "kubernetes")]
     pub kubernetes: Option<KubernetesConfig>,
+    /// Optional metadata store (TMS) settings.
+    ///
+    /// Absent by default. ADR 0003 §1 keeps a cluster without one "a complete,
+    /// supported Talon deployment offering exactly today's feature set" -- TMS
+    /// is "the price of admission for a specific group of features, and clusters
+    /// that do not need those features must not pay it".
+    #[cfg(feature = "etcd")]
+    pub metadata: Option<MetadataConfig>,
 }
 
 impl Default for CoordinatorConfig {
@@ -47,6 +55,47 @@ impl Default for CoordinatorConfig {
             etcd: None,
             #[cfg(feature = "kubernetes")]
             kubernetes: None,
+            #[cfg(feature = "etcd")]
+            metadata: None,
+        }
+    }
+}
+
+/// Optional metadata store (TMS) connection settings.
+///
+/// ADR 0003 §7 names etcd as the first backend able to carry hard links, because
+/// it provides atomic transactions across the transition, inode, and path index
+/// records that §5's promotion commit needs. A lease-only backend cannot, and
+/// must not advertise that capability.
+#[cfg(feature = "etcd")]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetadataConfig {
+    /// etcd endpoints holding TMS records.
+    ///
+    /// May be the same cluster serving `ClusterStateStore`. §7 permits sharing
+    /// the physical cluster but keeps the two under separate prefixes, because
+    /// membership is ephemeral and rebuildable while TMS records are durable and
+    /// not.
+    pub endpoints: Vec<String>,
+    /// Keyspace prefix for TMS records.
+    ///
+    /// Defaults to `/talon-metadata`, disjoint from the cluster-state prefix.
+    #[serde(default = "default_metadata_prefix")]
+    pub prefix: String,
+}
+
+#[cfg(feature = "etcd")]
+fn default_metadata_prefix() -> String {
+    talon_metadata::DEFAULT_METADATA_PREFIX.to_string()
+}
+
+#[cfg(feature = "etcd")]
+impl Default for MetadataConfig {
+    fn default() -> Self {
+        Self {
+            endpoints: Vec::new(),
+            prefix: default_metadata_prefix(),
         }
     }
 }
@@ -110,6 +159,15 @@ pub struct CoordinatorConfigPatch {
     #[cfg(feature = "etcd")]
     #[serde(skip)]
     pub etcd_client_key_path: Option<String>,
+    /// Optional metadata store block from the config file.
+    #[cfg(feature = "etcd")]
+    pub metadata: Option<MetadataConfig>,
+    /// Metadata store endpoints override.
+    #[cfg(feature = "etcd")]
+    pub metadata_endpoints: Option<Vec<String>>,
+    /// Metadata store keyspace prefix override.
+    #[cfg(feature = "etcd")]
+    pub metadata_prefix: Option<String>,
     /// env/CLI-only override for `kubernetes.namespace` (never a TOML key).
     #[cfg(feature = "kubernetes")]
     #[serde(skip)]
@@ -147,6 +205,12 @@ impl Patch for CoordinatorConfigPatch {
             etcd_client_cert_path: self.etcd_client_cert_path.or(base.etcd_client_cert_path),
             #[cfg(feature = "etcd")]
             etcd_client_key_path: self.etcd_client_key_path.or(base.etcd_client_key_path),
+            #[cfg(feature = "etcd")]
+            metadata: self.metadata.or(base.metadata),
+            #[cfg(feature = "etcd")]
+            metadata_endpoints: self.metadata_endpoints.or(base.metadata_endpoints),
+            #[cfg(feature = "etcd")]
+            metadata_prefix: self.metadata_prefix.or(base.metadata_prefix),
             #[cfg(feature = "kubernetes")]
             kubernetes_namespace: self.kubernetes_namespace.or(base.kubernetes_namespace),
         }
@@ -324,6 +388,26 @@ pub const COORDINATOR_ENV_SCHEMA: &[ConfigVar] = &[
         secret: false,
         help: "PEM client key path; mutual TLS.",
     },
+    ConfigVar {
+        env: "TALON_COORDINATOR_METADATA_ENDPOINTS",
+        key: "metadata.endpoints",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "Comma-separated etcd endpoints for the optional metadata store (TMS). \
+               Unset means no TMS: hard links and locks are refused with a distinct \
+               errno rather than approximated (ADR 0003 §4).",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_METADATA_PREFIX",
+        key: "metadata.prefix",
+        default: Some("/talon-metadata"),
+        cli: false,
+        secret: false,
+        help: "Keyspace prefix for metadata-store records. Must stay disjoint from the \
+               cluster-state prefix; the two stores have different durability \
+               invariants (ADR 0003 §7).",
+    },
     #[cfg(feature = "kubernetes")]
     ConfigVar {
         env: "TALON_COORDINATOR_K8S_NAMESPACE",
@@ -364,6 +448,8 @@ pub mod env_names {
     pub const ETCD_CLIENT_CERT_PATH: &str = "TALON_COORDINATOR_ETCD_CLIENT_CERT_PATH";
     #[cfg(feature = "etcd")]
     pub const ETCD_CLIENT_KEY_PATH: &str = "TALON_COORDINATOR_ETCD_CLIENT_KEY_PATH";
+    pub const METADATA_ENDPOINTS: &str = "TALON_COORDINATOR_METADATA_ENDPOINTS";
+    pub const METADATA_PREFIX: &str = "TALON_COORDINATOR_METADATA_PREFIX";
     #[cfg(feature = "kubernetes")]
     pub const K8S_NAMESPACE: &str = "TALON_COORDINATOR_K8S_NAMESPACE";
 }
@@ -445,6 +531,19 @@ impl CoordinatorConfigPatch {
             etcd_client_cert_path: get(env_names::ETCD_CLIENT_CERT_PATH),
             #[cfg(feature = "etcd")]
             etcd_client_key_path: get(env_names::ETCD_CLIENT_KEY_PATH),
+            #[cfg(feature = "etcd")]
+            metadata: None,
+            #[cfg(feature = "etcd")]
+            metadata_endpoints: get(env_names::METADATA_ENDPOINTS).map(|value| {
+                value
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|entry| !entry.is_empty())
+                    .map(str::to_string)
+                    .collect()
+            }),
+            #[cfg(feature = "etcd")]
+            metadata_prefix: get(env_names::METADATA_PREFIX),
             #[cfg(feature = "kubernetes")]
             kubernetes_namespace: get(env_names::K8S_NAMESPACE),
         })
@@ -526,6 +625,25 @@ impl CoordinatorConfig {
             kubernetes
         };
 
+        // The metadata block composes the same way the backend blocks do: a
+        // [metadata] table in the file, with environment scalars layered over
+        // it. Absent unless something asks for it -- ADR 0003 §1 keeps a cluster
+        // without TMS fully supported, so silence must not conjure a store.
+        #[cfg(feature = "etcd")]
+        let metadata = {
+            let mut metadata = merged.metadata;
+            if merged.metadata_endpoints.is_some() || merged.metadata_prefix.is_some() {
+                let block = metadata.get_or_insert_with(MetadataConfig::default);
+                if let Some(endpoints) = merged.metadata_endpoints {
+                    block.endpoints = endpoints;
+                }
+                if let Some(prefix) = merged.metadata_prefix {
+                    block.prefix = prefix;
+                }
+            }
+            metadata
+        };
+
         let config = Self {
             node_id: merged.node_id.unwrap_or_else(|| listen.clone()),
             admin_advertise: merged
@@ -555,6 +673,8 @@ impl CoordinatorConfig {
             etcd,
             #[cfg(feature = "kubernetes")]
             kubernetes,
+            #[cfg(feature = "etcd")]
+            metadata,
         };
         config.validate()?;
         Ok(config)
@@ -758,6 +878,77 @@ mod tests {
         );
         // Secret must never appear in Debug output.
         assert!(!format!("{config:?}").contains("s3cr3t"));
+    }
+
+    #[cfg(feature = "etcd")]
+    #[test]
+    fn no_metadata_block_means_no_metadata_store() {
+        // ADR 0003 §1: a cluster without TMS "is a complete, supported Talon
+        // deployment offering exactly today's feature set". Silence in the
+        // config must not conjure a store, because configuring one commits the
+        // deployment to backing up non-rebuildable state.
+        let config = CoordinatorConfig::resolve(
+            CoordinatorConfigPatch::default(),
+            CoordinatorConfigPatch::default(),
+            CoordinatorConfigPatch::default(),
+        )
+        .unwrap();
+        assert!(config.metadata.is_none());
+    }
+
+    #[cfg(feature = "etcd")]
+    #[test]
+    fn metadata_block_parses_from_toml_and_env_overrides_endpoints() {
+        let file = CoordinatorConfigPatch::from_toml(
+            "[metadata]\n\
+             endpoints = [\"https://etcd-a:2379\"]\n",
+        )
+        .unwrap();
+        let env = CoordinatorConfigPatch::from_env_with(|key| match key {
+            "TALON_COORDINATOR_METADATA_ENDPOINTS" => {
+                Some("https://tms-x:2379, https://tms-y:2379".into())
+            }
+            _ => None,
+        })
+        .unwrap();
+        let config =
+            CoordinatorConfig::resolve(file, env, CoordinatorConfigPatch::default()).unwrap();
+        let metadata = config.metadata.expect("metadata block present");
+        assert_eq!(
+            metadata.endpoints,
+            vec![
+                "https://tms-x:2379".to_string(),
+                "https://tms-y:2379".to_string()
+            ]
+        );
+        // The prefix defaults rather than being required.
+        assert_eq!(metadata.prefix, talon_metadata::DEFAULT_METADATA_PREFIX);
+    }
+
+    #[cfg(feature = "etcd")]
+    #[test]
+    fn the_metadata_prefix_stays_disjoint_from_cluster_state() {
+        // §7 permits sharing one physical etcd cluster but keeps the two stores
+        // separate, because membership is ephemeral and rebuildable while TMS
+        // records are durable and not. A shared prefix would make ADR 0001 §2's
+        // "bounded, rebuildable" invariant untrue by construction.
+        let config = CoordinatorConfig::resolve(
+            CoordinatorConfigPatch::from_toml(
+                "[metadata]\nendpoints = [\"https://etcd-a:2379\"]\n",
+            )
+            .unwrap(),
+            CoordinatorConfigPatch::default(),
+            CoordinatorConfigPatch::default(),
+        )
+        .unwrap();
+        let metadata = config.metadata.expect("metadata block present");
+        // Spelled out rather than imported: the point is that the two values
+        // must differ, so reading both from one constant would defeat the test.
+        let cluster_state_prefix = "/talon";
+        assert_ne!(metadata.prefix, cluster_state_prefix);
+        assert!(!metadata
+            .prefix
+            .starts_with(&format!("{cluster_state_prefix}/")));
     }
 
     #[cfg(feature = "kubernetes")]

--- a/crates/talon-coordinator/src/main.rs
+++ b/crates/talon-coordinator/src/main.rs
@@ -11,6 +11,9 @@ use talon_coordinator::{
     WriteDisposition,
 };
 use talon_core::{NodeInfo, NodeRole};
+use talon_metadata::ClusterCapabilities;
+#[cfg(feature = "etcd")]
+use talon_metadata::MetadataStore as _;
 use talon_transport::frame::HEADER_LEN;
 use talon_transport::{codec, ControlMessage, FrameHeader};
 use tokio::io::AsyncWriteExt;
@@ -114,6 +117,82 @@ impl Args {
             // flags. Feature-gated fields default to None here.
             ..Default::default()
         }
+    }
+}
+
+/// Connect the optional metadata store and derive what this cluster advertises.
+///
+/// A failure to reach a *configured* store is not fatal. ADR 0003 §6:
+///
+/// > TMS unavailability degrades TMS-backed features; it must not affect the
+/// > read path. Reads, cache hits and misses, placement lookups, and
+/// > write-through writes are unaffected. None consults TMS.
+///
+/// So an unreachable store still advertises its capabilities, with
+/// `store_reachable` false. Refusing to start would turn a metadata outage into
+/// a cache outage, which is the opposite of what §6 requires.
+async fn build_capabilities(config: &CoordinatorConfig) -> ClusterCapabilities {
+    #[cfg(feature = "etcd")]
+    {
+        let Some(metadata) = config.metadata.as_ref() else {
+            return ClusterCapabilities::none();
+        };
+        let store_config = talon_metadata::EtcdMetadataConfig {
+            endpoints: metadata.endpoints.clone(),
+            prefix: metadata.prefix.clone(),
+        };
+        match talon_metadata::EtcdMetadataStore::connect(&store_config).await {
+            Ok(store) => {
+                let advertised = store.capabilities();
+                let health = store.check_ready().await;
+                let store_reachable = health.as_ref().map(|h| h.ready).unwrap_or(false);
+                if store_reachable {
+                    tracing::info!(
+                        capabilities = %advertised,
+                        prefix = %metadata.prefix,
+                        "metadata store connected"
+                    );
+                } else {
+                    // Distinct from the "not configured" path below, as §6
+                    // requires: an operator must be able to tell an outage from
+                    // a deployment choice.
+                    tracing::warn!(
+                        capabilities = %advertised,
+                        prefix = %metadata.prefix,
+                        "metadata store configured but not ready; \
+                         TMS-backed features will fail closed"
+                    );
+                }
+                ClusterCapabilities {
+                    advertised,
+                    revision: talon_metadata::CapabilityRevision::new(1),
+                    store_reachable,
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    prefix = %metadata.prefix,
+                    "metadata store configured but unreachable; \
+                     TMS-backed features will fail closed"
+                );
+                // The capabilities an etcd-backed store would offer, reported as
+                // unreachable rather than absent. Dropping them here would make
+                // this indistinguishable from an unconfigured cluster and send
+                // clients the wrong errno (§4).
+                ClusterCapabilities {
+                    advertised: talon_metadata::CapabilitySet::none()
+                        .with(talon_metadata::Capability::HardLinks),
+                    revision: talon_metadata::CapabilityRevision::new(1),
+                    store_reachable: false,
+                }
+            }
+        }
+    }
+    #[cfg(not(feature = "etcd"))]
+    {
+        let _ = config;
+        ClusterCapabilities::none()
     }
 }
 
@@ -484,13 +563,17 @@ async fn main() -> anyhow::Result<()> {
         address: config.listen.clone(),
         role: NodeRole::Coordinator,
     };
-    let observability = Arc::new(CoordinatorObservability::new(
-        config.cluster_id.clone(),
-        node,
-        config.admin_advertise.clone(),
-        Duration::from_millis(config.state.request_timeout_ms),
-        store,
-    )?);
+    let capabilities = build_capabilities(&config).await;
+    let observability = Arc::new(
+        CoordinatorObservability::new(
+            config.cluster_id.clone(),
+            node,
+            config.admin_advertise.clone(),
+            Duration::from_millis(config.state.request_timeout_ms),
+            store,
+        )?
+        .with_capabilities(capabilities),
+    );
     observability.check_ready().await?;
     let state = Coordinator::new(
         Arc::clone(&observability),

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -168,6 +168,22 @@ PEM client key path; mutual TLS.
 - **Default:** none
 - **CLI flag:** not settable via CLI (config file or environment only)
 
+### `metadata.endpoints`
+
+Comma-separated etcd endpoints for the optional metadata store (TMS). Unset means no TMS: hard links and locks are refused with a distinct errno rather than approximated (ADR 0003 §4).
+
+- **Environment variable:** `TALON_COORDINATOR_METADATA_ENDPOINTS`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `metadata.prefix`
+
+Keyspace prefix for metadata-store records. Must stay disjoint from the cluster-state prefix; the two stores have different durability invariants (ADR 0003 §7).
+
+- **Environment variable:** `TALON_COORDINATOR_METADATA_PREFIX`
+- **Default:** `/talon-metadata`
+- **CLI flag:** not settable via CLI (config file or environment only)
+
 ### `kubernetes.namespace`
 
 Namespace holding Talon Lease objects.


### PR DESCRIPTION
Closes #395. Part of #380.

#393 added the capability snapshot and `GET /api/v1/capabilities`, but the
snapshot was always empty — a coordinator had no way to *have* a store. This
adds the `[metadata]` config block and wires the connection.

## An unreachable store does not stop the coordinator

§6:

> TMS unavailability degrades TMS-backed features; it must not affect the read
> path. Reads, cache hits and misses, placement lookups, and write-through writes
> are unaffected. None consults TMS.

Refusing to start on an unreachable TMS would turn a metadata outage into a
cache outage — the exact inversion §6 forbids.

## An unreachable store still advertises

Dropping the capabilities on connect failure would make it indistinguishable
from an unconfigured cluster, and §4 maps the two to different errnos on
purpose:

| | Not configured | Configured, unreachable |
|---|---|---|
| `link()` | `EPERM` | `EAGAIN` |
| locks | `EOPNOTSUPP` | `ENOLCK` |

One pair says stop asking, the other says retry. The two paths log at different
levels with different messages so an incident can separate an outage from a
deployment choice, as §6 requires.

## Absence means absence

No `[metadata]` block → no store, empty capability set, today's behaviour
exactly. §1 keeps such a cluster complete and supported, and configuring a store
commits the deployment to backing up state that *cannot* be rebuilt by listing
the object store:

> Backup and tested restore are mandatory once a deployment enables a TMS-backed
> feature.

So silence must not conjure one.

## Prefix separation

Defaults to `/talon-metadata`, disjoint from `ClusterStateStore`'s `/talon`. §7
permits sharing one physical etcd cluster but keeps the stores separate:
membership is ephemeral and rebuildable, TMS records are durable and not, and a
shared prefix would make ADR 0001 §2's "bounded, rebuildable" invariant untrue
by construction.

`the_metadata_prefix_stays_disjoint_from_cluster_state` spells both values out
rather than reading them from one constant — sharing a constant would defeat the
test.

## Feature wiring

`talon-coordinator/etcd` now forwards to `talon-metadata/etcd`, so the two are
enabled together rather than in a combination where the config block parses but
its store cannot be built.

## Validation

- 82 lib tests with `--features etcd`, 72 in the default build
- clippy `-D warnings` clean in both configurations
- `docs/reference/configuration.md` regenerated via `talon-gen-config-docs` for
  the drift gate
- `RUSTDOCFLAGS="-D warnings" cargo doc --all-features` clean

## Known gap

`store_reachable` is sampled once at startup. §6 wants it to track current
health, so a store that goes down later still reports reachable. Wiring it to
the periodic health path is a follow-up — it needs a refresh loop rather than a
one-shot, and belongs with the control-plane `CapabilityQuery` work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)