### PR TITLE
ci: publish images to GHCR on every main merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,10 @@ jobs:
     name: docker image build
     runs-on: ubuntu-latest
     # Smoke-build every container image on PRs (no push) so a broken Dockerfile
-    # fails CI. Publishing to GHCR happens separately on tags (release-images.yml).
+    # fails CI. A merge to main runs the real, publishing build in
+    # release-images.yml instead — running both would double the most expensive
+    # job in the repo for no extra signal, so this job is PR-only.
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -272,6 +275,12 @@ jobs:
           # The latency lab is a standalone stack; validate it parses too.
           docker compose -f deploy/testenv/docker-compose.yml config --quiet
           docker compose -f deploy/testenv/docker-compose.yml --profile tools config --quiet
+      # The builds read the main-seeded layer cache (written by
+      # release-images.yml on every merge) but do not write. This sacrifices
+      # layer reuse between pushes of one PR (entries written from a PR are
+      # only readable within that PR) to keep mode=max exports from churning
+      # the repository's 10GB Actions cache quota, which is already saturated
+      # by the rust-cache entries every other job depends on.
       - name: Build coordinator image
         uses: docker/build-push-action@v6
         with:
@@ -279,7 +288,6 @@ jobs:
           file: deploy/docker/coordinator.Dockerfile
           push: false
           cache-from: type=gha,scope=coordinator
-          cache-to: type=gha,scope=coordinator,mode=max
       - name: Build worker image
         uses: docker/build-push-action@v6
         with:
@@ -287,7 +295,6 @@ jobs:
           file: deploy/docker/worker.Dockerfile
           push: false
           cache-from: type=gha,scope=worker
-          cache-to: type=gha,scope=worker,mode=max
       - name: Build fuse image
         uses: docker/build-push-action@v6
         with:
@@ -295,7 +302,6 @@ jobs:
           file: deploy/docker/fuse.Dockerfile
           push: false
           cache-from: type=gha,scope=fuse
-          cache-to: type=gha,scope=fuse,mode=max
 
   helm:
     name: helm chart

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -2,16 +2,24 @@ name: Release images
 
 # Build and publish the Talon container images to GHCR.
 #
-# On a version tag (vX.Y.Z) each image is pushed to
-# ghcr.io/<owner>/talon-<binary> with semver, major.minor, sha, and `latest`
-# tags. Pull requests do NOT run this workflow — the docker-build job in ci.yml
-# already smoke-builds every image (no push) on PRs.
+# Merges to main publish ghcr.io/<owner>/talon-<binary> with `latest` and
+# `sha-<short>` tags, so the images the compose files, Helm chart, and docs
+# reference always track the default branch. `latest` always converges on the
+# newest merged commit; rapid merges may coalesce queued runs (the per-ref
+# concurrency group keeps one pending slot), so an intermediate commit is not
+# guaranteed its own sha-* image. A version tag (vX.Y.Z) additionally
+# publishes semver and major.minor tags; `latest` tracks main only, so a tag
+# publish racing a main publish can never leave `latest` mixed across the
+# three images. Pull requests do NOT run this workflow — the docker-build job
+# in ci.yml already smoke-builds every image (no push).
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
-  # Allow a manual publish of `latest` from the default branch.
+  # Allow a manual publish from the default branch.
   workflow_dispatch:
 
 # Least-privilege: only the GHCR push needs package write; the built-in
@@ -55,12 +63,16 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/talon-${{ matrix.image }}
+          # latest=false disables the implicit `latest` that semver tags would
+          # otherwise add (it would also fire on prereleases like v1.2.3-rc.1);
+          # `latest` comes only from the default-branch line below.
+          flavor: |
+            latest=false
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -71,4 +83,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,scope=${{ matrix.image }},mode=max
+          # Only main seeds the shared layer cache: entries written from tag
+          # refs are unreadable by other refs, so writing them would only churn
+          # the repository's 10GB Actions cache quota.
+          cache-to: ${{ github.ref == 'refs/heads/main' && format('type=gha,scope={0},mode=max', matrix.image) || '' }}


### PR DESCRIPTION
## Summary

`release-images.yml` only triggers on `v*` tags, no tag has ever been pushed, and the workflow has zero runs — so `ghcr.io/milvus-io/talon-*` does not exist and every reference to those images (docker-compose, Helm values, kubernetes manifests, docs) is dead. This publishes `sha-*` + `latest` on every merge to main, making the default branch continuously installable.

## Related issues

Closes #457. **Merge after #458** — nothing breaks in the other order, but with the chef caching in first, the publish builds start warm (~1–2 min/image instead of a full cold build per merge).

## Type of change

- [x] Docs / tests / tooling

## Changes

- `release-images.yml`:
  - `on.push` gains `branches: [main]`; every merge publishes `latest` + `sha-<short>`.
  - `latest` now tracks main only: `flavor: latest=false` plus removal of the tag-triggered raw-latest line. That line force-published `latest` on prereleases (`v1.2.3-rc.1` matches `refs/tags/v`), and with two publishers a tag run racing a main run could leave `latest` mixed across the three matrix images. Tags now publish `X.Y.Z` + `X.Y` + `sha-*` only.
  - Layer cache is written from main only (`cache-to` is conditional): entries written from tag refs are unreadable by other refs and would only churn the repository's Actions cache quota, which is already over the 10 GB limit.
- `ci.yml` `docker-build`: now PR-only (`if: github.event_name == 'pull_request'`). A merge to main runs the real, publishing build in release-images.yml — running both would double the most expensive job for no extra signal. PR builds read the main-seeded cache but no longer write it (PR-scoped entries are only readable within their own PR; sacrificing same-PR reuse keeps `mode=max` exports from evicting the rust-cache entries every other job depends on).

## Test plan

Validated on a fork running these exact files (publishes land in the fork's namespace via `github.repository_owner`):

- Push to main → three packages published with exactly `latest` + `sha-<short>`: [cold run](https://github.com/Thor-ChenBiao/talon/actions/runs/31225655912), [warm run](https://github.com/Thor-ChenBiao/talon/actions/runs/31226029555) (with #458's caching, the warm publish is 1–2 min/image).
- Tag/dispatch paths verified by walking the metadata-action config: `v1.2.3` → `1.2.3`, `1.2`, `sha-*` (no `latest`); `v1.2.3-rc.1` → prerelease + `sha-*` only; `workflow_dispatch` from main → `sha-*` + `latest`.
- Both files parse (PyYAML) and the conditional `cache-to` empty-string form is the documented build-push-action idiom.

## Rollout notes (maintainer action needed)

- **First publish creates the three GHCR packages private.** A repo admin must flip `talon-coordinator` / `talon-worker` / `talon-fuse` to public once, or the compose/helm/docs references stay broken for anonymous pulls.
- If the org restricts allowed actions, `docker/login-action@v3` and `docker/metadata-action@v5` are new to this repo (setup-buildx and build-push are already used in ci.yml).
- Rapid merges may coalesce queued publish runs (per-ref concurrency group keeps one pending slot), so an intermediate commit is not guaranteed its own `sha-*` image; `latest` always converges on the newest merge. Noted in the workflow header.
- Deliberately out of scope, possible follow-ups: an `if: github.repository == 'milvus-io/talon'` guard (forks have Actions disabled by default), linux/arm64 images, moving the compose `config --quiet` checks to a small always-on job.

## Performance impact

- [x] Not performance-sensitive (CI wiring only)

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`<type>(<scope>): <description>`)
- [x] No new dependencies without discussion
- [x] Rebased on the latest `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
