### PR TITLE
doc: use each contributor's own fork, not a hardcoded one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,15 +3,19 @@
 ## Fork-based PR workflow (MANDATORY — this overrides any earlier habit)
 
 Remotes:
-- `origin` = **beinan/talon** (the contributor fork) — push branches here.
+- `origin` = **your own personal fork** — push branches here. Each contributor
+  uses their *own* fork, not somebody else's: check `git remote -v` (or
+  `gh api repos/<owner>/talon --jq .permissions.push`) and use whatever fork
+  your credentials can actually push to. On this devbox that is
+  **Kazimierzsier/talon**.
 - `upstream` = **milvus-io/talon** — push is DISABLED. This is where PRs and issues live.
 
 **The loop — ONE PR at a time, repeat for every sub-task:**
 1. Branch from `upstream/main` (NOT fork main): `git fetch upstream main && git checkout -B <branch> upstream/main`.
 2. Implement + commit.
 3. Push the branch to the **fork**: `git push -u origin <branch>`.
-4. Open the PR to **upstream**: `gh pr create --repo milvus-io/talon --base main --head beinan:<branch> ...`.
-   - upstream CI runs on the PR. Do NOT open PRs inside the fork (`--repo beinan/talon`) — fork PR CI does not auto-trigger, and it is the wrong target.
+4. Open the PR to **upstream**: `gh pr create --repo milvus-io/talon --base main --head <your-fork-owner>:<branch> ...`.
+   - upstream CI runs on the PR. Do NOT open PRs inside the fork (`--repo <your-fork-owner>/talon`) — fork PR CI does not auto-trigger, and it is the wrong target.
 5. **Wait for upstream CI to go green** (a Docker Hub timeout is infra flake → `gh run rerun <run-id> --failed`, not a code issue).
 6. **Merge on upstream**: `gh pr merge <n> --repo milvus-io/talon --squash --delete-branch`. Close the sub-issue.
 7. **Go back to step 1** for the next sub-task — always re-branch fresh from the now-updated `upstream/main`. Never stack the next branch on the previous one.
@@ -19,7 +23,9 @@ Remotes:
 Issues (parent epics + sub-issues) are created and closed on **upstream** (`--repo milvus-io/talon`), because the fork has Issues disabled.
 
 **Never:**
-- Never open a PR with base = the fork (`beinan/talon`). Always base = `milvus-io/talon`.
+- Never push to a fork that is not yours. If `git push` returns 403, do not
+  "fix" it by switching to somebody else's fork — get credentials for your own.
+- Never open a PR with base = a fork. Always base = `milvus-io/talon`.
 - Never push to the fork's `main` to "trigger CI". Branch from `upstream/main` and PR to upstream.
 - Never rebase a feature branch onto the fork's squashed `main` — its history diverges from upstream and causes massive conflicts. Always base feature branches on `upstream/main`.
 
@@ -29,3 +35,16 @@ Issues (parent epics + sub-issues) are created and closed on **upstream** (`--re
 - Conventional-commits lint requires `doc:` (singular, not `docs:`), plus `feat:`/`fix:`/`test:`/`build:`/`ci:`/`chore:`.
 - PR title ≤ 72 chars.
 - Never commit secrets; secrets come from env only.
+
+## Auth gotcha: `workflow` scope
+
+Branching from `upstream/main` while your fork's `main` is behind means the
+pushed branch carries upstream's `.github/workflows/**` as *new* files, even
+when your own commits never touch them. GitHub then rejects the push:
+
+    refusing to allow an OAuth App to create or update workflow
+    `.github/workflows/ci.yml` without `workflow` scope
+
+Fix: `gh auth refresh -h github.com -s workflow` (then re-push). Syncing the
+fork first (`gh repo sync <your-fork> --source milvus-io/talon --branch main`)
+needs the same scope, so grant it once and both work.


### PR DESCRIPTION
The workflow named `beinan/talon` as `origin` for everyone. Anyone whose credentials cannot push there hits a 403 on step 3 with no guidance, and the natural-looking fix — retarget the push at whichever fork *is* reachable — means pushing branches into someone else's repository.

## Changes

- `origin` is stated as **your own fork**, with the way to confirm it: `gh api repos/<owner>/talon --jq .permissions.push`
- The PR command takes `<your-fork-owner>:<branch>` instead of a hardcoded owner
- A new **never** entry: *never push to a fork that is not yours* — if `git push` returns 403, get credentials for your own fork rather than retargeting someone else's

## Also documents the `workflow` scope failure

Not obvious from its error message, and it hits any contributor whose fork has fallen behind. Branching from `upstream/main` while the fork's `main` is behind carries upstream's `.github/workflows/**` along as *new* files, so GitHub rejects the push:

```
refusing to allow an OAuth App to create or update workflow
`.github/workflows/ci.yml` without `workflow` scope
```

...for "creating" workflows the contributor never touched. Both the push and `gh repo sync` need the same scope, so the fix is one `gh auth refresh -h github.com -s workflow`.

Documentation only — no code or CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)