### PR TITLE
feat: compute cache block placement in clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,6 +2610,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.19",
  "toml",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ bytes = "1"
 async-trait = "0.1"
 bincode = "1.3"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
+sha2 = "0.10"
 # Durable WAL record encoding (ADR 0003 §9.4 forbids serde/bincode/JSON on disk).
 # Pinned to the version already in the tree via tonic so both agree.
 prost = "0.14"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -36,11 +36,11 @@ deferred until workload data justifies them.
 
 ```
           +-------------------+
-          |    Coordinator    |   placement, membership, epoch
+          |    Coordinator    |   membership, metadata, compatibility lookup
           +-------------------+
              ^   (control)   ^
              |               |
-   heartbeat |               | placement lookup
+   heartbeat |               | membership snapshot
    inventory |               |
              |               |
    +---------+--+       +----+---------+
@@ -289,10 +289,12 @@ dedup (a correctness requirement — per-shard dedup would refetch the same
 
 ## 2. Coordinator
 
-- **Placement:** rendezvous (HRW) hashing, extended to **top-K** to reserve a
-  replica-ordering for later. Assumes stable worker IDs. Consistent-hashing
-  rings / virtual nodes deferred until worker capacities diverge enough to need
-  weighting.
+- **Placement:** clients cache healthy worker membership and run stable,
+  cross-language rendezvous (HRW) hashing locally, extended to **top-K** to
+  reserve a replica ordering for later. The coordinator retains the same
+  implementation for legacy lookup compatibility. Assumes stable worker IDs.
+  Consistent-hashing rings / virtual nodes are deferred until worker capacities
+  diverge enough to need weighting.
 - **Replication:** **RF=1** in v1 — the backing store is the durable source.
   Hot blocks may get RF=2 later once miss cost is measured. Avoid blanket
   multi-copy; it burns NVMe.

--- a/clients/java/src/main/java/io/milvus/talon/Placement.java
+++ b/clients/java/src/main/java/io/milvus/talon/Placement.java
@@ -1,5 +1,12 @@
 package io.milvus.talon;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -12,6 +19,9 @@ import java.util.List;
  * succeeding, from the wrong worker, until something else forces a refresh.
  */
 public final class Placement {
+
+    private static final byte[] DOMAIN =
+            "talon-cache-placement-v1\0".getBytes(StandardCharsets.US_ASCII);
 
     private final List<String> owners;
     private final long epoch;
@@ -28,5 +38,98 @@ public final class Placement {
 
     public long epoch() {
         return epoch;
+    }
+
+    /** Rank cache workers locally using the cross-language HRW v1 contract. */
+    public static List<NodeInfo> rank(BlockId block, List<NodeInfo> nodes, int k) {
+        if (k <= 0) {
+            return Collections.emptyList();
+        }
+        List<ScoredNode> ranked = new ArrayList<>();
+        for (NodeInfo node : nodes) {
+            if (node.isWorker()) {
+                ranked.add(new ScoredNode(score(block, node.id()), node));
+            }
+        }
+        ranked.sort((a, b) -> {
+            int scoreOrder = compareUnsigned(b.score, a.score);
+            return scoreOrder != 0 ? scoreOrder : a.node.id().compareTo(b.node.id());
+        });
+        List<NodeInfo> result = new ArrayList<>(Math.min(k, ranked.size()));
+        for (int i = 0; i < Math.min(k, ranked.size()); i++) {
+            result.add(ranked.get(i).node);
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    private static byte[] score(BlockId block, String workerId) {
+        try {
+            MessageDigest hash = MessageDigest.getInstance("SHA-256");
+            ByteArrayOutputStream encoded = new ByteArrayOutputStream();
+            encoded.writeBytes(DOMAIN);
+            encoded.write(backendTag(block.object().backend()));
+            field(encoded, block.object().bucket());
+            field(encoded, block.object().key());
+            encoded.writeBytes(littleEndianLong(block.offset()));
+            encoded.writeBytes(littleEndianInt(block.blockSize()));
+            field(encoded, block.version());
+            field(encoded, workerId);
+            return hash.digest(encoded.toByteArray());
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new AssertionError("SHA-256 is required by every Java runtime", impossible);
+        }
+    }
+
+    private static void field(ByteArrayOutputStream out, String value) {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        out.writeBytes(littleEndianLong(bytes.length));
+        out.writeBytes(bytes);
+    }
+
+    private static byte[] littleEndianLong(long value) {
+        return ByteBuffer.allocate(Long.BYTES)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .putLong(value)
+                .array();
+    }
+
+    private static byte[] littleEndianInt(int value) {
+        return ByteBuffer.allocate(Integer.BYTES)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .putInt(value)
+                .array();
+    }
+
+    private static int backendTag(ObjectId.Backend backend) {
+        switch (backend) {
+            case S3:
+                return 0;
+            case GCS:
+                return 1;
+            case AZURE:
+                return 2;
+            default:
+                throw new AssertionError("unhandled backend " + backend);
+        }
+    }
+
+    private static int compareUnsigned(byte[] left, byte[] right) {
+        for (int i = 0; i < left.length; i++) {
+            int order = Integer.compare(Byte.toUnsignedInt(left[i]), Byte.toUnsignedInt(right[i]));
+            if (order != 0) {
+                return order;
+            }
+        }
+        return 0;
+    }
+
+    private static final class ScoredNode {
+        final byte[] score;
+        final NodeInfo node;
+
+        ScoredNode(byte[] score, NodeInfo node) {
+            this.score = score;
+            this.node = node;
+        }
     }
 }

--- a/clients/java/src/main/java/io/milvus/talon/TalonClient.java
+++ b/clients/java/src/main/java/io/milvus/talon/TalonClient.java
@@ -8,6 +8,7 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,9 +42,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public final class TalonClient implements AutoCloseable {
 
-    /** Placement entries older than this are re-resolved. Matches the Rust default. */
+    /** Membership and placement freshness window. Matches the Rust default. */
     private static final long PLACEMENT_TTL_MS = 30_000;
-    /** Replicas requested per lookup. RF=1 in v1. */
+    /** Workers retained from the local ranking. RF=1 in v1. */
     private static final int REPLICAS_K = 1;
     private static final int CONNECT_TIMEOUT_MS = 10_000;
     private static final int READ_TIMEOUT_MS = 30_000;
@@ -52,6 +53,8 @@ public final class TalonClient implements AutoCloseable {
     private final int blockSize;
     private final AtomicInteger requestIds = new AtomicInteger(1);
     private final Map<BlockId, CachedPlacement> placementCache = new HashMap<>();
+    private final Object membershipLock = new Object();
+    private CachedMembership membership;
 
     private TalonClient(String coordinator, int blockSize) {
         this.coordinator = coordinator;
@@ -221,12 +224,22 @@ public final class TalonClient implements AutoCloseable {
 
     private static final class CachedPlacement {
         final List<String> addresses;
-        final long epoch;
         final long expiresAtMs;
 
-        CachedPlacement(List<String> addresses, long epoch, long expiresAtMs) {
+        CachedPlacement(List<String> addresses, long expiresAtMs) {
             this.addresses = addresses;
-            this.epoch = epoch;
+            this.expiresAtMs = expiresAtMs;
+        }
+    }
+
+    private static final class CachedMembership {
+        final List<NodeInfo> nodes;
+        final String identity;
+        final long expiresAtMs;
+
+        CachedMembership(List<NodeInfo> nodes, String identity, long expiresAtMs) {
+            this.nodes = nodes;
+            this.identity = identity;
             this.expiresAtMs = expiresAtMs;
         }
     }
@@ -274,55 +287,68 @@ public final class TalonClient implements AutoCloseable {
             }
         }
 
-        int id = requestIds.getAndIncrement();
-        Messages.Response resp =
-                controlRoundTrip(Messages.placementLookup(id, block, REPLICAS_K));
-        if (resp.tag != Messages.TAG_PLACEMENT_RESPONSE) {
-            throw unexpected("PlacementLookup", resp);
-        }
-        Placement placement = Messages.readPlacementResponse(resp.body);
-
-        // Owners are node ids; the data plane needs addresses.
-        Map<String, String> members = membershipByNodeId();
-        List<String> addresses = new ArrayList<>(placement.owners().size());
-        for (String owner : placement.owners()) {
-            String address = members.get(owner);
-            if (address != null) {
-                addresses.add(address);
-            }
+        CachedMembership members = membership(forceRefresh, now);
+        List<NodeInfo> owners = Placement.rank(block, members.nodes, REPLICAS_K);
+        List<String> addresses = new ArrayList<>(owners.size());
+        for (NodeInfo owner : owners) {
+            addresses.add(owner.address());
         }
         if (addresses.isEmpty()) {
-            throw new IOException(
-                    "no owner of " + block + " resolved to a dialable address (owners="
-                            + placement.owners() + ")");
+            throw new IOException("membership contains no worker for " + block);
         }
 
         synchronized (placementCache) {
-            // A different epoch means every cached entry may be stale, not just
-            // this one, so drop the lot rather than serving from the wrong
-            // worker until each entry happens to expire.
-            CachedPlacement previous = placementCache.get(block);
-            if (previous != null && previous.epoch != placement.epoch()) {
-                placementCache.clear();
-            }
             placementCache.put(
                     block,
-                    new CachedPlacement(addresses, placement.epoch(), now + PLACEMENT_TTL_MS));
+                    new CachedPlacement(addresses, now + PLACEMENT_TTL_MS));
         }
         return addresses;
     }
 
-    private Map<String, String> membershipByNodeId() throws IOException {
-        int id = requestIds.getAndIncrement();
-        Messages.Response resp = controlRoundTrip(Messages.membershipQuery(id));
-        if (resp.tag != Messages.TAG_MEMBERSHIP_LIST) {
-            throw unexpected("MembershipQuery", resp);
+    private CachedMembership membership(boolean forceRefresh, long now) throws IOException {
+        synchronized (membershipLock) {
+            if (!forceRefresh && membership != null && membership.expiresAtMs > now) {
+                return membership;
+            }
+
+            List<NodeInfo> nodes;
+            try {
+                int id = requestIds.getAndIncrement();
+                Messages.Response resp = controlRoundTrip(Messages.membershipQuery(id));
+                if (resp.tag != Messages.TAG_MEMBERSHIP_LIST) {
+                    throw unexpected("MembershipQuery", resp);
+                }
+                nodes = Messages.readMembershipList(resp.body);
+            } catch (IOException refreshFailure) {
+                if (membership != null) {
+                    return membership;
+                }
+                throw refreshFailure;
+            }
+
+            String identity = membershipIdentity(nodes);
+            boolean changed = membership != null && !membership.identity.equals(identity);
+            if (changed) {
+                synchronized (placementCache) {
+                    placementCache.clear();
+                }
+            }
+            membership =
+                    new CachedMembership(List.copyOf(nodes), identity, now + PLACEMENT_TTL_MS);
+            return membership;
         }
-        Map<String, String> byId = new HashMap<>();
-        for (NodeInfo node : Messages.readMembershipList(resp.body)) {
-            byId.put(node.id(), node.address());
+    }
+
+    private static String membershipIdentity(List<NodeInfo> nodes) {
+        List<String> fields = new ArrayList<>();
+        for (NodeInfo node : nodes) {
+            if (node.isWorker()) {
+                fields.add(node.id().length() + ":" + node.id() + node.address().length() + ":"
+                        + node.address());
+            }
         }
-        return byId;
+        fields.sort(Comparator.naturalOrder());
+        return String.join("|", fields);
     }
 
     // --- transport ---------------------------------------------------------

--- a/clients/java/src/test/java/io/milvus/talon/ConformanceTest.java
+++ b/clients/java/src/test/java/io/milvus/talon/ConformanceTest.java
@@ -45,6 +45,7 @@ public final class ConformanceTest {
         objectListPreservesMultiByteUtf8(byName);
         placementLookupEncodesIdentically(byName);
         membershipQueryEncodesIdentically(byName);
+        localPlacementMatchesRust();
         statObjectEncodesIdentically(byName);
         listObjectsEncodesEmptyPrefix(byName);
         errorResponseIsFlaggedAndCarriesAMessage(byName);
@@ -60,6 +61,29 @@ public final class ConformanceTest {
     }
 
     // --- the checks --------------------------------------------------------
+
+    private static void localPlacementMatchesRust() {
+        check("client-side HRW ranking matches Rust", () -> {
+            BlockId block =
+                    new BlockId(
+                            new ObjectId(
+                                    ObjectId.Backend.S3,
+                                    "datasets",
+                                    "training/part-0001"),
+                            268_435_456L,
+                            256 << 20,
+                            "etag-v7");
+            List<NodeInfo> nodes =
+                    Arrays.asList(
+                            new NodeInfo("worker-a", "10.0.0.1:7001", true),
+                            new NodeInfo("worker-b", "10.0.0.2:7001", true),
+                            new NodeInfo("worker-c", "10.0.0.3:7001", true));
+            List<NodeInfo> ranked = Placement.rank(block, nodes, 3);
+            assertEquals("worker-b", ranked.get(0).id(), "primary");
+            assertEquals("worker-a", ranked.get(1).id(), "secondary");
+            assertEquals("worker-c", ranked.get(2).id(), "tertiary");
+        });
+    }
 
     /** A header decodes to the fields the generator encoded. */
     private static void frameHeaderDecodes(Map<String, byte[]> v) {

--- a/crates/talon-client/src/main.rs
+++ b/crates/talon-client/src/main.rs
@@ -4,9 +4,8 @@
 //! sandbox has no `/dev/fuse`):
 //!
 //! 1. Parse `/az/<container>/<blob>` into an [`ObjectId`].
-//! 2. Ask the coordinator (`PlacementLookup`) which worker owns the block.
-//! 3. Resolve that owner id to an address (`MembershipQuery`).
-//! 4. Send a data-plane [`RangeRequest`] to the worker and read the raw bytes.
+//! 2. Fetch worker membership and compute HRW placement locally.
+//! 3. Send a data-plane [`RangeRequest`] to the selected worker.
 //!
 //! Prints byte count + elapsed time; writes the bytes to `--out` when given so
 //! the caller can `cmp` two reads for byte-exactness.
@@ -14,7 +13,7 @@
 use std::time::Instant;
 
 use clap::Parser;
-use talon_core::{BlockId, NodeRole, ObjectId, Version};
+use talon_core::{rank_cache_workers, BlockId, NodeRole, ObjectId, Version};
 use talon_transport::data::{self, RangeRequest};
 use talon_transport::frame::{Flags, HEADER_LEN};
 use talon_transport::{codec, ControlMessage, FrameHeader};
@@ -102,15 +101,18 @@ async fn main() -> anyhow::Result<()> {
             worker
         }
         None => {
-            // 1. Placement lookup: which worker owns this block?
-            let owners = placement_lookup(&args.coordinator, &block).await?;
+            let membership = membership_lookup(&args.coordinator).await?;
+            let owners = rank_cache_workers(&block, &membership, 1);
             let owner = owners
                 .first()
                 .ok_or_else(|| anyhow::anyhow!("no worker owns this block (empty cluster?)"))?;
             tracing::info!(owner = %owner, "resolved owner");
 
-            // 2. Resolve the owner id to a worker address.
-            let worker_addr = resolve_address(&args.coordinator, owner).await?;
+            let worker_addr = membership
+                .into_iter()
+                .find(|node| node.id == *owner)
+                .map(|node| node.address)
+                .ok_or_else(|| anyhow::anyhow!("owner {owner} not in membership list"))?;
             tracing::info!(%worker_addr, "resolved worker address");
             worker_addr
         }
@@ -152,30 +154,6 @@ async fn main() -> anyhow::Result<()> {
         println!("first {n} bytes (hex): {}", hex_prefix(&bytes[..n]));
     }
     Ok(())
-}
-
-/// Send a `PlacementLookup` and return the ordered owner ids.
-async fn placement_lookup(coordinator: &str, block: &BlockId) -> anyhow::Result<Vec<String>> {
-    let req = ControlMessage::PlacementLookup {
-        block: block.clone(),
-        k: 1,
-    };
-    match request_control(coordinator, &req).await? {
-        ControlMessage::PlacementResponse { owners, .. } => {
-            Ok(owners.into_iter().map(|n| n.0).collect())
-        }
-        other => anyhow::bail!("unexpected placement reply: {other:?}"),
-    }
-}
-
-/// Send a `MembershipQuery` and resolve `owner_id` to its worker address.
-async fn resolve_address(coordinator: &str, owner_id: &str) -> anyhow::Result<String> {
-    membership_lookup(coordinator)
-        .await?
-        .into_iter()
-        .find(|n| n.id.0 == owner_id)
-        .map(|n| n.address)
-        .ok_or_else(|| anyhow::anyhow!("owner {owner_id} not in membership list"))
 }
 
 /// Return the coordinator's current membership snapshot.

--- a/crates/talon-coordinator/src/placement.rs
+++ b/crates/talon-coordinator/src/placement.rs
@@ -6,9 +6,7 @@
 //! ordered replica list; RF stays 1 in v1, but the ordering reserves a stable
 //! replica sequence for a future RF=2.
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-use talon_core::{BlockId, NodeId, NodeInfo};
+use talon_core::{rank_cache_workers, BlockId, NodeId, NodeInfo};
 use xxhash_rust::xxh3::xxh3_64;
 
 /// A content-derived version of the placement/node set.
@@ -124,39 +122,13 @@ pub trait Placement {
 #[derive(Default)]
 pub struct RendezvousPlacement;
 
-impl RendezvousPlacement {
-    fn weight(block: &BlockId, node: &NodeId) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        block.hash(&mut hasher);
-        node.0.hash(&mut hasher);
-        hasher.finish()
-    }
-}
-
 impl Placement for RendezvousPlacement {
     fn locate(&self, block: &BlockId, nodes: &[NodeInfo]) -> Option<NodeId> {
-        nodes
-            .iter()
-            .max_by_key(|n| Self::weight(block, &n.id))
-            .map(|n| n.id.clone())
+        rank_cache_workers(block, nodes, 1).into_iter().next()
     }
 
     fn locate_top_k(&self, block: &BlockId, nodes: &[NodeInfo], k: usize) -> Vec<NodeId> {
-        if k == 0 {
-            return Vec::new();
-        }
-        let mut ranked: Vec<(u64, &NodeId)> = nodes
-            .iter()
-            .map(|n| (Self::weight(block, &n.id), &n.id))
-            .collect();
-        // Sort by descending weight; break ties on the node id so the order is
-        // fully deterministic even when two nodes hash to the same weight.
-        ranked.sort_unstable_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1 .0.cmp(&b.1 .0)));
-        ranked
-            .into_iter()
-            .take(k)
-            .map(|(_, id)| id.clone())
-            .collect()
+        rank_cache_workers(block, nodes, k)
     }
 }
 

--- a/crates/talon-core/Cargo.toml
+++ b/crates/talon-core/Cargo.toml
@@ -18,6 +18,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 percent-encoding.workspace = true
 url.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 divan.workspace = true

--- a/crates/talon-core/src/lib.rs
+++ b/crates/talon-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod key;
 pub mod metrics;
 pub mod namespace_policy;
 pub mod node;
+pub mod placement;
 pub mod status;
 pub mod store;
 pub mod trace;
@@ -31,6 +32,7 @@ pub use key::{Backend, BlockId, ObjectId, PageIndex, Version};
 pub use metrics::{Counter, Gauge, Histogram, Metrics};
 pub use namespace_policy::{NamespacePolicy, ObjectNamespace};
 pub use node::{NodeId, NodeInfo, NodeRole};
+pub use placement::{cache_membership_epoch, cache_placement_score, rank_cache_workers};
 pub use status::{
     NodeHealth, NodeMetricsSnapshot, NodeStatus, NodeStatusError, MAX_NODE_STATUS_BYTES,
     MAX_STATUS_FIELD_BYTES, MAX_STATUS_LABELS, MAX_STATUS_LABEL_KEY_BYTES,

--- a/crates/talon-core/src/placement.rs
+++ b/crates/talon-core/src/placement.rs
@@ -1,0 +1,162 @@
+//! Stable client-side placement for immutable cache blocks.
+//!
+//! Every client receives the same worker membership and ranks it locally. The
+//! byte encoding and hash are deliberately specified here rather than using
+//! Rust's `Hash` trait, whose format is not a cross-language protocol.
+
+use sha2::{Digest, Sha256};
+
+use crate::{Backend, BlockId, NodeId, NodeInfo, NodeRole};
+
+const PLACEMENT_DOMAIN: &[u8] = b"talon-cache-placement-v1\0";
+const MEMBERSHIP_DOMAIN: &[u8] = b"talon-cache-membership-v1\0";
+
+/// Compute the stable HRW score for one cache block and worker ID.
+///
+/// Scores are compared as unsigned 32-byte big-endian values. A larger score
+/// ranks first; equal scores are resolved by ascending worker ID.
+pub fn cache_placement_score(block: &BlockId, worker: &NodeId) -> [u8; 32] {
+    let mut hash = Sha256::new();
+    hash.update(PLACEMENT_DOMAIN);
+    hash.update([backend_tag(block.object.backend)]);
+    hash_field(&mut hash, block.object.bucket.as_bytes());
+    hash_field(&mut hash, block.object.object_path.as_bytes());
+    hash.update(block.offset.to_le_bytes());
+    hash.update(block.block_size.to_le_bytes());
+    hash_field(&mut hash, block.version.0.as_bytes());
+    hash_field(&mut hash, worker.0.as_bytes());
+    hash.finalize().into()
+}
+
+/// Rank up to `k` healthy-membership workers for an immutable cache block.
+///
+/// The caller is responsible for membership health/freshness. Non-worker
+/// records are ignored defensively so a management node can never become a
+/// data-plane target through a malformed snapshot.
+pub fn rank_cache_workers(block: &BlockId, nodes: &[NodeInfo], k: usize) -> Vec<NodeId> {
+    if k == 0 {
+        return Vec::new();
+    }
+    let mut ranked: Vec<([u8; 32], &NodeId)> = nodes
+        .iter()
+        .filter(|node| node.role == NodeRole::Worker)
+        .map(|node| (cache_placement_score(block, &node.id), &node.id))
+        .collect();
+    ranked.sort_unstable_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1 .0.cmp(&b.1 .0)));
+    ranked
+        .into_iter()
+        .take(k)
+        .map(|(_, id)| id.clone())
+        .collect()
+}
+
+/// Content-derived token for one client membership snapshot.
+///
+/// This token has equality semantics only. It lets a client invalidate all
+/// block placements when node identity or address changes without consulting a
+/// coordinator for each block.
+pub fn cache_membership_epoch(nodes: &[NodeInfo]) -> u64 {
+    if nodes.is_empty() {
+        return 0;
+    }
+    let mut workers: Vec<&NodeInfo> = nodes
+        .iter()
+        .filter(|node| node.role == NodeRole::Worker)
+        .collect();
+    if workers.is_empty() {
+        return 0;
+    }
+    workers.sort_unstable_by(|a, b| a.id.0.cmp(&b.id.0));
+    let mut hash = Sha256::new();
+    hash.update(MEMBERSHIP_DOMAIN);
+    for worker in workers {
+        hash_field(&mut hash, worker.id.0.as_bytes());
+        hash_field(&mut hash, worker.address.as_bytes());
+    }
+    let digest: [u8; 32] = hash.finalize().into();
+    let value = u64::from_be_bytes(digest[..8].try_into().expect("fixed digest length"));
+    value.max(1)
+}
+
+fn hash_field(hash: &mut Sha256, value: &[u8]) {
+    hash.update((value.len() as u64).to_le_bytes());
+    hash.update(value);
+}
+
+fn backend_tag(backend: Backend) -> u8 {
+    match backend {
+        Backend::S3 => 0,
+        Backend::Gcs => 1,
+        Backend::Azure => 2,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ObjectId, Version};
+
+    fn block() -> BlockId {
+        BlockId::new(
+            ObjectId::new(Backend::S3, "datasets", "training/part-0001"),
+            268_435_456,
+            256 << 20,
+            Version::new("etag-v7"),
+        )
+    }
+
+    fn worker(id: &str, address: &str) -> NodeInfo {
+        NodeInfo {
+            id: NodeId::new(id),
+            address: address.into(),
+            role: NodeRole::Worker,
+        }
+    }
+
+    #[test]
+    fn ranking_is_deterministic_and_input_order_independent() {
+        let nodes = vec![
+            worker("worker-a", "10.0.0.1:7001"),
+            worker("worker-b", "10.0.0.2:7001"),
+            worker("worker-c", "10.0.0.3:7001"),
+        ];
+        let mut reversed = nodes.clone();
+        reversed.reverse();
+        assert_eq!(
+            rank_cache_workers(&block(), &nodes, 3),
+            rank_cache_workers(&block(), &reversed, 3)
+        );
+        assert_eq!(
+            rank_cache_workers(&block(), &nodes, 3),
+            vec![
+                NodeId::new("worker-b"),
+                NodeId::new("worker-a"),
+                NodeId::new("worker-c"),
+            ]
+        );
+    }
+
+    #[test]
+    fn membership_epoch_tracks_addresses_but_scores_do_not() {
+        let nodes = vec![worker("worker-a", "old:7001")];
+        let moved = vec![worker("worker-a", "new:7001")];
+        assert_ne!(
+            cache_membership_epoch(&nodes),
+            cache_membership_epoch(&moved)
+        );
+        assert_eq!(
+            cache_placement_score(&block(), &nodes[0].id),
+            cache_placement_score(&block(), &moved[0].id)
+        );
+    }
+
+    #[test]
+    fn non_workers_are_never_ranked() {
+        let coordinator = NodeInfo {
+            id: NodeId::new("coordinator-a"),
+            address: "10.0.0.9:7000".into(),
+            role: NodeRole::Coordinator,
+        };
+        assert!(rank_cache_workers(&block(), &[coordinator], 1).is_empty());
+    }
+}

--- a/crates/talon-fuse/src/block_reader.rs
+++ b/crates/talon-fuse/src/block_reader.rs
@@ -1,30 +1,32 @@
-//! Block read orchestration: placement cache → coordinator → worker.
+//! Block read orchestration: local placement cache -> membership -> worker.
 //!
 //! [`BlockReader`] is the heart of the FUSE read path. Given a [`BlockId`] and a
 //! sub-range within it, it answers "where does this block live?" from the
-//! client-side [`PlacementCache`] when warm, or falls back to a
-//! [`CoordinatorClient`] lookup on a miss, then fetches the bytes from the
-//! owning worker with a [`WorkerClient`].
+//! client-side [`PlacementCache`] when warm. On a miss it ranks a cached worker
+//! membership snapshot locally, then fetches the bytes from the owning worker
+//! with a [`WorkerClient`].
 //!
 //! # Cached addresses, not node ids
 //!
 //! The placement cache stores an ordered list of **worker addresses** (what the
-//! client actually dials), derived by resolving the coordinator's owner
-//! [`NodeId`](talon_core::NodeId)s through the membership snapshot. Storing the
-//! dialable address keeps the hot path allocation-light and makes replica
-//! fallback a simple walk down the ordered list.
+//! client actually dials), derived from the same membership snapshot used for
+//! local HRW ranking. Storing the dialable address keeps the hot path
+//! allocation-light and makes replica fallback a simple walk down the ordered
+//! list.
 //!
 //! On a fetch failure the reader walks the cached replicas in order; if all are
-//! exhausted it invalidates the entry and performs one coordinator refresh
-//! before giving up. [`BlockReader::observe_epoch`] reconciles the cache when a
-//! different placement version is seen. Multi-block splitting is handled by
+//! exhausted it invalidates the entry and attempts one membership refresh
+//! before giving up. A failed refresh keeps using the last-good snapshot.
+//! [`BlockReader::observe_epoch`] reconciles the cache when a different
+//! membership token is seen. Multi-block splitting is handled by
 //! [`crate::read_plan`] and readahead by [`crate::prefetch`].
 
 use std::sync::Arc;
 
-use talon_core::{BlockId, ObjectId, Version};
+use talon_core::{rank_cache_workers, BlockId, ObjectId, Version};
 
 use crate::coordinator_client::{CoordinatorClient, CoordinatorError};
+use crate::membership_cache::{MembershipCache, MembershipSnapshot};
 use crate::metrics::ReadStats;
 use crate::placement_cache::{Cached, PlacementCache, RefreshReason};
 use crate::pool::ConnectionPool;
@@ -34,7 +36,7 @@ use crate::worker_client::{WorkerClient, WorkerError};
 /// Errors from a block read.
 #[derive(Debug, thiserror::Error)]
 pub enum BlockReadError {
-    /// The coordinator lookup failed.
+    /// Membership refresh failed before any snapshot was cached.
     #[error(transparent)]
     Coordinator(#[from] CoordinatorError),
     /// The worker fetch failed.
@@ -46,7 +48,7 @@ pub enum BlockReadError {
     /// An owner id had no resolvable worker address in membership.
     #[error("owner has no known worker address")]
     UnresolvedOwner,
-    /// Every replica failed, including after a coordinator refresh.
+    /// Every replica failed, including after a membership refresh.
     #[error("all replicas failed after refresh")]
     AllReplicasFailed,
 }
@@ -68,25 +70,29 @@ pub struct FileView<'a> {
     pub size: u64,
 }
 
-/// Orchestrates block reads against the coordinator + workers with caching.
+/// Orchestrates local block placement and worker reads with caching.
 #[derive(Clone)]
 pub struct BlockReader {
     coordinator: CoordinatorClient,
     cache: Arc<PlacementCache>,
-    /// Number of replicas to request from the coordinator (RF=1 → 1 in v1).
+    /// Number of workers retained from local ranking (RF=1 -> 1 in v1).
     replicas_k: u8,
     /// Read-path counters (cache hit/miss, worker fetches, bytes served).
     stats: ReadStats,
     /// Shared pool of worker connections, so warm fetches skip the TCP handshake
     /// (issue #181).
     worker_pool: Arc<ConnectionPool>,
+    /// Last authoritative worker set; stale snapshots remain usable on outage.
+    membership: Arc<MembershipCache>,
+    /// Serializes cold refreshes so an expired snapshot causes one control request.
+    membership_refresh: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl BlockReader {
     /// Create a reader over the given coordinator client and placement cache.
     ///
-    /// `replicas_k` is how many owners to request per placement lookup; with
-    /// RF=1 this is `1`, but requesting more reserves an ordered fallback list.
+    /// `replicas_k` is how many owners to retain from local placement; with RF=1
+    /// this is `1`, but a larger value reserves an ordered fallback list.
     /// Metrics are collected into a fresh [`ReadStats`]; use
     /// [`with_stats`](Self::with_stats) to share an existing one.
     pub fn new(coordinator: CoordinatorClient, cache: Arc<PlacementCache>, replicas_k: u8) -> Self {
@@ -102,12 +108,15 @@ impl BlockReader {
         replicas_k: u8,
         stats: ReadStats,
     ) -> Self {
+        let membership = Arc::new(MembershipCache::new(cache.ttl_ms()));
         Self {
             coordinator,
             cache,
             replicas_k: replicas_k.max(1),
             stats,
             worker_pool: Arc::new(ConnectionPool::new()),
+            membership,
+            membership_refresh: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
@@ -123,8 +132,8 @@ impl BlockReader {
 
     /// Read `len` bytes at `offset_in_block` within `block`.
     ///
-    /// Resolves placement (cache hit, else coordinator lookup that populates the
-    /// cache at `now_ms`), then fetches the sub-range from an owner. The
+    /// Resolves placement (cache hit, else local HRW over cached membership),
+    /// then fetches the sub-range from an owner. The
     /// absolute object offset handed to the worker is
     /// `block.offset + offset_in_block`.
     ///
@@ -135,8 +144,8 @@ impl BlockReader {
     /// ([`WorkerError::Remote`], a [`RefreshReason::WrongOwner`]) does not fail
     /// the read outright: the reader walks the ordered replica list from the
     /// cached placement. If every cached replica is exhausted, it invalidates
-    /// the entry and performs **one** coordinator refresh (which may return a
-    /// newer epoch / different owners), then retries against the fresh primary.
+    /// the entry and performs **one** membership refresh (which may return a
+    /// different worker set), then retries against the fresh primary.
     /// Only if that also fails does the error propagate.
     pub async fn read_block(
         &self,
@@ -168,14 +177,14 @@ impl BlockReader {
             }
             Err(reason) => {
                 // Every cached replica failed; drop the stale placement and do a
-                // single coordinator refresh before giving up.
+                // single membership refresh before giving up.
                 tracing::debug!(%block, ?reason, "all cached replicas failed; refreshing placement");
                 self.cache.invalidate(block, reason);
                 self.stats.record_coordinator_refresh();
             }
         }
 
-        let fresh = self.resolve_and_cache(block, now_ms).await?;
+        let fresh = self.resolve_and_cache_forced(block, now_ms).await?;
         let bytes = self
             .try_replicas(block, &fresh.replicas, abs_offset, len)
             .await
@@ -285,7 +294,7 @@ impl BlockReader {
     ///
     /// Placement is by `BlockId`; a write addresses the object's first block
     /// under `version` (the mount uses a canonical version, #182), so this
-    /// resolves the primary owner of block 0 through the same coordinator +
+    /// resolves the primary owner of block 0 through the same client-side
     /// placement path reads use, reusing the placement cache. Returns the
     /// dialable `host:port` of the primary owner.
     pub async fn resolve_owner(
@@ -307,33 +316,90 @@ impl BlockReader {
             .ok_or(BlockReadError::UnresolvedOwner)
     }
 
-    /// Look the block up via the coordinator and insert the resolved,
-    /// address-ordered placement into the cache.
+    /// Rank the block against cached membership and cache the ordered addresses.
     async fn resolve_and_cache(
         &self,
         block: &BlockId,
         now_ms: u64,
     ) -> Result<Cached, BlockReadError> {
-        let resolved = self
-            .coordinator
-            .locate_primary(block, self.replicas_k)
-            .await?
-            .ok_or(BlockReadError::NoOwners)?;
-        // Map ordered owner ids → dialable worker addresses, preserving order.
-        let replicas: Vec<String> = resolved
-            .owners
+        self.resolve_and_cache_inner(block, now_ms, false).await
+    }
+
+    async fn resolve_and_cache_forced(
+        &self,
+        block: &BlockId,
+        now_ms: u64,
+    ) -> Result<Cached, BlockReadError> {
+        self.resolve_and_cache_inner(block, now_ms, true).await
+    }
+
+    async fn resolve_and_cache_inner(
+        &self,
+        block: &BlockId,
+        now_ms: u64,
+        force_membership_refresh: bool,
+    ) -> Result<Cached, BlockReadError> {
+        let membership = self
+            .membership_snapshot(now_ms, force_membership_refresh)
+            .await?;
+        let owners = rank_cache_workers(block, &membership.nodes, self.replicas_k as usize);
+        if owners.is_empty() {
+            return Err(BlockReadError::NoOwners);
+        }
+        let replicas: Vec<String> = owners
             .iter()
-            .filter_map(|id| resolved.address_of(id).map(String::from))
+            .filter_map(|id| {
+                membership
+                    .nodes
+                    .iter()
+                    .find(|node| &node.id == id)
+                    .map(|node| node.address.clone())
+            })
             .collect();
         if replicas.is_empty() {
             return Err(BlockReadError::UnresolvedOwner);
         }
         let cached = Cached {
             replicas,
-            epoch: resolved.epoch,
+            epoch: membership.epoch,
         };
         self.cache.insert(block.clone(), cached.clone(), now_ms);
         Ok(cached)
+    }
+
+    async fn membership_snapshot(
+        &self,
+        now_ms: u64,
+        force_refresh: bool,
+    ) -> Result<MembershipSnapshot, BlockReadError> {
+        if !force_refresh {
+            if let Some(snapshot) = self.membership.fresh(now_ms) {
+                return Ok(snapshot);
+            }
+        }
+        let _refresh = self.membership_refresh.lock().await;
+        if !force_refresh {
+            if let Some(snapshot) = self.membership.fresh(now_ms) {
+                return Ok(snapshot);
+            }
+        }
+        match self.coordinator.membership().await {
+            Ok(nodes) => {
+                let (snapshot, changed) = self.membership.replace(nodes, now_ms);
+                if changed {
+                    self.cache.clear();
+                }
+                Ok(snapshot)
+            }
+            Err(error) => {
+                if let Some(snapshot) = self.membership.last_good() {
+                    tracing::warn!(%error, "membership refresh failed; using last-good snapshot");
+                    Ok(snapshot)
+                } else {
+                    Err(error.into())
+                }
+            }
+        }
     }
 }
 
@@ -357,8 +423,7 @@ mod tests {
         )
     }
 
-    /// A mock coordinator that answers PlacementLookup then MembershipQuery,
-    /// pointing the single owner `w1` at `worker_addr`.
+    /// A mock coordinator that advertises one worker membership entry.
     async fn mock_coordinator(worker_addr: String) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap().to_string();
@@ -381,12 +446,6 @@ mod tests {
                     full.extend_from_slice(&body);
                     let (_h, msg) = talon_transport::decode(&full).unwrap();
                     let reply = match msg {
-                        ControlMessage::PlacementLookup { .. } => {
-                            ControlMessage::PlacementResponse {
-                                owners: vec![NodeId::new("w1")],
-                                epoch: 3,
-                            }
-                        }
                         ControlMessage::MembershipQuery {} => ControlMessage::MembershipList {
                             nodes: vec![NodeInfo {
                                 id: NodeId::new("w1"),
@@ -514,9 +573,27 @@ mod tests {
         addr
     }
 
-    /// A mock coordinator that returns two ordered owners (w1, w2) and resolves
-    /// their addresses via membership.
-    async fn mock_coordinator_two(w1: String, w2: String) -> String {
+    /// Advertise two workers while assigning `primary` to whichever stable ID
+    /// ranks first for the test block.
+    async fn mock_coordinator_two(primary: String, secondary: String) -> String {
+        let candidates = vec![
+            NodeInfo {
+                id: NodeId::new("w1"),
+                address: String::new(),
+                role: NodeRole::Worker,
+            },
+            NodeInfo {
+                id: NodeId::new("w2"),
+                address: String::new(),
+                role: NodeRole::Worker,
+            },
+        ];
+        let first = rank_cache_workers(&block(), &candidates, 1).remove(0);
+        let (w1, w2) = if first == NodeId::new("w1") {
+            (primary, secondary)
+        } else {
+            (secondary, primary)
+        };
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap().to_string();
         tokio::spawn(async move {
@@ -538,12 +615,6 @@ mod tests {
                     full.extend_from_slice(&body);
                     let (_h, msg) = talon_transport::decode(&full).unwrap();
                     let reply = match msg {
-                        ControlMessage::PlacementLookup { .. } => {
-                            ControlMessage::PlacementResponse {
-                                owners: vec![NodeId::new("w1"), NodeId::new("w2")],
-                                epoch: 3,
-                            }
-                        }
                         ControlMessage::MembershipQuery {} => ControlMessage::MembershipList {
                             nodes: vec![
                                 NodeInfo {
@@ -606,7 +677,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty_cluster_yields_no_owners() {
-        // Coordinator answers with zero owners.
+        // Coordinator advertises an empty worker membership.
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap().to_string();
         tokio::spawn(async move {
@@ -616,10 +687,7 @@ mod tests {
             let h = FrameHeader::decode(&hdr).unwrap();
             let mut body = vec![0u8; h.length as usize];
             s.read_exact(&mut body).await.unwrap();
-            let reply = ControlMessage::PlacementResponse {
-                owners: vec![],
-                epoch: 0,
-            };
+            let reply = ControlMessage::MembershipList { nodes: Vec::new() };
             s.write_all(&talon_transport::encode(0, &reply).unwrap())
                 .await
                 .unwrap();
@@ -629,6 +697,45 @@ mod tests {
         let reader = BlockReader::new(CoordinatorClient::new(addr), cache, 1);
         let err = reader.read_block(&block(), 0, 16, 0).await.unwrap_err();
         assert!(matches!(err, BlockReadError::NoOwners));
+    }
+
+    #[tokio::test]
+    async fn coordinator_outage_uses_last_good_membership_for_a_new_block() {
+        let hits = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let worker_addr = mock_worker(Arc::clone(&hits)).await;
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let coordinator = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut header = [0u8; HEADER_LEN];
+            stream.read_exact(&mut header).await.unwrap();
+            let header = FrameHeader::decode(&header).unwrap();
+            let mut body = vec![0u8; header.length as usize];
+            stream.read_exact(&mut body).await.unwrap();
+            let reply = ControlMessage::MembershipList {
+                nodes: vec![NodeInfo {
+                    id: NodeId::new("worker-a"),
+                    address: worker_addr,
+                    role: NodeRole::Worker,
+                }],
+            };
+            stream
+                .write_all(&talon_transport::encode(0, &reply).unwrap())
+                .await
+                .unwrap();
+            stream.flush().await.unwrap();
+            // Dropping the listener simulates the complete management-plane outage.
+        });
+
+        let cache = Arc::new(PlacementCache::new(0));
+        let reader = BlockReader::new(CoordinatorClient::new(coordinator), cache, 1);
+        reader.read_block(&block(), 0, 16, 0).await.unwrap();
+        let mut next = block();
+        next.offset += u64::from(next.block_size);
+        let bytes = reader.read_block(&next, 0, 16, 1).await.unwrap();
+
+        assert_eq!(bytes.len(), 16);
+        assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 2);
     }
 
     #[tokio::test]
@@ -727,14 +834,15 @@ mod tests {
         let cache = Arc::new(PlacementCache::new(10_000));
         let reader = BlockReader::new(CoordinatorClient::new(coord_addr), Arc::clone(&cache), 1);
 
-        // Warm the cache (mock_coordinator answers epoch=3).
+        // Warm the cache from the locally versioned membership snapshot.
         let _ = reader.read_block(&block(), 0, 8, 0).await.unwrap();
         assert_eq!(cache.len(), 1);
+        let epoch = cache.get(&block(), 0).unwrap().epoch;
         // The identical version token does not invalidate.
-        assert!(!reader.observe_epoch(&block(), 3));
+        assert!(!reader.observe_epoch(&block(), epoch));
         assert_eq!(cache.len(), 1);
         // A different token drops the entry so the next read re-looks-up.
-        assert!(reader.observe_epoch(&block(), 4));
+        assert!(reader.observe_epoch(&block(), epoch.wrapping_add(1)));
         assert_eq!(cache.len(), 0);
     }
 

--- a/crates/talon-fuse/src/coordinator_client.rs
+++ b/crates/talon-fuse/src/coordinator_client.rs
@@ -1,12 +1,14 @@
 //! Control-plane client for talking to the coordinator.
 //!
-//! The FUSE client needs two answers from the coordinator on its read path:
+//! The FUSE read path fetches one answer from the coordinator:
 //!
-//! - **placement** — given a [`BlockId`], which worker(s) hold it, and at what
-//!   [`epoch`](ControlMessage::PlacementResponse)? ([`CoordinatorClient::placement_lookup`])
-//! - **membership** — a placement response names owners by [`NodeId`]; the
-//!   client resolves those ids to concrete `host:port` worker addresses with a
-//!   [`MembershipQuery`](ControlMessage::MembershipQuery). ([`CoordinatorClient::membership`])
+//! - **membership** - the client caches healthy worker IDs and addresses from a
+//!   [`MembershipQuery`](ControlMessage::MembershipQuery), then computes block
+//!   placement locally. ([`CoordinatorClient::membership`])
+//!
+//! [`CoordinatorClient::placement_lookup`] and
+//! [`CoordinatorClient::locate_primary`] remain available for wire compatibility
+//! with older callers, but the current read path does not use them.
 //!
 //! Both are single request/response round-trips over the control plane: write
 //! one [`MsgType::Control`] frame carrying a bincode [`ControlMessage`], read

--- a/crates/talon-fuse/src/lib.rs
+++ b/crates/talon-fuse/src/lib.rs
@@ -9,6 +9,7 @@ pub mod capability;
 pub mod coordinator_client;
 pub(crate) mod lock;
 pub mod mapping;
+pub mod membership_cache;
 pub mod metrics;
 #[cfg(feature = "mount")]
 pub mod mount;

--- a/crates/talon-fuse/src/membership_cache.rs
+++ b/crates/talon-fuse/src/membership_cache.rs
@@ -1,0 +1,101 @@
+//! Last-good worker membership used for client-side block placement.
+
+use std::sync::RwLock;
+
+use talon_core::{cache_membership_epoch, NodeInfo};
+
+use crate::lock::RwLockExt;
+
+/// One immutable membership view and its equality-only content token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MembershipSnapshot {
+    /// Healthy, ready workers advertised by the management plane.
+    pub nodes: Vec<NodeInfo>,
+    /// Content-derived token used to invalidate per-block placements.
+    pub epoch: u64,
+}
+
+struct Entry {
+    snapshot: MembershipSnapshot,
+    refreshed_ms: u64,
+}
+
+/// Short-TTL membership cache that retains stale data across refresh errors.
+pub struct MembershipCache {
+    ttl_ms: u64,
+    entry: RwLock<Option<Entry>>,
+}
+
+impl MembershipCache {
+    /// Create an empty cache.
+    pub fn new(ttl_ms: u64) -> Self {
+        Self {
+            ttl_ms,
+            entry: RwLock::new(None),
+        }
+    }
+
+    /// Return the snapshot only while its refresh TTL is current.
+    pub fn fresh(&self, now_ms: u64) -> Option<MembershipSnapshot> {
+        self.entry.read_recover().as_ref().and_then(|entry| {
+            (now_ms.saturating_sub(entry.refreshed_ms) <= self.ttl_ms)
+                .then(|| entry.snapshot.clone())
+        })
+    }
+
+    /// Return the last successful snapshot regardless of age.
+    pub fn last_good(&self) -> Option<MembershipSnapshot> {
+        self.entry
+            .read_recover()
+            .as_ref()
+            .map(|entry| entry.snapshot.clone())
+    }
+
+    /// Store a successful refresh and return whether membership changed.
+    pub fn replace(&self, nodes: Vec<NodeInfo>, now_ms: u64) -> (MembershipSnapshot, bool) {
+        let snapshot = MembershipSnapshot {
+            epoch: cache_membership_epoch(&nodes),
+            nodes,
+        };
+        let mut entry = self.entry.write_recover();
+        let changed = entry
+            .as_ref()
+            .is_some_and(|old| old.snapshot.epoch != snapshot.epoch);
+        *entry = Some(Entry {
+            snapshot: snapshot.clone(),
+            refreshed_ms: now_ms,
+        });
+        (snapshot, changed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use talon_core::{NodeId, NodeRole};
+
+    fn worker(address: &str) -> NodeInfo {
+        NodeInfo {
+            id: NodeId::new("worker-a"),
+            address: address.into(),
+            role: NodeRole::Worker,
+        }
+    }
+
+    #[test]
+    fn expiry_retains_a_last_good_snapshot() {
+        let cache = MembershipCache::new(100);
+        cache.replace(vec![worker("old:7001")], 10);
+        assert!(cache.fresh(110).is_some());
+        assert!(cache.fresh(111).is_none());
+        assert_eq!(cache.last_good().unwrap().nodes[0].address, "old:7001");
+    }
+
+    #[test]
+    fn address_change_advances_the_equality_token() {
+        let cache = MembershipCache::new(100);
+        assert!(!cache.replace(vec![worker("old:7001")], 0).1);
+        assert!(!cache.replace(vec![worker("old:7001")], 1).1);
+        assert!(cache.replace(vec![worker("new:7001")], 2).1);
+    }
+}

--- a/crates/talon-fuse/src/metrics.rs
+++ b/crates/talon-fuse/src/metrics.rs
@@ -1,7 +1,7 @@
 //! Read-path metrics.
 //!
 //! [`ReadStats`] is a small bundle of atomic counters the read path bumps as it
-//! serves blocks: placement-cache hits and misses, coordinator refreshes,
+//! serves blocks: placement-cache hits and misses, membership refreshes,
 //! per-replica worker fetch attempts and failures, and bytes served. It is
 //! cheap to share (all `Relaxed` atomics behind an `Arc`) and lets the mount
 //! layer expose live read-path health without threading a metrics facade
@@ -41,12 +41,14 @@ impl ReadStats {
         self.inner.cache_hits.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Record a placement-cache miss (a coordinator lookup was needed).
+    /// Record a placement-cache miss (local ranking was needed).
     pub fn record_cache_miss(&self) {
         self.inner.cache_misses.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Record a coordinator refresh after all cached replicas failed.
+    /// Record a forced membership refresh after all cached replicas failed.
+    ///
+    /// The method name is retained for metrics API compatibility.
     pub fn record_coordinator_refresh(&self) {
         self.inner
             .coordinator_refreshes
@@ -86,9 +88,11 @@ impl ReadStats {
 pub struct ReadStatsSnapshot {
     /// Placement-cache hits.
     pub cache_hits: u64,
-    /// Placement-cache misses (coordinator lookups triggered).
+    /// Placement-cache misses (local rankings triggered).
     pub cache_misses: u64,
-    /// Coordinator refreshes after all cached replicas failed.
+    /// Forced membership refreshes after all cached replicas failed.
+    ///
+    /// The field name is retained for metrics API compatibility.
     pub coordinator_refreshes: u64,
     /// Worker fetch attempts (per-replica dials).
     pub worker_fetches: u64,

--- a/crates/talon-fuse/src/placement_cache.rs
+++ b/crates/talon-fuse/src/placement_cache.rs
@@ -1,8 +1,8 @@
 //! Client-side placement cache with refresh and replica fallback.
 //!
 //! The FUSE client caches each block's ordered replica list + epoch for a short
-//! TTL, so most reads skip a coordinator round-trip. A cached entry is refreshed
-//! (evicted, forcing a re-lookup) on any staleness trigger:
+//! TTL, so most reads skip membership access and local HRW ranking. A cached
+//! entry is refreshed (evicted, forcing a re-rank) on any staleness trigger:
 //!
 //! - **TTL expiry** — the cached entry aged out.
 //! - **Version mismatch** — a response carried a different placement version.
@@ -39,9 +39,9 @@ pub struct Cached {
     pub replicas: Vec<String>,
     /// Placement version token these replicas were computed against.
     ///
-    /// This is an opaque coordinator-issued token (a content hash of the node
-    /// set), **not** a monotonically increasing counter. Clients compare it for
-    /// equality only — see [`PlacementCache::observe_epoch`].
+    /// This is a client-derived content token for the membership snapshot,
+    /// **not** a monotonically increasing counter. Clients compare it for
+    /// equality only - see [`PlacementCache::observe_epoch`].
     pub epoch: u64,
 }
 
@@ -63,6 +63,16 @@ impl PlacementCache {
             ttl_ms,
             entries: RwLock::new(HashMap::new()),
         }
+    }
+
+    /// Configured freshness window, also used for membership refreshes.
+    pub fn ttl_ms(&self) -> u64 {
+        self.ttl_ms
+    }
+
+    /// Invalidate all placements after a membership snapshot changes.
+    pub fn clear(&self) {
+        self.entries.write_recover().clear();
     }
 
     /// Insert/replace a fresh placement for `block` observed at `now_ms`.
@@ -105,15 +115,13 @@ impl PlacementCache {
 
     /// Reconcile against an observed placement version: if the cached entry's
     /// version differs from `observed_epoch`, drop it so the next access
-    /// re-looks-up.
+    /// re-ranks against membership.
     ///
-    /// The version is an opaque token (a content hash of the coordinator's node
-    /// set), not an ordered counter, so this compares for **inequality** rather
-    /// than `<`. Any difference — a membership change on one coordinator, or a
-    /// response served by a peer that observed a different set — invalidates the
-    /// entry. Because identical membership always hashes to the identical token
-    /// (issue #80), a client load-balanced across active-active coordinators
-    /// with a stable cluster sees no spurious invalidations.
+    /// The version is a content hash of the membership snapshot, not an ordered
+    /// counter, so this compares for **inequality** rather than `<`. Any
+    /// membership difference invalidates the entry. Identical membership always
+    /// hashes to the same token, so a client load-balanced across active-active
+    /// coordinators sees no spurious invalidations for a stable cluster.
     ///
     /// Returns `true` if the entry was invalidated by the version check.
     pub fn observe_epoch(&self, block: &BlockId, observed_epoch: u64) -> bool {

--- a/crates/talon-fuse/src/pool.rs
+++ b/crates/talon-fuse/src/pool.rs
@@ -3,9 +3,9 @@
 //! Both the [`CoordinatorClient`](crate::CoordinatorClient) and the
 //! [`WorkerClient`](crate::WorkerClient) previously dialed a **fresh** TCP
 //! connection per request and dropped it after one exchange. On the read hot
-//! path — a placement lookup plus a range fetch per block, many blocks per file
-//! — that pays a full TCP handshake (and the server's connection-limit permit
-//! dance) every time. This pool lets warm requests reuse an established
+//! path - periodic membership requests plus range fetches for many blocks per
+//! file - that pays a full TCP handshake (and the server's connection-limit
+//! permit dance) every time. This pool lets warm requests reuse an established
 //! connection (issue #181).
 //!
 //! # Model: exclusive checkout, not multiplexing

--- a/crates/talon-fuse/tests/read_path_e2e.rs
+++ b/crates/talon-fuse/tests/read_path_e2e.rs
@@ -6,9 +6,9 @@
 //! and no cloud backend. It asserts the behaviors the unit tests cover in
 //! isolation actually compose end to end:
 //!
-//! 1. A cold read is a cache **miss** → coordinator lookup → worker fetch →
-//!    bytes; the second read of the same block is a cache **hit** (no second
-//!    coordinator round-trip) and returns identical bytes.
+//! 1. A cold read is a cache **miss** -> membership fetch -> local placement ->
+//!    worker fetch -> bytes; the second read of the same block is a cache
+//!    **hit** (no second coordinator round-trip) and returns identical bytes.
 //! 2. A multi-block read splits across block boundaries and **stitches** the
 //!    per-block results into one contiguous buffer.
 //! 3. When the primary replica reports the block missing, the reader **falls
@@ -40,6 +40,12 @@ fn content_byte(abs_offset: u64) -> u8 {
 #[derive(Default)]
 struct WorkerCounters {
     fetches: AtomicU32,
+}
+
+#[derive(Default)]
+struct CoordinatorCounters {
+    membership_queries: AtomicU32,
+    placement_lookups: AtomicU32,
 }
 
 /// Spawn a mock worker that serves deterministic bytes for any range request,
@@ -85,11 +91,11 @@ async fn spawn_worker(counters: Arc<WorkerCounters>, fail_all: bool) -> String {
     addr
 }
 
-/// Spawn a mock coordinator that places every block on `owners` (in order),
-/// resolving each id to the paired worker address. Counts placement lookups so
-/// a test can prove the second read was a cache hit (no new lookup).
-async fn spawn_coordinator(owners: Vec<(String, String)>, lookups: Arc<AtomicU32>) -> String {
-    // owners: (node_id, worker_addr) in priority order.
+/// Spawn a mock coordinator that advertises the supplied worker membership.
+async fn spawn_coordinator(
+    owners: Vec<(String, String)>,
+    counters: Arc<CoordinatorCounters>,
+) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap().to_string();
     tokio::spawn(async move {
@@ -99,7 +105,7 @@ async fn spawn_coordinator(owners: Vec<(String, String)>, lookups: Arc<AtomicU32
                 Err(_) => return,
             };
             let owners = owners.clone();
-            let lookups = Arc::clone(&lookups);
+            let counters = Arc::clone(&counters);
             tokio::spawn(async move {
                 let mut hdr = [0u8; HEADER_LEN];
                 if sock.read_exact(&mut hdr).await.is_err() {
@@ -113,22 +119,25 @@ async fn spawn_coordinator(owners: Vec<(String, String)>, lookups: Arc<AtomicU32
                 let (_h, msg) = talon_transport::decode(&full).unwrap();
                 let reply = match msg {
                     ControlMessage::PlacementLookup { .. } => {
-                        lookups.fetch_add(1, Ordering::SeqCst);
+                        counters.placement_lookups.fetch_add(1, Ordering::SeqCst);
                         ControlMessage::PlacementResponse {
                             owners: owners.iter().map(|(id, _)| NodeId::new(id)).collect(),
                             epoch: 1,
                         }
                     }
-                    ControlMessage::MembershipQuery {} => ControlMessage::MembershipList {
-                        nodes: owners
-                            .iter()
-                            .map(|(id, a)| NodeInfo {
-                                id: NodeId::new(id),
-                                address: a.clone(),
-                                role: NodeRole::Worker,
-                            })
-                            .collect(),
-                    },
+                    ControlMessage::MembershipQuery {} => {
+                        counters.membership_queries.fetch_add(1, Ordering::SeqCst);
+                        ControlMessage::MembershipList {
+                            nodes: owners
+                                .iter()
+                                .map(|(id, a)| NodeInfo {
+                                    id: NodeId::new(id),
+                                    address: a.clone(),
+                                    role: NodeRole::Worker,
+                                })
+                                .collect(),
+                        }
+                    }
                     _ => ControlMessage::Ack {
                         ok: false,
                         detail: None,
@@ -151,8 +160,8 @@ fn object() -> ObjectId {
 async fn cold_read_miss_then_warm_hit_same_bytes() {
     let wc = Arc::new(WorkerCounters::default());
     let worker = spawn_worker(Arc::clone(&wc), false).await;
-    let lookups = Arc::new(AtomicU32::new(0));
-    let coord = spawn_coordinator(vec![("w1".into(), worker)], Arc::clone(&lookups)).await;
+    let counters = Arc::new(CoordinatorCounters::default());
+    let coord = spawn_coordinator(vec![("w1".into(), worker)], Arc::clone(&counters)).await;
 
     let cache = Arc::new(PlacementCache::new(10_000));
     let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
@@ -166,27 +175,29 @@ async fn cold_read_miss_then_warm_hit_same_bytes() {
         size: 1_000_000,
     };
 
-    // Cold read: miss → coordinator lookup → worker fetch. Kept within a single
-    // block (block 3 spans 3072..4096) so exactly one placement lookup happens.
+    // Cold read: membership fetch, local placement, then worker fetch. This stays
+    // within one block (block 3 spans 3072..4096).
     let first = reader.read(&view, 3100, 256, 0).await.unwrap();
     assert_eq!(first.len(), 256);
     for (i, b) in first.iter().enumerate() {
         assert_eq!(*b, content_byte(3100 + i as u64));
     }
     assert_eq!(
-        lookups.load(Ordering::SeqCst),
+        counters.membership_queries.load(Ordering::SeqCst),
         1,
-        "one placement lookup on miss"
+        "one membership query on miss"
     );
+    assert_eq!(counters.placement_lookups.load(Ordering::SeqCst), 0);
 
     // Warm read of the same block: cache hit, no new coordinator lookup.
     let second = reader.read(&view, 3100, 256, 1).await.unwrap();
     assert_eq!(second, first, "warm read returns identical bytes");
     assert_eq!(
-        lookups.load(Ordering::SeqCst),
+        counters.membership_queries.load(Ordering::SeqCst),
         1,
         "warm read must not re-query the coordinator"
     );
+    assert_eq!(counters.placement_lookups.load(Ordering::SeqCst), 0);
 
     let snap = reader.stats().snapshot();
     assert_eq!(snap.cache_misses, 1);
@@ -197,8 +208,8 @@ async fn cold_read_miss_then_warm_hit_same_bytes() {
 async fn multi_block_read_stitches_contiguous_bytes() {
     let wc = Arc::new(WorkerCounters::default());
     let worker = spawn_worker(Arc::clone(&wc), false).await;
-    let lookups = Arc::new(AtomicU32::new(0));
-    let coord = spawn_coordinator(vec![("w1".into(), worker)], lookups).await;
+    let counters = Arc::new(CoordinatorCounters::default());
+    let coord = spawn_coordinator(vec![("w1".into(), worker)], counters).await;
 
     let cache = Arc::new(PlacementCache::new(10_000));
     let reader = BlockReader::new(CoordinatorClient::new(coord), cache, 1);
@@ -235,10 +246,10 @@ async fn falls_back_to_healthy_replica() {
     let good = Arc::new(WorkerCounters::default());
     let w1 = spawn_worker(Arc::clone(&bad), true).await;
     let w2 = spawn_worker(Arc::clone(&good), false).await;
-    let lookups = Arc::new(AtomicU32::new(0));
+    let counters = Arc::new(CoordinatorCounters::default());
     let coord = spawn_coordinator(
         vec![("w1".into(), w1), ("w2".into(), w2)],
-        Arc::clone(&lookups),
+        Arc::clone(&counters),
     )
     .await;
 
@@ -260,10 +271,11 @@ async fn falls_back_to_healthy_replica() {
         assert_eq!(*b, content_byte(i as u64));
     }
     // Primary was tried once and failed; secondary served it — within the same
-    // cached placement (a single coordinator lookup, no refresh).
+    // locally cached placement (a single membership query, no refresh).
     assert_eq!(bad.fetches.load(Ordering::SeqCst), 1);
     assert_eq!(good.fetches.load(Ordering::SeqCst), 1);
-    assert_eq!(lookups.load(Ordering::SeqCst), 1);
+    assert_eq!(counters.membership_queries.load(Ordering::SeqCst), 1);
+    assert_eq!(counters.placement_lookups.load(Ordering::SeqCst), 0);
 
     let snap = reader.stats().snapshot();
     assert_eq!(snap.worker_failures, 1);

--- a/docs/adr/0001-management-plane-ha.md
+++ b/docs/adr/0001-management-plane-ha.md
@@ -30,7 +30,7 @@ metadata owner or route data-plane bytes through it.
 Every coordinator can serve all control and management operations:
 
 - worker registration and heartbeat;
-- membership and placement lookup;
+- membership snapshots and legacy placement lookup;
 - health, readiness, and Prometheus metrics;
 - management API and UI.
 
@@ -198,7 +198,25 @@ by the deployment's naming and label conventions.
 Talon does not introduce a custom resource definition or require an operator
 for this feature.
 
-### 7. Placement uses an opaque membership version
+### 7. Clients compute immutable cache-block placement
+
+**Amended 2026-08-06.** Read-path clients fetch a bounded healthy-worker
+membership snapshot and run deterministic HRW locally. Coordinators retain
+`PlacementLookup` for rolling compatibility, but current clients do not put a
+coordinator on each block-placement cache miss.
+
+The cross-language score is SHA-256 over the domain
+`talon-cache-placement-v1\0`, the canonical length-delimited `BlockId` fields,
+and the stable worker ID. Scores sort as unsigned 32-byte big-endian values in
+descending order, with ascending worker ID as the collision tie-breaker.
+
+Clients cache the last successful membership. TTL expiry attempts a refresh;
+if the management plane is unavailable, an existing client continues using the
+last-good snapshot and normal worker fallback. This is safe for immutable cache
+blocks because the origin remains authoritative. It does not apply to the
+TMS-confirmed durable write ownership defined by ADR 0003.
+
+### 7.1 Legacy placement responses use an opaque membership version
 
 The current wall-clock-seeded numeric epoch is process-specific. It cannot be
 the cross-coordinator source of truth.
@@ -253,9 +271,10 @@ If a coordinator cannot obtain a snapshot within its configured timeout:
 - the UI may retain the last successful response locally but must mark it stale
   with its observation time.
 
-Existing clients may continue using their short-lived placement cache and
-normal replica fallback. A coordinator-local last-good snapshot may be exposed
-for diagnostics but is not used as an unmarked authoritative response.
+Existing clients continue using their short-lived placement and membership
+caches with normal replica fallback. A coordinator-local last-good snapshot may
+be exposed for diagnostics but is not used as an unmarked authoritative
+response.
 
 Liveness remains true while the process can run its event loop and serve the
 liveness endpoint. This distinction lets an orchestrator remove an unready
@@ -376,12 +395,13 @@ sequenceDiagram
     participant C as Any Coordinator
     participant S as ClusterStateStore
 
-    F->>LB: PlacementLookup(block, replica count)
+    F->>LB: MembershipQuery (on startup/TTL refresh)
     LB->>C: Route request
     C->>S: linearizable snapshot(cluster)
     S-->>C: live node records + opaque revision
-    C->>C: filter healthy workers and run deterministic HRW
-    C-->>F: owners + PlacementVersion
+    C->>C: filter healthy and ready workers
+    C-->>F: worker membership
+    F->>F: cache membership and run deterministic HRW per block
 ```
 
 ### Coordinator failure

