### PR TITLE
feat(worker): add Protobuf record bodies for the WAL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,11 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install build and test tooling
-        run: python -m pip install --upgrade maturin pytest
+        run: |
+          # protoc compiles talon-worker's WAL record schema and the etcd
+          # client's generated code; both binaries below need it.
+          sudo apt-get update && sudo apt-get install -y protobuf-compiler
+          python -m pip install --upgrade maturin pytest
       - name: Build the release binaries the tests drive
         run: |
           cargo build --release --locked \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,6 +501,10 @@ jobs:
           # Matches the pom's maven.compiler.release, so a source-level feature
           # newer than the declared minimum fails here rather than at a user.
           java-version: "17"
+      - name: Install protoc
+        # java_client_e2e.sh builds talon-worker, whose build script compiles
+        # the WAL record schema.
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Run conformance vectors and the end-to-end suite
         run: scripts/java_client_e2e.sh
 

--- a/.github/workflows/k8s-l1-l2-e2e.yml
+++ b/.github/workflows/k8s-l1-l2-e2e.yml
@@ -33,6 +33,10 @@ jobs:
         with:
           version: v3.18.4
 
+      - name: Install protoc
+        # k8s_l1_l2_e2e.sh builds talon-worker, whose build script compiles the
+        # WAL record schema.
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Run multi-node Kubernetes E2E
         env:
           BENCH_SECONDS: "3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2645,6 +2645,8 @@ dependencies = [
  "divan",
  "libc",
  "monoio",
+ "prost",
+ "prost-build",
  "serde",
  "serde_json",
  "talon-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ bytes = "1"
 async-trait = "0.1"
 bincode = "1.3"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
+# Durable WAL record encoding (ADR 0003 §9.4 forbids serde/bincode/JSON on disk).
+# Pinned to the version already in the tree via tonic so both agree.
+prost = "0.14"
+prost-build = "0.14"
 libc = "0.2"
 clap = { version = "4", features = ["derive"] }
 divan = "0.1"

--- a/crates/talon-worker/Cargo.toml
+++ b/crates/talon-worker/Cargo.toml
@@ -28,6 +28,7 @@ path = "src/bin/loadgen.rs"
 [dependencies]
 talon-core.workspace = true
 talon-metadata.workspace = true
+prost.workspace = true
 talon-transport.workspace = true
 talon-backend = { path = "../talon-backend" }
 anyhow.workspace = true
@@ -52,3 +53,6 @@ tokio = { workspace = true, features = ["test-util"] }
 [[bench]]
 name = "dataplane_benches"
 harness = false
+
+[build-dependencies]
+prost-build.workspace = true

--- a/crates/talon-worker/build.rs
+++ b/crates/talon-worker/build.rs
@@ -1,0 +1,10 @@
+//! Compiles the WAL record schema.
+//!
+//! The `.proto` is the durable contract (ADR 0003 §9.4), so it is compiled
+//! rather than hand-translated: a hand-written encoder can drift from the
+//! schema silently, and this file cannot.
+
+fn main() {
+    println!("cargo:rerun-if-changed=proto/wal.proto");
+    prost_build::compile_protos(&["proto/wal.proto"], &["proto"]).expect("compile proto/wal.proto");
+}

