### PR TITLE
build(docker): cache dependency layers with cargo-chef

### DIFF
--- a/deploy/docker/coordinator.Dockerfile
+++ b/deploy/docker/coordinator.Dockerfile
@@ -1,28 +1,56 @@
 # Talon coordinator image.
 #
-# Multi-stage: a Rust build stage compiles the release binary with both
-# production state-store backends (etcd + Kubernetes), and a slim Debian runtime
-# stage ships only the binary. The container runs as a non-root user and bakes
-# in no configuration or secrets — everything comes from TALON_COORDINATOR_*
-# environment variables or a mounted --config file at runtime.
+# Multi-stage: cargo-chef stages cache the dependency build as its own image
+# layer (keyed by the workspace manifests + lockfile, so source-only changes
+# skip recompiling every dependency), a Rust build stage compiles the release
+# binary with both production state-store backends (etcd + Kubernetes), and a
+# slim Debian runtime stage ships only the binary. The container runs as a
+# non-root user and bakes in no configuration or secrets — everything comes
+# from TALON_COORDINATOR_* environment variables or a mounted --config file at
+# runtime.
 #
 # Build from the repository root:
 #   docker build -f deploy/docker/coordinator.Dockerfile -t talon-coordinator .
 
-# ---- build stage ---------------------------------------------------------
-FROM rust:1.96.1-bookworm AS build
+# ---- chef stage ----------------------------------------------------------
+FROM rust:1.96.1-bookworm AS chef
 
-# protoc is required to compile the etcd client's generated protobuf code.
+RUN cargo install cargo-chef --locked --version 0.1.77
+WORKDIR /src
+
+# ---- planner stage -------------------------------------------------------
+# `prepare` distills the workspace manifests into a recipe. It only parses
+# Cargo metadata, so it needs no system build dependencies, and its output
+# only changes when a manifest, the lockfile, or the toolchain pin changes.
+FROM chef AS planner
+
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ---- build stage ---------------------------------------------------------
+FROM chef AS build
+
+# protoc is required to compile the etcd client's generated protobuf code — a
+# third-party build script, which cargo-chef does not mask, so it already runs
+# while cooking dependencies below.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /src
+# Dependencies only: workspace build scripts are masked during the cook, and
+# COPY --from is content-addressed, so this expensive layer survives any
+# source-only change. --locked on the cook makes a stale lockfile fail here
+# in seconds instead of after the multi-minute dependency build.
+COPY --from=planner /src/recipe.json recipe.json
+RUN cargo chef cook --release --locked --recipe-path recipe.json \
+    --package talon-coordinator --features etcd,kubernetes
+
 COPY . .
 
 # Both production backends compiled in; rustls (not OpenSSL) keeps the runtime
-# free of a system TLS dependency.
-RUN cargo build --release -p talon-coordinator --features etcd,kubernetes \
+# free of a system TLS dependency. --locked: the image must build exactly the
+# dependency versions CI tested.
+RUN cargo build --release --locked -p talon-coordinator --features etcd,kubernetes \
     && strip target/release/talon-coordinator
 
 # ---- runtime stage -------------------------------------------------------

--- a/deploy/docker/fuse.Dockerfile
+++ b/deploy/docker/fuse.Dockerfile
@@ -1,8 +1,10 @@
 # Talon FUSE client image.
 #
-# Multi-stage: a Rust build stage compiles the release binary with the `mount`
-# feature (kernel FUSE adapter), and a slim Debian runtime stage ships the
-# binary plus libfuse3.
+# Multi-stage: cargo-chef stages cache the dependency build as its own image
+# layer (keyed by the workspace manifests + lockfile, so source-only changes
+# skip recompiling every dependency), a Rust build stage compiles the release
+# binary with the `mount` feature (kernel FUSE adapter), and a slim Debian
+# runtime stage ships the binary plus libfuse3.
 #
 # Mounting talks to the kernel, so a container running this image needs
 # `/dev/fuse` and the SYS_ADMIN capability, e.g.:
