### PR TITLE
test(fuse): mount pjdfstest with allow_other and default_permissions

### DIFF
--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -1929,9 +1929,29 @@ async fn mount_pjdfstest_compatibility_suite() {
 
     let mountpoint = std::env::temp_dir().join(format!("talon-pjdfstest-{}", std::process::id()));
     std::fs::create_dir_all(&mountpoint).unwrap();
-    let options = vec![MountOption::FSName("talon".into())];
+    // pjdfstest runs most of its checks as an unprivileged user (`-u 65534`),
+    // so both options are load-bearing and neither is sufficient alone.
+    //
+    // Without `AllowOther` the kernel refuses that user at the mount point
+    // before any request reaches Talon, so every such check failed with EACCES
+    // while testing nothing about this filesystem. Without `DefaultPermissions`
+    // the kernel performs no permission check of its own, so a chmod that
+    // should have been refused succeeds.
+    //
+    // Measured over the full suite (8798 assertions): 3277 failures with
+    // neither, 67 with both. Per-group, chmod went 64 -> 64 with
+    // `DefaultPermissions` alone, 64 -> 1 with `AllowOther` alone, and 64 -> 0
+    // with both.
+    //
+    // This mirrors `mount_metadata_enforces_multiuser_permissions`, the other
+    // test here that crosses a uid boundary; it has always mounted this way.
+    let options = vec![
+        MountOption::FSName("talon".into()),
+        MountOption::DefaultPermissions,
+        MountOption::AllowOther,
+    ];
     let session = fuser::spawn_mount2(adapter, &mountpoint, &options)
-        .expect("TALON_RUN_PJDFSTEST requires a working /dev/fuse");
+        .expect("TALON_RUN_PJDFSTEST requires a working /dev/fuse and user_allow_other");
 
     tokio::time::sleep(Duration::from_millis(100)).await;
     let test_dir = mountpoint.join("s3").join("bucket");

--- a/crates/talon-fuse/tests/posix/README.md
+++ b/crates/talon-fuse/tests/posix/README.md
@@ -14,8 +14,18 @@ The runner requires:
 
 - Linux with a mounted Talon FUSE filesystem
 - root privileges
+- `user_allow_other` in `/etc/fuse.conf`
 - `git`, `autoconf`, `automake`, `make`, a C compiler, `perl`, `prove`,
   `openssl`, and `findmnt`
+
+The `user_allow_other` line is not optional. pjdfstest runs most of its checks
+as an unprivileged user, and without it the kernel refuses that user at the
+mount point before any request reaches Talon — so the suite reports thousands of
+`EACCES` failures that say nothing about this filesystem. Add it with:
+
+```sh
+echo user_allow_other | sudo tee -a /etc/fuse.conf
+```
 
 On Ubuntu, the required user-space packages can be installed with:
 
@@ -52,8 +62,11 @@ The runner downloads and builds the pinned pjdfstest revision under
 running destructive filesystem tests against the host filesystem.
 
 The complete suite is not expected to pass until Talon implements all covered
-operations. Add operation-specific invocations and expected-result tracking
-incrementally as support is added.
+operations. As of 2026-07-29, with the mount options above, 67 of 8798
+assertions fail (99.2% pass). Before those options were corrected the same run
+reported 3277 failures — almost all of them the kernel refusing an unprivileged
+user at the mount point, not Talon rejecting anything. Treat a large jump in
+this number as a mount-configuration problem before reading it as a regression.
 
 ## Run through the kernel-mount fixture
 


### PR DESCRIPTION
## The 71% pass rate was measuring the wrong thing

pjdfstest reported **3277 of 8798 assertions failing**, and almost none of them
were about Talon.

It runs most of its checks as an unprivileged user (`-u 65534`). The mount did
not pass `AllowOther`, so **the kernel refused that user at the mount point and
no request ever reached this filesystem**. The suite was measuring whether a
non-root process could enter the mount.

With both options: **67 failures — 99.2% rather than 71%.** Those 67 are the
real gaps.

## Ablation: the result contradicted my expectation

I assumed `DefaultPermissions` was the fix. It is not.

| Mount options | chmod failures | Full suite |
|---|---|---|
| Neither (before) | 64 | **3277** |
| `DefaultPermissions` only | **64** — no change | — |
| `AllowOther` only | **1** | — |
| Both | **0** | **67** |

The single case `AllowOther` alone leaves is a chmod that *should* have been
refused and succeeded — exactly what `DefaultPermissions` exists to prevent. So
neither is redundant, but `AllowOther` is doing the heavy lifting.

**Control:** reverting the change reproduced the original failure count,
confirming the improvement came from this and not environment drift.

## Production was never affected

- `main.rs:292` already mounts with `DefaultPermissions`.
- `mount_metadata_enforces_multiuser_permissions` — the *other* test here that
  crosses a uid boundary — has always used both options, with the comment
  "requires an allow_other FUSE mount".

This mount point simply did not follow the pattern already established beside
it.

## Documentation

`AllowOther` requires `user_allow_other` in `/etc/fuse.conf`. The README now
states that as a hard requirement rather than a footnote, since omitting it
reproduces the same thousands of misleading `EACCES` failures. It also records
the current pass rate, so a large jump reads as a mount-configuration problem
before it reads as a regression.

## Validation

Run on a real kernel mount in a privileged pod:

- pjdfstest: 3277 → 67 failures of 8798
- All 17 `mount_e2e` tests still pass
- clippy `-D warnings`, fmt clean

## Follow-up

The remaining 67 are worth triaging — some are likely the known-broken hard
links (#363) and unimplemented POSIX locking. That is a separate issue, and it
is now a tractable list rather than a wall of noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)