### PR TITLE
ci(fuse): remove the fusermount3 copy that shadows the system one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,53 +73,61 @@ jobs:
       TALON_REQUIRE_FUSE: "1"
     steps:
       - uses: actions/checkout@v4
-      - name: Verify the runner can actually mount FUSE
-        # /dev/fuse existing is necessary but not sufficient (#405). An
-        # unprivileged process mounts through the setuid fusermount3 helper, so
-        # a missing setuid bit, a restrictive /etc/fuse.conf, or an AppArmor
-        # policy denying the helper all produce EPERM while /dev/fuse looks
-        # fine. Capture the evidence unconditionally: when this job fails, the
-        # log should already say which of those it was rather than requiring a
-        # second run to find out.
+      - name: Capture the FUSE environment
+        # /dev/fuse existing is necessary but not sufficient (#405). Capture
+        # everything that can make an unprivileged mount fail, so a failing run
+        # is diagnosable from its own log rather than from a second run.
         run: |
           if [ ! -e /dev/fuse ]; then
             echo "::error::/dev/fuse is missing on this runner; the FUSE mount test cannot run"
             exit 1
           fi
-          echo "--- identity (root skips fusermount3 entirely) ---"
+          echo "--- identity (root would bypass fusermount3 entirely) ---"
           id
           echo "--- /dev/fuse ---"
           ls -l /dev/fuse
-          echo "--- fusermount3 (expect -rwsr-xr-x; a missing 's' is the bug) ---"
-          ls -l "$(command -v fusermount3 || echo /usr/bin/fusermount3)" || true
+          echo "--- fusermount3 on PATH, and every copy of it ---"
+          ls -l "$(command -v fusermount3)" 2>/dev/null || echo "(none on PATH)"
+          ls -l /usr/bin/fusermount3 /usr/local/bin/fusermount3 2>/dev/null || true
           echo "--- /etc/fuse.conf ---"
           cat /etc/fuse.conf 2>/dev/null || echo "(absent)"
           echo "--- apparmor ---"
           aa-status --enabled 2>/dev/null && echo "apparmor enabled" || echo "apparmor not enabled or unavailable"
-      - name: Ensure fusermount3 can mount as an unprivileged user
-        # The actual cause of #405. An unprivileged process mounts through the
-        # setuid fusermount3 helper; without the setuid bit it gets EPERM while
-        # /dev/fuse still looks perfectly healthy, so the pre-flight check above
-        # passes and every mount test then fails identically.
+      - name: Ensure an unprivileged FUSE mount is possible
+        # Some runner images carry a second fusermount3 in /usr/local/bin, owned
+        # by the runner user and without the setuid bit, which shadows the
+        # system helper on PATH. An unprivileged process invoking it cannot
+        # mount, which is #405: every mount test then fails with EPERM in the
+        # same second while /dev/fuse looks perfectly healthy.
         #
-        # Reproduced as a controlled experiment: same container, same non-root
-        # user, same code, with the bit the tests pass and without it they fail
-        # with the exact message CI produces.
+        # Captured from a failing runner:
+        #   -rwxrwxrwx 1 runner runner /usr/local/bin/fusermount3
+        # against a passing one:
+        #   -rwsr-xr-x 1 root   root   /usr/bin/fusermount3
         #
-        # Restoring it here rather than waiting on the runner image keeps the
-        # job honest -- it still exercises the real unprivileged mount path,
-        # which is what makes this test worth running at all.
+        # Remove the shadow rather than chmod-ing it. Adding setuid to a
+        # runner-writable binary would be worse than the bug, and removing it
+        # keeps the job exercising the real system helper -- which is the only
+        # reason this test is worth running.
         run: |
-          helper="$(command -v fusermount3 || echo /usr/bin/fusermount3)"
-          if [ ! -u "$helper" ]; then
-            echo "$helper is missing its setuid bit (see #405); restoring it"
-            sudo chmod u+s "$helper"
+          shadow=/usr/local/bin/fusermount3
+          if [ -e "$shadow" ] && [ ! -u "$shadow" ]; then
+            echo "removing non-setuid $shadow which shadows the system helper (#405)"
+            sudo rm -f "$shadow"
+            hash -r 2>/dev/null || true
           fi
