### PR TITLE
perf: make stable-membership placement O(1)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -289,12 +289,11 @@ dedup (a correctness requirement — per-shard dedup would refetch the same
 
 ## 2. Coordinator
 
-- **Placement:** clients cache healthy worker membership and run stable,
-  cross-language rendezvous (HRW) hashing locally, extended to **top-K** to
-  reserve a replica ordering for later. The coordinator retains the same
-  implementation for legacy lookup compatibility. Assumes stable worker IDs.
-  Consistent-hashing rings / virtual nodes are deferred until worker capacities
-  diverge enough to need weighting.
+- **Placement:** clients build a deterministic cross-language **Maglev table**
+  when healthy worker membership changes. Stable membership makes primary block
+  lookup O(1), independent of worker count; top-K probes the same table for
+  distinct fallback workers. The coordinator retains equivalent legacy lookup
+  compatibility. Assumes stable worker IDs.
 - **Replication:** **RF=1** in v1 — the backing store is the durable source.
   Hot blocks may get RF=2 later once miss cost is measured. Avoid blanket
   multi-copy; it burns NVMe.
@@ -417,7 +416,7 @@ dedup (a correctness requirement — per-shard dedup would refetch the same
 
 ## v1 summary
 
-Single coordinator, K8s membership, rendezvous / top-K placement, RF=1, NVMe
+Single coordinator, K8s membership, Maglev / top-K placement, RF=1, NVMe
 block cache, custom TCP data plane, read-only FUSE, and pluggable blob backends
 (S3 / GCS / Azure Blob).
 

--- a/clients/java/src/main/java/io/milvus/talon/Placement.java
+++ b/clients/java/src/main/java/io/milvus/talon/Placement.java
@@ -8,6 +8,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -20,8 +21,12 @@ import java.util.List;
  */
 public final class Placement {
 
-    private static final byte[] DOMAIN =
-            "talon-cache-placement-v1\0".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] BLOCK_DOMAIN =
+            "talon-cache-maglev-block-v1\0".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] WORKER_DOMAIN =
+            "talon-cache-maglev-worker-v1\0".getBytes(StandardCharsets.US_ASCII);
+    private static final int MIN_TABLE_SIZE = 4_096;
+    private static final int SLOTS_PER_WORKER = 64;
 
     private final List<String> owners;
     private final long epoch;
@@ -31,7 +36,7 @@ public final class Placement {
         this.epoch = epoch;
     }
 
-    /** Owner node ids, highest-weight first. Resolve to addresses via membership. */
+    /** Owner node ids, primary first. Resolve to addresses via membership. */
     public List<String> owners() {
         return owners;
     }
@@ -40,39 +45,125 @@ public final class Placement {
         return epoch;
     }
 
-    /** Rank cache workers locally using the cross-language HRW v1 contract. */
+    /** Cold-path convenience wrapper; hot clients cache {@link Table}. */
     public static List<NodeInfo> rank(BlockId block, List<NodeInfo> nodes, int k) {
-        if (k <= 0) {
-            return Collections.emptyList();
-        }
-        List<ScoredNode> ranked = new ArrayList<>();
-        for (NodeInfo node : nodes) {
-            if (node.isWorker()) {
-                ranked.add(new ScoredNode(score(block, node.id()), node));
-            }
-        }
-        ranked.sort((a, b) -> {
-            int scoreOrder = compareUnsigned(b.score, a.score);
-            return scoreOrder != 0 ? scoreOrder : a.node.id().compareTo(b.node.id());
-        });
-        List<NodeInfo> result = new ArrayList<>(Math.min(k, ranked.size()));
-        for (int i = 0; i < Math.min(k, ranked.size()); i++) {
-            result.add(ranked.get(i).node);
-        }
-        return Collections.unmodifiableList(result);
+        return new Table(nodes).rank(block, k);
     }
 
-    private static byte[] score(BlockId block, String workerId) {
+    /** Deterministic Maglev index rebuilt only when worker membership changes. */
+    public static final class Table {
+        private final List<NodeInfo> workers;
+        private final int[] slots;
+        private final int mask;
+
+        public Table(List<NodeInfo> nodes) {
+            List<NodeInfo> sorted = new ArrayList<>();
+            for (NodeInfo node : nodes) {
+                if (node.isWorker()) {
+                    sorted.add(node);
+                }
+            }
+            sorted.sort(Comparator.comparing(NodeInfo::id));
+            List<NodeInfo> unique = new ArrayList<>(sorted.size());
+            for (NodeInfo node : sorted) {
+                if (unique.isEmpty()
+                        || !unique.get(unique.size() - 1).id().equals(node.id())) {
+                    unique.add(node);
+                }
+            }
+            workers = Collections.unmodifiableList(unique);
+            if (workers.isEmpty()) {
+                slots = new int[0];
+                mask = 0;
+                return;
+            }
+
+            long wanted = Math.max(MIN_TABLE_SIZE, (long) workers.size() * SLOTS_PER_WORKER);
+            int tableSize = 1;
+            while (tableSize < wanted) {
+                if (tableSize >= (1 << 30)) {
+                    throw new IllegalArgumentException("cache placement table is too large");
+                }
+                tableSize <<= 1;
+            }
+            mask = tableSize - 1;
+            slots = new int[tableSize];
+            java.util.Arrays.fill(slots, -1);
+            int[] next = new int[workers.size()];
+            int[] offsets = new int[workers.size()];
+            int[] skips = new int[workers.size()];
+            for (int i = 0; i < workers.size(); i++) {
+                byte[] digest = workerHash(workers.get(i).id());
+                offsets[i] = (int) littleEndianLong(digest, 0) & mask;
+                skips[i] = ((int) littleEndianLong(digest, 8) | 1) & mask;
+            }
+
+            int filled = 0;
+            while (filled < tableSize) {
+                for (int worker = 0; worker < workers.size() && filled < tableSize; worker++) {
+                    int slot;
+                    do {
+                        slot = (int) (offsets[worker] + (long) next[worker] * skips[worker]) & mask;
+                        next[worker]++;
+                    } while (slots[slot] != -1);
+                    slots[slot] = worker;
+                    filled++;
+                }
+            }
+        }
+
+        /** One hash plus one array access: O(1), independent of worker count. */
+        public NodeInfo primary(BlockId block) {
+            if (slots.length == 0) {
+                return null;
+            }
+            byte[] digest = blockHash(block);
+            return workers.get(slots[(int) littleEndianLong(digest, 0) & mask]);
+        }
+
+        public List<NodeInfo> rank(BlockId block, int k) {
+            int target = Math.min(Math.max(k, 0), workers.size());
+            if (target == 0) {
+                return Collections.emptyList();
+            }
+            byte[] digest = blockHash(block);
+            int start = (int) littleEndianLong(digest, 0) & mask;
+            int step = ((int) littleEndianLong(digest, 8) | 1) & mask;
+            List<Integer> selected = new ArrayList<>(target);
+            List<NodeInfo> result = new ArrayList<>(target);
+            for (int probe = 0; probe < slots.length && result.size() < target; probe++) {
+                int worker = slots[(int) (start + (long) probe * step) & mask];
+                if (!selected.contains(worker)) {
+                    selected.add(worker);
+                    result.add(workers.get(worker));
+                }
+            }
+            return Collections.unmodifiableList(result);
+        }
+    }
+
+    private static byte[] blockHash(BlockId block) {
         try {
             MessageDigest hash = MessageDigest.getInstance("SHA-256");
             ByteArrayOutputStream encoded = new ByteArrayOutputStream();
-            encoded.writeBytes(DOMAIN);
+            encoded.writeBytes(BLOCK_DOMAIN);
             encoded.write(backendTag(block.object().backend()));
             field(encoded, block.object().bucket());
             field(encoded, block.object().key());
             encoded.writeBytes(littleEndianLong(block.offset()));
             encoded.writeBytes(littleEndianInt(block.blockSize()));
             field(encoded, block.version());
+            return hash.digest(encoded.toByteArray());
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new AssertionError("SHA-256 is required by every Java runtime", impossible);
+        }
+    }
+
+    private static byte[] workerHash(String workerId) {
+        try {
+            MessageDigest hash = MessageDigest.getInstance("SHA-256");
+            ByteArrayOutputStream encoded = new ByteArrayOutputStream();
+            encoded.writeBytes(WORKER_DOMAIN);
             field(encoded, workerId);
             return hash.digest(encoded.toByteArray());
         } catch (NoSuchAlgorithmException impossible) {
@@ -91,6 +182,12 @@ public final class Placement {
                 .order(ByteOrder.LITTLE_ENDIAN)
                 .putLong(value)
                 .array();
+    }
+
+    private static long littleEndianLong(byte[] bytes, int offset) {
+        return ByteBuffer.wrap(bytes, offset, Long.BYTES)
+                .order(ByteOrder.LITTLE_ENDIAN)
+                .getLong();
     }
 
     private static byte[] littleEndianInt(int value) {
@@ -113,23 +210,4 @@ public final class Placement {
         }
     }
 
-    private static int compareUnsigned(byte[] left, byte[] right) {
-        for (int i = 0; i < left.length; i++) {
-            int order = Integer.compare(Byte.toUnsignedInt(left[i]), Byte.toUnsignedInt(right[i]));
-            if (order != 0) {
-                return order;
-            }
-        }
-        return 0;
-    }
-
-    private static final class ScoredNode {
-        final byte[] score;
-        final NodeInfo node;
-
-        ScoredNode(byte[] score, NodeInfo node) {
-            this.score = score;
-            this.node = node;
-        }
-    }
 }

--- a/clients/java/src/main/java/io/milvus/talon/TalonClient.java
+++ b/clients/java/src/main/java/io/milvus/talon/TalonClient.java
@@ -233,12 +233,16 @@ public final class TalonClient implements AutoCloseable {
     }
 
     private static final class CachedMembership {
-        final List<NodeInfo> nodes;
+        final Placement.Table placement;
         final String identity;
         final long expiresAtMs;
 
         CachedMembership(List<NodeInfo> nodes, String identity, long expiresAtMs) {
-            this.nodes = nodes;
+            this(new Placement.Table(nodes), identity, expiresAtMs);
+        }
+
+        CachedMembership(Placement.Table placement, String identity, long expiresAtMs) {
+            this.placement = placement;
             this.identity = identity;
             this.expiresAtMs = expiresAtMs;
         }
@@ -288,7 +292,15 @@ public final class TalonClient implements AutoCloseable {
         }
 
         CachedMembership members = membership(forceRefresh, now);
-        List<NodeInfo> owners = Placement.rank(block, members.nodes, REPLICAS_K);
+        List<NodeInfo> owners;
+        if (REPLICAS_K == 1) {
+            NodeInfo primary = members.placement.primary(block);
+            owners = primary == null
+                    ? java.util.Collections.emptyList()
+                    : java.util.Collections.singletonList(primary);
+        } else {
+            owners = members.placement.rank(block, REPLICAS_K);
+        }
         List<String> addresses = new ArrayList<>(owners.size());
         for (NodeInfo owner : owners) {
             addresses.add(owner.address());
@@ -328,6 +340,12 @@ public final class TalonClient implements AutoCloseable {
 
             String identity = membershipIdentity(nodes);
             boolean changed = membership != null && !membership.identity.equals(identity);
+            if (membership != null && !changed) {
+                membership =
+                        new CachedMembership(
+                                membership.placement, identity, now + PLACEMENT_TTL_MS);
+                return membership;
+            }
             if (changed) {
                 synchronized (placementCache) {
                     placementCache.clear();

--- a/clients/java/src/test/java/io/milvus/talon/ConformanceTest.java
+++ b/clients/java/src/test/java/io/milvus/talon/ConformanceTest.java
@@ -63,7 +63,7 @@ public final class ConformanceTest {
     // --- the checks --------------------------------------------------------
 
     private static void localPlacementMatchesRust() {
-        check("client-side HRW ranking matches Rust", () -> {
+        check("client-side Maglev ranking matches Rust", () -> {
             BlockId block =
                     new BlockId(
                             new ObjectId(
@@ -79,9 +79,13 @@ public final class ConformanceTest {
                             new NodeInfo("worker-b", "10.0.0.2:7001", true),
                             new NodeInfo("worker-c", "10.0.0.3:7001", true));
             List<NodeInfo> ranked = Placement.rank(block, nodes, 3);
-            assertEquals("worker-b", ranked.get(0).id(), "primary");
+            assertEquals("worker-c", ranked.get(0).id(), "primary");
             assertEquals("worker-a", ranked.get(1).id(), "secondary");
-            assertEquals("worker-c", ranked.get(2).id(), "tertiary");
+            assertEquals("worker-b", ranked.get(2).id(), "tertiary");
+            assertEquals("worker-c", Placement.rank(block, nodes, 1).get(0).id(), "top one");
+            List<NodeInfo> topTwo = Placement.rank(block, nodes, 2);
+            assertEquals("worker-c", topTwo.get(0).id(), "top-two primary");
+            assertEquals("worker-a", topTwo.get(1).id(), "top-two secondary");
         });
     }
 

--- a/crates/talon-client/src/main.rs
+++ b/crates/talon-client/src/main.rs
@@ -4,7 +4,7 @@
 //! sandbox has no `/dev/fuse`):
 //!
 //! 1. Parse `/az/<container>/<blob>` into an [`ObjectId`].
-//! 2. Fetch worker membership and compute HRW placement locally.
+//! 2. Fetch worker membership and compute Maglev placement locally.
 //! 3. Send a data-plane [`RangeRequest`] to the selected worker.
 //!
 //! Prints byte count + elapsed time; writes the bytes to `--out` when given so
@@ -13,7 +13,7 @@
 use std::time::Instant;
 
 use clap::Parser;
-use talon_core::{rank_cache_workers, BlockId, NodeRole, ObjectId, Version};
+use talon_core::{BlockId, CachePlacementTable, NodeRole, ObjectId, Version};
 use talon_transport::data::{self, RangeRequest};
 use talon_transport::frame::{Flags, HEADER_LEN};
 use talon_transport::{codec, ControlMessage, FrameHeader};
@@ -21,7 +21,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
 /// Block size used only to compute the placement key (must match the worker's
-/// so HRW selects the same owner; with a single worker any value works).
+/// so Maglev selects the same owner; with a single worker any value works).
 const PLACEMENT_BLOCK_SIZE: u32 = 256 << 20;
 /// Placeholder version matching the worker's block identity.
 const PLACEHOLDER_VERSION: &str = "e2e-v1";
@@ -102,17 +102,12 @@ async fn main() -> anyhow::Result<()> {
         }
         None => {
             let membership = membership_lookup(&args.coordinator).await?;
-            let owners = rank_cache_workers(&block, &membership, 1);
-            let owner = owners
-                .first()
+            let placement = CachePlacementTable::new(&membership);
+            let owner = placement
+                .primary(&block)
                 .ok_or_else(|| anyhow::anyhow!("no worker owns this block (empty cluster?)"))?;
-            tracing::info!(owner = %owner, "resolved owner");
-
-            let worker_addr = membership
-                .into_iter()
-                .find(|node| node.id == *owner)
-                .map(|node| node.address)
-                .ok_or_else(|| anyhow::anyhow!("owner {owner} not in membership list"))?;
+            tracing::info!(owner = %owner.id, "resolved owner");
+            let worker_addr = owner.address.clone();
             tracing::info!(%worker_addr, "resolved worker address");
             worker_addr
         }

--- a/crates/talon-coordinator/benches/placement_benches.rs
+++ b/crates/talon-coordinator/benches/placement_benches.rs
@@ -1,13 +1,15 @@
-//! Microbenchmarks for the coordinator placement hot path.
+//! Microbenchmarks for cache placement and membership reconciliation.
 //!
-//! - `RendezvousPlacement::locate` / `locate_top_k` run on every client
-//!   placement lookup, scaling with cluster size.
+//! - `CachePlacementTable::primary` is the stable-membership client hot path.
+//!   Table construction is deliberately outside the timed loop.
 //! - `Epoch::for_nodes` computes the deterministic placement version (a content
 //!   hash of the healthy node set) on every membership reconcile, so it is
 //!   benchmarked across representative cluster sizes too (#80).
 
-use talon_coordinator::{Epoch, Placement, RendezvousPlacement};
-use talon_core::{Backend, BlockId, NodeId, NodeInfo, NodeRole, ObjectId, Version};
+use talon_coordinator::Epoch;
+use talon_core::{
+    Backend, BlockId, CachePlacementTable, NodeId, NodeInfo, NodeRole, ObjectId, Version,
+};
 
 fn main() {
     divan::main();
@@ -32,21 +34,19 @@ fn block(i: u64) -> BlockId {
     )
 }
 
-#[divan::bench(args = [8, 64, 256])]
-fn locate(bencher: divan::Bencher, node_count: u32) {
-    let placement = RendezvousPlacement;
-    let nodes = nodes(node_count);
+#[divan::bench(args = [8, 64, 256, 10_000])]
+fn primary(bencher: divan::Bencher, node_count: u32) {
+    let table = CachePlacementTable::new(&nodes(node_count));
     let id = block(42);
-    bencher.bench(|| placement.locate(divan::black_box(&id), divan::black_box(&nodes)));
+    bencher.bench(|| table.primary(divan::black_box(&id)));
 }
 
 /// Top-3 replica ordering (the shape a RF>1 lookup would use).
-#[divan::bench(args = [8, 64, 256])]
-fn locate_top_k(bencher: divan::Bencher, node_count: u32) {
-    let placement = RendezvousPlacement;
-    let nodes = nodes(node_count);
+#[divan::bench(args = [8, 64, 256, 10_000])]
+fn top_k(bencher: divan::Bencher, node_count: u32) {
+    let table = CachePlacementTable::new(&nodes(node_count));
     let id = block(42);
-    bencher.bench(|| placement.locate_top_k(divan::black_box(&id), divan::black_box(&nodes), 3));
+    bencher.bench(|| table.rank(divan::black_box(&id), 3));
 }
 
 /// Deterministic placement-version hash over the node set (per reconcile).

--- a/crates/talon-coordinator/src/placement.rs
+++ b/crates/talon-coordinator/src/placement.rs
@@ -1,10 +1,8 @@
 //! Object placement strategy.
 //!
-//! Placement uses rendezvous (highest-random-weight, HRW) hashing so that the
-//! set of blocks that must move when a node joins or leaves is minimized. On
-//! top of the single-owner `locate`, [`Placement::locate_top_k`] returns an
-//! ordered replica list; RF stays 1 in v1, but the ordering reserves a stable
-//! replica sequence for a future RF=2.
+//! Current clients prebuild a deterministic Maglev table when membership
+//! changes, making per-block primary lookup O(1). This module retains the
+//! coordinator lookup adapter for older clients.
 
 use talon_core::{rank_cache_workers, BlockId, NodeId, NodeInfo};
 use xxhash_rust::xxh3::xxh3_64;
@@ -107,18 +105,15 @@ pub trait Placement {
     /// `k = 1`.
     fn locate(&self, block: &BlockId, nodes: &[NodeInfo]) -> Option<NodeId>;
 
-    /// Return up to `k` nodes for `block`, ordered by descending HRW weight.
+    /// Return up to `k` deterministic nodes for `block`, primary first.
     ///
-    /// The ordering is deterministic and stable under membership changes: the
-    /// relative order of any two surviving nodes never changes when a third
-    /// node is added or removed (the HRW property). `k = 1` yields the same
-    /// result as [`Placement::locate`].
+    /// `k = 1` yields the same result as [`Placement::locate`].
     fn locate_top_k(&self, block: &BlockId, nodes: &[NodeInfo], k: usize) -> Vec<NodeId>;
 }
 
-/// Rendezvous (highest random weight) hashing placement.
+/// Compatibility adapter using the same deterministic Maglev mapping as clients.
 ///
-/// Minimizes reassignment when nodes join or leave the cluster.
+/// The historical type name is retained to avoid breaking coordinator callers.
 #[derive(Default)]
 pub struct RendezvousPlacement;
 
@@ -185,21 +180,18 @@ mod tests {
     }
 
     #[test]
-    fn top_k_stable_under_membership_change() {
-        // Removing a node never reorders the two surviving nodes (HRW property).
+    fn membership_change_never_returns_a_removed_worker() {
         let p = RendezvousPlacement;
         let full = nodes(&["a", "b", "c", "d", "e"]);
         for i in 0..100 {
             let blk = block(i);
             let full_rank = p.locate_top_k(&blk, &full, full.len());
-            // Drop the top-ranked node and re-rank.
             let dropped = &full_rank[0];
             let survivors: Vec<NodeInfo> =
                 full.iter().filter(|n| &n.id != dropped).cloned().collect();
             let sub_rank = p.locate_top_k(&blk, &survivors, survivors.len());
-            let expected: Vec<&NodeId> = full_rank.iter().skip(1).collect();
-            let got: Vec<&NodeId> = sub_rank.iter().collect();
-            assert_eq!(expected, got, "surviving order changed for block {i}");
+            assert!(!sub_rank.contains(dropped));
+            assert_eq!(sub_rank.len(), survivors.len());
         }
     }
 

--- a/crates/talon-coordinator/src/service.rs
+++ b/crates/talon-coordinator/src/service.rs
@@ -19,7 +19,7 @@ use crate::{Epoch, Membership, Placement};
 /// The result of a placement lookup: ordered owners at a given epoch.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PlacementResult {
-    /// Ordered replica node ids (highest HRW weight first). Empty if no nodes.
+    /// Ordered replica node ids (primary first). Empty if no nodes.
     pub owners: Vec<String>,
     /// The placement epoch these owners were computed at.
     pub epoch: Epoch,

--- a/crates/talon-core/src/lib.rs
+++ b/crates/talon-core/src/lib.rs
@@ -32,7 +32,7 @@ pub use key::{Backend, BlockId, ObjectId, PageIndex, Version};
 pub use metrics::{Counter, Gauge, Histogram, Metrics};
 pub use namespace_policy::{NamespacePolicy, ObjectNamespace};
 pub use node::{NodeId, NodeInfo, NodeRole};
-pub use placement::{cache_membership_epoch, cache_placement_score, rank_cache_workers};
+pub use placement::{cache_membership_epoch, rank_cache_workers, CachePlacementTable};
 pub use status::{
     NodeHealth, NodeMetricsSnapshot, NodeStatus, NodeStatusError, MAX_NODE_STATUS_BYTES,
     MAX_STATUS_FIELD_BYTES, MAX_STATUS_LABELS, MAX_STATUS_LABEL_KEY_BYTES,

--- a/crates/talon-core/src/placement.rs
+++ b/crates/talon-core/src/placement.rs
@@ -8,45 +8,165 @@ use sha2::{Digest, Sha256};
 
 use crate::{Backend, BlockId, NodeId, NodeInfo, NodeRole};
 
-const PLACEMENT_DOMAIN: &[u8] = b"talon-cache-placement-v1\0";
+const BLOCK_DOMAIN: &[u8] = b"talon-cache-maglev-block-v1\0";
+const WORKER_DOMAIN: &[u8] = b"talon-cache-maglev-worker-v1\0";
 const MEMBERSHIP_DOMAIN: &[u8] = b"talon-cache-membership-v1\0";
+const MIN_TABLE_SIZE: usize = 4_096;
+const SLOTS_PER_WORKER: usize = 64;
+const EMPTY_SLOT: u32 = u32::MAX;
 
-/// Compute the stable HRW score for one cache block and worker ID.
-///
-/// Scores are compared as unsigned 32-byte big-endian values. A larger score
-/// ranks first; equal scores are resolved by ascending worker ID.
-pub fn cache_placement_score(block: &BlockId, worker: &NodeId) -> [u8; 32] {
+fn cache_block_hash(block: &BlockId) -> [u8; 32] {
     let mut hash = Sha256::new();
-    hash.update(PLACEMENT_DOMAIN);
+    hash.update(BLOCK_DOMAIN);
     hash.update([backend_tag(block.object.backend)]);
     hash_field(&mut hash, block.object.bucket.as_bytes());
     hash_field(&mut hash, block.object.object_path.as_bytes());
     hash.update(block.offset.to_le_bytes());
     hash.update(block.block_size.to_le_bytes());
     hash_field(&mut hash, block.version.0.as_bytes());
-    hash_field(&mut hash, worker.0.as_bytes());
     hash.finalize().into()
 }
 
-/// Rank up to `k` healthy-membership workers for an immutable cache block.
+/// A deterministic Maglev table built once per healthy-worker membership.
 ///
-/// The caller is responsible for membership health/freshness. Non-worker
-/// records are ignored defensively so a management node can never become a
-/// data-plane target through a malformed snapshot.
-pub fn rank_cache_workers(block: &BlockId, nodes: &[NodeInfo], k: usize) -> Vec<NodeId> {
-    if k == 0 {
-        return Vec::new();
+/// Construction is intentionally paid when membership changes. While the
+/// membership is stable, primary block placement is one hash and one array
+/// lookup: O(1) time with no worker-list scan.
+#[derive(Debug, Clone)]
+pub struct CachePlacementTable {
+    workers: Vec<NodeInfo>,
+    slots: Vec<u32>,
+    mask: usize,
+}
+
+impl CachePlacementTable {
+    /// Build the placement index for one membership snapshot.
+    pub fn new(nodes: &[NodeInfo]) -> Self {
+        let mut workers: Vec<NodeInfo> = nodes
+            .iter()
+            .filter(|node| node.role == NodeRole::Worker)
+            .cloned()
+            .collect();
+        workers.sort_unstable_by(|a, b| a.id.0.cmp(&b.id.0));
+        workers.dedup_by(|a, b| a.id == b.id);
+        if workers.is_empty() {
+            return Self {
+                workers,
+                slots: Vec::new(),
+                mask: 0,
+            };
+        }
+        assert!(
+            workers.len() < EMPTY_SLOT as usize,
+            "too many cache workers"
+        );
+        let wanted = workers
+            .len()
+            .saturating_mul(SLOTS_PER_WORKER)
+            .max(MIN_TABLE_SIZE);
+        let table_size = wanted
+            .checked_next_power_of_two()
+            .expect("cache placement table size overflow");
+        let mask = table_size - 1;
+        let mut slots = vec![EMPTY_SLOT; table_size];
+        let mut next = vec![0usize; workers.len()];
+        let permutations: Vec<(usize, usize)> = workers
+            .iter()
+            .map(|worker| worker_permutation(&worker.id, mask))
+            .collect();
+        let mut filled = 0usize;
+        while filled < table_size {
+            for (worker_index, &(offset, skip)) in permutations.iter().enumerate() {
+                let slot = loop {
+                    let candidate =
+                        offset.wrapping_add(next[worker_index].wrapping_mul(skip)) & mask;
+                    next[worker_index] += 1;
+                    if slots[candidate] == EMPTY_SLOT {
+                        break candidate;
+                    }
+                };
+                slots[slot] = worker_index as u32;
+                filled += 1;
+                if filled == table_size {
+                    break;
+                }
+            }
+        }
+        Self {
+            workers,
+            slots,
+            mask,
+        }
     }
-    let mut ranked: Vec<([u8; 32], &NodeId)> = nodes
-        .iter()
-        .filter(|node| node.role == NodeRole::Worker)
-        .map(|node| (cache_placement_score(block, &node.id), &node.id))
-        .collect();
-    ranked.sort_unstable_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1 .0.cmp(&b.1 .0)));
-    ranked
+
+    /// Return the primary worker in O(1) time.
+    pub fn primary(&self, block: &BlockId) -> Option<&NodeInfo> {
+        let digest = cache_block_hash(block);
+        let slot = u64::from_le_bytes(digest[..8].try_into().unwrap()) as usize & self.mask;
+        self.slots
+            .get(slot)
+            .map(|&worker| &self.workers[worker as usize])
+    }
+
+    /// Return up to `k` distinct workers, primary first.
+    pub fn rank(&self, block: &BlockId, k: usize) -> Vec<&NodeInfo> {
+        let target = k.min(self.workers.len());
+        if target == 0 {
+            return Vec::new();
+        }
+        let digest = cache_block_hash(block);
+        let start = u64::from_le_bytes(digest[..8].try_into().unwrap()) as usize & self.mask;
+        let step = (u64::from_le_bytes(digest[8..16].try_into().unwrap()) as usize | 1) & self.mask;
+        let mut result = Vec::with_capacity(target);
+        for probe in 0..self.slots.len() {
+            let slot = start.wrapping_add(probe.wrapping_mul(step)) & self.mask;
+            let worker = self.slots[slot];
+            if !result
+                .iter()
+                .any(|node: &&NodeInfo| node.id == self.workers[worker as usize].id)
+            {
+                result.push(&self.workers[worker as usize]);
+                if result.len() == target {
+                    break;
+                }
+            }
+        }
+        result
+    }
+
+    /// Number of healthy workers indexed by this table.
+    pub fn worker_count(&self) -> usize {
+        self.workers.len()
+    }
+
+    /// Canonically ID-sorted workers retained by the index.
+    pub fn workers(&self) -> &[NodeInfo] {
+        &self.workers
+    }
+
+    #[cfg(test)]
+    fn slot_count(&self) -> usize {
+        self.slots.len()
+    }
+}
+
+fn worker_permutation(worker: &NodeId, mask: usize) -> (usize, usize) {
+    let mut hash = Sha256::new();
+    hash.update(WORKER_DOMAIN);
+    hash_field(&mut hash, worker.0.as_bytes());
+    let digest: [u8; 32] = hash.finalize().into();
+    let offset = u64::from_le_bytes(digest[..8].try_into().unwrap()) as usize & mask;
+    let skip = (u64::from_le_bytes(digest[8..16].try_into().unwrap()) as usize | 1) & mask;
+    (offset, skip)
+}
+
+/// Cold-path convenience wrapper. Hot clients should cache a
+/// [`CachePlacementTable`] with their membership snapshot.
+pub fn rank_cache_workers(block: &BlockId, nodes: &[NodeInfo], k: usize) -> Vec<NodeId> {
+    CachePlacementTable::new(nodes)
+        .rank(block, k)
         .into_iter()
-        .take(k)
-        .map(|(_, id)| id.clone())
+        .map(|node| node.id.clone())
         .collect()
 }
 
@@ -129,24 +249,30 @@ mod tests {
         assert_eq!(
             rank_cache_workers(&block(), &nodes, 3),
             vec![
-                NodeId::new("worker-b"),
-                NodeId::new("worker-a"),
                 NodeId::new("worker-c"),
+                NodeId::new("worker-a"),
+                NodeId::new("worker-b"),
             ]
         );
     }
 
     #[test]
-    fn membership_epoch_tracks_addresses_but_scores_do_not() {
+    fn membership_epoch_tracks_addresses_but_placement_does_not() {
         let nodes = vec![worker("worker-a", "old:7001")];
         let moved = vec![worker("worker-a", "new:7001")];
         assert_ne!(
             cache_membership_epoch(&nodes),
             cache_membership_epoch(&moved)
         );
+        let before = CachePlacementTable::new(&nodes);
+        let after = CachePlacementTable::new(&moved);
         assert_eq!(
-            cache_placement_score(&block(), &nodes[0].id),
-            cache_placement_score(&block(), &moved[0].id)
+            before.primary(&block()).unwrap().id,
+            after.primary(&block()).unwrap().id
+        );
+        assert_ne!(
+            before.primary(&block()).unwrap().address,
+            after.primary(&block()).unwrap().address
         );
     }
 
@@ -158,5 +284,28 @@ mod tests {
             role: NodeRole::Coordinator,
         };
         assert!(rank_cache_workers(&block(), &[coordinator], 1).is_empty());
+    }
+
+    #[test]
+    fn table_indexes_every_worker_and_bounds_replica_count() {
+        let nodes: Vec<NodeInfo> = (0..128)
+            .map(|i| worker(&format!("worker-{i:03}"), &format!("10.0.0.{i}:7001")))
+            .collect();
+        let table = CachePlacementTable::new(&nodes);
+        assert_eq!(table.worker_count(), nodes.len());
+        assert!(table.slot_count().is_power_of_two());
+        assert!(table.slot_count() >= nodes.len() * SLOTS_PER_WORKER);
+        for k in [0, 1, 2, 3, 16, 127, 128, 256] {
+            let ranked = table.rank(&block(), k);
+            assert_eq!(ranked.len(), k.min(nodes.len()));
+            let mut ids: Vec<&NodeId> = ranked.iter().map(|node| &node.id).collect();
+            ids.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+            ids.dedup();
+            assert_eq!(ids.len(), ranked.len());
+        }
+        assert_eq!(
+            table.primary(&block()).unwrap().id,
+            table.rank(&block(), 1)[0].id
+        );
     }
 }

--- a/crates/talon-fuse/src/block_reader.rs
+++ b/crates/talon-fuse/src/block_reader.rs
@@ -10,7 +10,7 @@
 //!
 //! The placement cache stores an ordered list of **worker addresses** (what the
 //! client actually dials), derived from the same membership snapshot used for
-//! local HRW ranking. Storing the dialable address keeps the hot path
+//! local Maglev lookup. Storing the dialable address keeps the hot path
 //! allocation-light and makes replica fallback a simple walk down the ordered
 //! list.
 //!
@@ -23,7 +23,7 @@
 
 use std::sync::Arc;
 
-use talon_core::{rank_cache_workers, BlockId, ObjectId, Version};
+use talon_core::{BlockId, ObjectId, Version};
 
 use crate::coordinator_client::{CoordinatorClient, CoordinatorError};
 use crate::membership_cache::{MembershipCache, MembershipSnapshot};
@@ -132,7 +132,7 @@ impl BlockReader {
 
     /// Read `len` bytes at `offset_in_block` within `block`.
     ///
-    /// Resolves placement (cache hit, else local HRW over cached membership),
+    /// Resolves placement (cache hit, else local Maglev lookup),
     /// then fetches the sub-range from an owner. The
     /// absolute object offset handed to the worker is
     /// `block.offset + offset_in_block`.
@@ -342,20 +342,20 @@ impl BlockReader {
         let membership = self
             .membership_snapshot(now_ms, force_membership_refresh)
             .await?;
-        let owners = rank_cache_workers(block, &membership.nodes, self.replicas_k as usize);
-        if owners.is_empty() {
-            return Err(BlockReadError::NoOwners);
-        }
-        let replicas: Vec<String> = owners
-            .iter()
-            .filter_map(|id| {
-                membership
-                    .nodes
-                    .iter()
-                    .find(|node| &node.id == id)
-                    .map(|node| node.address.clone())
-            })
-            .collect();
+        let replicas = if self.replicas_k == 1 {
+            vec![membership
+                .placement
+                .primary(block)
+                .ok_or(BlockReadError::NoOwners)?
+                .address
+                .clone()]
+        } else {
+            let owners = membership.placement.rank(block, self.replicas_k as usize);
+            if owners.is_empty() {
+                return Err(BlockReadError::NoOwners);
+            }
+            owners.iter().map(|node| node.address.clone()).collect()
+        };
         if replicas.is_empty() {
             return Err(BlockReadError::UnresolvedOwner);
         }
@@ -588,7 +588,11 @@ mod tests {
                 role: NodeRole::Worker,
             },
         ];
-        let first = rank_cache_workers(&block(), &candidates, 1).remove(0);
+        let first = talon_core::CachePlacementTable::new(&candidates)
+            .primary(&block())
+            .unwrap()
+            .id
+            .clone();
         let (w1, w2) = if first == NodeId::new("w1") {
             (primary, secondary)
         } else {

--- a/crates/talon-fuse/src/coordinator_client.rs
+++ b/crates/talon-fuse/src/coordinator_client.rs
@@ -32,7 +32,7 @@ use crate::pool::ConnectionPool;
 /// Placement answer for a block: ordered owners + the epoch they hold at.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Placement {
-    /// Ordered replica node ids (highest HRW weight first). Empty if no nodes.
+    /// Ordered replica node ids (primary first). Empty if no nodes.
     pub owners: Vec<NodeId>,
     /// Placement epoch these owners were computed against.
     pub epoch: u64,
@@ -181,7 +181,7 @@ impl CoordinatorClient {
     /// Locate `block` and resolve the primary owner to a worker address.
     /// Combines [`placement_lookup`](Self::placement_lookup) with a
     /// [`membership`](Self::membership) resolution so a caller gets a directly
-    /// dialable `host:port` for the highest-weight owner. Returns `Ok(None)`
+    /// dialable `host:port` for the primary owner. Returns `Ok(None)`
     /// when there are no owners (empty cluster). Returns the resolved address
     /// plus the full ordered owner list and epoch so the caller can cache the
     /// placement and fall back to other replicas.

--- a/crates/talon-fuse/src/membership_cache.rs
+++ b/crates/talon-fuse/src/membership_cache.rs
@@ -1,16 +1,16 @@
 //! Last-good worker membership used for client-side block placement.
 
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
-use talon_core::{cache_membership_epoch, NodeInfo};
+use talon_core::{cache_membership_epoch, CachePlacementTable, NodeInfo};
 
 use crate::lock::RwLockExt;
 
 /// One immutable membership view and its equality-only content token.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct MembershipSnapshot {
-    /// Healthy, ready workers advertised by the management plane.
-    pub nodes: Vec<NodeInfo>,
+    /// Prebuilt O(1) placement index for the advertised healthy workers.
+    pub placement: Arc<CachePlacementTable>,
     /// Content-derived token used to invalidate per-block placements.
     pub epoch: u64,
 }
@@ -53,14 +53,19 @@ impl MembershipCache {
 
     /// Store a successful refresh and return whether membership changed.
     pub fn replace(&self, nodes: Vec<NodeInfo>, now_ms: u64) -> (MembershipSnapshot, bool) {
-        let snapshot = MembershipSnapshot {
-            epoch: cache_membership_epoch(&nodes),
-            nodes,
-        };
+        let epoch = cache_membership_epoch(&nodes);
         let mut entry = self.entry.write_recover();
-        let changed = entry
-            .as_ref()
-            .is_some_and(|old| old.snapshot.epoch != snapshot.epoch);
+        if let Some(current) = entry.as_mut() {
+            if current.snapshot.epoch == epoch {
+                current.refreshed_ms = now_ms;
+                return (current.snapshot.clone(), false);
+            }
+        }
+        let snapshot = MembershipSnapshot {
+            epoch,
+            placement: Arc::new(CachePlacementTable::new(&nodes)),
+        };
+        let changed = entry.is_some();
         *entry = Some(Entry {
             snapshot: snapshot.clone(),
             refreshed_ms: now_ms,
@@ -88,14 +93,18 @@ mod tests {
         cache.replace(vec![worker("old:7001")], 10);
         assert!(cache.fresh(110).is_some());
         assert!(cache.fresh(111).is_none());
-        assert_eq!(cache.last_good().unwrap().nodes[0].address, "old:7001");
+        assert_eq!(
+            cache.last_good().unwrap().placement.workers()[0].address,
+            "old:7001"
+        );
     }
 
     #[test]
     fn address_change_advances_the_equality_token() {
         let cache = MembershipCache::new(100);
-        assert!(!cache.replace(vec![worker("old:7001")], 0).1);
-        assert!(!cache.replace(vec![worker("old:7001")], 1).1);
+        let first = cache.replace(vec![worker("old:7001")], 0).0;
+        let unchanged = cache.replace(vec![worker("old:7001")], 1).0;
+        assert!(Arc::ptr_eq(&first.placement, &unchanged.placement));
         assert!(cache.replace(vec![worker("new:7001")], 2).1);
     }
 }

--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -156,7 +156,7 @@ pub(crate) fn to_file_attr(attr: Attr, _request_uid: u32, _request_gid: u32) -> 
 ///
 /// **Placement is version-independent on the mount path in v1, by design.** The
 /// coordinator locates a block by hashing the [`BlockId`](talon_core::BlockId) the client sends
-/// (rendezvous/HRW), and the worker is the sole authority on *freshness*: it
+/// (Maglev), and the worker is the sole authority on *freshness*: it
 /// resolves each object's real ETag itself and refuses to serve stale bytes
 /// (issues #119, #163). The client never transmits a version to the worker —
 /// [`RangeRequest`](talon_transport::RangeRequest) carries only `object` +
@@ -191,7 +191,7 @@ pub struct TalonFuse {
     ///
     /// The mount path is version-independent by design (see
     /// [`CANONICAL_MOUNT_VERSION`]): this value only keys the client's placement
-    /// cache and feeds the HRW hash, never the bytes the worker returns. It is
+    /// cache and feeds the Maglev hash, never the bytes the worker returns. It is
     /// normally [`CANONICAL_MOUNT_VERSION`].
     version: talon_core::Version,
     /// Readahead tuning (sequential-run trigger + prefetch window). The window

--- a/crates/talon-fuse/src/placement_cache.rs
+++ b/crates/talon-fuse/src/placement_cache.rs
@@ -1,7 +1,7 @@
 //! Client-side placement cache with refresh and replica fallback.
 //!
 //! The FUSE client caches each block's ordered replica list + epoch for a short
-//! TTL, so most reads skip membership access and local HRW ranking. A cached
+//! TTL, so most reads skip membership access and local Maglev lookup. A cached
 //! entry is refreshed (evicted, forcing a re-rank) on any staleness trigger:
 //!
 //! - **TTL expiry** — the cached entry aged out.

--- a/crates/talon-fuse/tests/read_path_e2e.rs
+++ b/crates/talon-fuse/tests/read_path_e2e.rs
@@ -22,7 +22,9 @@
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
-use talon_core::{Backend, NodeId, NodeInfo, NodeRole, ObjectId, Version};
+use talon_core::{
+    Backend, BlockId, CachePlacementTable, NodeId, NodeInfo, NodeRole, ObjectId, Version,
+};
 use talon_fuse::{BlockReader, CoordinatorClient, FileView, PlacementCache};
 use talon_transport::frame::{FrameHeader, HEADER_LEN};
 use talon_transport::{
@@ -241,11 +243,35 @@ async fn multi_block_read_stitches_contiguous_bytes() {
 
 #[tokio::test]
 async fn falls_back_to_healthy_replica() {
-    // Primary w1 always fails; secondary w2 serves the bytes.
+    // Whichever stable ID Maglev selects as primary always fails; the other
+    // worker serves the bytes.
     let bad = Arc::new(WorkerCounters::default());
     let good = Arc::new(WorkerCounters::default());
-    let w1 = spawn_worker(Arc::clone(&bad), true).await;
-    let w2 = spawn_worker(Arc::clone(&good), false).await;
+    let primary = spawn_worker(Arc::clone(&bad), true).await;
+    let secondary = spawn_worker(Arc::clone(&good), false).await;
+    let candidates = vec![
+        NodeInfo {
+            id: NodeId::new("w1"),
+            address: String::new(),
+            role: NodeRole::Worker,
+        },
+        NodeInfo {
+            id: NodeId::new("w2"),
+            address: String::new(),
+            role: NodeRole::Worker,
+        },
+    ];
+    let block = BlockId::new(object(), 0, 1024, Version::new("v1"));
+    let first = CachePlacementTable::new(&candidates)
+        .primary(&block)
+        .unwrap()
+        .id
+        .clone();
+    let (w1, w2) = if first == NodeId::new("w1") {
+        (primary, secondary)
+    } else {
+        (secondary, primary)
+    };
     let counters = Arc::new(CoordinatorCounters::default());
     let coord = spawn_coordinator(
         vec![("w1".into(), w1), ("w2".into(), w2)],

--- a/docs/adr/0001-management-plane-ha.md
+++ b/docs/adr/0001-management-plane-ha.md
@@ -201,14 +201,15 @@ for this feature.
 ### 7. Clients compute immutable cache-block placement
 
 **Amended 2026-08-06.** Read-path clients fetch a bounded healthy-worker
-membership snapshot and run deterministic HRW locally. Coordinators retain
+membership snapshot and build a deterministic Maglev table locally. Coordinators retain
 `PlacementLookup` for rolling compatibility, but current clients do not put a
 coordinator on each block-placement cache miss.
 
-The cross-language score is SHA-256 over the domain
-`talon-cache-placement-v1\0`, the canonical length-delimited `BlockId` fields,
-and the stable worker ID. Scores sort as unsigned 32-byte big-endian values in
-descending order, with ascending worker ID as the collision tie-breaker.
+Workers sort by stable ID before table construction. SHA-256 with separate
+worker and block domains derives each worker's Maglev permutation and each
+block's table slot. The table is rebuilt only when membership identity changes;
+while membership is stable, primary lookup is one block hash and one array
+access rather than a worker-list scan.
 
 Clients cache the last successful membership. TTL expiry attempts a refresh;
 if the management plane is unavailable, an existing client continues using the
@@ -401,7 +402,8 @@ sequenceDiagram
     S-->>C: live node records + opaque revision
     C->>C: filter healthy and ready workers
     C-->>F: worker membership
-    F->>F: cache membership and run deterministic HRW per block
+    F->>F: build Maglev table when membership changes
+    F->>F: O(1) table lookup per block
 ```
 
 ### Coordinator failure

--- a/docs/reference/wire-protocol.md
+++ b/docs/reference/wire-protocol.md
@@ -152,15 +152,18 @@ reconnect**, not attempt to resynchronise.
 A correct client does more than encode messages:
 
 **Client-side placement.** Current clients cache the healthy workers returned by
-`MembershipList` and rank them locally for each immutable cache block. The HRW
-score is SHA-256 over `talon-cache-placement-v1\0`, the canonical
-length-delimited `BlockId` fields, and the stable worker ID. Scores sort in
-descending unsigned byte order, with ascending worker ID as the tie-breaker.
-`PlacementLookup` remains a compatibility operation for older clients.
+`MembershipList` and build a deterministic Maglev table when that membership
+changes. Workers sort by stable ID. The table size is the next power of two at
+or above `max(4096, 64 * worker_count)`; SHA-256 domains
+`talon-cache-maglev-worker-v1\0` and `talon-cache-maglev-block-v1\0` derive
+worker permutations and block slots from the same canonical length-delimited
+fields in every language. A primary lookup is one block hash and one table
+access, O(1) regardless of worker count. `PlacementLookup` remains a
+compatibility operation for older clients.
 
 **Placement caching.** Cache locally ranked worker addresses rather than node
 IDs. When membership identity or address changes, invalidate affected placement
-entries and re-rank them against the new snapshot.
+entries and resolve them against the rebuilt table.
 
 **Replica fallback.** On a fetch failure, walk the cached replicas in order. If
 all are exhausted, invalidate the entry, refresh membership once, and retry

--- a/docs/use-cases/training.md
+++ b/docs/use-cases/training.md
@@ -27,7 +27,7 @@ straight from the block file into the socket — the block is never copied into 
 buffer on the way past. See [Data-plane runtime](../explanation/data-plane-runtime.md).
 
 **Scales cache capacity with the fleet.** Blocks are placed across workers by
-rendezvous hashing, so adding a worker adds capacity and moves a minimal share
+deterministic Maglev placement, so adding a worker adds capacity and remaps a bounded share
 of existing placements. A dataset larger than one node's NVMe is still fully
 cacheable.
 


### PR DESCRIPTION
## Summary
- build a deterministic cross-language Maglev table only when healthy worker membership changes
- resolve the RF=1 primary with one block hash and one array lookup, with no worker-list scan or ID-to-address scan
- retain deterministic top-K fallback probing and matching Rust/Java behavior
- reuse the exact placement table when a membership refresh returns the same identity

## Complexity
- membership update: table rebuild cost is paid on the cold path
- stable-membership primary lookup: O(1) time
- table memory: O(N), using the next power of two above max(4096, 64 * workers)

## Verification
- `cargo test --workspace --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all --check`
- `cargo deny check advisories bans sources`
- `mdbook build docs/book`
- `lychee --offline --no-progress README.md DESIGN.md CONTRIBUTING.md BENCHMARKS.md 'docs/**/*.md' '.github/**/*.md'`\n- `typos`\n- primary lookup benchmark median: 180 ns (8 workers), 151 ns (64), 150 ns (256), 151 ns (10,000)\n\nJava compilation remains CI-only because this devbox has neither `mvn` nor `javac`.