### PR TITLE
feat: enforce static namespace policy

### DIFF
--- a/crates/talon-coordinator/src/config.rs
+++ b/crates/talon-coordinator/src/config.rs
@@ -1,10 +1,11 @@
 //! Layered coordinator configuration.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 use talon_core::{
-    ConfigVar, ControlTlsConfig, ControlTlsConfigPatch, Patch, MAX_STATUS_FIELD_BYTES,
+    ConfigVar, ControlTlsConfig, ControlTlsConfigPatch, NamespacePolicy, ObjectNamespace, Patch,
+    MAX_STATUS_FIELD_BYTES,
 };
 
 #[cfg(feature = "kubernetes")]
@@ -56,6 +57,8 @@ pub struct CoordinatorConfig {
     pub node_id: String,
     /// Optional mTLS material for the privileged coordinator-worker channel.
     pub control_tls: Option<ControlTlsConfig>,
+    /// Operator-owned worker grants loaded from mounted static policy data.
+    pub namespace_policy: Option<NamespacePolicy>,
     /// Shared-state and lease settings.
     pub state: ClusterStateConfig,
     /// etcd backend connection settings, required when `state.backend` is etcd.
@@ -84,6 +87,7 @@ impl Default for CoordinatorConfig {
             cluster_id: "default".into(),
             node_id: "127.0.0.1:7000".into(),
             control_tls: None,
+            namespace_policy: None,
             state: ClusterStateConfig::default(),
             #[cfg(feature = "etcd")]
             etcd: None,
@@ -152,6 +156,8 @@ pub struct CoordinatorConfigPatch {
     pub node_id: Option<String>,
     /// Optional `[control_tls]` block.
     pub control_tls: Option<ControlTlsConfigPatch>,
+    /// Path to a static namespace authorization policy.
+    pub namespace_policy_path: Option<PathBuf>,
     /// Shared-state backend selector.
     pub state_backend: Option<StateBackend>,
     /// Whether active-active coordinator mode is requested.
@@ -222,6 +228,7 @@ impl Patch for CoordinatorConfigPatch {
             cluster_id: self.cluster_id.or(base.cluster_id),
             node_id: self.node_id.or(base.node_id),
             control_tls: merge_control_tls(self.control_tls, base.control_tls),
+            namespace_policy_path: self.namespace_policy_path.or(base.namespace_policy_path),
             state_backend: self.state_backend.or(base.state_backend),
             ha_enabled: self.ha_enabled.or(base.ha_enabled),
             coordinator_replicas: self.coordinator_replicas.or(base.coordinator_replicas),
@@ -341,6 +348,14 @@ pub const COORDINATOR_ENV_SCHEMA: &[ConfigVar] = &[
         cli: false,
         secret: false,
         help: "Lowercase DNS trust domain required in peer workload URI SANs.",
+    },
+    ConfigVar {
+        env: "TALON_COORDINATOR_NAMESPACE_POLICY_PATH",
+        key: "namespace_policy_path",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "Mounted static namespace authorization policy (TOML).",
     },
     ConfigVar {
         env: "TALON_COORDINATOR_STATE_BACKEND",
@@ -512,6 +527,7 @@ pub mod env_names {
     pub const CONTROL_TLS_CERT_PATH: &str = "TALON_COORDINATOR_CONTROL_TLS_CERT_PATH";
     pub const CONTROL_TLS_KEY_PATH: &str = "TALON_COORDINATOR_CONTROL_TLS_KEY_PATH";
     pub const CONTROL_TLS_TRUST_DOMAIN: &str = "TALON_COORDINATOR_CONTROL_TLS_TRUST_DOMAIN";
+    pub const NAMESPACE_POLICY_PATH: &str = "TALON_COORDINATOR_NAMESPACE_POLICY_PATH";
     pub const STATE_BACKEND: &str = "TALON_COORDINATOR_STATE_BACKEND";
     pub const HA_ENABLED: &str = "TALON_COORDINATOR_HA_ENABLED";
     pub const REPLICAS: &str = "TALON_COORDINATOR_REPLICAS";
@@ -580,6 +596,7 @@ impl CoordinatorConfigPatch {
                 get(env_names::CONTROL_TLS_KEY_PATH),
                 get(env_names::CONTROL_TLS_TRUST_DOMAIN),
             ),
+            namespace_policy_path: get(env_names::NAMESPACE_POLICY_PATH).map(PathBuf::from),
             state_backend: get(env_names::STATE_BACKEND)
                 .map(|value| parse(value, env_names::STATE_BACKEND))
                 .transpose()?,
@@ -657,6 +674,11 @@ impl CoordinatorConfig {
         let admin_listen = merged.admin_listen.unwrap_or(defaults.admin_listen);
         let cluster_id = merged.cluster_id.unwrap_or(defaults.cluster_id);
         let control_tls = merged.control_tls.unwrap_or_default().resolve()?;
+        let namespace_policy = merged
+            .namespace_policy_path
+            .as_deref()
+            .map(NamespacePolicy::from_file)
+            .transpose()?;
 
         // Fold backend blocks with their env/CLI scalar overrides. The block may
         // come entirely from an env override even with no `[etcd]`/`[kubernetes]`
@@ -748,6 +770,7 @@ impl CoordinatorConfig {
             admin_listen,
             cluster_id,
             control_tls,
+            namespace_policy,
             state: ClusterStateConfig {
                 backend: merged.state_backend.unwrap_or(default_state.backend),
                 ha_enabled: merged.ha_enabled.unwrap_or(default_state.ha_enabled),
@@ -774,6 +797,15 @@ impl CoordinatorConfig {
         };
         config.validate()?;
         Ok(config)
+    }
+
+    /// Check the operator policy before targeting a worker for a namespace.
+    ///
+    /// No loaded policy is an explicit deny-all state.
+    pub fn authorizes_worker_namespace(&self, worker_id: &str, target: &ObjectNamespace) -> bool {
+        self.namespace_policy
+            .as_ref()
+            .is_some_and(|policy| policy.authorizes(worker_id, target))
     }
 
     /// Validate addresses, bounded identity fields, and state timing.
@@ -901,6 +933,42 @@ mod tests {
             CoordinatorConfig::resolve(Default::default(), Default::default(), secure).unwrap();
         assert_eq!(config.control_listen.as_deref(), Some("127.0.0.1:7002"));
         assert!(config.control_tls.is_some());
+    }
+
+    #[test]
+    fn coordinator_namespace_authorization_is_worker_scoped() {
+        let mut config = CoordinatorConfig::default();
+        let target = "s3/data/models/v1".parse().unwrap();
+        assert!(!config.authorizes_worker_namespace("worker-a", &target));
+
+        config.namespace_policy = Some(
+            NamespacePolicy::from_toml(
+                "version = 1\n\
+                 [[workers]]\n\
+                 node_id = \"worker-a\"\n\
+                 grants = [\"s3/data/models\"]\n",
+            )
+            .unwrap(),
+        );
+        assert!(config.authorizes_worker_namespace("worker-a", &target));
+        assert!(!config.authorizes_worker_namespace("worker-b", &target));
+    }
+
+    #[test]
+    fn coordinator_namespace_policy_path_parses_from_file_and_environment_layers() {
+        let file =
+            CoordinatorConfigPatch::from_toml("namespace_policy_path = \"/policy/file.toml\"\n")
+                .unwrap();
+        let env = CoordinatorConfigPatch::from_env_with(|key| {
+            (key == "TALON_COORDINATOR_NAMESPACE_POLICY_PATH")
+                .then(|| "/policy/env.toml".to_string())
+        })
+        .unwrap();
+        let merged = env.merge(file);
+        assert_eq!(
+            merged.namespace_policy_path.as_deref(),
+            Some(std::path::Path::new("/policy/env.toml"))
+        );
     }
 
     #[test]

--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -22,7 +22,9 @@ use serde::Deserialize;
 use std::path::PathBuf;
 
 use crate::status::MAX_STATUS_FIELD_BYTES;
-use crate::{ControlTlsConfig, ControlTlsConfigPatch, Error, Result};
+use crate::{
+    ControlTlsConfig, ControlTlsConfigPatch, Error, NamespacePolicy, ObjectNamespace, Result,
+};
 
 /// A configuration patch: a set of optionally-present overrides.
 ///
@@ -103,6 +105,8 @@ pub struct WorkerConfig {
     pub cluster_id: String,
     /// Optional mTLS material for the privileged coordinator-worker channel.
     pub control_tls: Option<ControlTlsConfig>,
+    /// Operator-owned grants loaded from mounted static policy data.
+    pub namespace_policy: Option<NamespacePolicy>,
     /// Stable node identity; defaults to the RPC listen address when unset.
     pub node_id: Option<String>,
     /// Control-plane heartbeat interval in milliseconds.
@@ -236,6 +240,7 @@ impl Default for WorkerConfig {
             control_listen: None,
             cluster_id: "default".into(),
             control_tls: None,
+            namespace_policy: None,
             node_id: None,
             heartbeat_interval_ms: 5_000,
             block_size: 256 << 20,
@@ -285,6 +290,8 @@ pub struct WorkerConfigPatch {
     pub cluster_id: Option<String>,
     /// Optional `[control_tls]` block.
     pub control_tls: Option<ControlTlsConfigPatch>,
+    /// Path to a static namespace authorization policy.
+    pub namespace_policy_path: Option<PathBuf>,
     /// Override for [`WorkerConfig::node_id`].
     pub node_id: Option<String>,
     /// Override for [`WorkerConfig::heartbeat_interval_ms`].
@@ -345,6 +352,7 @@ impl Patch for WorkerConfigPatch {
             control_listen: self.control_listen.or(base.control_listen),
             cluster_id: self.cluster_id.or(base.cluster_id),
             control_tls: merge_control_tls(self.control_tls, base.control_tls),
+            namespace_policy_path: self.namespace_policy_path.or(base.namespace_policy_path),
             node_id: self.node_id.or(base.node_id),
             heartbeat_interval_ms: self.heartbeat_interval_ms.or(base.heartbeat_interval_ms),
             block_size: self.block_size.or(base.block_size),
@@ -472,6 +480,14 @@ pub const WORKER_ENV_SCHEMA: &[ConfigVar] = &[
         cli: false,
         secret: false,
         help: "Lowercase DNS trust domain required in peer workload URI SANs.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_NAMESPACE_POLICY_PATH",
+        key: "namespace_policy_path",
+        default: None,
+        cli: false,
+        secret: false,
+        help: "Mounted static namespace authorization policy (TOML).",
     },
     ConfigVar {
         env: "TALON_WORKER_HEARTBEAT_INTERVAL_MS",
@@ -703,6 +719,7 @@ pub(crate) mod worker_env {
     pub const CONTROL_TLS_CERT_PATH: &str = "TALON_WORKER_CONTROL_TLS_CERT_PATH";
     pub const CONTROL_TLS_KEY_PATH: &str = "TALON_WORKER_CONTROL_TLS_KEY_PATH";
     pub const CONTROL_TLS_TRUST_DOMAIN: &str = "TALON_WORKER_CONTROL_TLS_TRUST_DOMAIN";
+    pub const NAMESPACE_POLICY_PATH: &str = "TALON_WORKER_NAMESPACE_POLICY_PATH";
     pub const HEARTBEAT_INTERVAL_MS: &str = "TALON_WORKER_HEARTBEAT_INTERVAL_MS";
     pub const BLOCK_SIZE: &str = "TALON_WORKER_BLOCK_SIZE";
     pub const CACHE_DIRS: &str = "TALON_WORKER_CACHE_DIRS";
@@ -793,6 +810,7 @@ impl WorkerConfigPatch {
                 get(worker_env::CONTROL_TLS_KEY_PATH),
                 get(worker_env::CONTROL_TLS_TRUST_DOMAIN),
             ),
+            namespace_policy_path: get(worker_env::NAMESPACE_POLICY_PATH).map(PathBuf::from),
             heartbeat_interval_ms: get(worker_env::HEARTBEAT_INTERVAL_MS)
                 .map(|v| parse_u64(v, worker_env::HEARTBEAT_INTERVAL_MS))
                 .transpose()?,
@@ -871,6 +889,11 @@ impl WorkerConfig {
             &listen,
         );
         let control_tls = merged.control_tls.unwrap_or_default().resolve()?;
+        let namespace_policy = merged
+            .namespace_policy_path
+            .as_deref()
+            .map(NamespacePolicy::from_file)
+            .transpose()?;
         let cfg = WorkerConfig {
             // Advertise the routable address if set, else fall back to the bind
             // address (issue #118: never silently advertise a wildcard bind).
@@ -881,6 +904,7 @@ impl WorkerConfig {
             control_listen: merged.control_listen.or(d.control_listen),
             cluster_id: merged.cluster_id.unwrap_or(d.cluster_id),
             control_tls,
+            namespace_policy,
             node_id: merged.node_id.or(d.node_id),
             heartbeat_interval_ms: merged
                 .heartbeat_interval_ms
@@ -918,6 +942,16 @@ impl WorkerConfig {
         };
         cfg.validate()?;
         Ok(cfg)
+    }
+
+    /// Check this worker's operator-owned grant for a privileged namespace.
+    ///
+    /// No loaded policy is an explicit deny-all state.
+    pub fn authorizes_namespace(&self, target: &ObjectNamespace) -> bool {
+        let node_id = self.node_id.as_deref().unwrap_or(&self.listen);
+        self.namespace_policy
+            .as_ref()
+            .is_some_and(|policy| policy.authorizes(node_id, target))
     }
 
     /// Fail fast on invalid configuration with an actionable message.
@@ -1394,6 +1428,41 @@ mod tests {
         let config = WorkerConfig::resolve(Default::default(), Default::default(), secure).unwrap();
         assert_eq!(config.control_listen.as_deref(), Some("127.0.0.1:7002"));
         assert!(config.control_tls.is_some());
+    }
+
+    #[test]
+    fn worker_namespace_authorization_uses_its_stable_node_id() {
+        let mut config = WorkerConfig::default();
+        let target = "s3/data/models/v1".parse().unwrap();
+        assert!(!config.authorizes_namespace(&target));
+
+        config.node_id = Some("worker-a".into());
+        config.namespace_policy = Some(
+            NamespacePolicy::from_toml(
+                "version = 1\n\
+                 [[workers]]\n\
+                 node_id = \"worker-a\"\n\
+                 grants = [\"s3/data/models\"]\n",
+            )
+            .unwrap(),
+        );
+        assert!(config.authorizes_namespace(&target));
+        assert!(!config.authorizes_namespace(&"s3/data/private".parse().unwrap()));
+    }
+
+    #[test]
+    fn worker_namespace_policy_path_parses_from_file_and_environment_layers() {
+        let file = WorkerConfigPatch::from_toml("namespace_policy_path = \"/policy/file.toml\"\n")
+            .unwrap();
+        let env = WorkerConfigPatch::from_env_with(|key| {
+            (key == "TALON_WORKER_NAMESPACE_POLICY_PATH").then(|| "/policy/env.toml".to_string())
+        })
+        .unwrap();
+        let merged = env.merge(file);
+        assert_eq!(
+            merged.namespace_policy_path.as_deref(),
+            Some(std::path::Path::new("/policy/env.toml"))
+        );
     }
 
     #[test]

--- a/crates/talon-core/src/lib.rs
+++ b/crates/talon-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod control_identity;
 pub mod error;
 pub mod key;
 pub mod metrics;
+pub mod namespace_policy;
 pub mod node;
 pub mod status;
 pub mod store;
@@ -28,6 +29,7 @@ pub use control_identity::{
 pub use error::{Error, Result};
 pub use key::{Backend, BlockId, ObjectId, PageIndex, Version};
 pub use metrics::{Counter, Gauge, Histogram, Metrics};
+pub use namespace_policy::{NamespacePolicy, ObjectNamespace};
 pub use node::{NodeId, NodeInfo, NodeRole};
 pub use status::{
     NodeHealth, NodeMetricsSnapshot, NodeStatus, NodeStatusError, MAX_NODE_STATUS_BYTES,

--- a/crates/talon-core/src/namespace_policy.rs
+++ b/crates/talon-core/src/namespace_policy.rs
@@ -1,0 +1,282 @@
+//! Static namespace authorization policy for privileged control-plane traffic.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::path::Path;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer};
+
+use crate::{Backend, Error, Result};
+
+const POLICY_VERSION: u16 = 1;
+
+/// A canonical object-store namespace: `backend/bucket[/path-prefix]`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ObjectNamespace {
+    backend: Backend,
+    bucket: String,
+    prefix: Option<String>,
+}
+
+impl ObjectNamespace {
+    /// Return the object-store backend.
+    pub fn backend(&self) -> Backend {
+        self.backend
+    }
+
+    /// Return the bucket or container name.
+    pub fn bucket(&self) -> &str {
+        &self.bucket
+    }
+
+    /// Return the optional object-key prefix.
+    pub fn prefix(&self) -> Option<&str> {
+        self.prefix.as_deref()
+    }
+
+    /// Whether this namespace grant contains `target`.
+    pub fn contains(&self, target: &Self) -> bool {
+        if self.backend != target.backend || self.bucket != target.bucket {
+            return false;
+        }
+        match (&self.prefix, &target.prefix) {
+            (None, _) => true,
+            (Some(_), None) => false,
+            (Some(grant), Some(target)) => {
+                target == grant
+                    || target
+                        .strip_prefix(grant)
+                        .is_some_and(|suffix| suffix.starts_with('/'))
+            }
+        }
+    }
+}
+
+impl FromStr for ObjectNamespace {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        if value.starts_with('/') || value.ends_with('/') {
+            return Err(Error::Other(format!(
+                "namespace must not start or end with '/': {value:?}"
+            )));
+        }
+        let mut parts = value.split('/');
+        let backend_name = parts
+            .next()
+            .filter(|part| !part.is_empty())
+            .ok_or_else(|| Error::Other(format!("namespace is missing a backend: {value:?}")))?;
+        let backend = backend_name.parse::<Backend>()?;
+        if backend.prefix() != backend_name {
+            return Err(Error::Other(format!(
+                "namespace backend is not canonical: {backend_name:?}"
+            )));
+        }
+        let bucket = parts
+            .next()
+            .filter(|part| valid_component(part))
+            .ok_or_else(|| {
+                Error::Other(format!(
+                    "namespace is missing or has an invalid bucket/container: {value:?}"
+                ))
+            })?;
+        let prefix_parts = parts
+            .map(|part| {
+                valid_component(part).then_some(part).ok_or_else(|| {
+                    Error::Other(format!(
+                        "namespace has an invalid path component: {value:?}"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let prefix = (!prefix_parts.is_empty()).then(|| prefix_parts.join("/"));
+        Ok(Self {
+            backend,
+            bucket: bucket.to_string(),
+            prefix,
+        })
+    }
+}
+
+impl fmt::Display for ObjectNamespace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.backend, self.bucket)?;
+        if let Some(prefix) = &self.prefix {
+            write!(f, "/{prefix}")?;
+        }
+        Ok(())
+    }
+}
+
+fn valid_component(component: &str) -> bool {
+    !component.is_empty() && component != "." && component != ".." && !component.contains('\0')
+}
+
+impl<'de> Deserialize<'de> for ObjectNamespace {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+/// Operator-owned namespace grants indexed by stable worker node ID.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamespacePolicy {
+    workers: HashMap<String, Vec<ObjectNamespace>>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PolicyFile {
+    version: u16,
+    #[serde(default)]
+    workers: Vec<WorkerGrants>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WorkerGrants {
+    node_id: String,
+    #[serde(default)]
+    grants: Vec<ObjectNamespace>,
+}
+
+impl NamespacePolicy {
+    /// Parse and validate a versioned TOML policy document.
+    pub fn from_toml(value: &str) -> Result<Self> {
+        let raw: PolicyFile = toml::from_str(value)
+            .map_err(|error| Error::Other(format!("invalid namespace policy: {error}")))?;
+        if raw.version != POLICY_VERSION {
+            return Err(Error::Other(format!(
+                "unsupported namespace policy version {}; expected {POLICY_VERSION}",
+                raw.version
+            )));
+        }
+        let mut workers = HashMap::with_capacity(raw.workers.len());
+        for worker in raw.workers {
+            if worker.node_id.is_empty() {
+                return Err(Error::Other(
+                    "namespace policy worker node_id must not be empty".into(),
+                ));
+            }
+            if workers
+                .insert(worker.node_id.clone(), worker.grants)
+                .is_some()
+            {
+                return Err(Error::Other(format!(
+                    "namespace policy contains duplicate worker node_id {:?}",
+                    worker.node_id
+                )));
+            }
+        }
+        Ok(Self { workers })
+    }
+
+    /// Load and validate a TOML policy file. A missing configured file is an error.
+    pub fn from_file(path: &Path) -> Result<Self> {
+        let value = std::fs::read_to_string(path).map_err(|error| {
+            Error::Other(format!(
+                "failed to read namespace policy {}: {error}",
+                path.display()
+            ))
+        })?;
+        Self::from_toml(&value)
+    }
+
+    /// Whether the operator policy authorizes `worker_id` for `target`.
+    pub fn authorizes(&self, worker_id: &str, target: &ObjectNamespace) -> bool {
+        self.workers
+            .get(worker_id)
+            .is_some_and(|grants| grants.iter().any(|grant| grant.contains(target)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_namespace_rejects_ambiguous_paths() {
+        for invalid in [
+            "",
+            "/s3/bucket",
+            "s3",
+            "s3/",
+            "s3/bucket/",
+            "s3//key",
+            "s3/bucket/a//b",
+            "s3/bucket/./a",
+            "s3/bucket/a/../b",
+            "unknown/bucket",
+        ] {
+            assert!(invalid.parse::<ObjectNamespace>().is_err(), "{invalid}");
+        }
+        assert!("azure/container/models".parse::<ObjectNamespace>().is_err());
+        assert_eq!(
+            "az/container/models"
+                .parse::<ObjectNamespace>()
+                .unwrap()
+                .to_string(),
+            "az/container/models"
+        );
+    }
+
+    #[test]
+    fn grants_match_only_on_path_component_boundaries() {
+        let grant = "s3/data/models".parse::<ObjectNamespace>().unwrap();
+        assert!(grant.contains(&"s3/data/models".parse().unwrap()));
+        assert!(grant.contains(&"s3/data/models/v1".parse().unwrap()));
+        assert!(!grant.contains(&"s3/data/modelsmith".parse().unwrap()));
+        assert!(!grant.contains(&"s3/data".parse().unwrap()));
+        assert!(!grant.contains(&"gcs/data/models".parse().unwrap()));
+    }
+
+    #[test]
+    fn policy_is_worker_scoped_and_fail_closed() {
+        let policy = NamespacePolicy::from_toml(
+            "version = 1\n\
+             [[workers]]\n\
+             node_id = \"worker-a\"\n\
+             grants = [\"s3/data/models\", \"gcs/checkpoints\"]\n",
+        )
+        .unwrap();
+        assert!(policy.authorizes("worker-a", &"s3/data/models/v1".parse().unwrap()));
+        assert!(!policy.authorizes("worker-a", &"s3/data/private".parse().unwrap()));
+        assert!(!policy.authorizes("worker-b", &"s3/data/models".parse().unwrap()));
+    }
+
+    #[test]
+    fn policy_rejects_unknown_versions_and_duplicate_workers() {
+        assert!(NamespacePolicy::from_toml("version = 2").is_err());
+        assert!(NamespacePolicy::from_toml(
+            "version = 1\n\
+             [[workers]]\nnode_id = \"same\"\n\
+             [[workers]]\nnode_id = \"same\"\n"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn configured_policy_file_is_loaded_and_missing_files_fail() {
+        let path = std::env::temp_dir().join(format!(
+            "talon-namespace-policy-{}-{}.toml",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::write(
+            &path,
+            "version = 1\n[[workers]]\nnode_id = \"worker-a\"\ngrants = [\"s3/data\"]\n",
+        )
+        .unwrap();
+        let policy = NamespacePolicy::from_file(&path).unwrap();
+        std::fs::remove_file(&path).unwrap();
+
+        assert!(policy.authorizes("worker-a", &"s3/data/models".parse().unwrap()));
+        assert!(NamespacePolicy::from_file(&path).is_err());
+    }
+}

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -137,6 +137,7 @@ impl Args {
             cluster_id: self.cluster_id,
             node_id: self.node_id,
             control_tls: None,
+            namespace_policy_path: None,
             heartbeat_interval_ms: self.heartbeat_interval_ms,
             block_size: self.block_size,
             data_plane_rings: self.data_plane_rings,

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -38,6 +38,7 @@
 # Reference
 
 - [Configuration reference](./reference/configuration.md)
+- [Namespace authorization policy](./reference/namespace-policy.md)
 - [REST API reference](./reference/rest-api.md)
 - [Wire protocol reference](./reference/wire-protocol.md)
 

--- a/docs/book/src/reference/namespace-policy.md
+++ b/docs/book/src/reference/namespace-policy.md
@@ -1,0 +1,1 @@
+{{#include ../../../reference/namespace-policy.md}}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -86,6 +86,14 @@ Lowercase DNS trust domain required in peer workload URI SANs.
 - **Default:** none
 - **CLI flag:** not settable via CLI (config file or environment only)
 
+### `namespace_policy_path`
+
+Mounted static namespace authorization policy (TOML).
+
+- **Environment variable:** `TALON_COORDINATOR_NAMESPACE_POLICY_PATH`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+
 ### `state_backend`
 
 Shared-state backend: memory | etcd | kubernetes.
@@ -319,6 +327,14 @@ PEM worker private-key file path; key bytes never enter configuration.
 Lowercase DNS trust domain required in peer workload URI SANs.
 
 - **Environment variable:** `TALON_WORKER_CONTROL_TLS_TRUST_DOMAIN`
+- **Default:** none
+- **CLI flag:** not settable via CLI (config file or environment only)
+
+### `namespace_policy_path`
+
+Mounted static namespace authorization policy (TOML).
+
+- **Environment variable:** `TALON_WORKER_NAMESPACE_POLICY_PATH`
 - **Default:** none
 - **CLI flag:** not settable via CLI (config file or environment only)
 

--- a/docs/reference/namespace-policy.md
+++ b/docs/reference/namespace-policy.md
@@ -1,0 +1,30 @@
+# Namespace authorization policy
+
+Coordinators and workers load the same operator-owned TOML file through
+`namespace_policy_path` or the corresponding environment variable. The file is
+read and validated at process startup.
+
+```toml
+version = 1
+
+[[workers]]
+node_id = "worker-a"
+grants = [
+  "s3/datasets/training",
+  "gcs/checkpoints",
+]
+
+[[workers]]
+node_id = "worker-b"
+grants = ["az/models"]
+```
+
+Each grant is a canonical `backend/bucket[/path-prefix]` namespace. Backends
+are `s3`, `gcs`, and `az`. Prefix matching is path-component aware: a grant for
+`s3/datasets/training` includes `s3/datasets/training/v1`, but not
+`s3/datasets/training-private`.
+
+The `node_id` must match the worker's stable configured identity. A missing
+policy, an unknown worker, an empty grant list, or a namespace outside every
+grant denies authorization. A configured file that is missing or malformed
+prevents the process from starting.


### PR DESCRIPTION
## Summary

- add a versioned static namespace policy keyed by stable worker node ID
- parse canonical `backend/bucket[/prefix]` grants with component-boundary authorization
- load the same mounted policy through coordinator and worker config, failing closed when absent or unmatched
- expose local coordinator and worker authorization checks and document the policy format

## Verification

- `PROTOC=/home/coder/talon/target/tools/protoc/bin/protoc cargo test --workspace --all-features --locked`
- `PROTOC=/home/coder/talon/target/tools/protoc/bin/protoc cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo deny check advisories bans sources`
- `just check-config-docs`
- `just linkcheck`
- `mdbook build docs/book`
- `git diff --check`

Closes #449