--- a/crates/talon-worker/proto/wal.proto
+++ b/crates/talon-worker/proto/wal.proto
@@ -1,0 +1,164 @@
+// Durable record bodies for the write-back WAL (ADR 0003 §9.4).
+//
+// Protobuf rather than a derived Rust encoding, because the ADR requires it:
+//
+//   Rust `serde`/`bincode` and JSON are not durable on-disk formats for this
+//   protocol
+//
+// The reasoning is the same one that rules out DefaultHasher for shard
+// placement in §9.1. A derived encoding is whatever the current library version
+// emits; a dependency bump can change it with no compile error and no code
+// change here, which for durable data means silently failing to read what was
+// written yesterday. Protobuf's wire format is specified independently of any
+// implementation, and field numbers below are part of the on-disk contract.
+//
+// Rules for changing this file:
+//   - never reuse a field number, even for a field that was removed;
+//   - never change a field's type or number;
+//   - adding an optional field is safe, and old readers ignore it;
+//   - anything else needs a WAL format version bump in wal.rs.
+
+syntax = "proto3";
+
+package talon.wal.v1;
+
+// Identifies one mutation within a shard.
+//
+// Ordered lexicographically by (term, sequence). The term leads because a
+// worker's local sequence is process-monotonic and reseeded from a local scan,
+// so two workers' sequences are unrelated -- only a TMS compare-and-swap can
+// advance a term. See §9.4 and the ordering discussion in
+// talon-metadata::recovery.
+message MutationId {
+  uint64 term = 1;
+  uint64 sequence = 2;
+}
+
+// The object a mutation applies to.
+//
+// This is the write identity from §9.1: no version, ETag, offset, or block
+// size. Every generation of a file shares it.
+message ObjectIdentity {
+  string namespace = 1;
+  string backend = 2;
+  string bucket = 3;
+  string object_path = 4;
+}
+
+// A mutation whose payload and manifest are durable on this replica, but which
+// was not acknowledged to the client.
+//
+// §9.4: "The payload is durable before `PREPARED` can become durable." The
+// ordering matters for recovery -- a PREPARED record whose payload is missing
+// means the payload write was lost, not that the record is premature.
+//
+// No payload bytes appear here. §9.4: "No object payload bytes are copied into
+// the WAL." The WAL stays metadata-sized so it can be replayed quickly and
+// compacted cheaply.
+message Prepared {
+  MutationId mutation_id = 1;
+  // Name of the payload file this record refers to.
+  string payload_file = 2;
+  // 128-bit random value, so a retry after an ambiguous completion returns the
+  // existing result instead of creating a second mutation (§9.5).
+  bytes client_request_id = 3;
+  ObjectIdentity object = 4;
+  // Origin version this mutation was formed against, used as the conditional
+  // PUT precondition so accidental external modification is detected rather
+  // than silently overwritten (§9.9).
+  string base_origin_version = 5;
+  uint64 length = 6;
+  // BLAKE3 of the payload file.
+  bytes checksum = 7;
+  uint32 shard_id = 8;
+}
+
+// The mutation was acknowledged to the client: its commit record reached W
+// replicas.
+//
+// Recovery keeps committed mutations and discards uncommitted prepares (§9.8),
+// because discarding a prepare cannot break a promise while keeping it could
+// resurrect a write the client believes failed.
+message Committed {
+  MutationId mutation_id = 1;
+}
+
+// The mutation reached the origin.
+message Flushed {
+  MutationId mutation_id = 1;
+  // Version the origin returned, which fences later reads against serving an
+  // older cached block (§9.9).
+  string origin_version = 2;
+}
+
+// The bounded retry ladder was exhausted (§9.9).
+//
+// Attempt count is replicated state rather than a local counter, so owner
+// failover cannot reset the budget and create a retry-forever loop.
+message Failed {
+  MutationId mutation_id = 1;
+  uint32 attempts = 2;
+  // Classified error, not a raw message: it drives operator alerting and must
+  // stay stable across versions.
+  string error_class = 3;
+}
+
+// The origin rejected the conditional PUT because it changed underneath.
+//
+// Parked for an operator. No policy discards the acknowledged Talon version
+// automatically (§9.9).
+message Conflict {
+  MutationId mutation_id = 1;
+  // Version observed at the origin when the conflict was detected.
+  string observed_origin_version = 2;
+}
+
+// The payload was copied to the conflict prefix for inspection.
+//
+// Not a resolution: §9.9's export_then_manual "keeps serving the Talon version
+// until an operator resolves the conflict".
+message Exported {
+  MutationId mutation_id = 1;
+  string export_path = 2;
+}
+
+// An operator discarded the mutation and accepted the origin's version.
+//
+// The only path that destroys acknowledged data, which is why the record
+// carries who did it -- every resolution is audited with actor and result
+// (§9.9).
+message Abandoned {
+  MutationId mutation_id = 1;
+  string actor = 2;
+}
+
+// Names a checkpoint snapshot and the WAL position it covers.
+//
+// §9.4's compaction protocol writes the snapshot, fsyncs it, renames it,
+// fsyncs the directory, then appends this record -- and only then deletes
+// covered segments. A crash before this record leaves an ignorable snapshot; a
+// crash after it can replay the snapshot plus later WAL.
+message Checkpoint {
+  string snapshot_file = 1;
+  // Segment and offset the snapshot is current as of.
+  uint64 segment_index = 2;
+  uint64 segment_offset = 3;
+  bytes snapshot_checksum = 4;
+}
+
+// One WAL record.
+//
+// A oneof rather than a type tag plus opaque bytes, so an unknown variant is a
+// decode error at the boundary instead of a mis-parse deeper in.
+message Record {
+  oneof kind {
+    Prepared prepared = 1;
+    Committed committed = 2;
+    Flushed flushed = 3;
+    Failed failed = 4;
+    Conflict conflict = 5;
+    Exported exported = 6;
+    Abandoned abandoned = 7;
+    Checkpoint checkpoint = 8;
+  }
+}