@@ -14,18 +16,41 @@
 # Build from the repository root:
 #   docker build -f deploy/docker/fuse.Dockerfile -t talon-fuse .
 
-# ---- build stage ---------------------------------------------------------
-FROM rust:1.96.1-bookworm AS build
+# ---- chef stage ----------------------------------------------------------
+FROM rust:1.96.1-bookworm AS chef
 
-# fuser links libfuse via pkg-config; the -dev package provides the headers.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends pkg-config libfuse3-dev \
-    && rm -rf /var/lib/apt/lists/*
-
+RUN cargo install cargo-chef --locked --version 0.1.77
 WORKDIR /src
+
+# ---- planner stage -------------------------------------------------------
+# `prepare` distills the workspace manifests into a recipe. It only parses
+# Cargo metadata, so it needs no system build dependencies, and its output
+# only changes when a manifest, the lockfile, or the toolchain pin changes.
+FROM chef AS planner
+
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ---- build stage ---------------------------------------------------------
+FROM chef AS build
+
+# No system build dependencies: fuser is pinned with default-features = false
+# (crates/talon-fuse/Cargo.toml), which drops its libfuse/pkg-config link path
+# — the crate talks to /dev/fuse directly. Only the runtime stage needs the
+# fuse3 package (for the fusermount3 helper).
+
+# Dependencies only: workspace build scripts are masked during the cook, and
+# COPY --from is content-addressed, so this expensive layer survives any
+# source-only change. --locked on the cook makes a stale lockfile fail here
+# in seconds instead of after the multi-minute dependency build.
+COPY --from=planner /src/recipe.json recipe.json
+RUN cargo chef cook --release --locked --recipe-path recipe.json \
+    --package talon-fuse --features mount
+
 COPY . .
 
-RUN cargo build --release -p talon-fuse --features mount \
+# --locked: the image must build exactly the dependency versions CI tested.
+RUN cargo build --release --locked -p talon-fuse --features mount \
     && strip target/release/talon-fuse
 
 # ---- runtime stage -------------------------------------------------------

--- a/deploy/docker/worker.Dockerfile
+++ b/deploy/docker/worker.Dockerfile
@@ -1,27 +1,55 @@
 # Talon worker image.
 #
-# Multi-stage: a Rust build stage compiles the release binary, and a slim Debian
-# runtime stage ships only the binary. Runs as a non-root user; configuration
-# and the object-store credentials come from TALON_WORKER_* environment
-# variables at runtime (the Azure SAS token is env-only and never baked in).
+# Multi-stage: cargo-chef stages cache the dependency build as its own image
+# layer (keyed by the workspace manifests + lockfile, so source-only changes
+# skip recompiling every dependency), a Rust build stage compiles the release
+# binary, and a slim Debian runtime stage ships only the binary. Runs as a
+# non-root user; configuration and the object-store credentials come from
+# TALON_WORKER_* environment variables at runtime (the Azure SAS token is
+# env-only and never baked in).
 #
 # Build from the repository root:
 #   docker build -f deploy/docker/worker.Dockerfile -t talon-worker .
 
+# ---- chef stage ----------------------------------------------------------
+FROM rust:1.96.1-bookworm AS chef
+
+RUN cargo install cargo-chef --locked --version 0.1.77
+WORKDIR /src
+
+# ---- planner stage -------------------------------------------------------
+# `prepare` distills the workspace manifests into a recipe. It only parses
+# Cargo metadata, so it needs no system build dependencies, and its output
+# only changes when a manifest, the lockfile, or the toolchain pin changes.
+FROM chef AS planner
+
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
 # ---- build stage ---------------------------------------------------------
-FROM rust:1.96.1-bookworm AS build
+FROM chef AS build
 
 # protoc compiles the WAL record schema (proto/wal.proto). ADR 0003 §9.4
 # requires a specified on-disk format rather than a derived Rust encoding, so
-# the build now depends on it.
+# the build depends on it. The worker's own build script is masked during the
+# cook, so protoc is only exercised by the final build — installing it before
+# the cook just keeps this apt layer stable.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /src
+# Dependencies only: workspace build scripts are masked during the cook, and
+# COPY --from is content-addressed, so this expensive layer survives any
+# source-only change. --locked on the cook makes a stale lockfile fail here
+# in seconds instead of after the multi-minute dependency build.
+COPY --from=planner /src/recipe.json recipe.json
+RUN cargo chef cook --release --locked --recipe-path recipe.json \
+    --package talon-worker
+
 COPY . .
 
-RUN cargo build --release -p talon-worker \
+# --locked: the image must build exactly the dependency versions CI tested.
+RUN cargo build --release --locked -p talon-worker \
     && strip target/release/talon-worker
 
 # ---- runtime stage -------------------------------------------------------


### PR DESCRIPTION
## Summary

The three image builds were a plain `COPY . .` + full `cargo build --release`, so any source change recompiled every dependency from scratch and the buildx GHA cache only ever served the apt layers. This splits each Dockerfile through cargo-chef so the dependency graph is cached as its own image layer, and passes `--locked` so images can only build the exact dependency versions CI tested.

## Related issues

Part of #457.

## Type of change

- [x] Docs / tests / tooling

## Changes

- `deploy/docker/{coordinator,worker,fuse}.Dockerfile`: four-stage cargo-chef structure (`chef` → `planner` → cook → build). The cook layer is keyed by the workspace manifests + lockfile (recipe.json is `COPY --from`ed content-addressed), so source-only changes reuse the compiled dependency layer instead of rebuilding all ~360 locked packages.
- `--locked` on both `cargo chef cook` and the final `cargo build`: previously the image builds ran without `--locked` (unlike every cargo invocation in CI), so a manifest/lockfile drift would silently re-resolve dependency versions CI never tested; now it fails in seconds in the cook layer.
- fuse build stage drops `pkg-config`/`libfuse3-dev`: `fuser` is pinned with `default-features = false` (see `crates/talon-fuse/Cargo.toml`) and talks to `/dev/fuse` directly, so the libfuse link path those packages served never compiles. Runtime stage still ships `fuse3` for `fusermount3`.
- cargo-chef pinned at 0.1.77 and installed via `cargo install --locked` in the shared `chef` stage (no additional Docker Hub image pull; the install layer caches until the base image changes).

Trade-offs, deliberately accepted:
- A manifest/lockfile change rebuilds the whole dependency layer (that is the cache key working as intended).
- `scripts/k8s_l1_l2_e2e.sh` does plain uncached `docker build`, so it pays the chef install (~50 s measured) once per run; its two image builds share the identical chef/planner layers via the runner's local BuildKit cache, and the job has a 50-minute timeout against a measured ~18-minute wall.

## Test plan

Validated on a fork running these exact files through the real workflows:

- Cold build of all three images (buildx + `type=gha` cache, same config as ci.yml/release-images.yml): [run 31225655912](https://github.com/Thor-ChenBiao/talon/actions/runs/31225655912) — coordinator 4m31s / worker 3m49s / fuse 4m05s, all green. The fuse image builds without the dropped packages.
- Source-only change on top: [run 31226029555](https://github.com/Thor-ChenBiao/talon/actions/runs/31226029555) — the cook layer is `CACHED` in all three builds; the final build compiles only the workspace crates (worker: 22 s) and per-image time drops to 1–2 min.
- No Rust code changes; build contexts, stage inputs, and runtime stages are unchanged, so `docker compose build` and the Helm/k8s image contracts are unaffected.

## Performance impact

- [x] Not performance-sensitive (build tooling only; runtime stages byte-identical apart from the fuse build-stage packages)

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`<type>(<scope>): <description>`)
- [x] No new dependencies without discussion — cargo-chef is a pinned, build-stage-only tool; happy to discuss if this counts
- [x] Rebased on the latest `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
