### PR TITLE
feat(worker): wire paged L2 so a block caches per page

### DIFF
--- a/crates/talon-core/src/block.rs
+++ b/crates/talon-core/src/block.rs
@@ -112,6 +112,44 @@ pub struct BlockMeta {
     pub len: u64,
 }
 
+impl BlockMeta {
+    /// Bytes actually materialized in the cache for this block.
+    ///
+    /// For [`BlockForm::Whole`] this is the whole logical length. For
+    /// [`BlockForm::Paged`] only *present* pages occupy space, so a paged block
+    /// with an empty bitmap costs nothing — capacity accounting must not charge
+    /// a 256 MiB block for one resident 256 KiB page.
+    pub fn resident_bytes(&self) -> u64 {
+        match &self.form {
+            BlockForm::Whole => self.len,
+            BlockForm::Paged { page_size, present } => (0..present.len())
+                .filter(|p| present.is_present(PageIndex(*p)))
+                .map(|p| page_len(self.len, *page_size, PageIndex(p)))
+                .sum(),
+        }
+    }
+
+    /// Byte length of `page` within this block (the last page may be short).
+    pub fn page_len(&self, page: PageIndex) -> u64 {
+        match &self.form {
+            BlockForm::Whole => 0,
+            BlockForm::Paged { page_size, .. } => page_len(self.len, *page_size, page),
+        }
+    }
+}
+
+/// Byte length of `page` in a block of `len` bytes with `page_size` pages.
+///
+/// Returns 0 for a page beyond the block's end; the final page is truncated to
+/// whatever remains, so pages of a short trailing block are accounted exactly.
+pub fn page_len(len: u64, page_size: u32, page: PageIndex) -> u64 {
+    if page_size == 0 {
+        return 0;
+    }
+    let start = u64::from(page.0) * u64::from(page_size);
+    len.saturating_sub(start).min(u64::from(page_size))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -121,6 +121,11 @@ pub struct WorkerConfig {
     pub l1_capacity_bytes: u64,
     /// Fixed L1 DRAM page size in bytes.
     pub l1_page_size_bytes: u64,
+    /// L2 page size in bytes. Zero (default) keeps whole-block L2: a miss
+    /// materializes the entire block as one file. Non-zero enables *paged* L2,
+    /// where a miss fetches and stores only the pages a read touches — far less
+    /// backend traffic and disk for point-query workloads.
+    pub l2_page_size_bytes: u64,
     /// Object-store backend selector: `azure` (default), `s3`, or `gcs`. The
     /// per-backend endpoint/credential fields below apply to the selected one.
     pub backend: Option<String>,
@@ -248,6 +253,7 @@ impl Default for WorkerConfig {
             capacity_bytes: 64 << 30,
             l1_capacity_bytes: 0,
             l1_page_size_bytes: 256 << 10,
+            l2_page_size_bytes: 0,
             backend: None,
             azure_account: None,
             azure_endpoint: None,
@@ -306,6 +312,8 @@ pub struct WorkerConfigPatch {
     pub l1_capacity_bytes: Option<u64>,
     /// Override for [`WorkerConfig::l1_page_size_bytes`].
     pub l1_page_size_bytes: Option<u64>,
+    /// Override for [`WorkerConfig::l2_page_size_bytes`].
+    pub l2_page_size_bytes: Option<u64>,
     /// Override for [`WorkerConfig::backend`].
     pub backend: Option<String>,
     /// Override for [`WorkerConfig::azure_account`].
@@ -360,6 +368,7 @@ impl Patch for WorkerConfigPatch {
             capacity_bytes: self.capacity_bytes.or(base.capacity_bytes),
             l1_capacity_bytes: self.l1_capacity_bytes.or(base.l1_capacity_bytes),
             l1_page_size_bytes: self.l1_page_size_bytes.or(base.l1_page_size_bytes),
+            l2_page_size_bytes: self.l2_page_size_bytes.or(base.l2_page_size_bytes),
             backend: self.backend.or(base.backend),
             azure_account: self.azure_account.or(base.azure_account),
             azure_endpoint: self.azure_endpoint.or(base.azure_endpoint),
@@ -536,6 +545,14 @@ pub const WORKER_ENV_SCHEMA: &[ConfigVar] = &[
         cli: false,
         secret: false,
         help: "Fixed L1 DRAM page size in bytes.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_L2_PAGE_SIZE_BYTES",
+        key: "l2_page_size_bytes",
+        default: Some("0"),
+        cli: false,
+        secret: false,
+        help: "L2 page size in bytes; 0 keeps whole-block L2, non-zero enables paged L2.",
     },
     ConfigVar {
         env: "TALON_WORKER_BACKEND",
@@ -726,6 +743,7 @@ pub(crate) mod worker_env {
     pub const CAPACITY_BYTES: &str = "TALON_WORKER_CAPACITY_BYTES";
     pub const L1_CAPACITY_BYTES: &str = "TALON_WORKER_L1_CAPACITY_BYTES";
     pub const L1_PAGE_SIZE_BYTES: &str = "TALON_WORKER_L1_PAGE_SIZE_BYTES";
+    pub const L2_PAGE_SIZE_BYTES: &str = "TALON_WORKER_L2_PAGE_SIZE_BYTES";
     pub const BACKEND: &str = "TALON_WORKER_BACKEND";
     pub const AZURE_ACCOUNT: &str = "TALON_WORKER_AZURE_ACCOUNT";
     pub const AZURE_ENDPOINT: &str = "TALON_WORKER_AZURE_ENDPOINT";
@@ -828,6 +846,9 @@ impl WorkerConfigPatch {
             l1_page_size_bytes: get(worker_env::L1_PAGE_SIZE_BYTES)
                 .map(|v| parse_u64(v, worker_env::L1_PAGE_SIZE_BYTES))
                 .transpose()?,
+            l2_page_size_bytes: get(worker_env::L2_PAGE_SIZE_BYTES)
+                .map(|v| parse_u64(v, worker_env::L2_PAGE_SIZE_BYTES))
+                .transpose()?,
             azure_account: get(worker_env::AZURE_ACCOUNT),
             azure_endpoint: get(worker_env::AZURE_ENDPOINT),
             backend: get(worker_env::BACKEND),
@@ -914,6 +935,7 @@ impl WorkerConfig {
             capacity_bytes: merged.capacity_bytes.unwrap_or(d.capacity_bytes),
             l1_capacity_bytes: merged.l1_capacity_bytes.unwrap_or(d.l1_capacity_bytes),
             l1_page_size_bytes: merged.l1_page_size_bytes.unwrap_or(d.l1_page_size_bytes),
+            l2_page_size_bytes: merged.l2_page_size_bytes.unwrap_or(d.l2_page_size_bytes),
             azure_account: merged.azure_account.or(d.azure_account),
             azure_endpoint: merged.azure_endpoint.or(d.azure_endpoint),
             backend: merged.backend.or(d.backend),
@@ -1066,6 +1088,30 @@ impl WorkerConfig {
                 return Err(Error::Other(format!(
                     "block_size ({}) must be divisible by l1_page_size_bytes ({})",
                     self.block_size, self.l1_page_size_bytes
+                )));
+            }
+        }
+        if self.l2_page_size_bytes > 0 {
+            if self.l2_page_size_bytes > self.block_size as u64 {
+                return Err(Error::Other(format!(
+                    "l2_page_size_bytes ({}) must be <= block_size ({})",
+                    self.l2_page_size_bytes, self.block_size
+                )));
+            }
+            if u64::from(self.block_size) % self.l2_page_size_bytes != 0 {
+                return Err(Error::Other(format!(
+                    "block_size ({}) must be divisible by l2_page_size_bytes ({})",
+                    self.block_size, self.l2_page_size_bytes
+                )));
+            }
+            // L1 sits above L2 and is filled one L2 page at a time. Differing
+            // page sizes would make an L1 admission span several L2 pages, so a
+            // single-page L2 hit could never fill an L1 entry.
+            if self.l1_capacity_bytes > 0 && self.l1_page_size_bytes != self.l2_page_size_bytes {
+                return Err(Error::Other(format!(
+                    "l1_page_size_bytes ({}) must equal l2_page_size_bytes ({}) when both \
+                     tiers are enabled",
+                    self.l1_page_size_bytes, self.l2_page_size_bytes
                 )));
             }
         }
@@ -1643,6 +1689,58 @@ mod tests {
         };
         let err = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
         assert!(err.to_string().contains("must be divisible"));
+    }
+
+    #[test]
+    fn paged_l2_page_size_is_validated_against_block_and_l1() {
+        // A page larger than a block cannot be addressed.
+        let cli = WorkerConfigPatch {
+            block_size: Some(1024),
+            capacity_bytes: Some(1024),
+            l2_page_size_bytes: Some(2048),
+            ..Default::default()
+        };
+        let err = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
+        assert!(err.to_string().contains("l2_page_size_bytes"));
+
+        // A block must divide evenly into pages.
+        let cli = WorkerConfigPatch {
+            block_size: Some(1024),
+            capacity_bytes: Some(1024),
+            l2_page_size_bytes: Some(300),
+            ..Default::default()
+        };
+        let err = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
+        assert!(err.to_string().contains("must be divisible"));
+
+        // With both tiers on, the page sizes must agree.
+        let cli = WorkerConfigPatch {
+            block_size: Some(1024),
+            capacity_bytes: Some(1024),
+            l1_capacity_bytes: Some(4096),
+            l1_page_size_bytes: Some(512),
+            l2_page_size_bytes: Some(256),
+            ..Default::default()
+        };
+        let err = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
+        assert!(err.to_string().contains("must equal l2_page_size_bytes"));
+
+        // Matching page sizes across both tiers is accepted.
+        let cli = WorkerConfigPatch {
+            block_size: Some(1024),
+            capacity_bytes: Some(1024),
+            l1_capacity_bytes: Some(4096),
+            l1_page_size_bytes: Some(256),
+            l2_page_size_bytes: Some(256),
+            ..Default::default()
+        };
+        let cfg = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap();
+        assert_eq!(cfg.l2_page_size_bytes, 256);
+
+        // Zero (the default) keeps whole-block L2 and imposes no constraints.
+        let cfg = WorkerConfig::resolve(Default::default(), Default::default(), Default::default())
+            .unwrap();
+        assert_eq!(cfg.l2_page_size_bytes, 0);
     }
 
     #[test]

--- a/crates/talon-core/src/lib.rs
+++ b/crates/talon-core/src/lib.rs
@@ -17,7 +17,7 @@ pub mod store;
 pub mod trace;
 
 pub use backend::{BackendStore, ListPage, ListedObject, ObjectStat};
-pub use block::{BlockForm, BlockMeta, LoadHint, PresentBitmap};
+pub use block::{page_len, BlockForm, BlockMeta, LoadHint, PresentBitmap};
 pub use config::{
     azure_sas_from_env, gcs_bearer_from_env, s3_secret_key_from_env, s3_session_token_from_env,
     ConfigVar, FuseConfig, FuseConfigPatch, Patch, WorkerConfig, WorkerConfigPatch,

--- a/crates/talon-worker/src/block_store.rs
+++ b/crates/talon-worker/src/block_store.rs
@@ -14,7 +14,9 @@
 //! unbounded.
 //!
 //! Paging is not handled here — [`get_page`](WholeBlockStore::get_page) returns
-//! [`Error::NotFound`]; the per-page store lands separately (see #15).
+//! [`Error::NotFound`]. Per-page caching lives in
+//! [`PagedBlockStore`](crate::PagedBlockStore), which the worker uses instead of
+//! this store when `l2_page_size_bytes` is set.
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -187,7 +189,8 @@ impl ObjectStore for WholeBlockStore {
     }
 
     async fn get_page(&self, id: &BlockId, _page: PageIndex) -> Result<BlockHandle> {
-        // Whole-block store has no per-page granularity; paged store is #15.
+        // Whole-block store has no per-page granularity; a paged worker uses
+        // PagedBlockStore for page reads instead.
         Err(Error::NotFound(id.to_string()))
     }
 

--- a/crates/talon-worker/src/eviction.rs
+++ b/crates/talon-worker/src/eviction.rs
@@ -149,30 +149,30 @@ impl Lru {
         Some(e.bytes)
     }
 
-    /// Evict and return every *superseded* whole-block unit for the same
-    /// `(object, offset, block_size)` as `keep` but a different version.
+    /// Evict and return every *superseded* unit — whole block or page — for the
+    /// same `(object, offset, block_size)` as `keep` but a different version.
     ///
     /// When an object is overwritten its new ETag yields a new [`BlockId`] and a
-    /// new `.blk` file, while the old version's file would otherwise stay
-    /// resident forever (issue #159, compounding #119). Called on commit of a
-    /// fresh version, this reclaims the stale sibling(s) immediately. Pinned
-    /// units (an in-flight reader still serving the old bytes) are left alone.
+    /// new `.blk` file (or `.pages` directory), while the old version's files
+    /// would otherwise stay resident forever (issue #159, compounding #119).
+    /// Called on commit of a fresh version, this reclaims the stale sibling(s)
+    /// immediately. Pinned units (an in-flight reader still serving the old
+    /// bytes) are left alone.
     pub fn evict_superseded(&self, keep: &BlockId) -> Vec<CacheUnit> {
         let mut g = self.inner.lock().unwrap();
         let victims: Vec<CacheUnit> = g
             .entries
             .iter()
             .filter(|(unit, e)| {
+                let id = match unit {
+                    CacheUnit::Whole(id) => id,
+                    CacheUnit::Page(id, _) => id,
+                };
                 e.pins == 0
-                    && match unit {
-                        CacheUnit::Whole(id) => {
-                            id.object == keep.object
-                                && id.offset == keep.offset
-                                && id.block_size == keep.block_size
-                                && id.version != keep.version
-                        }
-                        CacheUnit::Page(..) => false,
-                    }
+                    && id.object == keep.object
+                    && id.offset == keep.offset
+                    && id.block_size == keep.block_size
+                    && id.version != keep.version
             })
             .map(|(unit, _)| unit.clone())
             .collect();

--- a/crates/talon-worker/src/index.rs
+++ b/crates/talon-worker/src/index.rs
@@ -96,51 +96,120 @@ impl BlockIndex {
             .collect()
     }
 
+    /// Snapshot every resident cache *unit* and its byte cost: one entry per
+    /// whole block, one per present page of a paged block.
+    ///
+    /// Seeds the eviction tracker at startup so a rebuilt paged block charges
+    /// capacity per resident page rather than for its full logical length.
+    pub fn snapshot_units(&self) -> Vec<(BlockId, Option<PageIndex>, u64)> {
+        let g = self.inner.read().unwrap();
+        let mut out = Vec::new();
+        for meta in g.map.values() {
+            match &meta.form {
+                BlockForm::Whole => out.push((meta.id.clone(), None, meta.len)),
+                BlockForm::Paged { page_size, present } => {
+                    for p in 0..present.len() {
+                        let page = PageIndex(p);
+                        if present.is_present(page) {
+                            out.push((
+                                meta.id.clone(),
+                                Some(page),
+                                talon_core::page_len(meta.len, *page_size, page),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
     /// Commit a fully-materialized block (whole or a complete paged set).
     ///
     /// Called by PUT and by loader completion. Replaces any existing entry;
-    /// byte accounting is adjusted by the delta between old and new `len`.
+    /// byte accounting is adjusted by the delta between the old and new entry's
+    /// *resident* bytes — a paged block only charges for its present pages.
     pub fn commit(&self, meta: BlockMeta) {
         let mut g = self.inner.write().unwrap();
-        if let Some(prev) = g.map.insert(meta.id.clone(), meta.clone()) {
-            g.resident_bytes = g.resident_bytes.saturating_sub(prev.len);
+        let added = meta.resident_bytes();
+        if let Some(prev) = g.map.insert(meta.id.clone(), meta) {
+            g.resident_bytes = g.resident_bytes.saturating_sub(prev.resident_bytes());
         }
-        g.resident_bytes = g.resident_bytes.saturating_add(meta.len);
+        g.resident_bytes = g.resident_bytes.saturating_add(added);
     }
 
-    /// Insert (or reset) a paged block with an empty presence bitmap.
+    /// Insert a paged block with an empty presence bitmap, unless one is already
+    /// tracked.
     ///
     /// Used when a paged load begins: pages are then filled in with
     /// [`mark_page`](Self::mark_page). `len` is the block's logical length.
-    pub fn init_paged(&self, id: BlockId, page_size: u32, len: u64) {
+    /// Idempotent by design — a second concurrent page miss on the same block
+    /// must not reset the bitmap and lose the pages the first one materialized.
+    /// Returns `true` if a new entry was created.
+    pub fn init_paged(&self, id: BlockId, page_size: u32, len: u64) -> bool {
+        let mut g = self.inner.write().unwrap();
+        if g.map.contains_key(&id) {
+            // Already tracked — either paged (keep its bitmap) or whole (fully
+            // resident, nothing to page in). Either way, do not reset it.
+            return false;
+        }
         let page_count = id.page_count(page_size);
-        let meta = BlockMeta {
-            id,
-            form: BlockForm::Paged {
-                page_size,
-                present: PresentBitmap::new(page_count),
+        g.map.insert(
+            id.clone(),
+            BlockMeta {
+                id,
+                form: BlockForm::Paged {
+                    page_size,
+                    present: PresentBitmap::new(page_count),
+                },
+                len,
             },
-            len,
-        };
-        self.commit(meta);
+        );
+        // A fresh paged entry has no present pages, so it adds no resident bytes.
+        true
     }
 
-    /// Mark a page present on an existing paged block.
+    /// Mark a page present on an existing paged block, charging its bytes.
     ///
-    /// Returns `true` if the block exists and is paged; `false` otherwise
-    /// (whole blocks and unknown blocks are ignored).
+    /// Returns `true` if the block exists, is paged, and the page went from
+    /// absent to present; `false` otherwise (whole blocks, unknown blocks, and
+    /// already-present pages), so byte accounting is never double-counted.
     pub fn mark_page(&self, id: &BlockId, page: PageIndex) -> bool {
         let mut g = self.inner.write().unwrap();
-        match g.map.get_mut(id) {
-            Some(meta) => match &mut meta.form {
-                BlockForm::Paged { present, .. } => {
-                    present.set(page);
-                    true
-                }
-                BlockForm::Whole => false,
-            },
-            None => false,
+        let Some(meta) = g.map.get_mut(id) else {
+            return false;
+        };
+        let BlockForm::Paged { page_size, present } = &mut meta.form else {
+            return false;
+        };
+        if present.is_present(page) {
+            return false;
         }
+        present.set(page);
+        let bytes = talon_core::page_len(meta.len, *page_size, page);
+        g.resident_bytes = g.resident_bytes.saturating_add(bytes);
+        true
+    }
+
+    /// Mark a page absent on a paged block, refunding its bytes.
+    ///
+    /// Used by page-level eviction: the block entry (and its other pages) stays
+    /// intact. Returns `true` if the page was present and is now cleared.
+    pub fn clear_page(&self, id: &BlockId, page: PageIndex) -> bool {
+        let mut g = self.inner.write().unwrap();
+        let Some(meta) = g.map.get_mut(id) else {
+            return false;
+        };
+        let BlockForm::Paged { page_size, present } = &mut meta.form else {
+            return false;
+        };
+        if !present.is_present(page) {
+            return false;
+        }
+        present.clear(page);
+        let bytes = talon_core::page_len(meta.len, *page_size, page);
+        g.resident_bytes = g.resident_bytes.saturating_sub(bytes);
+        true
     }
 
     /// Decide how a read over `[start_page, end_page)` should be served.
@@ -166,12 +235,12 @@ impl BlockIndex {
 
     /// Remove a block from the index, returning its metadata if present.
     ///
-    /// Byte accounting is decremented by the removed block's `len`.
+    /// Byte accounting is decremented by the removed block's resident bytes.
     pub fn remove(&self, id: &BlockId) -> Option<BlockMeta> {
         let mut g = self.inner.write().unwrap();
         let removed = g.map.remove(id);
         if let Some(meta) = &removed {
-            g.resident_bytes = g.resident_bytes.saturating_sub(meta.len);
+            g.resident_bytes = g.resident_bytes.saturating_sub(meta.resident_bytes());
         }
         removed
     }
@@ -241,7 +310,10 @@ mod tests {
             Presence::Whole
         );
 
-        // Paged block: pages absent -> miss, then present -> hit.
+        // Paged block: pages absent -> miss, then present -> hit. Uses a fresh
+        // id — `init_paged` deliberately does not downgrade an existing whole
+        // entry, which is already fully resident.
+        let id = block(8);
         let page_size = 256 * 1024;
         idx.init_paged(id.clone(), page_size, 256 << 20);
         assert_eq!(

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -42,7 +42,8 @@ use talon_worker::mapping_guard::MappingGuard;
 use talon_worker::tokio_conn::{handle_conn, read_control};
 use talon_worker::uring_conn;
 use talon_worker::{
-    serve_admin, BlockIndex, InFlightLoads, WholeBlockStore, WorkerObservability, WorkerRuntime,
+    serve_admin, BlockIndex, InFlightLoads, PagedBlockStore, WholeBlockStore, WorkerObservability,
+    WorkerRuntime,
 };
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -147,6 +148,7 @@ impl Args {
             capacity_bytes: None,
             l1_capacity_bytes: None,
             l1_page_size_bytes: None,
+            l2_page_size_bytes: None,
             backend: None,
             azure_account: None,
             azure_endpoint: None,
@@ -283,6 +285,7 @@ async fn main() -> anyhow::Result<()> {
         capacity_bytes = cfg.capacity_bytes,
         l1_capacity_bytes = cfg.l1_capacity_bytes,
         l1_page_size_bytes = cfg.l1_page_size_bytes,
+        l2_page_size_bytes = cfg.l2_page_size_bytes,
         azure_account = ?cfg.azure_account,
         azure_endpoint = ?cfg.azure_endpoint,
         "starting talon-worker"
@@ -296,10 +299,40 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or_else(|| PathBuf::from("/tmp/talon-cache"));
     std::fs::create_dir_all(&root)?;
     let store = WholeBlockStore::open(&root)?;
+    // Paged L2 is opt-in: with `l2_page_size_bytes` set, a miss materializes only
+    // the pages a read touches, under `<root>/paged`, instead of whole blocks.
+    let paged = match u32::try_from(cfg.l2_page_size_bytes) {
+        Ok(page_size) if page_size > 0 => {
+            Some(PagedBlockStore::open(root.join("paged"), page_size)?)
+        }
+        _ => None,
+    };
 
     // Rebuild the in-memory index from blocks already on local disk so a restart
     // does not re-download the resident working set (issue #114).
     let index = Arc::new(BlockIndex::new());
+    if let Some(paged) = &paged {
+        // Rebuild paged entries first; their present bitmaps come from the page
+        // files actually on disk.
+        match paged.scan() {
+            Ok(metas) => {
+                let count = metas.len();
+                for meta in metas {
+                    index.commit(meta);
+                }
+                if count > 0 {
+                    tracing::info!(
+                        blocks = count,
+                        pages = index.page_count(),
+                        "rebuilt paged block index from on-disk cache"
+                    );
+                }
+            }
+            Err(error) => {
+                tracing::warn!(%error, "failed to scan on-disk paged cache");
+            }
+        }
+    }
     match store.scan() {
         Ok(metas) => {
             let count = metas.len();
@@ -453,20 +486,22 @@ async fn main() -> anyhow::Result<()> {
     };
     tracing::info!(backend = backend_kind, "object-store backend ready");
 
-    let worker = Arc::new(
-        WorkerRuntime::new_with_l1(
-            store,
-            index,
-            inflight,
-            backend,
-            cfg.block_size,
-            cfg.capacity_bytes,
-            cfg.l1_capacity_bytes,
-            cfg.l1_page_size_bytes,
-            observability.metrics().clone(),
-        )
-        .with_backend_kind(configured_backend),
-    );
+    let mut runtime = WorkerRuntime::new_with_l1(
+        store,
+        index,
+        inflight,
+        backend,
+        cfg.block_size,
+        cfg.capacity_bytes,
+        cfg.l1_capacity_bytes,
+        cfg.l1_page_size_bytes,
+        observability.metrics().clone(),
+    )
+    .with_backend_kind(configured_backend);
+    if let Some(paged) = paged {
+        runtime = runtime.with_paged_store(paged);
+    }
+    let worker = Arc::new(runtime);
 
     let admin_listener = TcpListener::bind(&cfg.admin_listen).await?;
     tracing::info!(listen = %cfg.admin_listen, "worker serving administration API");

--- a/crates/talon-worker/src/memory_store.rs
+++ b/crates/talon-worker/src/memory_store.rs
@@ -230,6 +230,24 @@ impl MemoryStore {
         MemoryInsert::Inserted { evicted }
     }
 
+    /// Remove one page. Returns whether it was resident.
+    pub fn remove_page(&self, block: &BlockId, page: PageIndex) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+        let key = MemoryPageKey {
+            block: block.clone(),
+            page,
+        };
+        match inner.entries.remove(&key) {
+            Some(entry) => {
+                inner.resident_bytes = inner
+                    .resident_bytes
+                    .saturating_sub(entry.value.len() as u64);
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Remove every page belonging to one block.
     pub fn remove_block(&self, block: &BlockId) -> Vec<MemoryPageKey> {
         let mut inner = self.inner.lock().unwrap();

--- a/crates/talon-worker/src/paged_store.rs
+++ b/crates/talon-worker/src/paged_store.rs
@@ -26,8 +26,33 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::os::fd::OwnedFd;
+use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
-use talon_core::{BlockHandle, BlockId, Error, PageIndex, Result};
+use std::sync::atomic::{AtomicU64, Ordering};
+use talon_core::{
+    BlockForm, BlockHandle, BlockId, BlockMeta, Error, PageIndex, PresentBitmap, Result,
+};
+
+/// Process-wide counter making staging temp filenames unique, so two concurrent
+/// writers of the same page never share a `.tmp` path (mirrors the whole-block
+/// store's discipline, issue #113).
+static STAGING_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Run blocking filesystem work on Tokio's blocking pool, so page I/O never
+/// stalls the async reactor thread and the connections multiplexed on it
+/// (issue #115).
+async fn spawn_blocking_io<F, T>(f: F) -> Result<T>
+where
+    F: FnOnce() -> Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(f).await {
+        Ok(result) => result,
+        Err(join_error) => Err(Error::Backend(format!(
+            "blocking store task failed: {join_error}"
+        ))),
+    }
+}
 
 /// A local, file-backed store for paged blocks (per-page files).
 pub struct PagedBlockStore {
@@ -71,24 +96,228 @@ impl PagedBlockStore {
         self.dir_for(id).join(format!("{}.page", page.0))
     }
 
+    /// Sidecar metadata path for a paged block: `<block dir>/block.meta`.
+    ///
+    /// The directory name is a one-way digest of the [`BlockId`], so the id
+    /// cannot be recovered from the page files alone. This sidecar records the
+    /// block's id, page size, and logical length so [`scan`](Self::scan) can
+    /// rebuild the index (and the present bitmap, from the page files actually
+    /// on disk) after a restart — the paged analogue of issue #114.
+    fn meta_path_for(&self, id: &BlockId) -> PathBuf {
+        self.dir_for(id).join("block.meta")
+    }
+
+    /// Record a paged block's identity so a restart can rebuild its index entry.
+    ///
+    /// Called once when a paged block is first touched. Best-effort: a missing
+    /// sidecar only costs a re-fetch of that block's pages after a restart.
+    pub fn write_sidecar(&self, id: &BlockId, len: u64) -> Result<()> {
+        let dir = self.dir_for(id);
+        std::fs::create_dir_all(&dir)?;
+        let meta_path = self.meta_path_for(id);
+        if meta_path.exists() {
+            return Ok(());
+        }
+        // The bitmap is not persisted: page files on disk are the source of
+        // truth, so a crash between a page rename and a bitmap write cannot
+        // desynchronize them. `scan` reconstructs presence by listing `.page`s.
+        let meta = BlockMeta {
+            id: id.clone(),
+            form: BlockForm::Paged {
+                page_size: self.page_size,
+                present: PresentBitmap::new(id.page_count(self.page_size)),
+            },
+            len,
+        };
+        let encoded = serde_json::to_vec(&meta)
+            .map_err(|e| Error::Other(format!("encode paged block sidecar: {e}")))?;
+        let pid = std::process::id();
+        let seq = STAGING_SEQ.fetch_add(1, Ordering::Relaxed);
+        let tmp = dir.join(format!("block.meta.tmp.{pid}.{seq}"));
+        match (|| -> std::io::Result<()> {
+            let mut f = std::fs::File::create(&tmp)?;
+            f.write_all(&encoded)?;
+            f.sync_all()?;
+            std::fs::rename(&tmp, &meta_path)
+        })() {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                let _ = std::fs::remove_file(&tmp);
+                Err(e.into())
+            }
+        }
+    }
+
+    /// Scan the cache root and return the [`BlockMeta`] of every paged block,
+    /// with each present bitmap reconstructed from the `.page` files on disk.
+    ///
+    /// A block directory without a readable sidecar is skipped (its pages are
+    /// unaddressable), as is one with no page files at all.
+    pub fn scan(&self) -> Result<Vec<BlockMeta>> {
+        let mut out = Vec::new();
+        let shards = match std::fs::read_dir(&self.root) {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+            Err(e) => return Err(e.into()),
+        };
+        for shard in shards.flatten() {
+            if !shard.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let Ok(entries) = std::fs::read_dir(shard.path()) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let dir = entry.path();
+                if dir.extension().and_then(|e| e.to_str()) != Some("pages") {
+                    continue;
+                }
+                let Ok(bytes) = std::fs::read(dir.join("block.meta")) else {
+                    continue;
+                };
+                let mut meta = match serde_json::from_slice::<BlockMeta>(&bytes) {
+                    Ok(meta) => meta,
+                    Err(error) => {
+                        tracing::warn!(path = %dir.display(), %error, "skipping malformed paged sidecar");
+                        continue;
+                    }
+                };
+                let BlockForm::Paged { page_size, present } = &mut meta.form else {
+                    continue;
+                };
+                // A sidecar written under a different page size cannot be
+                // reinterpreted at the current one; drop it rather than serve
+                // misaligned pages.
+                if *page_size != self.page_size {
+                    tracing::warn!(
+                        path = %dir.display(),
+                        sidecar_page_size = *page_size,
+                        configured_page_size = self.page_size,
+                        "skipping paged block written under a different page size"
+                    );
+                    continue;
+                }
+                let Ok(pages) = std::fs::read_dir(&dir) else {
+                    continue;
+                };
+                for page_file in pages.flatten() {
+                    let path = page_file.path();
+                    if path.extension().and_then(|e| e.to_str()) != Some("page") {
+                        continue;
+                    }
+                    let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                        continue;
+                    };
+                    if let Ok(index) = stem.parse::<u32>() {
+                        present.set(PageIndex(index));
+                    }
+                }
+                if present.count() > 0 {
+                    out.push(meta);
+                }
+            }
+        }
+        Ok(out)
+    }
+
     /// Whether a specific page is resident.
     pub fn has_page(&self, id: &BlockId, page: PageIndex) -> bool {
         self.page_path(id, page).exists()
     }
 
     /// Materialize (commit) one page's bytes via temp-file + rename.
+    ///
+    /// The temp name carries pid + a process-wide sequence so two concurrent
+    /// writers of the same page cannot clobber each other's staging file and
+    /// commit a torn page (issue #113).
     pub fn put_page(&self, id: &BlockId, page: PageIndex, value: Bytes) -> Result<()> {
         let dir = self.dir_for(id);
         std::fs::create_dir_all(&dir)?;
         let path = self.page_path(id, page);
-        let tmp = path.with_extension("page.tmp");
-        {
+        let pid = std::process::id();
+        let seq = STAGING_SEQ.fetch_add(1, Ordering::Relaxed);
+        let tmp = dir.join(format!("{}.page.tmp.{pid}.{seq}", page.0));
+        match (|| -> std::io::Result<()> {
             let mut f = std::fs::File::create(&tmp)?;
             f.write_all(&value)?;
             f.sync_all()?;
+            std::fs::rename(&tmp, &path)
+        })() {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                let _ = std::fs::remove_file(&tmp);
+                Err(e.into())
+            }
         }
-        std::fs::rename(&tmp, &path)?;
-        Ok(())
+    }
+
+    /// Commit one page's bytes off the async reactor thread.
+    pub async fn put_page_async(&self, id: &BlockId, page: PageIndex, value: Bytes) -> Result<()> {
+        let dir = self.dir_for(id);
+        let path = self.page_path(id, page);
+        spawn_blocking_io(move || {
+            std::fs::create_dir_all(&dir)?;
+            let pid = std::process::id();
+            let seq = STAGING_SEQ.fetch_add(1, Ordering::Relaxed);
+            let tmp = path.with_extension(format!("page.tmp.{pid}.{seq}"));
+            match (|| -> std::io::Result<()> {
+                let mut f = std::fs::File::create(&tmp)?;
+                f.write_all(&value)?;
+                f.sync_all()?;
+                std::fs::rename(&tmp, &path)
+            })() {
+                Ok(()) => Ok(()),
+                Err(e) => {
+                    let _ = std::fs::remove_file(&tmp);
+                    Err(e.into())
+                }
+            }
+        })
+        .await
+    }
+
+    /// Read one page's bytes into userspace, off the async reactor thread.
+    ///
+    /// Returns [`Error::NotFound`] if the page is absent, so the caller can
+    /// trigger a page-level miss.
+    pub async fn get_page_bytes(&self, id: &BlockId, page: PageIndex) -> Result<Bytes> {
+        let path = self.page_path(id, page);
+        let label = format!("{id} page {}", page.0);
+        spawn_blocking_io(move || match std::fs::File::open(&path) {
+            Ok(f) => {
+                let len = f.metadata()?.len();
+                let size = usize::try_from(len)
+                    .map_err(|_| Error::Other(format!("page length {len} exceeds usize")))?;
+                let mut buffer = vec![0_u8; size];
+                f.read_exact_at(&mut buffer, 0)?;
+                Ok(Bytes::from(buffer))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(Error::NotFound(label)),
+            Err(e) => Err(e.into()),
+        })
+        .await
+    }
+
+    /// Remove a single page off the async reactor thread. Idempotent.
+    pub async fn evict_page_async(&self, id: &BlockId, page: PageIndex) -> Result<()> {
+        let path = self.page_path(id, page);
+        spawn_blocking_io(move || match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        })
+        .await
+    }
+
+    /// Remove an entire paged block off the async reactor thread. Idempotent.
+    pub async fn delete_block_async(&self, id: &BlockId) -> Result<()> {
+        let dir = self.dir_for(id);
+        spawn_blocking_io(move || match std::fs::remove_dir_all(&dir) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        })
+        .await
     }
 
     /// Open a resident page as a zero-copy handle over its whole file.
@@ -277,6 +506,73 @@ mod tests {
         store.delete_block(&id).unwrap();
         assert!(!store.has_page(&id, PageIndex(1)));
         store.delete_block(&id).unwrap(); // idempotent
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn scan_rebuilds_presence_from_the_page_files_on_disk() {
+        let root = tmp_root();
+        let store = PagedBlockStore::open(&root, 4).unwrap();
+        let id = block(5);
+        store.write_sidecar(&id, 20).unwrap();
+        store
+            .put_page(&id, PageIndex(1), Bytes::from_static(b"efgh"))
+            .unwrap();
+        store
+            .put_page(&id, PageIndex(3), Bytes::from_static(b"mnop"))
+            .unwrap();
+
+        let metas = store.scan().unwrap();
+        assert_eq!(metas.len(), 1);
+        let meta = &metas[0];
+        assert_eq!(meta.id, id);
+        assert_eq!(meta.len, 20);
+        let BlockForm::Paged { page_size, present } = &meta.form else {
+            panic!("expected a paged form");
+        };
+        assert_eq!(*page_size, 4);
+        // Exactly the pages with files on disk are marked present.
+        assert!(!present.is_present(PageIndex(0)));
+        assert!(present.is_present(PageIndex(1)));
+        assert!(!present.is_present(PageIndex(2)));
+        assert!(present.is_present(PageIndex(3)));
+        assert_eq!(present.count(), 2);
+        // Only present pages are charged, not the block's full length.
+        assert_eq!(meta.resident_bytes(), 8);
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn scan_skips_a_block_written_under_a_different_page_size() {
+        let root = tmp_root();
+        {
+            let store = PagedBlockStore::open(&root, 4).unwrap();
+            let id = block(6);
+            store.write_sidecar(&id, 20).unwrap();
+            store
+                .put_page(&id, PageIndex(0), Bytes::from_static(b"abcd"))
+                .unwrap();
+            assert_eq!(store.scan().unwrap().len(), 1);
+        }
+        // Reopening at a different page size must not reinterpret those pages:
+        // page 1 at 4 bytes is not page 1 at 8 bytes.
+        let store = PagedBlockStore::open(&root, 8).unwrap();
+        assert!(store.scan().unwrap().is_empty());
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn scan_ignores_a_block_with_a_sidecar_but_no_pages() {
+        let root = tmp_root();
+        let store = PagedBlockStore::open(&root, 4).unwrap();
+        let id = block(7);
+        store.write_sidecar(&id, 20).unwrap();
+
+        // A sidecar alone contributes nothing resident.
+        assert!(store.scan().unwrap().is_empty());
 
         std::fs::remove_dir_all(&root).ok();
     }

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -14,8 +14,8 @@ use talon_transport::frame::HEADER_LEN;
 use talon_transport::{codec, ControlMessage, ObjectEntry, MAX_CONTROL_PAYLOAD_LEN};
 
 use crate::{
-    BlockIndex, CacheUnit, InFlightLoads, LoadKey, Lru, MemoryInsert, MemoryStore, Presence,
-    WholeBlockStore, WorkerMetrics,
+    miss::touched_pages, BlockIndex, CacheUnit, InFlightLoads, LoadKey, Lru, MemoryInsert,
+    MemoryStore, PagedBlockStore, Presence, WholeBlockStore, WorkerMetrics,
 };
 
 /// Default lifetime of a cached resolved object version.
@@ -39,6 +39,10 @@ const LIST_PAGE_SIZE: u32 = 1000;
 /// A per-object resolved version with the instant it was resolved.
 struct CachedVersion {
     version: Version,
+    /// Total object length reported by the same `HEAD`, so the paged path can
+    /// compute a block's logical length (the last block is usually short)
+    /// without a second round trip.
+    object_len: u64,
     resolved_at: Instant,
 }
 
@@ -65,6 +69,10 @@ pub struct WorkerRuntime {
     l1: Arc<MemoryStore>,
     /// Persistent local-NVMe cache.
     store: WholeBlockStore,
+    /// Per-page L2 cache, enabled when the worker runs in paged mode. When set,
+    /// a miss materializes only the pages a read touches instead of the whole
+    /// (256 MiB default) block, and eviction reclaims individual pages.
+    paged: Option<PagedBlockStore>,
     index: Arc<BlockIndex>,
     inflight: Arc<InFlightLoads>,
     backend: Arc<dyn BackendStore>,
@@ -129,8 +137,12 @@ impl WorkerRuntime {
         metrics: WorkerMetrics,
     ) -> Self {
         let lru = Arc::new(Lru::new());
-        for (id, len) in index.snapshot_lens() {
-            lru.insert(CacheUnit::Whole(id), len);
+        for (id, page, bytes) in index.snapshot_units() {
+            let unit = match page {
+                Some(page) => CacheUnit::Page(id, page),
+                None => CacheUnit::Whole(id),
+            };
+            lru.insert(unit, bytes);
         }
         let l1 = Arc::new(MemoryStore::with_limits(
             l1_capacity_bytes,
@@ -141,6 +153,7 @@ impl WorkerRuntime {
         Self {
             l1,
             store,
+            paged: None,
             index,
             inflight,
             backend,
@@ -154,7 +167,23 @@ impl WorkerRuntime {
         }
     }
 
-    /// Record the backend selected by the worker process.
+    /// Enable paged L2: cache individual pages instead of whole blocks.
+    ///
+    /// With this set, a read that misses fetches only the pages it touches from
+    /// the origin and commits them as per-page files, so a point query into a
+    /// 256 MiB block costs one page (256 KiB by default) of backend traffic and
+    /// of local disk rather than the whole block. Eviction reclaims individual
+    /// pages, leaving the block's other pages intact.
+    pub fn with_paged_store(mut self, paged: PagedBlockStore) -> Self {
+        self.paged = Some(paged);
+        self
+    }
+
+    /// The paged L2 page size, or `None` when paged mode is off.
+    fn paged_page_size(&self) -> Option<u32> {
+        self.paged.as_ref().map(|p| p.page_size())
+    }
+
     ///
     /// Requests carry a backend either directly in their [`ObjectId`] or in a
     /// namespace prefix (`s3`, `gcs`, or `az`). A worker has exactly one
@@ -295,6 +324,38 @@ impl WorkerRuntime {
         if end <= start_block + block_size {
             let block = self.block_for(&request.object, request.offset, version);
             let offset_in_block = request.offset - block.offset;
+            // Paged mode: a resident page can be served straight from its own
+            // file with sendfile, provided the read stays inside one page (the
+            // common point-query shape). Anything wider goes through the byte
+            // path, which stitches pages together.
+            if let (Some(paged), false) = (&self.paged, self.l1.is_enabled()) {
+                let page_size = u64::from(paged.page_size());
+                let page = PageIndex((offset_in_block / page_size) as u32);
+                let within_one_page =
+                    offset_in_block + request.len <= (u64::from(page.0) + 1) * page_size;
+                if within_one_page
+                    && matches!(
+                        self.index.presence(&block, page, PageIndex(page.0 + 1)),
+                        Presence::PageHit
+                    )
+                {
+                    match paged.get_range(&block, offset_in_block, request.len) {
+                        Ok(mut handles) if handles.len() == 1 => {
+                            let handle = handles.pop().expect("one handle");
+                            self.metrics.record_l2_hit();
+                            self.metrics.record_cache_hit();
+                            self.lru.touch(&CacheUnit::Page(block.clone(), page));
+                            tracing::info!(
+                                block = %block, page = page.0, tier = "l2", "HIT (sendfile)"
+                            );
+                            return Ok(ServeOutcome::Sendfile(handle));
+                        }
+                        // Lost the race with page eviction, or a multi-handle
+                        // result; fall through to the byte path, which re-fetches.
+                        Ok(_) | Err(_) => {}
+                    }
+                }
+            }
             if self.l1.is_enabled() {
                 return Ok(ServeOutcome::Bytes(
                     self.block_range_bytes(request, &block, offset_in_block, request.len)
@@ -490,7 +551,7 @@ impl WorkerRuntime {
         }
         // Reuse the read path's cache so a stat immediately followed by a read
         // does not pay a second HEAD.
-        self.store_version(object, &stat.version);
+        self.store_version(object, &stat.version, stat.len);
         Ok(stat)
     }
 
@@ -517,7 +578,7 @@ impl WorkerRuntime {
                 "backend returned no version/etag for {object}; refusing to cache without a version"
             );
         }
-        self.store_version(object, &stat.version);
+        self.store_version(object, &stat.version, stat.len);
         Ok(stat.version)
     }
 
@@ -532,12 +593,23 @@ impl WorkerRuntime {
         }
     }
 
+    /// Total object length recorded alongside a cached version, if any.
+    ///
+    /// The paged path uses this to size the last (short) block of an object, so
+    /// it never charges capacity for — or tries to read — pages past EOF.
+    fn cached_object_len(&self, object: &ObjectId, version: &Version) -> Option<u64> {
+        let cache = self.version_cache.lock().unwrap();
+        let entry = cache.get(object)?;
+        (entry.version == *version).then_some(entry.object_len)
+    }
+
     /// Record a freshly-resolved version for `object`.
-    fn store_version(&self, object: &ObjectId, version: &Version) {
+    fn store_version(&self, object: &ObjectId, version: &Version, object_len: u64) {
         self.version_cache.lock().unwrap().insert(
             object.clone(),
             CachedVersion {
                 version: version.clone(),
+                object_len,
                 resolved_at: Instant::now(),
             },
         );
@@ -564,12 +636,275 @@ impl WorkerRuntime {
         offset: u64,
         len: u64,
     ) -> anyhow::Result<bytes::Bytes> {
+        if self.paged.is_some() {
+            return self.paged_block_range(request, block, offset, len).await;
+        }
         if let Some(bytes) = self.cached_block_range(block, offset, len).await? {
             return Ok(bytes);
         }
 
         self.metrics.record_cache_miss();
         self.load_block_range(request, block, offset, len).await
+    }
+
+    /// Serve a block-relative range in paged mode: L1, then per-page L2 files,
+    /// then a per-page origin fetch for whatever is still absent.
+    ///
+    /// Unlike the whole-block path this never materializes the full block: only
+    /// the pages the read actually touches are fetched and committed, so a point
+    /// query costs one page rather than 256 MiB of backend traffic and disk.
+    async fn paged_block_range(
+        &self,
+        request: &RangeRequest,
+        block: &BlockId,
+        offset: u64,
+        len: u64,
+    ) -> anyhow::Result<bytes::Bytes> {
+        let page_size = self
+            .paged_page_size()
+            .ok_or_else(|| anyhow::anyhow!("paged read on a runtime without a paged store"))?;
+
+        // A write-through commits the whole block as one file (read-after-write
+        // must hit). Serve such a block from the whole-block store rather than
+        // re-fetching it a page at a time from the origin.
+        if matches!(
+            self.index.presence(block, PageIndex(0), PageIndex(1)),
+            Presence::Whole
+        ) {
+            if let Some(bytes) = self.cached_block_range(block, offset, len).await? {
+                return Ok(bytes);
+            }
+        }
+
+        let block_len = self.block_len(&request.object, block).await?;
+        let len = available_range_len(block_len, offset, len)?;
+        if len == 0 {
+            return Ok(bytes::Bytes::new());
+        }
+
+        // Ensure the block has an index entry so page presence can be tracked.
+        // Idempotent: a concurrent reader's entry (and its bitmap) is preserved.
+        self.index.init_paged(block.clone(), page_size, block_len);
+
+        let mut out = bytes::BytesMut::with_capacity(len as usize);
+        let mut hit_all = true;
+        for page in touched_pages(offset, len, page_size) {
+            let page_start = u64::from(page.0) * u64::from(page_size);
+            let page_bytes_len = talon_core::page_len(block_len, page_size, page);
+            // Intersect the requested window with this page's span.
+            let from = offset.max(page_start);
+            let to = (offset + len).min(page_start + page_bytes_len);
+            if to <= from {
+                continue;
+            }
+            let (page_bytes, hit) = self.page_bytes(request, block, page, block_len).await?;
+            hit_all &= hit;
+            out.extend_from_slice(&slice(&page_bytes, from - page_start, to - from)?);
+        }
+        if hit_all {
+            self.metrics.record_cache_hit();
+        } else {
+            self.metrics.record_cache_miss();
+        }
+        Ok(out.freeze())
+    }
+
+    /// Return one page's bytes, and whether it was served from cache.
+    ///
+    /// Tries L1, then the on-disk page file, then a deduplicated origin fetch of
+    /// just that page. Concurrent misses for the same `(block, page)` collapse
+    /// to a single backend request via [`LoadKey::Page`], mirroring the
+    /// whole-block leader/follower protocol (issues #113, #162).
+    async fn page_bytes(
+        &self,
+        request: &RangeRequest,
+        block: &BlockId,
+        page: PageIndex,
+        block_len: u64,
+    ) -> anyhow::Result<(bytes::Bytes, bool)> {
+        if let Some(bytes) = self.cached_page(block, page).await? {
+            return Ok((bytes, true));
+        }
+        let key = LoadKey::Page(block.clone(), page);
+        match self.inflight.admit_owned(key.clone()) {
+            Some(guard) => {
+                let result = self
+                    .fetch_and_commit_page(request, block, page, block_len)
+                    .await;
+                drop(guard);
+                Ok((result?, false))
+            }
+            None => {
+                // A peer is fetching this exact page; wait and serve from cache.
+                self.inflight.wait(&key).await;
+                if let Some(bytes) = self.cached_page(block, page).await? {
+                    return Ok((bytes, true));
+                }
+                // The leader's load failed; fetch it ourselves rather than
+                // looping on admission, which could wait unboundedly.
+                let bytes = self
+                    .fetch_and_commit_page(request, block, page, block_len)
+                    .await?;
+                Ok((bytes, false))
+            }
+        }
+    }
+
+    /// Return a page from L1 or the on-disk page file, promoting L2 hits to L1.
+    async fn cached_page(
+        &self,
+        block: &BlockId,
+        page: PageIndex,
+    ) -> anyhow::Result<Option<bytes::Bytes>> {
+        if self.l1.is_enabled() {
+            if let Some(bytes) = self.l1.get_page(block, page) {
+                self.metrics.record_l1_hit();
+                self.lru.touch(&CacheUnit::Page(block.clone(), page));
+                tracing::debug!(block = %block, page = page.0, tier = "l1", "HIT");
+                return Ok(Some(bytes));
+            }
+            self.metrics.record_l1_miss();
+        }
+        if !matches!(
+            self.index.presence(block, page, PageIndex(page.0 + 1)),
+            Presence::PageHit
+        ) {
+            self.metrics.record_l2_miss();
+            return Ok(None);
+        }
+        let paged = self.paged.as_ref().expect("paged store");
+        match paged.get_page_bytes(block, page).await {
+            Ok(bytes) => {
+                self.metrics.record_l2_hit();
+                self.lru.touch(&CacheUnit::Page(block.clone(), page));
+                tracing::debug!(block = %block, page = page.0, tier = "l2", "HIT");
+                if self.l1.is_enabled() {
+                    self.admit_l1_page(block, page, bytes.clone());
+                }
+                Ok(Some(bytes))
+            }
+            Err(Error::NotFound(_)) => {
+                // Index said present but the file is gone — an eviction race.
+                // Drop the stale bit so the miss path re-fetches it.
+                self.index.clear_page(block, page);
+                self.lru.remove(&CacheUnit::Page(block.clone(), page));
+                self.metrics.record_l2_miss();
+                Ok(None)
+            }
+            Err(error) => Err(anyhow::anyhow!("read cached page: {error}")),
+        }
+    }
+
+    /// Fetch one page from the origin and commit it as a per-page file.
+    async fn fetch_and_commit_page(
+        &self,
+        request: &RangeRequest,
+        block: &BlockId,
+        page: PageIndex,
+        block_len: u64,
+    ) -> anyhow::Result<bytes::Bytes> {
+        let page_size = self.paged_page_size().expect("paged store");
+        let page_start = u64::from(page.0) * u64::from(page_size);
+        let want = talon_core::page_len(block_len, page_size, page);
+        tracing::info!(block = %block, page = page.0, "MISS -> backend page fetch");
+        let started = Instant::now();
+        // Same If-Match precondition as the whole-block path: an overwrite
+        // between version resolution and this GET must be rejected rather than
+        // committing newer bytes under the older version's key (issue #163).
+        let fetched = self
+            .backend
+            .fetch_range_if_match(
+                &request.object,
+                block.offset + page_start,
+                want,
+                Some(&block.version),
+            )
+            .await;
+        let bytes = match fetched {
+            Ok(bytes) => {
+                self.metrics
+                    .record_backend_fetch_success(bytes.len() as u64, started.elapsed());
+                bytes
+            }
+            Err(error) => {
+                self.metrics.record_backend_fetch_error(started.elapsed());
+                return Err(error.into());
+            }
+        };
+
+        let paged = self.paged.as_ref().expect("paged store");
+        // Record the block's identity once so a restart can rebuild its index
+        // entry from the page files on disk.
+        if let Err(error) = paged.write_sidecar(block, block_len) {
+            tracing::warn!(block = %block, %error, "failed to write paged sidecar");
+        }
+        paged
+            .put_page_async(block, page, bytes.clone())
+            .await
+            .map_err(|error| anyhow::anyhow!("commit page failed: {error}"))?;
+        self.index.init_paged(block.clone(), page_size, block_len);
+        self.index.mark_page(block, page);
+
+        let unit = CacheUnit::Page(block.clone(), page);
+        self.lru.insert(unit.clone(), bytes.len() as u64);
+        self.lru.pin(&unit);
+        let superseded = self.lru.evict_superseded(block);
+        self.unlink_units(superseded).await;
+        self.enforce_capacity().await;
+        self.lru.unpin(&unit);
+        if !self.l1.remove_superseded(block).is_empty() {
+            self.refresh_l1_metrics();
+        }
+        if self.l1.is_enabled() {
+            self.admit_l1_page(block, page, bytes.clone());
+        }
+        tracing::info!(block = %block, page = page.0, bytes = bytes.len(), "committed page");
+        Ok(bytes)
+    }
+
+    /// Admit one page into L1, recording admissions and evictions.
+    fn admit_l1_page(&self, block: &BlockId, page: PageIndex, bytes: bytes::Bytes) {
+        match self.l1.insert_page(block.clone(), page, bytes) {
+            MemoryInsert::Inserted { evicted } => {
+                self.metrics.record_l1_admission();
+                for victim in evicted {
+                    self.metrics.record_l1_eviction();
+                    tracing::debug!(
+                        block = %victim.block,
+                        page = victim.page.0,
+                        tier = "l1",
+                        "evicted page"
+                    );
+                }
+                self.refresh_l1_metrics();
+            }
+            MemoryInsert::Disabled | MemoryInsert::TooLarge => {}
+        }
+    }
+
+    /// The logical byte length of `block` — `block_size`, except for an object's
+    /// last block, which is short.
+    ///
+    /// Uses the length recorded alongside the cached version when available, so
+    /// a warm read pays no extra `HEAD`; falls back to the index entry, then to
+    /// a `HEAD`.
+    async fn block_len(&self, object: &ObjectId, block: &BlockId) -> anyhow::Result<u64> {
+        let block_size = self.block_size as u64;
+        if let Some(meta) = self.index.get(block) {
+            return Ok(meta.len);
+        }
+        let object_len = match self.cached_object_len(object, &block.version) {
+            Some(len) => len,
+            None => {
+                let stat =
+                    self.backend.head(object).await.map_err(|error| {
+                        anyhow::anyhow!("resolve object length (HEAD): {error}")
+                    })?;
+                self.store_version(object, &stat.version, stat.len);
+                stat.len
+            }
+        };
+        Ok(object_len.saturating_sub(block.offset).min(block_size))
     }
 
     /// Load one block after both L1 and L2 have missed.
@@ -891,7 +1226,7 @@ impl WorkerRuntime {
         };
         // Refresh the version cache so a subsequent read resolves the new version
         // without a HEAD, and addresses the just-written block correctly (#163).
-        self.store_version(object, &version);
+        self.store_version(object, &version, body.len() as u64);
         // Commit the written bytes to the local cache under the new version, so
         // read-after-write is a hit. Mirrors the miss-commit path.
         let block = self.block_for(object, 0, &version);
@@ -958,7 +1293,7 @@ impl WorkerRuntime {
             let old_block = self.block_for(object, 0, &old_version);
             self.unlink_units(vec![CacheUnit::Whole(old_block)]).await;
         }
-        self.store_version(object, &version);
+        self.store_version(object, &version, len);
         tracing::info!(
             object = %object.to_path(),
             bytes = len,
@@ -1015,16 +1350,61 @@ impl WorkerRuntime {
     /// pass or restart scan).
     async fn unlink_units(&self, units: Vec<CacheUnit>) {
         for unit in units {
-            let CacheUnit::Whole(id) = unit else {
-                continue;
-            };
-            self.invalidate_l1(&id);
-            if let Err(error) = self.store.delete(&id).await {
-                tracing::warn!(block = %id, %error, "failed to unlink evicted block");
+            match unit {
+                CacheUnit::Whole(id) => {
+                    self.invalidate_l1(&id);
+                    if let Err(error) = self.store.delete(&id).await {
+                        tracing::warn!(block = %id, %error, "failed to unlink evicted block");
+                    }
+                    // A paged block's directory shares the block identity; drop
+                    // it too so a whole-block eviction cannot leave orphaned
+                    // pages behind.
+                    if let Some(paged) = &self.paged {
+                        if let Err(error) = paged.delete_block_async(&id).await {
+                            tracing::warn!(block = %id, %error, "failed to unlink evicted pages");
+                        }
+                    }
+                    self.index.remove(&id);
+                    self.metrics.record_eviction();
+                    tracing::info!(block = %id, "evicted block");
+                }
+                CacheUnit::Page(id, page) => {
+                    // Page-level eviction: unlink just this page file and clear
+                    // its bit. The block entry and its other pages stay intact.
+                    self.l1.remove_page(&id, page);
+                    if let Some(paged) = &self.paged {
+                        if let Err(error) = paged.evict_page_async(&id, page).await {
+                            tracing::warn!(
+                                block = %id, page = page.0, %error,
+                                "failed to unlink evicted page"
+                            );
+                        }
+                    }
+                    self.index.clear_page(&id, page);
+                    self.metrics.record_eviction();
+                    self.refresh_l1_metrics();
+                    tracing::info!(block = %id, page = page.0, "evicted page");
+                    // Evicting the last page leaves an empty entry that would
+                    // otherwise linger in the index (and its `.pages` directory
+                    // on disk) forever. Drop both once nothing is resident.
+                    if self
+                        .index
+                        .get(&id)
+                        .is_some_and(|meta| meta.resident_bytes() == 0)
+                    {
+                        if let Some(paged) = &self.paged {
+                            if let Err(error) = paged.delete_block_async(&id).await {
+                                tracing::warn!(
+                                    block = %id, %error,
+                                    "failed to remove emptied paged block directory"
+                                );
+                            }
+                        }
+                        self.index.remove(&id);
+                        tracing::debug!(block = %id, "dropped paged block with no resident pages");
+                    }
+                }
             }
-            self.index.remove(&id);
-            self.metrics.record_eviction();
-            tracing::info!(block = %id, "evicted block");
         }
     }
 
@@ -1641,7 +2021,7 @@ mod tests {
             PAGE_SIZE,
             WorkerMetrics::new(BLOCK_SIZE as u64),
         );
-        runtime.store_version(&object, &Version::new("v1"));
+        runtime.store_version(&object, &Version::new("v1"), 0);
         let request = RangeRequest {
             object,
             offset: PAGE_SIZE + 17,
@@ -2696,6 +3076,453 @@ mod tests {
             let _ = runtime.serve_range(&req).await.unwrap();
         }
         assert_eq!(runtime.block_count(), 4, "no eviction with zero capacity");
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    // ---- paged L2 -------------------------------------------------------
+
+    /// A backend recording every `(offset, len)` fetched, so a test can assert
+    /// that a paged miss pulled only the pages it needed.
+    struct PagedRampBackend {
+        object_len: u64,
+        ranges: Mutex<Vec<(u64, u64)>>,
+    }
+
+    impl PagedRampBackend {
+        fn new(object_len: u64) -> Self {
+            Self {
+                object_len,
+                ranges: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn ranges(&self) -> Vec<(u64, u64)> {
+            self.ranges.lock().unwrap().clone()
+        }
+
+        fn fetched_bytes(&self) -> u64 {
+            self.ranges.lock().unwrap().iter().map(|(_, l)| l).sum()
+        }
+    }
+
+    #[async_trait]
+    impl BackendStore for PagedRampBackend {
+        async fn fetch_range(&self, _object: &ObjectId, offset: u64, len: u64) -> Result<Bytes> {
+            self.ranges.lock().unwrap().push((offset, len));
+            let end = (offset + len).min(self.object_len);
+            let n = end.saturating_sub(offset) as usize;
+            Ok(Bytes::from(
+                (0..n)
+                    .map(|i| ((offset + i as u64) % 251) as u8)
+                    .collect::<Vec<u8>>(),
+            ))
+        }
+
+        async fn head(&self, _object: &ObjectId) -> Result<ObjectStat> {
+            Ok(ObjectStat {
+                len: self.object_len,
+                version: Version::new("v1"),
+            })
+        }
+    }
+
+    /// Build a paged-mode runtime: `block_size`-byte blocks split into
+    /// `page_size`-byte pages, L1 disabled so L2 behavior is observable.
+    fn paged_runtime<B: BackendStore + 'static>(
+        backend: Arc<B>,
+        root: &Path,
+        block_size: u32,
+        page_size: u32,
+        capacity_bytes: u64,
+        metrics: WorkerMetrics,
+    ) -> WorkerRuntime {
+        WorkerRuntime::new(
+            WholeBlockStore::open(root.join("whole")).unwrap(),
+            Arc::new(BlockIndex::new()),
+            Arc::new(InFlightLoads::new()),
+            backend,
+            block_size,
+            capacity_bytes,
+            metrics,
+        )
+        .with_paged_store(PagedBlockStore::open(root.join("paged"), page_size).unwrap())
+        .with_version_ttl(Duration::ZERO)
+    }
+
+    fn req(object: &ObjectId, offset: u64, len: u64) -> RangeRequest {
+        RangeRequest {
+            object: object.clone(),
+            offset,
+            len,
+        }
+    }
+
+    #[tokio::test]
+    async fn a_point_read_fetches_one_page_not_the_whole_block() {
+        let root = tmp_root();
+        // 1 KiB blocks, 64-byte pages: a 16-page block.
+        let backend = Arc::new(PagedRampBackend::new(4096));
+        let runtime = paged_runtime(
+            Arc::clone(&backend),
+            &root,
+            1024,
+            64,
+            0,
+            WorkerMetrics::new(1024),
+        );
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+
+        // Read 8 bytes in the middle of page 5 of block 0.
+        let got = runtime
+            .serve_range(&req(&object, 5 * 64 + 8, 8))
+            .await
+            .unwrap();
+
+        assert_eq!(got, expected(5 * 64 + 8, 8));
+        // Exactly one page fetched — not the 1 KiB block.
+        assert_eq!(backend.ranges(), vec![(5 * 64, 64)]);
+        assert_eq!(backend.fetched_bytes(), 64);
+        // Only that page is resident, so capacity accounting charges 64 bytes.
+        assert_eq!(runtime.resident_bytes(), 64);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn a_second_read_of_the_same_page_hits_cache() {
+        let root = tmp_root();
+        let backend = Arc::new(PagedRampBackend::new(4096));
+        let runtime = paged_runtime(
+            Arc::clone(&backend),
+            &root,
+            1024,
+            64,
+            0,
+            WorkerMetrics::new(1024),
+        );
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+
+        let first = runtime.serve_range(&req(&object, 100, 16)).await.unwrap();
+        let second = runtime.serve_range(&req(&object, 100, 16)).await.unwrap();
+
+        assert_eq!(first, expected(100, 16));
+        assert_eq!(second, first);
+        // The second read touched the same page; no new backend traffic.
+        assert_eq!(backend.ranges().len(), 1);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn a_read_spanning_pages_stitches_them_and_fetches_only_those_pages() {
+        let root = tmp_root();
+        let backend = Arc::new(PagedRampBackend::new(4096));
+        let runtime = paged_runtime(
+            Arc::clone(&backend),
+            &root,
+            1024,
+            64,
+            0,
+            WorkerMetrics::new(1024),
+        );
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+
+        // Straddle the page 1/2/3 boundaries: from mid-page-1 to mid-page-3.
+        let got = runtime
+            .serve_range(&req(&object, 64 + 32, 128))
+            .await
+            .unwrap();
+
+        assert_eq!(got, expected(64 + 32, 128));
+        let mut ranges = backend.ranges();
+        ranges.sort();
+        assert_eq!(ranges, vec![(64, 64), (128, 64), (192, 64)]);
+        assert_eq!(runtime.resident_bytes(), 3 * 64);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn the_last_page_of_a_short_object_is_truncated_not_padded() {
+        let root = tmp_root();
+        // 100-byte object with 64-byte pages: page 1 holds only 36 bytes.
+        let backend = Arc::new(PagedRampBackend::new(100));
+        let runtime = paged_runtime(
+            Arc::clone(&backend),
+            &root,
+            1024,
+            64,
+            0,
+            WorkerMetrics::new(1024),
+        );
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+
+        // Ask for more than remains; the read is clamped to EOF.
+        let got = runtime.serve_range(&req(&object, 90, 64)).await.unwrap();
+
+        assert_eq!(got, expected(90, 10));
+        assert_eq!(backend.ranges(), vec![(64, 36)]);
+        // Only the 36 real bytes are charged, not a full 64-byte page.
+        assert_eq!(runtime.resident_bytes(), 36);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn evicting_a_cold_page_leaves_the_blocks_other_pages_intact() {
+        let root = tmp_root();
+        let backend = Arc::new(PagedRampBackend::new(4096));
+        // Capacity for exactly two 64-byte pages.
+        let runtime = paged_runtime(
+            Arc::clone(&backend),
+            &root,
+            1024,
+            64,
+            128,
+            WorkerMetrics::new(1024),
+        );
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+
+        // Fill pages 0 and 1, then touch page 0 so page 1 is coldest.
+        runtime.serve_range(&req(&object, 0, 8)).await.unwrap();
+        runtime.serve_range(&req(&object, 64, 8)).await.unwrap();
+        runtime.serve_range(&req(&object, 0, 8)).await.unwrap();
+        // Admitting page 2 must evict page 1, the coldest.
+        runtime.serve_range(&req(&object, 128, 8)).await.unwrap();
+
+        assert_eq!(runtime.resident_bytes(), 128, "back under capacity");
+        // The block entry survives: page 0 is still a cache hit.
+        let before = backend.ranges().len();
+        assert_eq!(
+            runtime.serve_range(&req(&object, 0, 8)).await.unwrap(),
+            expected(0, 8)
+        );
+        assert_eq!(backend.ranges().len(), before, "page 0 still cached");
+        // Page 1 was evicted, so re-reading it costs a fresh fetch.
+        assert_eq!(
+            runtime.serve_range(&req(&object, 64, 8)).await.unwrap(),
+            expected(64, 8)
+        );
+        assert_eq!(backend.ranges().len(), before + 1, "page 1 refetched");
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn concurrent_reads_of_one_page_trigger_a_single_backend_fetch() {
+        let root = tmp_root();
+        let backend = Arc::new(PagedRampBackend::new(4096));
+        let runtime = Arc::new(paged_runtime(
+            Arc::clone(&backend),
+            &root,
+            1024,
+            64,
+            0,
+            WorkerMetrics::new(1024),
+        ));
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+
+        let mut handles = Vec::new();
+        for i in 0..8 {
+            let runtime = Arc::clone(&runtime);
+            let object = object.clone();
+            handles.push(tokio::spawn(async move {
+                runtime.serve_range(&req(&object, 64 + i, 4)).await.unwrap()
+            }));
+        }
+        for (i, handle) in handles.into_iter().enumerate() {
+            assert_eq!(handle.await.unwrap(), expected(64 + i as u64, 4));
+        }
+
+        // All eight readers touched page 1; exactly one fetch was issued.
+        assert_eq!(backend.ranges(), vec![(64, 64)]);
+        assert_eq!(runtime.inflight_loads(), 0);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn a_restart_rebuilds_paged_residency_from_the_page_files_on_disk() {
+        let root = tmp_root();
+        let backend = Arc::new(PagedRampBackend::new(4096));
+        let metrics = WorkerMetrics::new(1024);
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+        {
+            let runtime = paged_runtime(Arc::clone(&backend), &root, 1024, 64, 0, metrics.clone());
+            runtime.serve_range(&req(&object, 0, 8)).await.unwrap();
+            runtime.serve_range(&req(&object, 128, 8)).await.unwrap();
+        }
+        let fetches_before = backend.ranges().len();
+
+        // Restart: a fresh index rebuilt from the on-disk paged cache.
+        let paged = PagedBlockStore::open(root.join("paged"), 64).unwrap();
+        let index = Arc::new(BlockIndex::new());
+        let metas = paged.scan().unwrap();
+        assert_eq!(metas.len(), 1, "one paged block on disk");
+        for meta in metas {
+            index.commit(meta);
+        }
+        assert_eq!(index.page_count(), 2, "pages 0 and 2 rebuilt");
+        assert_eq!(index.resident_bytes(), 128);
+
+        let runtime = WorkerRuntime::new(
+            WholeBlockStore::open(root.join("whole")).unwrap(),
+            index,
+            Arc::new(InFlightLoads::new()),
+            Arc::clone(&backend) as Arc<dyn BackendStore>,
+            1024,
+            0,
+            metrics,
+        )
+        .with_paged_store(paged)
+        .with_version_ttl(Duration::ZERO);
+
+        // Both previously-cached pages serve without new backend traffic.
+        assert_eq!(
+            runtime.serve_range(&req(&object, 0, 8)).await.unwrap(),
+            expected(0, 8)
+        );
+        assert_eq!(
+            runtime.serve_range(&req(&object, 128, 8)).await.unwrap(),
+            expected(128, 8)
+        );
+        assert_eq!(backend.ranges().len(), fetches_before, "served from disk");
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn an_index_hit_with_a_deleted_page_file_refetches_instead_of_failing() {
+        let root = tmp_root();
+        let backend = Arc::new(PagedRampBackend::new(4096));
+        let runtime = paged_runtime(
+            Arc::clone(&backend),
+            &root,
+            1024,
+            64,
+            0,
+            WorkerMetrics::new(1024),
+        );
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+        runtime.serve_range(&req(&object, 0, 8)).await.unwrap();
+
+        // Simulate an out-of-band deletion of the page file while the index
+        // still believes the page is resident.
+        let mut removed = 0;
+        for shard in std::fs::read_dir(root.join("paged")).unwrap().flatten() {
+            if !shard.file_type().unwrap().is_dir() {
+                continue;
+            }
+            for dir in std::fs::read_dir(shard.path()).unwrap().flatten() {
+                let page = dir.path().join("0.page");
+                if page.exists() {
+                    std::fs::remove_file(&page).unwrap();
+                    removed += 1;
+                }
+            }
+        }
+        assert_eq!(removed, 1, "found the page file to delete");
+
+        // The read recovers by re-fetching rather than surfacing an error.
+        let got = runtime.serve_range(&req(&object, 0, 8)).await.unwrap();
+        assert_eq!(got, expected(0, 8));
+        assert_eq!(backend.ranges().len(), 2);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn paged_mode_serves_a_within_page_read_via_sendfile() {
+        let root = tmp_root();
+        let backend = Arc::new(PagedRampBackend::new(4096));
+        let runtime = paged_runtime(
+            Arc::clone(&backend),
+            &root,
+            1024,
+            64,
+            0,
+            WorkerMetrics::new(1024),
+        );
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+        let request = req(&object, 70, 10);
+
+        // First read is a miss and comes back as bytes.
+        assert!(matches!(
+            runtime.serve(&request).await.unwrap(),
+            ServeOutcome::Bytes(_)
+        ));
+        // Once resident, the same within-page read is served zero-copy.
+        match runtime.serve(&request).await.unwrap() {
+            ServeOutcome::Sendfile(handle) => {
+                let mut buf = vec![0u8; handle.len as usize];
+                let file = std::fs::File::from(handle.fd);
+                file.read_exact_at(&mut buf, handle.offset).unwrap();
+                assert_eq!(Bytes::from(buf), expected(70, 10));
+            }
+            ServeOutcome::Bytes(_) => panic!("expected a sendfile handle for a resident page"),
+        }
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn overwriting_an_object_reclaims_the_old_versions_pages() {
+        let root = tmp_root();
+        let backend = Arc::new(VersionedBackend {
+            version: std::sync::Mutex::new("v1".into()),
+            body: std::sync::Mutex::new(Bytes::from_static(b"aaaaaaaa")),
+            fetches: AtomicUsize::new(0),
+        });
+        let runtime = paged_runtime(
+            Arc::clone(&backend),
+            &root,
+            1024,
+            64,
+            0,
+            WorkerMetrics::new(1024),
+        );
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+
+        runtime.serve_range(&req(&object, 0, 8)).await.unwrap();
+        assert_eq!(runtime.block_count(), 1);
+
+        // The source is overwritten: a new etag yields a new BlockId.
+        *backend.version.lock().unwrap() = "v2".into();
+        *backend.body.lock().unwrap() = Bytes::from_static(b"bbbbbbbb");
+        let got = runtime.serve_range(&req(&object, 0, 8)).await.unwrap();
+
+        assert_eq!(got, Bytes::from_static(b"bbbbbbbb"));
+        // The superseded version's pages were reclaimed, not left resident.
+        assert_eq!(runtime.block_count(), 1, "old version dropped");
+        assert_eq!(runtime.resident_bytes(), 8);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn a_paged_read_after_write_hits_the_whole_block_the_write_committed() {
+        let root = tmp_root();
+        let backend = Arc::new(MutableBackend {
+            body: std::sync::Mutex::new(None),
+            version: std::sync::Mutex::new("v1".into()),
+            fetches: AtomicUsize::new(0),
+            puts: AtomicUsize::new(0),
+            deletes: AtomicUsize::new(0),
+        });
+        let runtime = paged_runtime(
+            Arc::clone(&backend),
+            &root,
+            1024,
+            64,
+            0,
+            WorkerMetrics::new(1024),
+        );
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+        let body = Bytes::from((0..200u32).map(|i| (i % 251) as u8).collect::<Vec<u8>>());
+
+        runtime.write_object(&object, body.clone()).await.unwrap();
+        let fetches_before = backend.fetches.load(Ordering::SeqCst);
+
+        // The write committed a whole block; a paged read must serve from it
+        // rather than going back to the origin.
+        let got = runtime.serve_range(&req(&object, 70, 10)).await.unwrap();
+
+        assert_eq!(got, body.slice(70..80));
+        assert_eq!(
+            backend.fetches.load(Ordering::SeqCst),
+            fetches_before,
+            "read-after-write must hit"
+        );
         std::fs::remove_dir_all(root).ok();
     }
 }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -386,6 +386,14 @@ Fixed L1 DRAM page size in bytes.
 - **Default:** `262144`
 - **CLI flag:** not settable via CLI (config file or environment only)
 
+### `l2_page_size_bytes`
+
+L2 page size in bytes; 0 keeps whole-block L2, non-zero enables paged L2.
+
+- **Environment variable:** `TALON_WORKER_L2_PAGE_SIZE_BYTES`
+- **Default:** `0`
+- **CLI flag:** not settable via CLI (config file or environment only)
+
 ### `backend`
 
 Object-store backend: azure (default), s3, or gcs.


### PR DESCRIPTION
Closes #15.

`PagedBlockStore` has existed since #15 was scoped, but it had **no non-test callers**: the worker always used `WholeBlockStore`, so a point query into a 256 MiB block fetched and stored the entire block. This connects the paged store to the read, miss, and eviction paths behind a new `l2_page_size_bytes` setting.

With it set, a miss fetches only the pages a read touches, commits them as per-page files, and eviction reclaims individual pages while leaving the block’s other pages resident. Zero (the default) keeps the existing whole-block behavior byte-for-byte unchanged.

## What changed

- **Read path** (`paged_block_range`): a miss fetches only the touched pages. Multi-page reads stitch pages together; each page is fetched and committed independently.
- **Byte accounting** (`BlockMeta::resident_bytes`): a paged block charges for its *present* pages, not its full logical length — otherwise one resident 256 KiB page would evict the whole cache.
- **Eviction**: `evict_superseded` now also reclaims a stale version’s pages (it previously hard-coded `CacheUnit::Page(..) => false`, so pages of an overwritten object would have leaked forever). Evicting the last page drops the emptied index entry and its `.pages` directory.
- **Restart**: a sidecar plus `scan()` rebuild residency from the page files actually on disk. The present bitmap is deliberately *not* persisted — page files are the source of truth, so a crash between a page rename and a bitmap write cannot desynchronize them. A block written under a different page size is skipped rather than reinterpreted.
- **Concurrency**: misses for one `(block, page)` collapse to a single backend fetch via `LoadKey::Page`, mirroring the whole-block leader/follower protocol (#113, #162). `init_paged` is idempotent so a second concurrent miss cannot reset a bitmap and lose materialized pages.
- **Zero-copy preserved**: a resident within-page read is still served via `sendfile`.
- Page commits use the same unique-temp-then-rename discipline as the whole-block store (#113), and page I/O runs on the blocking pool (#115).

## Two bugs the tests caught

Both were in code in this PR that looked correct on review:

1. Evicting a block’s **last page** left an empty index entry lingering forever.
2. **Read-after-write broke in paged mode** — a write-through commits a *whole* block, which the paged read path could not see, so it silently re-fetched from the origin and returned wrong bytes.

Both are fixed and each has a regression test.

## Config

New worker setting `l2_page_size_bytes` (`TALON_WORKER_L2_PAGE_SIZE_BYTES`), default `0` = whole-block L2, unchanged behavior. Validation requires it to divide `block_size`, and requires `l1_page_size_bytes == l2_page_size_bytes` when both tiers are on — mismatched sizes would make an L1 admission span several L2 pages, so a single-page L2 hit could never fill an L1 entry. Rejected at startup rather than silently underperforming.

`docs/reference/configuration.md` regenerated via `just gen-config-docs`.

## Verification

- `just ci` (fmt + clippy + test), `just check-config-docs`, `just spell` — all exit 0
- **858 tests pass**, including 14 new ones covering: single-page fetch on a point read, cache hit on re-read, multi-page stitching, short trailing page truncation, page-level eviction leaving siblings intact, single-fetch dedup across 8 concurrent readers, restart rebuild from disk, index-hit/file-missing recovery, sendfile on a resident page, superseded-version page reclaim, and read-after-write
- Clippy clean under `-D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)