### PR TITLE
feat(core): model control-plane workload identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2556,12 +2556,14 @@ dependencies = [
  "async-trait",
  "bytes",
  "divan",
+ "percent-encoding",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,4 +65,6 @@ tokio-util = { version = "0.7", features = ["io"] }
 etcd-client = { version = "0.19", default-features = false, features = ["tls", "tls-roots"] }
 # gRPC status codes surfaced by etcd-client errors. Pinned to the same tonic
 # major the etcd client depends on so error mapping stays in sync.
+percent-encoding = "2"
 tonic = { version = "0.14", default-features = false }
+url = "2"

--- a/crates/talon-coordinator/src/config.rs
+++ b/crates/talon-coordinator/src/config.rs
@@ -3,13 +3,41 @@
 use std::path::Path;
 
 use serde::Deserialize;
-use talon_core::{ConfigVar, Patch, MAX_STATUS_FIELD_BYTES};
+use talon_core::{
+    ConfigVar, ControlTlsConfig, ControlTlsConfigPatch, Patch, MAX_STATUS_FIELD_BYTES,
+};
 
 #[cfg(feature = "kubernetes")]
 use crate::KubernetesConfig;
 use crate::{ClusterStateConfig, StateBackend};
 #[cfg(feature = "etcd")]
 use crate::{EtcdConfig, EtcdTlsConfig};
+
+fn merge_control_tls(
+    higher: Option<ControlTlsConfigPatch>,
+    lower: Option<ControlTlsConfigPatch>,
+) -> Option<ControlTlsConfigPatch> {
+    match (higher, lower) {
+        (Some(higher), Some(lower)) => Some(higher.merge(lower)),
+        (Some(patch), None) | (None, Some(patch)) => Some(patch),
+        (None, None) => None,
+    }
+}
+
+fn optional_control_tls_patch(
+    ca_cert_path: Option<String>,
+    cert_path: Option<String>,
+    key_path: Option<String>,
+    trust_domain: Option<String>,
+) -> Option<ControlTlsConfigPatch> {
+    let patch = ControlTlsConfigPatch {
+        ca_cert_path: ca_cert_path.map(Into::into),
+        cert_path: cert_path.map(Into::into),
+        key_path: key_path.map(Into::into),
+        trust_domain,
+    };
+    (!patch.is_empty()).then_some(patch)
+}
 
 /// Fully resolved coordinator configuration.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -24,6 +52,8 @@ pub struct CoordinatorConfig {
     pub cluster_id: String,
     /// Stable coordinator node identity.
     pub node_id: String,
+    /// Optional mTLS material for the privileged coordinator-worker channel.
+    pub control_tls: Option<ControlTlsConfig>,
     /// Shared-state and lease settings.
     pub state: ClusterStateConfig,
     /// etcd backend connection settings, required when `state.backend` is etcd.
@@ -50,6 +80,7 @@ impl Default for CoordinatorConfig {
             admin_advertise: "127.0.0.1:8000".into(),
             cluster_id: "default".into(),
             node_id: "127.0.0.1:7000".into(),
+            control_tls: None,
             state: ClusterStateConfig::default(),
             #[cfg(feature = "etcd")]
             etcd: None,
@@ -114,6 +145,8 @@ pub struct CoordinatorConfigPatch {
     pub cluster_id: Option<String>,
     /// Override for [`CoordinatorConfig::node_id`].
     pub node_id: Option<String>,
+    /// Optional `[control_tls]` block.
+    pub control_tls: Option<ControlTlsConfigPatch>,
     /// Shared-state backend selector.
     pub state_backend: Option<StateBackend>,
     /// Whether active-active coordinator mode is requested.
@@ -182,6 +215,7 @@ impl Patch for CoordinatorConfigPatch {
             admin_advertise: self.admin_advertise.or(base.admin_advertise),
             cluster_id: self.cluster_id.or(base.cluster_id),
             node_id: self.node_id.or(base.node_id),
+            control_tls: merge_control_tls(self.control_tls, base.control_tls),
             state_backend: self.state_backend.or(base.state_backend),
             ha_enabled: self.ha_enabled.or(base.ha_enabled),
             coordinator_replicas: self.coordinator_replicas.or(base.coordinator_replicas),
@@ -261,6 +295,38 @@ pub const COORDINATOR_ENV_SCHEMA: &[ConfigVar] = &[
         cli: true,
         secret: false,
         help: "Stable coordinator node identity.",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_CONTROL_TLS_CA_CERT_PATH",
+        key: "control_tls.ca_cert_path",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "PEM CA bundle for the privileged coordinator-worker mTLS channel.",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_CONTROL_TLS_CERT_PATH",
+        key: "control_tls.cert_path",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "PEM coordinator certificate chain for the privileged mTLS channel.",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_CONTROL_TLS_KEY_PATH",
+        key: "control_tls.key_path",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "PEM coordinator private-key file path; key bytes never enter configuration.",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_CONTROL_TLS_TRUST_DOMAIN",
+        key: "control_tls.trust_domain",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "Lowercase DNS trust domain required in peer workload URI SANs.",
     },
     ConfigVar {
         env: "TALON_COORDINATOR_STATE_BACKEND",
@@ -427,6 +493,10 @@ pub mod env_names {
     pub const ADMIN_ADVERTISE: &str = "TALON_COORDINATOR_ADMIN_ADVERTISE";
     pub const CLUSTER_ID: &str = "TALON_COORDINATOR_CLUSTER_ID";
     pub const NODE_ID: &str = "TALON_COORDINATOR_NODE_ID";
+    pub const CONTROL_TLS_CA_CERT_PATH: &str = "TALON_COORDINATOR_CONTROL_TLS_CA_CERT_PATH";
+    pub const CONTROL_TLS_CERT_PATH: &str = "TALON_COORDINATOR_CONTROL_TLS_CERT_PATH";
+    pub const CONTROL_TLS_KEY_PATH: &str = "TALON_COORDINATOR_CONTROL_TLS_KEY_PATH";
+    pub const CONTROL_TLS_TRUST_DOMAIN: &str = "TALON_COORDINATOR_CONTROL_TLS_TRUST_DOMAIN";
     pub const STATE_BACKEND: &str = "TALON_COORDINATOR_STATE_BACKEND";
     pub const HA_ENABLED: &str = "TALON_COORDINATOR_HA_ENABLED";
     pub const REPLICAS: &str = "TALON_COORDINATOR_REPLICAS";
@@ -488,6 +558,12 @@ impl CoordinatorConfigPatch {
             admin_advertise: get(env_names::ADMIN_ADVERTISE),
             cluster_id: get(env_names::CLUSTER_ID),
             node_id: get(env_names::NODE_ID),
+            control_tls: optional_control_tls_patch(
+                get(env_names::CONTROL_TLS_CA_CERT_PATH),
+                get(env_names::CONTROL_TLS_CERT_PATH),
+                get(env_names::CONTROL_TLS_KEY_PATH),
+                get(env_names::CONTROL_TLS_TRUST_DOMAIN),
+            ),
             state_backend: get(env_names::STATE_BACKEND)
                 .map(|value| parse(value, env_names::STATE_BACKEND))
                 .transpose()?,
@@ -563,6 +639,7 @@ impl CoordinatorConfig {
         let listen = merged.listen.unwrap_or(defaults.listen);
         let admin_listen = merged.admin_listen.unwrap_or(defaults.admin_listen);
         let cluster_id = merged.cluster_id.unwrap_or(defaults.cluster_id);
+        let control_tls = merged.control_tls.unwrap_or_default().resolve()?;
 
         // Fold backend blocks with their env/CLI scalar overrides. The block may
         // come entirely from an env override even with no `[etcd]`/`[kubernetes]`
@@ -652,6 +729,7 @@ impl CoordinatorConfig {
             listen,
             admin_listen,
             cluster_id,
+            control_tls,
             state: ClusterStateConfig {
                 backend: merged.state_backend.unwrap_or(default_state.backend),
                 ha_enabled: merged.ha_enabled.unwrap_or(default_state.ha_enabled),
@@ -700,6 +778,9 @@ impl CoordinatorConfig {
             }
         }
         self.state.validate()?;
+        if let Some(control_tls) = &self.control_tls {
+            control_tls.validate()?;
+        }
 
         // The selected backend must have a matching configuration block, and the
         // block itself must be valid. Memory needs no block.
@@ -770,6 +851,43 @@ mod tests {
         assert_eq!(config.admin_advertise, "public:8000");
         assert_eq!(config.node_id, "cli:7000");
         assert_eq!(config.cluster_id, "prod");
+    }
+
+    #[test]
+    fn control_tls_composes_file_and_environment_layers() {
+        let file = CoordinatorConfigPatch::from_toml(
+            "[control_tls]\n\
+             ca_cert_path = \"/tls/ca.pem\"\n\
+             cert_path = \"/tls/file-cert.pem\"\n\
+             key_path = \"/tls/key.pem\"\n\
+             trust_domain = \"prod.example.com\"\n",
+        )
+        .unwrap();
+        let env = CoordinatorConfigPatch::from_env_with(|key| {
+            (key == "TALON_COORDINATOR_CONTROL_TLS_CERT_PATH")
+                .then(|| "/tls/env-cert.pem".to_string())
+        })
+        .unwrap();
+        let config =
+            CoordinatorConfig::resolve(file, env, CoordinatorConfigPatch::default()).unwrap();
+        let tls = config.control_tls.expect("control TLS configured");
+        assert_eq!(tls.ca_cert_path, std::path::Path::new("/tls/ca.pem"));
+        assert_eq!(tls.cert_path, std::path::Path::new("/tls/env-cert.pem"));
+        assert_eq!(tls.key_path, std::path::Path::new("/tls/key.pem"));
+        assert_eq!(tls.trust_domain, "prod.example.com");
+
+        let partial = CoordinatorConfigPatch::from_env_with(|key| {
+            (key == "TALON_COORDINATOR_CONTROL_TLS_TRUST_DOMAIN")
+                .then(|| "prod.example.com".to_string())
+        })
+        .unwrap();
+        let error = CoordinatorConfig::resolve(
+            CoordinatorConfigPatch::default(),
+            partial,
+            CoordinatorConfigPatch::default(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("ca_cert_path"));
     }
 
     #[test]

--- a/crates/talon-core/Cargo.toml
+++ b/crates/talon-core/Cargo.toml
@@ -16,6 +16,8 @@ bytes.workspace = true
 async-trait.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+percent-encoding.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 divan.workspace = true

--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -22,7 +22,7 @@ use serde::Deserialize;
 use std::path::PathBuf;
 
 use crate::status::MAX_STATUS_FIELD_BYTES;
-use crate::{Error, Result};
+use crate::{ControlTlsConfig, ControlTlsConfigPatch, Error, Result};
 
 /// A configuration patch: a set of optionally-present overrides.
 ///
@@ -31,6 +31,32 @@ use crate::{Error, Result};
 pub trait Patch {
     /// Overlay `self` onto `base`, letting `self`'s set fields win.
     fn merge(self, base: Self) -> Self;
+}
+
+fn merge_control_tls(
+    higher: Option<ControlTlsConfigPatch>,
+    lower: Option<ControlTlsConfigPatch>,
+) -> Option<ControlTlsConfigPatch> {
+    match (higher, lower) {
+        (Some(higher), Some(lower)) => Some(higher.merge(lower)),
+        (Some(patch), None) | (None, Some(patch)) => Some(patch),
+        (None, None) => None,
+    }
+}
+
+fn optional_control_tls_patch(
+    ca_cert_path: Option<String>,
+    cert_path: Option<String>,
+    key_path: Option<String>,
+    trust_domain: Option<String>,
+) -> Option<ControlTlsConfigPatch> {
+    let patch = ControlTlsConfigPatch {
+        ca_cert_path: ca_cert_path.map(PathBuf::from),
+        cert_path: cert_path.map(PathBuf::from),
+        key_path: key_path.map(PathBuf::from),
+        trust_domain,
+    };
+    (!patch.is_empty()).then_some(patch)
 }
 
 /// One configurable setting, described once and reused by both the runtime
@@ -73,6 +99,8 @@ pub struct WorkerConfig {
     pub coordinator: String,
     /// Logical cluster advertised in node status.
     pub cluster_id: String,
+    /// Optional mTLS material for the privileged coordinator-worker channel.
+    pub control_tls: Option<ControlTlsConfig>,
     /// Stable node identity; defaults to the RPC listen address when unset.
     pub node_id: Option<String>,
     /// Control-plane heartbeat interval in milliseconds.
@@ -204,6 +232,7 @@ impl Default for WorkerConfig {
             admin_listen: "127.0.0.1:8001".into(),
             coordinator: "127.0.0.1:7000".into(),
             cluster_id: "default".into(),
+            control_tls: None,
             node_id: None,
             heartbeat_interval_ms: 5_000,
             block_size: 256 << 20,
@@ -249,6 +278,8 @@ pub struct WorkerConfigPatch {
     pub coordinator: Option<String>,
     /// Override for [`WorkerConfig::cluster_id`].
     pub cluster_id: Option<String>,
+    /// Optional `[control_tls]` block.
+    pub control_tls: Option<ControlTlsConfigPatch>,
     /// Override for [`WorkerConfig::node_id`].
     pub node_id: Option<String>,
     /// Override for [`WorkerConfig::heartbeat_interval_ms`].
@@ -307,6 +338,7 @@ impl Patch for WorkerConfigPatch {
             admin_listen: self.admin_listen.or(base.admin_listen),
             coordinator: self.coordinator.or(base.coordinator),
             cluster_id: self.cluster_id.or(base.cluster_id),
+            control_tls: merge_control_tls(self.control_tls, base.control_tls),
             node_id: self.node_id.or(base.node_id),
             heartbeat_interval_ms: self.heartbeat_interval_ms.or(base.heartbeat_interval_ms),
             block_size: self.block_size.or(base.block_size),
@@ -394,6 +426,38 @@ pub const WORKER_ENV_SCHEMA: &[ConfigVar] = &[
         cli: true,
         secret: false,
         help: "Stable worker node identity.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_CONTROL_TLS_CA_CERT_PATH",
+        key: "control_tls.ca_cert_path",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "PEM CA bundle for the privileged coordinator-worker mTLS channel.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_CONTROL_TLS_CERT_PATH",
+        key: "control_tls.cert_path",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "PEM worker certificate chain for the privileged mTLS channel.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_CONTROL_TLS_KEY_PATH",
+        key: "control_tls.key_path",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "PEM worker private-key file path; key bytes never enter configuration.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_CONTROL_TLS_TRUST_DOMAIN",
+        key: "control_tls.trust_domain",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "Lowercase DNS trust domain required in peer workload URI SANs.",
     },
     ConfigVar {
         env: "TALON_WORKER_HEARTBEAT_INTERVAL_MS",
@@ -620,6 +684,10 @@ pub(crate) mod worker_env {
     pub const COORDINATOR: &str = "TALON_WORKER_COORDINATOR";
     pub const CLUSTER_ID: &str = "TALON_WORKER_CLUSTER_ID";
     pub const NODE_ID: &str = "TALON_WORKER_NODE_ID";
+    pub const CONTROL_TLS_CA_CERT_PATH: &str = "TALON_WORKER_CONTROL_TLS_CA_CERT_PATH";
+    pub const CONTROL_TLS_CERT_PATH: &str = "TALON_WORKER_CONTROL_TLS_CERT_PATH";
+    pub const CONTROL_TLS_KEY_PATH: &str = "TALON_WORKER_CONTROL_TLS_KEY_PATH";
+    pub const CONTROL_TLS_TRUST_DOMAIN: &str = "TALON_WORKER_CONTROL_TLS_TRUST_DOMAIN";
     pub const HEARTBEAT_INTERVAL_MS: &str = "TALON_WORKER_HEARTBEAT_INTERVAL_MS";
     pub const BLOCK_SIZE: &str = "TALON_WORKER_BLOCK_SIZE";
     pub const CACHE_DIRS: &str = "TALON_WORKER_CACHE_DIRS";
@@ -703,6 +771,12 @@ impl WorkerConfigPatch {
             coordinator: get(worker_env::COORDINATOR),
             cluster_id: get(worker_env::CLUSTER_ID),
             node_id: get(worker_env::NODE_ID),
+            control_tls: optional_control_tls_patch(
+                get(worker_env::CONTROL_TLS_CA_CERT_PATH),
+                get(worker_env::CONTROL_TLS_CERT_PATH),
+                get(worker_env::CONTROL_TLS_KEY_PATH),
+                get(worker_env::CONTROL_TLS_TRUST_DOMAIN),
+            ),
             heartbeat_interval_ms: get(worker_env::HEARTBEAT_INTERVAL_MS)
                 .map(|v| parse_u64(v, worker_env::HEARTBEAT_INTERVAL_MS))
                 .transpose()?,
@@ -780,6 +854,7 @@ impl WorkerConfig {
             merged.advertise_addr.unwrap_or_else(|| listen.clone()),
             &listen,
         );
+        let control_tls = merged.control_tls.unwrap_or_default().resolve()?;
         let cfg = WorkerConfig {
             // Advertise the routable address if set, else fall back to the bind
             // address (issue #118: never silently advertise a wildcard bind).
@@ -788,6 +863,7 @@ impl WorkerConfig {
             admin_listen: merged.admin_listen.unwrap_or(d.admin_listen),
             coordinator: merged.coordinator.unwrap_or(d.coordinator),
             cluster_id: merged.cluster_id.unwrap_or(d.cluster_id),
+            control_tls,
             node_id: merged.node_id.or(d.node_id),
             heartbeat_interval_ms: merged
                 .heartbeat_interval_ms
@@ -891,6 +967,9 @@ impl WorkerConfig {
                     node_id.len()
                 )));
             }
+        }
+        if let Some(control_tls) = &self.control_tls {
+            control_tls.validate()?;
         }
         if self.block_size == 0 {
             return Err(Error::Other("block_size must be > 0".into()));
@@ -1541,6 +1620,40 @@ mod tests {
         };
         let patch = WorkerConfigPatch::from_env_with(map).unwrap();
         assert_eq!(patch.advertise_addr.as_deref(), Some("worker-1.svc:7001"));
+    }
+
+    #[test]
+    fn worker_control_tls_composes_file_and_environment_layers() {
+        let file = WorkerConfigPatch::from_toml(
+            "[control_tls]\n\
+             ca_cert_path = \"/tls/ca.pem\"\n\
+             cert_path = \"/tls/file-cert.pem\"\n\
+             key_path = \"/tls/key.pem\"\n\
+             trust_domain = \"prod.example.com\"\n",
+        )
+        .unwrap();
+        let env = WorkerConfigPatch::from_env_with(|key| {
+            (key == "TALON_WORKER_CONTROL_TLS_CERT_PATH").then(|| "/tls/env-cert.pem".to_string())
+        })
+        .unwrap();
+        let config = WorkerConfig::resolve(file, env, WorkerConfigPatch::default()).unwrap();
+        let tls = config.control_tls.expect("control TLS configured");
+        assert_eq!(tls.ca_cert_path, PathBuf::from("/tls/ca.pem"));
+        assert_eq!(tls.cert_path, PathBuf::from("/tls/env-cert.pem"));
+        assert_eq!(tls.key_path, PathBuf::from("/tls/key.pem"));
+        assert_eq!(tls.trust_domain, "prod.example.com");
+
+        let partial = WorkerConfigPatch::from_env_with(|key| {
+            (key == "TALON_WORKER_CONTROL_TLS_KEY_PATH").then(|| "/tls/key.pem".to_string())
+        })
+        .unwrap();
+        let error = WorkerConfig::resolve(
+            WorkerConfigPatch::default(),
+            partial,
+            WorkerConfigPatch::default(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("ca_cert_path"));
     }
 
     #[test]

--- a/crates/talon-core/src/control_identity.rs
+++ b/crates/talon-core/src/control_identity.rs
@@ -1,0 +1,471 @@
+//! Workload identity and TLS configuration for the privileged control plane.
+//!
+//! ADR 0004 keeps PEM contents out of configuration structs and binds each
+//! coordinator/worker connection to one canonical URI SAN. This module defines
+//! that shared model without opening sockets or changing runtime traffic.
+
+use std::fmt;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
+use serde::Deserialize;
+use url::Url;
+
+use crate::{Error, Result};
+
+const ID_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
+
+/// Role encoded in a Talon workload URI SAN.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WorkloadRole {
+    /// Active coordinator with management-tier authority.
+    Coordinator,
+    /// Cache worker with object-store access.
+    Worker,
+}
+
+impl WorkloadRole {
+    /// Canonical URI path spelling.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Coordinator => "coordinator",
+            Self::Worker => "worker",
+        }
+    }
+}
+
+impl fmt::Display for WorkloadRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for WorkloadRole {
+    type Err = WorkloadIdentityError;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        match value {
+            "coordinator" => Ok(Self::Coordinator),
+            "worker" => Ok(Self::Worker),
+            _ => Err(WorkloadIdentityError::InvalidRole(value.to_owned())),
+        }
+    }
+}
+
+/// Authenticated identity encoded in one canonical workload URI SAN.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct WorkloadIdentity {
+    trust_domain: String,
+    cluster_id: String,
+    role: WorkloadRole,
+    node_id: String,
+}
+
+impl WorkloadIdentity {
+    /// Construct and validate an identity.
+    pub fn new(
+        trust_domain: impl Into<String>,
+        cluster_id: impl Into<String>,
+        role: WorkloadRole,
+        node_id: impl Into<String>,
+    ) -> std::result::Result<Self, WorkloadIdentityError> {
+        let trust_domain = trust_domain.into();
+        validate_trust_domain(&trust_domain)?;
+        let cluster_id = cluster_id.into();
+        let node_id = node_id.into();
+        if cluster_id.is_empty() {
+            return Err(WorkloadIdentityError::EmptyComponent("cluster_id"));
+        }
+        if node_id.is_empty() {
+            return Err(WorkloadIdentityError::EmptyComponent("node_id"));
+        }
+        Ok(Self {
+            trust_domain,
+            cluster_id,
+            role,
+            node_id,
+        })
+    }
+
+    /// Parse a URI and reject every non-canonical spelling.
+    pub fn parse(uri: &str) -> std::result::Result<Self, WorkloadIdentityError> {
+        let parsed = Url::parse(uri).map_err(|error| WorkloadIdentityError::InvalidUri {
+            detail: error.to_string(),
+        })?;
+        if parsed.scheme() != "spiffe" {
+            return Err(WorkloadIdentityError::WrongScheme(
+                parsed.scheme().to_owned(),
+            ));
+        }
+        if !parsed.username().is_empty()
+            || parsed.password().is_some()
+            || parsed.port().is_some()
+            || parsed.query().is_some()
+            || parsed.fragment().is_some()
+        {
+            return Err(WorkloadIdentityError::InvalidUri {
+                detail: "userinfo, ports, query strings, and fragments are forbidden".into(),
+            });
+        }
+        let trust_domain = parsed
+            .host_str()
+            .ok_or_else(|| WorkloadIdentityError::InvalidTrustDomain("missing host".into()))?;
+        validate_trust_domain(trust_domain)?;
+
+        let raw: Vec<_> = parsed.path().split('/').collect();
+        if raw.len() != 5 || !raw[0].is_empty() || raw[1] != "talon" {
+            return Err(WorkloadIdentityError::InvalidPath);
+        }
+        let cluster_id = decode_component(raw[2], "cluster_id")?;
+        let role = raw[3].parse()?;
+        let node_id = decode_component(raw[4], "node_id")?;
+        let identity = Self::new(trust_domain, cluster_id, role, node_id)?;
+        let canonical = identity.to_uri();
+        if uri != canonical {
+            return Err(WorkloadIdentityError::NonCanonical { canonical });
+        }
+        Ok(identity)
+    }
+
+    /// Canonical SPIFFE-compatible URI SAN value.
+    pub fn to_uri(&self) -> String {
+        format!(
+            "spiffe://{}/talon/{}/{}/{}",
+            self.trust_domain,
+            encode_component(&self.cluster_id),
+            self.role,
+            encode_component(&self.node_id)
+        )
+    }
+
+    /// Configured trust domain.
+    pub fn trust_domain(&self) -> &str {
+        &self.trust_domain
+    }
+
+    /// Logical Talon cluster.
+    pub fn cluster_id(&self) -> &str {
+        &self.cluster_id
+    }
+
+    /// Workload role.
+    pub fn role(&self) -> WorkloadRole {
+        self.role
+    }
+
+    /// Stable node identity.
+    pub fn node_id(&self) -> &str {
+        &self.node_id
+    }
+}
+
+impl fmt::Display for WorkloadIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_uri())
+    }
+}
+
+impl FromStr for WorkloadIdentity {
+    type Err = WorkloadIdentityError;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+/// Why a workload URI SAN was rejected.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum WorkloadIdentityError {
+    /// URI parsing failed.
+    #[error("invalid workload identity URI: {detail}")]
+    InvalidUri { detail: String },
+    /// Only the SPIFFE scheme is accepted.
+    #[error("workload identity uses scheme {0:?}, expected \"spiffe\"")]
+    WrongScheme(String),
+    /// Trust domain is not one canonical DNS name.
+    #[error("invalid workload identity trust domain: {0}")]
+    InvalidTrustDomain(String),
+    /// URI path does not have the fixed Talon shape.
+    #[error("workload identity path must be /talon/<cluster>/<role>/<node>")]
+    InvalidPath,
+    /// Role is unknown.
+    #[error("invalid workload role {0:?}")]
+    InvalidRole(String),
+    /// Required identity component is empty.
+    #[error("workload identity {0} must not be empty")]
+    EmptyComponent(&'static str),
+    /// Percent decoding did not produce UTF-8.
+    #[error("workload identity {component} is not valid UTF-8")]
+    InvalidUtf8 { component: &'static str },
+    /// URI is valid but has an ambiguous or non-canonical spelling.
+    #[error("non-canonical workload identity; expected {canonical}")]
+    NonCanonical { canonical: String },
+}
+
+/// File-backed TLS material and trust domain for a control endpoint.
+///
+/// This stores paths only. PEM certificate and private-key bytes are loaded by
+/// the future listener implementation and must use a redacting wrapper there.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ControlTlsConfig {
+    /// CA bundle used to validate the peer certificate.
+    pub ca_cert_path: PathBuf,
+    /// This workload's leaf certificate chain.
+    pub cert_path: PathBuf,
+    /// This workload's private key file.
+    pub key_path: PathBuf,
+    /// Expected SPIFFE trust domain.
+    pub trust_domain: String,
+}
+
+impl fmt::Debug for ControlTlsConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ControlTlsConfig")
+            .field("ca_cert_path", &self.ca_cert_path)
+            .field("cert_path", &self.cert_path)
+            .field("key_path", &"<redacted>")
+            .field("trust_domain", &self.trust_domain)
+            .finish()
+    }
+}
+
+impl ControlTlsConfig {
+    /// Validate paths and the canonical trust domain.
+    pub fn validate(&self) -> Result<()> {
+        for (name, path) in [
+            ("ca_cert_path", &self.ca_cert_path),
+            ("cert_path", &self.cert_path),
+            ("key_path", &self.key_path),
+        ] {
+            if path.as_os_str().is_empty() {
+                return Err(Error::Other(format!(
+                    "control_tls.{name} must not be empty"
+                )));
+            }
+        }
+        validate_trust_domain(&self.trust_domain)
+            .map_err(|error| Error::Other(format!("control_tls.trust_domain is invalid: {error}")))
+    }
+}
+
+/// Optional fields contributed by one configuration layer.
+#[derive(Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ControlTlsConfigPatch {
+    /// Override for [`ControlTlsConfig::ca_cert_path`].
+    pub ca_cert_path: Option<PathBuf>,
+    /// Override for [`ControlTlsConfig::cert_path`].
+    pub cert_path: Option<PathBuf>,
+    /// Override for [`ControlTlsConfig::key_path`].
+    pub key_path: Option<PathBuf>,
+    /// Override for [`ControlTlsConfig::trust_domain`].
+    pub trust_domain: Option<String>,
+}
+
+impl fmt::Debug for ControlTlsConfigPatch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ControlTlsConfigPatch")
+            .field("ca_cert_path", &self.ca_cert_path)
+            .field("cert_path", &self.cert_path)
+            .field("key_path", &self.key_path.as_ref().map(|_| "<redacted>"))
+            .field("trust_domain", &self.trust_domain)
+            .finish()
+    }
+}
+
+impl ControlTlsConfigPatch {
+    /// Whether this layer contributes no TLS setting.
+    pub fn is_empty(&self) -> bool {
+        self.ca_cert_path.is_none()
+            && self.cert_path.is_none()
+            && self.key_path.is_none()
+            && self.trust_domain.is_none()
+    }
+
+    /// Overlay this higher-precedence layer onto `base`.
+    pub fn merge(self, base: Self) -> Self {
+        Self {
+            ca_cert_path: self.ca_cert_path.or(base.ca_cert_path),
+            cert_path: self.cert_path.or(base.cert_path),
+            key_path: self.key_path.or(base.key_path),
+            trust_domain: self.trust_domain.or(base.trust_domain),
+        }
+    }
+
+    /// Resolve an optional block, requiring all fields when any is present.
+    pub fn resolve(self) -> Result<Option<ControlTlsConfig>> {
+        if self.is_empty() {
+            return Ok(None);
+        }
+        let missing = |name: &str| {
+            Error::Other(format!(
+                "control_tls.{name} is required when control-plane TLS is configured"
+            ))
+        };
+        let config = ControlTlsConfig {
+            ca_cert_path: self.ca_cert_path.ok_or_else(|| missing("ca_cert_path"))?,
+            cert_path: self.cert_path.ok_or_else(|| missing("cert_path"))?,
+            key_path: self.key_path.ok_or_else(|| missing("key_path"))?,
+            trust_domain: self.trust_domain.ok_or_else(|| missing("trust_domain"))?,
+        };
+        config.validate()?;
+        Ok(Some(config))
+    }
+}
+
+fn validate_trust_domain(value: &str) -> std::result::Result<(), WorkloadIdentityError> {
+    if value.is_empty() {
+        return Err(WorkloadIdentityError::InvalidTrustDomain("empty".into()));
+    }
+    if value != value.to_ascii_lowercase()
+        || !value.is_ascii()
+        || value.len() > 253
+        || value.parse::<std::net::IpAddr>().is_ok()
+        || value.split('.').any(|label| {
+            label.is_empty()
+                || label.len() > 63
+                || !label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+                || !label
+                    .as_bytes()
+                    .first()
+                    .is_some_and(u8::is_ascii_alphanumeric)
+                || !label
+                    .as_bytes()
+                    .last()
+                    .is_some_and(u8::is_ascii_alphanumeric)
+        })
+    {
+        return Err(WorkloadIdentityError::InvalidTrustDomain(
+            "must be one canonical lowercase ASCII DNS name, not an IP address".into(),
+        ));
+    }
+    let parsed = Url::parse(&format!("spiffe://{value}/"))
+        .map_err(|error| WorkloadIdentityError::InvalidTrustDomain(error.to_string()))?;
+    if parsed.host_str() != Some(value)
+        || parsed.username() != ""
+        || parsed.password().is_some()
+        || parsed.port().is_some()
+        || parsed.as_str() != format!("spiffe://{value}/")
+    {
+        return Err(WorkloadIdentityError::InvalidTrustDomain(
+            "must be one canonical lowercase DNS name without a port".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn encode_component(value: &str) -> String {
+    utf8_percent_encode(value, ID_ENCODE_SET).to_string()
+}
+
+fn decode_component(
+    value: &str,
+    component: &'static str,
+) -> std::result::Result<String, WorkloadIdentityError> {
+    percent_decode_str(value)
+        .decode_utf8()
+        .map(|value| value.into_owned())
+        .map_err(|_| WorkloadIdentityError::InvalidUtf8 { component })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workload_identity_round_trips_reserved_and_unicode_ids() {
+        let identity = WorkloadIdentity::new(
+            "prod.example.com",
+            "cluster/east",
+            WorkloadRole::Worker,
+            "worker 1/东京",
+        )
+        .unwrap();
+        let uri =
+            "spiffe://prod.example.com/talon/cluster%2Feast/worker/worker%201%2F%E4%B8%9C%E4%BA%AC";
+        assert_eq!(identity.to_uri(), uri);
+        assert_eq!(WorkloadIdentity::parse(uri).unwrap(), identity);
+    }
+
+    #[test]
+    fn noncanonical_identity_spellings_are_rejected() {
+        for uri in [
+            "SPIFFE://prod.example.com/talon/c/worker/n",
+            "spiffe://PROD.example.com/talon/c/worker/n",
+            "spiffe://prod.example.com/talon/%63/worker/n",
+            "spiffe://prod.example.com/talon/c/worker/a%2fb",
+            "spiffe://prod.example.com/talon/c/worker/n?admin=true",
+        ] {
+            assert!(
+                WorkloadIdentity::parse(uri).is_err(),
+                "{uri} must not acquire an identity"
+            );
+        }
+    }
+
+    #[test]
+    fn wrong_shape_role_and_trust_domain_are_rejected() {
+        for uri in [
+            "https://prod.example.com/talon/c/worker/n",
+            "spiffe://prod.example.com/talon/c/client/n",
+            "spiffe://prod.example.com/other/c/worker/n",
+            "spiffe://127.0.0.1/talon/c/worker/n",
+            "spiffe://prod.example.com:443/talon/c/worker/n",
+        ] {
+            assert!(WorkloadIdentity::parse(uri).is_err());
+        }
+    }
+
+    #[test]
+    fn tls_patch_merges_layers_and_requires_a_complete_block() {
+        let file = ControlTlsConfigPatch {
+            ca_cert_path: Some("/tls/ca.pem".into()),
+            cert_path: Some("/tls/old-cert.pem".into()),
+            key_path: Some("/tls/key.pem".into()),
+            trust_domain: Some("prod.example.com".into()),
+        };
+        let env = ControlTlsConfigPatch {
+            cert_path: Some("/tls/cert.pem".into()),
+            ..Default::default()
+        };
+        let resolved = env.merge(file).resolve().unwrap().unwrap();
+        assert_eq!(resolved.cert_path, PathBuf::from("/tls/cert.pem"));
+        assert_eq!(resolved.ca_cert_path, PathBuf::from("/tls/ca.pem"));
+
+        let error = ControlTlsConfigPatch {
+            trust_domain: Some("prod.example.com".into()),
+            ..Default::default()
+        }
+        .resolve()
+        .unwrap_err();
+        assert!(error.to_string().contains("ca_cert_path"));
+        assert_eq!(ControlTlsConfigPatch::default().resolve().unwrap(), None);
+    }
+
+    #[test]
+    fn tls_config_debug_redacts_the_private_key_path() {
+        let config = ControlTlsConfig {
+            ca_cert_path: "/tls/ca.pem".into(),
+            cert_path: "/tls/cert.pem".into(),
+            key_path: "/tls/key.pem".into(),
+            trust_domain: "prod.example.com".into(),
+        };
+        let debug = format!("{config:?}");
+        assert!(!debug.contains("/tls/key.pem"));
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("PRIVATE KEY"));
+
+        let patch = ControlTlsConfigPatch {
+            key_path: Some("/tls/key.pem".into()),
+            ..Default::default()
+        };
+        assert!(!format!("{patch:?}").contains("/tls/key.pem"));
+    }
+}

--- a/crates/talon-core/src/lib.rs
+++ b/crates/talon-core/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod backend;
 pub mod block;
 pub mod config;
+pub mod control_identity;
 pub mod error;
 pub mod key;
 pub mod metrics;
@@ -20,6 +21,9 @@ pub use config::{
     azure_sas_from_env, gcs_bearer_from_env, s3_secret_key_from_env, s3_session_token_from_env,
     ConfigVar, FuseConfig, FuseConfigPatch, Patch, WorkerConfig, WorkerConfigPatch,
     FUSE_ENV_SCHEMA, WORKER_ENV_SCHEMA,
+};
+pub use control_identity::{
+    ControlTlsConfig, ControlTlsConfigPatch, WorkloadIdentity, WorkloadIdentityError, WorkloadRole,
 };
 pub use error::{Error, Result};
 pub use key::{Backend, BlockId, ObjectId, PageIndex, Version};

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -129,6 +129,7 @@ impl Args {
             coordinator: self.coordinator,
             cluster_id: self.cluster_id,
             node_id: self.node_id,
+            control_tls: None,
             heartbeat_interval_ms: self.heartbeat_interval_ms,
             block_size: self.block_size,
             data_plane_rings: self.data_plane_rings,

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -46,6 +46,38 @@ Stable coordinator node identity.
 - **Default:** `<listen>`
 - **CLI flag:** `--node-id`
 
+### `control_tls.ca_cert_path`
+
+PEM CA bundle for the privileged coordinator-worker mTLS channel.
+
+- **Environment variable:** `TALON_COORDINATOR_CONTROL_TLS_CA_CERT_PATH`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `control_tls.cert_path`
+
+PEM coordinator certificate chain for the privileged mTLS channel.
+
+- **Environment variable:** `TALON_COORDINATOR_CONTROL_TLS_CERT_PATH`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `control_tls.key_path`
+
+PEM coordinator private-key file path; key bytes never enter configuration.
+
+- **Environment variable:** `TALON_COORDINATOR_CONTROL_TLS_KEY_PATH`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `control_tls.trust_domain`
+
+Lowercase DNS trust domain required in peer workload URI SANs.
+
+- **Environment variable:** `TALON_COORDINATOR_CONTROL_TLS_TRUST_DOMAIN`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+
 ### `state_backend`
 
 Shared-state backend: memory | etcd | kubernetes.
@@ -241,6 +273,38 @@ Stable worker node identity.
 - **Environment variable:** `TALON_WORKER_NODE_ID`
 - **Default:** `<listen>`
 - **CLI flag:** `--node-id`
+
+### `control_tls.ca_cert_path`
+
+PEM CA bundle for the privileged coordinator-worker mTLS channel.
+
+- **Environment variable:** `TALON_WORKER_CONTROL_TLS_CA_CERT_PATH`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `control_tls.cert_path`
+
+PEM worker certificate chain for the privileged mTLS channel.
+
+- **Environment variable:** `TALON_WORKER_CONTROL_TLS_CERT_PATH`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `control_tls.key_path`
+
+PEM worker private-key file path; key bytes never enter configuration.
+
+- **Environment variable:** `TALON_WORKER_CONTROL_TLS_KEY_PATH`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `control_tls.trust_domain`
+
+Lowercase DNS trust domain required in peer workload URI SANs.
+
+- **Environment variable:** `TALON_WORKER_CONTROL_TLS_TRUST_DOMAIN`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
 
 ### `heartbeat_interval_ms`
 


### PR DESCRIPTION
## Summary

- add canonical SPIFFE-compatible coordinator/worker workload identities
- reject ambiguous URI spellings, invalid roles, IP trust domains, and malformed paths
- add shared all-or-none control-plane TLS configuration with redacted key paths
- compose TLS settings across TOML and environment layers for both processes
- regenerate the configuration reference

This models ADR 0004 sequence item 1 only. It does not open TLS listeners, change runtime traffic, or enable hard links.

## Verification

- `PROTOC=<workspace protoc 29.3> just test`
- `PROTOC=<workspace protoc 29.3> cargo clippy -p talon-core -p talon-coordinator -p talon-worker --all-targets --all-features -- -D warnings`
- `just check-config-docs`
- `cargo fmt --all -- --check`
- `typos <changed files>`
- `lychee --offline --no-progress docs/reference/configuration.md`
- `mdbook build docs/book`
- `git diff --check`

Closes #436
Parent: #434
Blocks #420