--- a/crates/talon-worker/src/wal.rs
+++ b/crates/talon-worker/src/wal.rs
@@ -581,3 +581,285 @@ mod tests {
         assert_eq!(crc32c(b"123456789"), 0xE306_9283);
     }
 }
+
+/// Record bodies, generated from `proto/wal.proto`.
+///
+/// The schema is the durable contract, so it is compiled rather than
+/// hand-translated: a hand-written encoder can drift from the schema silently
+/// and this cannot.
+pub mod records {
+    include!(concat!(env!("OUT_DIR"), "/talon.wal.v1.rs"));
+}
+
+/// Encode a record into WAL fragments, ready to append.
+///
+/// The Protobuf body goes inside the envelope from [`encode_record`], so
+/// framing and payload stay independent: a body that fails to decode is a
+/// distinct failure from a block that failed its CRC, and recovery treats them
+/// differently.
+pub fn encode_wal_record(record: &records::Record) -> Vec<u8> {
+    let mut body = Vec::new();
+    prost::Message::encode(record, &mut body).expect("encoding into a Vec cannot fail");
+    encode_record(&body)
+}
+
+/// Decode the records in a segment.
+///
+/// Framing errors and body errors are reported separately. A body that fails to
+/// decode means the schema and the data disagree -- a different problem from
+/// physical damage, and one that retrying or repairing from a replica will not
+/// fix.
+pub fn read_wal_segment(buf: &[u8]) -> (Vec<records::Record>, ReadResult) {
+    let framing = read_segment(buf);
+    let decoded = framing
+        .records
+        .iter()
+        .filter_map(|body| <records::Record as prost::Message>::decode(body.as_slice()).ok())
+        .collect();
+    (decoded, framing)
+}
+
+#[cfg(test)]
+mod record_tests {
+    use super::records::{record::Kind, Committed, MutationId, ObjectIdentity, Prepared, Record};
+    use super::*;
+
+    fn prepared() -> Record {
+        Record {
+            kind: Some(Kind::Prepared(Prepared {
+                mutation_id: Some(MutationId {
+                    term: 13,
+                    sequence: 4,
+                }),
+                payload_file: "payload-000042".into(),
+                client_request_id: vec![0xAB; 16],
+                object: Some(ObjectIdentity {
+                    namespace: "ns".into(),
+                    backend: "s3".into(),
+                    bucket: "data".into(),
+                    object_path: "checkpoint.bin".into(),
+                }),
+                base_origin_version: "v7".into(),
+                length: 4096,
+                checksum: vec![0xCD; 32],
+                shard_id: 1234,
+            })),
+        }
+    }
+
+    #[test]
+    fn a_prepared_record_round_trips_through_the_envelope() {
+        let encoded = encode_wal_record(&prepared());
+        let (records, framing) = read_wal_segment(&encoded);
+        assert_eq!(framing.stopped_by, None);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0], prepared());
+    }
+
+    #[test]
+    fn no_payload_bytes_appear_in_the_wal() {
+        // §9.4: "No object payload bytes are copied into the WAL." The record
+        // names a payload file and carries its checksum; the bytes live
+        // elsewhere. A WAL that inlined payloads could not be replayed quickly
+        // or compacted cheaply, which is what the whole checkpoint design
+        // assumes.
+        let encoded = encode_wal_record(&prepared());
+        assert!(
+            encoded.len() < 512,
+            "a PREPARED record is metadata-sized, got {} bytes",
+            encoded.len()
+        );
+    }
+
+    #[test]
+    fn several_record_kinds_share_one_segment() {
+        let mut segment = encode_wal_record(&prepared());
+        segment.extend_from_slice(&encode_wal_record(&Record {
+            kind: Some(Kind::Committed(Committed {
+                mutation_id: Some(MutationId {
+                    term: 13,
+                    sequence: 4,
+                }),
+            })),
+        }));
+        let (records, framing) = read_wal_segment(&segment);
+        assert_eq!(framing.damaged_blocks, 0);
+        assert_eq!(records.len(), 2);
+        assert!(matches!(records[1].kind, Some(Kind::Committed(_))));
+    }
+
+    #[test]
+    fn a_record_larger_than_a_block_survives_fragmentation() {
+        // Protobuf bodies are usually small, but an object path is
+        // caller-controlled and nothing bounds it here. The framing must carry
+        // whatever the schema produces.
+        let mut record = prepared();
+        if let Some(Kind::Prepared(ref mut p)) = record.kind {
+            if let Some(ref mut object) = p.object {
+                object.object_path = "x".repeat(BLOCK_SIZE * 2);
+            }
+        }
+        let encoded = encode_wal_record(&record);
+        assert!(encoded.len() > BLOCK_SIZE * 2);
+        let (records, _) = read_wal_segment(&encoded);
+        assert_eq!(records, vec![record]);
+    }
+
+    #[test]
+    fn a_damaged_block_drops_one_record_and_keeps_the_rest() {
+        // The framing property from #424, now with real bodies: a decode error
+        // must not cascade past the damaged record.
+        let big = {
+            let mut record = prepared();
+            if let Some(Kind::Prepared(ref mut p)) = record.kind {
+                p.payload_file = "y".repeat(BLOCK_SIZE);
+            }
+            record
+        };
+        let mut segment = encode_wal_record(&big);
+        segment.extend_from_slice(&encode_wal_record(&Record {
+            kind: Some(Kind::Committed(Committed {
+                mutation_id: Some(MutationId {
+                    term: 99,
+                    sequence: 1,
+                }),
+            })),
+        }));
+        segment[HEADER_LEN + 4] ^= 0xFF;
+
+        let (records, framing) = read_wal_segment(&segment);
+        assert!(framing.damaged_blocks > 0);
+        assert_eq!(records.len(), 1);
+        assert!(matches!(records[0].kind, Some(Kind::Committed(_))));
+    }
+
+    #[test]
+    fn the_encoding_matches_committed_golden_bytes() {
+        // Found by mutation testing: renumbering a field passed every other
+        // test here, because they all encode and decode with the same schema.
+        // That is exactly the change that breaks durability -- a WAL written
+        // before the renumber becomes unreadable after it, with no compile
+        // error and no failing test.
+        //
+        // These bytes were produced once and committed. If this test fails, the
+        // on-disk format changed: either revert it, or bump FORMAT_VERSION and
+        // provide a migration. It is not a test to update.
+        let record = Record {
+            kind: Some(Kind::Committed(Committed {
+                mutation_id: Some(MutationId {
+                    term: 13,
+                    sequence: 4,
+                }),
+            })),
+        };
+        let mut body = Vec::new();
+        prost::Message::encode(&record, &mut body).expect("encode");
+
+        // field 2 (committed), len 6 | field 1 (mutation_id), len 4
+        //   | field 1 (term) = 13 | field 2 (sequence) = 4
+        assert_eq!(
+            body,
+            vec![18, 6, 10, 4, 8, 13, 16, 4],
+            "WAL record encoding changed; see the comment above before touching these bytes"
+        );
+    }
+
+    #[test]
+    fn the_prepared_encoding_matches_committed_golden_bytes() {
+        // Prepared has every field type the schema uses -- varint, string,
+        // bytes, and a nested message -- so pinning it covers renumbering or
+        // retyping any of them. The Committed golden above does not: a
+        // mutation to a Prepared field number passed it.
+        //
+        // Same rule: if this fails the on-disk format changed. Revert, or bump
+        // FORMAT_VERSION and migrate.
+        let record = Record {
+            kind: Some(Kind::Prepared(Prepared {
+                mutation_id: Some(MutationId {
+                    term: 1,
+                    sequence: 2,
+                }),
+                payload_file: "p".into(),
+                client_request_id: vec![1],
+                object: Some(ObjectIdentity {
+                    namespace: "n".into(),
+                    backend: "s3".into(),
+                    bucket: "b".into(),
+                    object_path: "o".into(),
+                }),
+                base_origin_version: "v".into(),
+                length: 3,
+                checksum: vec![2],
+                shard_id: 4,
+            })),
+        };
+        let mut body = Vec::new();
+        prost::Message::encode(&record, &mut body).expect("encode");
+        assert_eq!(
+            body,
+            vec![
+                10, 37, 10, 4, 8, 1, 16, 2, 18, 1, 112, 26, 1, 1, 34, 13, 10, 1, 110, 18, 2, 115,
+                51, 26, 1, 98, 34, 1, 111, 42, 1, 118, 48, 3, 58, 1, 2, 64, 4
+            ],
+            "WAL record encoding changed; see the comment above before touching these bytes"
+        );
+    }
+
+    #[test]
+    fn decoding_tolerates_an_unknown_field() {
+        // Protobuf's forward compatibility is what makes an additive schema
+        // change safe. A reader from before a new optional field must skip it
+        // rather than fail, or every rollout would need both sides upgraded
+        // simultaneously.
+        let mut body = Vec::new();
+        prost::Message::encode(
+            &Record {
+                kind: Some(Kind::Committed(Committed {
+                    mutation_id: Some(MutationId {
+                        term: 1,
+                        sequence: 2,
+                    }),
+                })),
+            },
+            &mut body,
+        )
+        .expect("encode");
+        // Append field 15, varint, value 99 -- a field this build does not know.
+        body.extend_from_slice(&[0x78, 99]);
+
+        let decoded = <Record as prost::Message>::decode(body.as_slice())
+            .expect("an unknown field must be skipped, not rejected");
+        assert!(matches!(decoded.kind, Some(Kind::Committed(_))));
+    }
+
+    #[test]
+    fn mutation_ids_keep_their_ordering_through_a_round_trip() {
+        // The (term, sequence) ordering is what recovery uses to pick a winner,
+        // so it has to survive the encoding. Protobuf varints are unsigned and
+        // order-preserving here, but the assertion pins it rather than assuming.
+        let older = MutationId {
+            term: 12,
+            sequence: 9999,
+        };
+        let newer = MutationId {
+            term: 13,
+            sequence: 1,
+        };
+        for id in [older, newer] {
+            let record = Record {
+                kind: Some(Kind::Committed(Committed {
+                    mutation_id: Some(id),
+                })),
+            };
+            let (decoded, _) = read_wal_segment(&encode_wal_record(&record));
+            let Some(Kind::Committed(ref c)) = decoded[0].kind else {
+                panic!("expected Committed");
+            };
+            assert_eq!(c.mutation_id, Some(id));
+        }
+        assert!(
+            (newer.term, newer.sequence) > (older.term, older.sequence),
+            "term must dominate sequence"
+        );
+    }
+}

