### PR TITLE
doc: surface saturation results from the data-plane runtime page

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ Start with the section that matches what you're doing:
 - **Understanding Talon** — [DESIGN.md](DESIGN.md) (v1 architecture and the
   decisions behind it) and the [architecture decision records](docs/adr/).
 - **Contributing** — [CONTRIBUTING.md](CONTRIBUTING.md) (build, test, submit
-  changes) and [BENCHMARKS.md](BENCHMARKS.md) (the microbenchmark harness).
+  changes) and [BENCHMARKS.md](BENCHMARKS.md) (the benchmark harness, plus the
+  measured throughput ceilings on loopback and across the network).
 
 ## Contributing
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -54,4 +54,4 @@
 # Contributing
 
 - [Contributing guide](./contributing/contributing.md)
-- [Benchmarks](./contributing/benchmarks.md)
+- [Benchmarks and measured ceilings](./contributing/benchmarks.md)

--- a/docs/explanation/data-plane-runtime.md
+++ b/docs/explanation/data-plane-runtime.md
@@ -224,6 +224,51 @@ cargo bench -p talon-worker --bench dataplane_benches   # latency floor
 scripts/dataplane_loadtest.sh                           # concurrent sweep
 ```
 
+## What binds the serve path, once a plane is chosen
+
+The tables above compare the two planes against each other. They do not say what
+the ceiling is, or which resource reaches it first — and that turns out to
+decide which optimisations are worth attempting at all.
+
+Measured on a managed Kubernetes cluster (`Standard_E64ads_v5` class node, worker
+capped at 8 CPU by its cgroup), 64 KiB ranges, all cache hits, 32 connections at
+pipeline depth 16:
+
+| path | rps | GB/s | Gbps |
+|---|---|---|---|
+| loopback | 167,278 | 11.0 | 87.7 |
+| **cross-node** | **44,662** | **2.93** | **23.4** |
+
+Two findings, and they point the same way.
+
+**On loopback, 85% of the worker's CPU is kernel time** — `sendfile` copying
+bytes and the TCP stack — against 15% in Talon's own code, sampled from
+`utime`/`stime` in `/proc/<pid>/stat` across the measured window. Halving *all*
+of Talon's user-space work on the serve path would move total CPU by about 7%.
+Only changes that remove copies or syscalls act on the large share.
+
+**Across the network, the NIC binds first.** 23.4 Gbps against a 25 GbE link is
+the wire, saturated, at 27% of the loopback rate. On that cluster the worker is
+not the constraint at all.
+
+The consequence for anyone optimising here: **a change that moves the loopback
+number but not the cross-node number has not made the deployed system faster.**
+Loopback measures a component ceiling with the network taken out of the way; it
+is a useful instrument, not a capacity claim.
+
+Two results already follow from this. Pipelining — keeping requests in flight
+per connection rather than paying a round trip each — doubles cross-node
+throughput (22,315 → 44,592 rps), because it fills a link that was idling.
+Multiplexing, serving one connection's requests concurrently with out-of-order
+replies, was implemented and measured and **did not pay**: kernel time unchanged,
+user time up 12.6% for scheduling overhead, and max latency 99× worse, because
+two responses' bytes must never interleave and `sendfile` cannot be paused, so
+the write half must be held exclusively — reintroducing at the writer the
+serialisation it removes at the reader. It was not merged.
+
+[BENCHMARKS.md](../../BENCHMARKS.md) records the full tables, the method, and the
+conditions under which multiplexing could still be worth revisiting.
+
 ## Coexistence with Tokio
 
 Even on a ring, the worker is not Tokio-free, and the reason is worth stating.


### PR DESCRIPTION
Follow-up to #465, which recorded where the serve path saturates but put the results somewhere nobody would look for them.

## The problem

#465 landed the measurements in `BENCHMARKS.md`, which renders under **Contributing → Benchmarks** — a page about how to run the benchmark tooling. What those measurements establish is not tooling, it is an architectural conclusion:

- on loopback, **85% of the worker's CPU is kernel time** (`sendfile` + TCP stack), 15% is Talon's own code
- across nodes, the **NIC saturates at 23.4 Gbps** — 27% of the loopback rate — so on a real cluster the worker is not the constraint

Someone asking "what limits the serve path?" reads **Explanation → Data-plane runtime**, which discusses performance at length, compares both planes across a connection sweep, and mentioned none of it.

## The change

Adds a *What binds the serve path, once a plane is chosen* section to `docs/explanation/data-plane-runtime.md`, immediately after the plane-comparison tables it qualifies. It states both ceilings, the CPU split and how it was sampled, and the operative consequence:

> a change that moves the loopback number but not the cross-node number has not made the deployed system faster

It also summarises the two results that follow — pipelining doubles cross-node throughput; multiplexing was implemented, measured, and not merged — and links onward to `BENCHMARKS.md` for the full tables and method.

Two smaller discoverability fixes: the nav entry becomes "Benchmarks and measured ceilings", and the README pointer describes what the page now contains rather than just "the microbenchmark harness".

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)