### PR TITLE
ci(e2e): stage the overwrite fixture instead of piping it to mc

### DIFF
--- a/scripts/k8s_l1_l2_e2e.sh
+++ b/scripts/k8s_l1_l2_e2e.sh
@@ -256,8 +256,18 @@ make_repeated_file() {
 upload_file() {
   local source="$1"
   local key="$2"
-  kubectl -n "$NAMESPACE" exec -i minio-client -- \
-    mc pipe "local/$BUCKET/$key" <"$source"
+  # Stage to the pod's filesystem first, then have mc read from there, rather
+  # than piping the fixture straight into `mc pipe` over `kubectl exec`.
+  #
+  # The direct pipe held a single API-server stream open for the whole 16 MiB
+  # transfer while mc consumed it, and that stalled at 0 B and was SIGKILLed
+  # (exit 137) reproducibly (#426). The seeding path already stages the same way
+  # and moves several hundred MiB without trouble, so this uses the mechanism
+  # that is known to work here instead of a second one that is not.
+  stage_file "$source" "$key"
+  # shellcheck disable=SC2016 # $1 expands in the container shell.
+  kubectl -n "$NAMESPACE" exec minio-client -- \
+    sh -c 'mc cp "/tmp/fixtures/$1" "$2/$1"' sh "$key" "local/$BUCKET"
 }
 
 stage_file() {


### PR DESCRIPTION
Fixes #426.

## The failure

`3-worker L1/L2 E2E and benchmark` failed reproducibly at:

```
[00:16:17] verifying source overwrite replaces stale L1 and L2 versions
 0 B / ?      (the transfer never advances)
command terminated with exit code 137
```

137 is SIGKILL. Two runs on the same PR failed at the same step with the same
code, so not random — and the branch under test was #425, whose entire diff is a
`pub mod` line plus a file of pure functions with no call sites, so not the code
either.

## Cause

`upload_file` was the **only** place that piped a fixture straight into
`mc pipe` over `kubectl exec`:

```sh
kubectl exec -i minio-client -- mc pipe "local/$BUCKET/$key" <"$source"
```

That holds a single API-server stream open for the whole 16 MiB while `mc`
consumes it.

Seeding — which moves several hundred MiB — has always done it differently:
stage to the pod's filesystem, then `mc mirror`. So the reliable mechanism was
already in the script, and this one call site used a second one that is not.

## Verification

Staged 16 MiB through `kubectl exec` into a real cluster: **complete and
byte-exact in ~9 seconds**. That is the path the fix uses.

## Note on diagnosis

I initially called this a flake and re-ran it. That was wrong — it reproduced
identically. Worth recording because the job **does not run on `main`** (it is
`pull_request` only, gated on paths), so there is no baseline and every failure
has to be re-litigated as "is this my change". #426 suggests running it on
`main` for that reason; this PR only fixes the stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)