-          ls -l "$helper"
-          if [ ! -u "$helper" ]; then
-            echo "::error::$helper still has no setuid bit; unprivileged mounts cannot work"
+          helper="$(command -v fusermount3 || true)"
+          if [ -z "$helper" ] || [ ! -u "$helper" ]; then
+            echo "::error::no setuid fusermount3 on PATH (found: ${helper:-none}); unprivileged mounts cannot work"
+            ls -l "$helper" 2>/dev/null || true
             exit 1
           fi
+          ls -l "$helper"
+          # pjdfstest mounts with allow_other (#419), which needs this enabled.
+          if ! grep -q '^user_allow_other' /etc/fuse.conf 2>/dev/null; then
+            echo user_allow_other | sudo tee -a /etc/fuse.conf >/dev/null
+          fi
+          grep '^user_allow_other' /etc/fuse.conf
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: Swatinem/rust-cache@v2

--- a/crates/talon-fuse/tests/mount_e2e.rs
+++ b/crates/talon-fuse/tests/mount_e2e.rs
@@ -1413,24 +1413,32 @@ async fn mount_hard_links_to_objects_are_refused() {
         assert_eq!(retained, b"ne");
         drop(final_handle);
 
-        for _ in 0..100 {
-            let has_orphan = operation_store
+        // Orphan reclamation happens on a background task, so this polls rather
+        // than asserting immediately. The budget is deliberately generous: a
+        // fixed wall-clock window in a test that waits on background work will
+        // eventually find the slowest machine in the fleet, and when it does the
+        // failure looks like an orphan-handling regression rather than the
+        // timing artifact it is. Observed at 0.57s locally against a CI runner
+        // where the whole job took 122s (#423).
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        let orphan_remains = || {
+            operation_store
                 .lock()
                 .unwrap()
                 .keys()
-                .any(|path| path.starts_with("/s3/bucket/.__talon_internal/unlinked/"));
-            if !has_orphan {
+                .any(|path| path.starts_with("/s3/bucket/.__talon_internal/unlinked/"))
+        };
+        let started = std::time::Instant::now();
+        while std::time::Instant::now() < deadline {
+            if !orphan_remains() {
                 break;
             }
             std::thread::sleep(Duration::from_millis(10));
         }
         assert!(
-            !operation_store
-                .lock()
-                .unwrap()
-                .keys()
-                .any(|path| path.starts_with("/s3/bucket/.__talon_internal/unlinked/")),
-            "final release should delete the last-link orphan"
+            !orphan_remains(),
+            "final release should delete the last-link orphan; still present after {:?}",
+            started.elapsed()
         );
         Ok::<(), std::io::Error>(())
     })


### PR DESCRIPTION
Fixes #405.

## The failing capture

The diagnostics added in #418 finally ran on a failing runner
([job 90729415987](https://github.com/milvus-io/talon/actions/runs/30494155396/job/90729415987)):

| | Passing runner | **Failing runner** |
|---|---|---|
| Path resolved | `/usr/bin/fusermount3` | **`/usr/local/bin/fusermount3`** |
| Mode | `-rwsr-xr-x` | **`-rwxrwxrwx`** |
| Owner | `root:root` | **`runner:runner`** |
| setuid | yes | **no** |

Some runner images carry a **second `fusermount3` in `/usr/local/bin`**, owned
by the runner user and without the setuid bit, shadowing the system helper on
`PATH`. An unprivileged process invoking it cannot mount — so every mount test
fails with `EPERM` in the same second while `/dev/fuse` looks perfectly healthy.

Images with the extra copy fail, images without it pass. That is exactly the
intermittency observed, and nothing about Talon varies between them.

## Correcting my earlier claim

I previously reported the cause as a missing setuid bit and opened a fix for it.
That was right about the **mechanism** and wrong about the **object** — the
system helper was never the problem.

The distinction matters, because that fix did `chmod u+s` on whatever `PATH`
resolved to. On a failing runner that would have **added the setuid bit to a
runner-writable binary** — worse than the bug — while its comment asserted a
cause that was not the cause. It is removed here.

## Why remove rather than repair

Removing the shadow keeps the job exercising the real system helper, which is
the only reason this test is worth running, and makes a reappearance visible
rather than silently patched over.

## Also

The step enables `user_allow_other`, which the runner ships commented out
(`#user_allow_other`). That does not affect these tests, but it is required by
the pjdfstest suite enabled in #419, which mounts with `AllowOther` — so that
suite would otherwise fail on CI for an unrelated reason.

## Validation

Best judged by its own CI run and by `main` staying green afterwards. The
capture step now lists *every* copy of `fusermount3`, not just the one on
`PATH`, so a recurrence is immediately visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)