### PR TITLE
feat(coordinator): refresh capability reachability from the health path

### DIFF
--- a/crates/talon-coordinator/src/main.rs
+++ b/crates/talon-coordinator/src/main.rs
@@ -131,11 +131,16 @@ impl Args {
 /// So an unreachable store still advertises its capabilities, with
 /// `store_reachable` false. Refusing to start would turn a metadata outage into
 /// a cache outage, which is the opposite of what §6 requires.
-async fn build_capabilities(config: &CoordinatorConfig) -> ClusterCapabilities {
+async fn build_capabilities(
+    config: &CoordinatorConfig,
+) -> (
+    ClusterCapabilities,
+    Option<Arc<dyn talon_metadata::MetadataStore>>,
+) {
     #[cfg(feature = "etcd")]
     {
         let Some(metadata) = config.metadata.as_ref() else {
-            return ClusterCapabilities::none();
+            return (ClusterCapabilities::none(), None);
         };
         let store_config = talon_metadata::EtcdMetadataConfig {
             endpoints: metadata.endpoints.clone(),
@@ -163,11 +168,14 @@ async fn build_capabilities(config: &CoordinatorConfig) -> ClusterCapabilities {
                          TMS-backed features will fail closed"
                     );
                 }
-                ClusterCapabilities {
-                    advertised,
-                    revision: talon_metadata::CapabilityRevision::new(1),
-                    store_reachable,
-                }
+                (
+                    ClusterCapabilities {
+                        advertised,
+                        revision: talon_metadata::CapabilityRevision::new(1),
+                        store_reachable,
+                    },
+                    Some(Arc::new(store) as Arc<dyn talon_metadata::MetadataStore>),
+                )
             }
             Err(error) => {
                 tracing::warn!(
@@ -180,19 +188,26 @@ async fn build_capabilities(config: &CoordinatorConfig) -> ClusterCapabilities {
                 // unreachable rather than absent. Dropping them here would make
                 // this indistinguishable from an unconfigured cluster and send
                 // clients the wrong errno (§4).
-                ClusterCapabilities {
-                    advertised: talon_metadata::CapabilitySet::none()
-                        .with(talon_metadata::Capability::HardLinks),
-                    revision: talon_metadata::CapabilityRevision::new(1),
-                    store_reachable: false,
-                }
+                // No handle: the connection never succeeded, so there is
+                // nothing to sample. Reachability stays false until a restart,
+                // which is honest -- a store that was never reachable cannot be
+                // observed to recover through a handle that does not exist.
+                (
+                    ClusterCapabilities {
+                        advertised: talon_metadata::CapabilitySet::none()
+                            .with(talon_metadata::Capability::HardLinks),
+                        revision: talon_metadata::CapabilityRevision::new(1),
+                        store_reachable: false,
+                    },
+                    None,
+                )
             }
         }
     }
     #[cfg(not(feature = "etcd"))]
     {
         let _ = config;
-        ClusterCapabilities::none()
+        (ClusterCapabilities::none(), None)
     }
 }
 
@@ -563,17 +578,19 @@ async fn main() -> anyhow::Result<()> {
         address: config.listen.clone(),
         role: NodeRole::Coordinator,
     };
-    let capabilities = build_capabilities(&config).await;
-    let observability = Arc::new(
-        CoordinatorObservability::new(
-            config.cluster_id.clone(),
-            node,
-            config.admin_advertise.clone(),
-            Duration::from_millis(config.state.request_timeout_ms),
-            store,
-        )?
-        .with_capabilities(capabilities),
-    );
+    let (capabilities, metadata_store) = build_capabilities(&config).await;
+    let mut observability = CoordinatorObservability::new(
+        config.cluster_id.clone(),
+        node,
+        config.admin_advertise.clone(),
+        Duration::from_millis(config.state.request_timeout_ms),
+        store,
+    )?
+    .with_capabilities(capabilities);
+    if let Some(metadata_store) = metadata_store {
+        observability = observability.with_metadata_store(metadata_store);
+    }
+    let observability = Arc::new(observability);
     observability.check_ready().await?;
     let state = Coordinator::new(
         Arc::clone(&observability),

--- a/crates/talon-coordinator/src/observability.rs
+++ b/crates/talon-coordinator/src/observability.rs
@@ -13,7 +13,7 @@ use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
-use talon_metadata::ClusterCapabilities;
+use talon_metadata::{ClusterCapabilities, MetadataStore};
 
 use talon_core::metrics::labels;
 use talon_core::{
@@ -423,7 +423,23 @@ pub struct CoordinatorObservability {
     request_timeout: Duration,
     metrics: CoordinatorMetrics,
     store: Arc<dyn ClusterStateStore>,
+    /// What this cluster advertises, and the store that backs it.
+    ///
+    /// `advertised` and `revision` are fixed at construction: they describe the
+    /// deployment's configuration. Reachability is not part of that -- ADR 0003
+    /// §6 requires "not configured" and "configured but unreachable" to be
+    /// separable *during an incident*, which a value sampled once at startup
+    /// cannot do. So it lives in an atomic, refreshed on the readiness path.
     capabilities: ClusterCapabilities,
+    /// Current reachability of the metadata store.
+    ///
+    /// Kept beside `capabilities` rather than inside it so a reachability change
+    /// cannot be mistaken for a capability change: the revision must not advance
+    /// when a store blips, or every outage would look like a reconfiguration and
+    /// invalidate every client's cached capability set.
+    metadata_reachable: AtomicBool,
+    /// Handle used to sample reachability. `None` when no store is configured.
+    metadata_store: Option<Arc<dyn MetadataStore>>,
 }
 
 impl CoordinatorObservability {
@@ -453,6 +469,8 @@ impl CoordinatorObservability {
             // degraded one, so this is the correct default and not a
             // placeholder.
             capabilities: ClusterCapabilities::none(),
+            metadata_reachable: AtomicBool::new(true),
+            metadata_store: None,
         })
     }
 
@@ -462,7 +480,19 @@ impl CoordinatorObservability {
     /// omitting this leaves the empty set from [`ClusterCapabilities::none`].
     #[must_use]
     pub fn with_capabilities(mut self, capabilities: ClusterCapabilities) -> Self {
+        self.metadata_reachable = AtomicBool::new(capabilities.store_reachable);
         self.capabilities = capabilities;
+        self
+    }
+
+    /// Attach the metadata store used to sample reachability.
+    ///
+    /// Without this the advertised reachability stays at whatever
+    /// [`with_capabilities`](Self::with_capabilities) recorded, which is a
+    /// startup fact. §6 needs a current one.
+    #[must_use]
+    pub fn with_metadata_store(mut self, store: Arc<dyn MetadataStore>) -> Self {
+        self.metadata_store = Some(store);
         self
     }
 
@@ -470,8 +500,52 @@ impl CoordinatorObservability {
     ///
     /// ADR 0003 §4 requires these to be discoverable "without attempting an
     /// operation", which is what the management API endpoint is for.
-    pub fn capabilities(&self) -> &ClusterCapabilities {
-        &self.capabilities
+    pub fn capabilities(&self) -> ClusterCapabilities {
+        ClusterCapabilities {
+            advertised: self.capabilities.advertised,
+            // Deliberately unchanged by reachability: a store blip is not a
+            // reconfiguration, and advancing this would invalidate every
+            // client's cached capability set on every outage.
+            revision: self.capabilities.revision,
+            store_reachable: self.metadata_reachable.load(Ordering::Acquire),
+        }
+    }
+
+    /// Sample the metadata store and update advertised reachability.
+    ///
+    /// Runs on the readiness path, never on the read path. §6 is explicit that
+    /// "reads, cache hits and misses, placement lookups, and write-through
+    /// writes are unaffected. None consults TMS", so request handling reads the
+    /// cached atomic rather than probing the store.
+    ///
+    /// A cluster with no store keeps reporting reachable: an empty capability
+    /// set is always serviceable, and there is nothing that could be down.
+    async fn refresh_metadata_reachability(&self) {
+        let Some(store) = self.metadata_store.as_ref() else {
+            return;
+        };
+        let reachable = match tokio::time::timeout(self.request_timeout, store.check_ready()).await
+        {
+            Ok(Ok(health)) => health.ready,
+            Ok(Err(_)) | Err(_) => false,
+        };
+        let previous = self.metadata_reachable.swap(reachable, Ordering::AcqRel);
+        if previous != reachable {
+            // Logged at the transition rather than every sample, and separately
+            // from the "not configured" case, so an incident can tell an outage
+            // from a deployment choice (§6).
+            if reachable {
+                tracing::info!(
+                    capabilities = %self.capabilities.advertised,
+                    "metadata store reachable again; TMS-backed features restored"
+                );
+            } else {
+                tracing::warn!(
+                    capabilities = %self.capabilities.advertised,
+                    "metadata store became unreachable; TMS-backed features fail closed"
+                );
+            }
+        }
     }
 
     /// Coordinator metric handles.
@@ -507,6 +581,11 @@ impl CoordinatorObservability {
         self.metrics
             .record_state("readiness", &result, started.elapsed());
         self.ready.store(result.is_ok(), Ordering::Release);
+        // Sampled alongside cluster-state readiness so reachability tracks the
+        // present rather than startup. A metadata failure must not affect this
+        // result: §6 keeps TMS outages away from the read path, and readiness
+        // gates the read path.
+        self.refresh_metadata_reachability().await;
         result
     }
 
@@ -853,6 +932,191 @@ fn generate_incarnation_id() -> std::io::Result<String> {
         write!(id, "{byte:02x}").expect("writing to a String cannot fail");
     }
     Ok(id)
+}
+
+#[cfg(test)]
+mod capability_tests {
+    use super::*;
+    use crate::MemoryStateStore;
+    use async_trait::async_trait;
+    use talon_core::{NodeId, NodeRole};
+    use talon_metadata::{
+        BackendHealth, Capability, CapabilityRevision, CapabilitySet, InodeNumber, InodeRecord,
+        MappingRevision, MetadataBackend, MetadataError, MetadataResult, NamespaceId,
+        PathIndexEntry, Transaction, TransactionOutcome,
+    };
+
+    /// A store whose reachability the test controls.
+    struct FlakyStore {
+        ready: AtomicBool,
+    }
+
+    #[async_trait]
+    impl MetadataStore for FlakyStore {
+        fn backend(&self) -> MetadataBackend {
+            MetadataBackend::Memory
+        }
+
+        fn capabilities(&self) -> CapabilitySet {
+            CapabilitySet::none().with(Capability::HardLinks)
+        }
+
+        async fn check_ready(&self) -> MetadataResult<BackendHealth> {
+            if self.ready.load(Ordering::Acquire) {
+                Ok(BackendHealth {
+                    ready: true,
+                    detail: "up".to_owned(),
+                })
+            } else {
+                Err(MetadataError::Unavailable {
+                    backend: MetadataBackend::Memory,
+                    detail: "simulated outage".to_owned(),
+                })
+            }
+        }
+
+        async fn mapping_revision(
+            &self,
+            _namespace: &NamespaceId,
+        ) -> MetadataResult<MappingRevision> {
+            Ok(MappingRevision::INITIAL)
+        }
+
+        async fn resolve_path(
+            &self,
+            _namespace: &NamespaceId,
+            _path: &str,
+        ) -> MetadataResult<Option<PathIndexEntry>> {
+            Ok(None)
+        }
+
+        async fn load_inode(
+            &self,
+            _namespace: &NamespaceId,
+            inode: InodeNumber,
+        ) -> MetadataResult<InodeRecord> {
+            Err(MetadataError::NotFound {
+                key: format!("inode/{inode}"),
+            })
+        }
+
+        async fn commit(&self, _transaction: &Transaction) -> MetadataResult<TransactionOutcome> {
+            Err(MetadataError::Unavailable {
+                backend: MetadataBackend::Memory,
+                detail: "not used in this test".to_owned(),
+            })
+        }
+    }
+
+    fn observability(store: Arc<dyn MetadataStore>) -> CoordinatorObservability {
+        CoordinatorObservability::new(
+            "c".into(),
+            NodeInfo {
+                id: NodeId::new("coord"),
+                address: "coord:7000".into(),
+                role: NodeRole::Coordinator,
+            },
+            "coord:8000".into(),
+            Duration::from_secs(1),
+            Arc::new(MemoryStateStore::new()),
+        )
+        .expect("observability")
+        .with_capabilities(ClusterCapabilities {
+            advertised: CapabilitySet::none().with(Capability::HardLinks),
+            revision: CapabilityRevision::new(3),
+            store_reachable: true,
+        })
+        .with_metadata_store(store)
+    }
+
+    #[tokio::test]
+    async fn reachability_tracks_the_present_not_startup() {
+        // ADR 0003 §6 requires "not configured" and "configured but unreachable"
+        // to be separable *during an incident* -- which is exactly when a value
+        // sampled once at startup is stale.
+        let store = Arc::new(FlakyStore {
+            ready: AtomicBool::new(true),
+        });
+        let obs = observability(store.clone());
+        obs.check_ready().await.expect("cluster state is ready");
+        assert!(obs.capabilities().store_reachable);
+
+        store.ready.store(false, Ordering::Release);
+        obs.check_ready()
+            .await
+            .expect("cluster state is still ready");
+        assert!(
+            !obs.capabilities().store_reachable,
+            "an outage after startup must be visible"
+        );
+
+        store.ready.store(true, Ordering::Release);
+        obs.check_ready().await.expect("cluster state is ready");
+        assert!(
+            obs.capabilities().store_reachable,
+            "recovery must be visible too"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_store_outage_does_not_advance_the_capability_revision() {
+        // A blip is not a reconfiguration. Advancing the revision here would
+        // invalidate every client's cached capability set on every outage, and
+        // would make the revision useless as a change signal.
+        let store = Arc::new(FlakyStore {
+            ready: AtomicBool::new(true),
+        });
+        let obs = observability(store.clone());
+        obs.check_ready().await.expect("ready");
+        let before = obs.capabilities().revision;
+
+        store.ready.store(false, Ordering::Release);
+        obs.check_ready().await.expect("ready");
+
+        assert_eq!(obs.capabilities().revision, before);
+        assert_eq!(
+            obs.capabilities().advertised,
+            CapabilitySet::none().with(Capability::HardLinks),
+            "an unreachable store still advertises what it offers"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_metadata_outage_does_not_make_the_cluster_unready() {
+        // §6: "TMS unavailability degrades TMS-backed features; it must not
+        // affect the read path." Readiness gates the read path, so a metadata
+        // outage must not turn the coordinator unready.
+        let store = Arc::new(FlakyStore {
+            ready: AtomicBool::new(false),
+        });
+        let obs = observability(store);
+        obs.check_ready()
+            .await
+            .expect("a metadata outage must not fail cluster readiness");
+        assert!(obs.is_ready(), "the read path stays available");
+        assert!(!obs.capabilities().store_reachable);
+    }
+
+    #[tokio::test]
+    async fn a_cluster_without_a_metadata_store_stays_reachable() {
+        // An empty capability set is always serviceable: there is nothing that
+        // could be down, so reporting it unreachable would invent an outage.
+        let obs = CoordinatorObservability::new(
+            "c".into(),
+            NodeInfo {
+                id: NodeId::new("coord"),
+                address: "coord:7000".into(),
+                role: NodeRole::Coordinator,
+            },
+            "coord:8000".into(),
+            Duration::from_secs(1),
+            Arc::new(MemoryStateStore::new()),
+        )
+        .expect("observability");
+        obs.check_ready().await.expect("ready");
+        assert!(obs.capabilities().store_reachable);
+        assert!(obs.capabilities().advertised.is_empty());
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #398. Part of #380. Follow-up to #397.

`build_capabilities` sampled the store once at startup, so `store_reachable` was
a startup fact. §6 needs a current one:

> Operations requiring TMS fail closed, with the same errno as an unconfigured
> cluster plus a distinct log and metric so "not configured" and "configured but
> unreachable" are separable in an incident.

An incident is exactly when a startup-sampled value is stale.

## Three invariants, each with a test

**Reachability tracks the present.** It now lives in an atomic refreshed on the
readiness path. Request handling reads that atomic rather than probing the
store, which preserves §6's other requirement — "reads, cache hits and misses,
placement lookups, and write-through writes are unaffected. None consults TMS."

**A metadata outage does not make the coordinator unready.** Readiness gates the
read path, so failing it on a TMS outage would turn a metadata failure into a
cache failure — the inversion §6 forbids.

**A store blip does not advance the capability revision.** Reachability is kept
*beside* the capability set rather than inside it. A blip is not a
reconfiguration: advancing the revision would invalidate every client's cached
capability set on every outage and make the revision useless as a change signal.

## Confirmed by mutation testing

| Mutation | Result |
|---|---|
| `capabilities()` reports the startup value instead of the atomic | ✅ 2 tests fail |
| Revision advances when the store is unreachable | ✅ 1 test fails |

## A failed initial connection

Yields no store handle, so reachability stays `false` until a restart. That is
honest — a store that was never reachable cannot be observed to recover through
a handle that does not exist — and it still advertises the capabilities it would
offer, so clients get `EAGAIN` rather than `EPERM` (§4).

## Validation

- 76 lib tests default, 86 with `--features etcd`
- clippy `-D warnings` clean in both configurations
- `cargo doc --all-features` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)