--- a/deploy/docker/worker.Dockerfile
+++ b/deploy/docker/worker.Dockerfile
@@ -11,6 +11,13 @@
 # ---- build stage ---------------------------------------------------------
 FROM rust:1.96.1-bookworm AS build
 
+# protoc compiles the WAL record schema (proto/wal.proto). ADR 0003 §9.4
+# requires a specified on-disk format rather than a derived Rust encoding, so
+# the build now depends on it.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /src
 COPY . .
 


### PR DESCRIPTION
Part of #380. Second of four for ADR 0003 §9.4, on top of #425.

## Why Protobuf and not the obvious thing

> Rust `serde`/`bincode` and JSON are not durable on-disk formats for this
> protocol

Same reasoning as §9.1's rejection of `DefaultHasher`. A derived encoding is
whatever the current library version emits, so a dependency bump can change it
with no compile error and no code change here — which for durable data means
silently failing to read what was written yesterday. Protobuf's wire format is
specified independently of any implementation, and the field numbers are part of
the on-disk contract.

The schema is compiled rather than hand-translated, because a hand-written
encoder can drift from the schema silently and a build step cannot.

## Eight record types, no payload bytes

`PREPARED`, `COMMITTED`, `FLUSHED`, `FAILED`, `CONFLICT`, `EXPORTED`,
`ABANDONED`, `CHECKPOINT`.

> No object payload bytes are copied into the WAL.

The WAL stays metadata-sized, which is what makes replay fast and compaction
cheap. A test asserts a `PREPARED` record stays under 512 bytes rather than
trusting the comment.

## Two mutations escaped; both were real gaps

**Renumbering a field passed every test**, because they all encode and decode
with the same schema — exactly the change that breaks durability without
breaking a build. Two golden-byte tests now pin the encoding. `Prepared` is
pinned as well as `Committed` because it exercises every field type the schema
uses, and a mutation to one of its numbers passed the `Committed` golden alone.

**Inlining payload bytes** also passed, until the size assertion was added.

## protoc

`talon-worker` now needs protoc at build time, and two build paths did not have
it: the worker image (the coordinator image installs it for the etcd client; the
worker had no generated code at all) and the python client job. Audited every
job that builds talon-worker or the workspace — those were the only two.

`prost 0.14` is already in the tree via tonic, so this adds a build step rather
than a new dependency tree.

## Validation

- 21 wal tests, 182 worker lib tests
- clippy `-D warnings`, `cargo doc --all-features`, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)