--- a/docs/reference/wire-protocol.md
+++ b/docs/reference/wire-protocol.md
@@ -122,8 +122,9 @@ enum NodeRole { Coordinator = 0, Worker = 1 }  // u32 tag
 // NodeId and Version are newtypes over String: encoded exactly as a String.
 ```
 
-`PlacementResponse` returns node **ids**; a client resolves those to dialable
-addresses through `MembershipList`.
+For legacy placement lookup, `PlacementResponse` returns node **ids** that the
+caller resolves to dialable addresses through `MembershipList`. Current clients
+use `MembershipList` directly and compute placement locally.
 
 ## Data plane
 
@@ -150,24 +151,30 @@ reconnect**, not attempt to resynchronise.
 
 A correct client does more than encode messages:
 
-**Placement caching.** `PlacementLookup` returns owners in preference order.
-Cache the resolved addresses rather than the node ids, so a fetch does not
-re-resolve membership.
+**Client-side placement.** Current clients cache the healthy workers returned by
+`MembershipList` and rank them locally for each immutable cache block. The HRW
+score is SHA-256 over `talon-cache-placement-v1\0`, the canonical
+length-delimited `BlockId` fields, and the stable worker ID. Scores sort in
+descending unsigned byte order, with ascending worker ID as the tie-breaker.
+`PlacementLookup` remains a compatibility operation for older clients.
+
+**Placement caching.** Cache locally ranked worker addresses rather than node
+IDs. When membership identity or address changes, invalidate affected placement
+entries and re-rank them against the new snapshot.
 
 **Replica fallback.** On a fetch failure, walk the cached replicas in order. If
-all are exhausted, invalidate the entry, refresh from the coordinator once, and
-retry before giving up.
+all are exhausted, invalidate the entry, refresh membership once, and retry
+before giving up. If membership refresh fails, an existing client retains its
+last-good snapshot so a coordinator outage does not interrupt cached data-plane
+placement.
 
-**Epoch reconciliation.** `PlacementResponse` carries the epoch its owners were
-computed at. Observing a different epoch means the cached placement may be
-stale; invalidate it rather than continuing to use it. Failing to do this is the
-subtle bug — reads keep succeeding, from the wrong worker, until something else
-forces a refresh.
+**Legacy epoch reconciliation.** `PlacementResponse` carries the epoch its
+owners were computed at. Clients still using this compatibility operation must
+invalidate a cached placement when they observe a different epoch.
 
 **Multi-block ranges.** A range spanning block boundaries splits into one fetch
 per block, each addressed by its own `BlockId`. Block size is a worker
-configuration value; a client learns the object's layout from the block ids the
-coordinator returns.
+configuration value and is part of every locally constructed `BlockId`.
 
 ## Conformance vectors
 


### PR DESCRIPTION
## Summary
- compute immutable cache-block placement in Rust and Java clients using a stable cross-language SHA-256 HRW contract
- cache healthy worker membership with last-good fallback and serialized refreshes, removing `PlacementLookup` from the normal block read path
- retain coordinator placement handling for rolling compatibility and document the amended architecture

## Verification
- `cargo test --workspace --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo deny check advisories bans sources`
- `cargo fmt --all --check`
- `mdbook build docs/book`
- offline `lychee` link check and `typos`
- generated config and API documentation checks

Java compilation was not available locally because this devbox has neither `mvn` nor `javac`; the cross-language golden ranking test is included for CI.