### PR TITLE
bench: generate the data-plane charts from the recorded measurements

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -148,10 +148,14 @@ Tuning the ring count and connection count raises the peak further, on the same
 out of cores, because a single pipelined ring already spends 88% of its time in
 the kernel and additional rings contend for one shared network stack.
 
+![Throughput and CPU used across 1, 2, 4 and 8 io_uring rings](docs/assets/bench/ring-scaling.svg)
+
 CPU was sampled from `utime`/`stime` in `/proc/<pid>/stat` across the measured
 window. The split is the finding: **six sevenths of the worker's CPU is spent
 inside the kernel** — `sendfile` copying bytes and the TCP stack — and only one
 seventh in Talon's own code (frame decode, cache lookup, response assembly).
+
+![Worker CPU split: 85% kernel time, 15% Talon's own code](docs/assets/bench/cpu-split.svg)
 
 The practical consequence is that user-space optimizations on this path have a
 small denominator. Halving *all* of Talon's user-space work on the serve path
@@ -172,6 +176,8 @@ Cross-node throughput is **27% of the loopback rate at the same 32 connections**
 (24% of the 189,379 rps peak reached at 64 connections), and 23.4 Gbps against a
 25 GbE link is the wire, saturated. On this cluster the NIC runs out well before
 the worker does — the worker is not the constraint at all.
+
+![Loopback vs cross-node throughput against the 25 GbE line rate](docs/assets/bench/throughput-ceilings.svg)
 
 **Read the loopback number as a component ceiling, not a capacity claim.** It
 measures how fast the serve path can go when the network is free. Any change
@@ -240,13 +246,38 @@ which is the condition to test before revisiting it. It does not pay here.
   be compared against numbers here. When a candidate and its baseline both sit
   at a suspiciously equal ceiling, suspect the harness.
 
+## Charts
+
+The figures above are generated, not hand-drawn. `bench/data/dataplane.json`
+holds the measurements and is the single source of truth for both the charts and
+the tables on this page; `scripts/bench_charts.py` renders it to SVG:
+
+```sh
+just bench-charts           # re-render docs/assets/bench/*.svg
+just bench-charts --check   # non-zero exit if a chart is stale
+```
+
+Dependencies are declared inline (PEP 723), so `uv` builds a throwaway
+environment on demand — there is nothing to install and matplotlib is not a
+project dependency.
+
+**To record a new measurement, edit the JSON and re-run — never edit an SVG.**
+Keeping one source means a re-measurement cannot leave the charts saying one
+thing and the prose another. Output is byte-reproducible (fixed `svg.hashsalt`,
+no render timestamp), so an unchanged run produces no diff and `--check` is
+meaningful. `--check` renders to a scratch directory rather than the committed
+paths, so it reports drift instead of silently repairing it.
+
 ## For coding agents
 
-- One command surface: `just bench`, `just bench-save`, `just bench-check`.
+- One command surface: `just bench`, `just bench-save`, `just bench-check`,
+  `just bench-charts`.
 - `bench-check` output is a markdown table and its exit code is the verdict
   (0 = within threshold, 1 = regression). Parse either.
 - `bench/results/latest.json` and `bench/baselines/<name>.json` are stable
   `{ "binary::name[/arg]": median_ns }` maps for programmatic diffing.
+- `bench/data/dataplane.json` is the structured record of the data-plane
+  measurements — read numbers from there rather than parsing prose or SVGs.
 - Prefer scoping with `-p <crate>` while iterating; run the full suite before
   saving a baseline.
 

--- a/Justfile
+++ b/Justfile
@@ -89,6 +89,11 @@ bench-check *ARGS:
 bench-baseline NAME="main":
     @cat bench/baselines/{{NAME}}.json
 
+# Render the data-plane charts used in the README and docs from
+# bench/data/dataplane.json. Needs `uv` (deps are declared inline, PEP 723).
+bench-charts *ARGS:
+    uv run scripts/bench_charts.py {{ARGS}}
+
 # --- supply chain / coverage ---
 
 # Check the dependency tree for RUSTSEC advisories, banned crates, and unknown

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ before the cache does. Both numbers are published together, because a change
 that moves the loopback figure and not the cross-node one has not made anything
 faster ([how this is measured](BENCHMARKS.md)).
 
+![Loopback vs cross-node throughput against the 25 GbE line rate](docs/assets/bench/throughput-ceilings.svg)
+
 Read it through a FUSE mount:
 
 ```sh

--- a/bench/data/dataplane.json
+++ b/bench/data/dataplane.json
@@ -1,0 +1,85 @@
+{
+  "_comment": [
+    "Measured data-plane results, the source of truth for the charts rendered by",
+    "scripts/bench_charts.py and for the tables in BENCHMARKS.md.",
+    "",
+    "Host: managed Kubernetes, Standard_E64ads_v5 class node, worker capped at",
+    "8 CPU by its cgroup. 64 KiB ranges, all cache hits. Warmup excluded.",
+    "Regenerate the charts after editing: just bench-charts"
+  ],
+  "host": "Standard_E64ads_v5 class node, worker capped at 8 CPU (cgroup)",
+  "range_bytes": 65536,
+  "ring_scaling_depth16": {
+    "_comment": "8 rings, 64 connections, depth 16, 15 s after 5 s warmup. Peak reproduced within 1% (187,553 on a repeat run).",
+    "connections": 64,
+    "depth": 16,
+    "rows": [
+      {
+        "rings": 1,
+        "rps": 51718,
+        "cpu_cores": 1.0,
+        "kernel_share": 0.88
+      },
+      {
+        "rings": 2,
+        "rps": 71907,
+        "cpu_cores": 1.99,
+        "kernel_share": 0.88
+      },
+      {
+        "rings": 4,
+        "rps": 138144,
+        "cpu_cores": 3.98,
+        "kernel_share": 0.88
+      },
+      {
+        "rings": 8,
+        "rps": 189379,
+        "cpu_cores": 5.71,
+        "kernel_share": 0.89
+      }
+    ]
+  },
+  "loopback_vs_network": {
+    "_comment": "Same worker, 32 connections, depth 16, 20 s after 6 s warmup. Directly comparable to each other.",
+    "connections": 32,
+    "depth": 16,
+    "rows": [
+      {
+        "path": "loopback",
+        "rps": 167278,
+        "gbps": 87.7,
+        "p50_us": 4617.0,
+        "p99_us": 35244.2
+      },
+      {
+        "path": "cross-node",
+        "rps": 44662,
+        "gbps": 23.4,
+        "p50_us": 20269.2,
+        "p99_us": 49904.7
+      }
+    ],
+    "nic_line_rate_gbps": 25.0
+  },
+  "cpu_split_loopback": {
+    "_comment": "Sampled from utime/stime in /proc/<pid>/stat across the measured window, 32 connections.",
+    "kernel_ticks": 12873,
+    "user_ticks": 2206
+  },
+  "pipelining_cross_node": {
+    "_comment": "Cross-node, 32 connections. Depth is requests in flight per connection.",
+    "rows": [
+      {
+        "depth": 1,
+        "rps": 22315,
+        "p50_us": 762.1
+      },
+      {
+        "depth": 16,
+        "rps": 44592,
+        "p50_us": 20249.5
+      }
+    ]
+  }
+}

--- a/docs/assets/bench/cpu-split.svg
+++ b/docs/assets/bench/cpu-split.svg
@@ -1,0 +1,1297 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="493.482656pt" height="151.854828pt" viewBox="0 0 493.482656 151.854828" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 151.854828 
+L 493.482656 151.854828 
+L 493.482656 0 
+L 0 0 
+L 0 151.854828 
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 45.861328 127.654125 
+L 447.621328 127.654125 
+L 447.621328 22.318125 
+L 45.861328 22.318125 
+L 45.861328 127.654125 
+z
+" style="fill: none"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="text_1">
+     <!-- sendfile and the TCP stack (kernel) vs Talon's own code (user)  ·  loopback, sampled from /proc/&lt;pid&gt;/stat -->
+     <g style="fill: #8a94a6" transform="translate(7.2 142.492719) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-13af" d="M 3431 3500 
+L 3431 0 
+L 2853 0 
+L 2853 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4316 967 4589 
+Q 1238 4863 1797 4863 
+L 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 3431 3500 
+z
+M 2853 4856 
+L 3431 4856 
+L 3431 4128 
+L 2853 4128 
+L 2853 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-37" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-26" d="M 4122 4306 
+L 4122 3641 
+Q 3803 3938 3442 4084 
+Q 3081 4231 2675 4231 
+Q 1875 4231 1450 3742 
+Q 1025 3253 1025 2328 
+Q 1025 1406 1450 917 
+Q 1875 428 2675 428 
+Q 3081 428 3442 575 
+Q 3803 722 4122 1019 
+L 4122 359 
+Q 3791 134 3420 21 
+Q 3050 -91 2638 -91 
+Q 1578 -91 968 557 
+Q 359 1206 359 2328 
+Q 359 3453 968 4101 
+Q 1578 4750 2638 4750 
+Q 3056 4750 3426 4639 
+Q 3797 4528 4122 4306 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-33" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4e" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-59" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-a" d="M 1147 4666 
+L 1147 2931 
+L 616 2931 
+L 616 4666 
+L 1147 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5a" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-45" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-f" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-50" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-49" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-12" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-1f" d="M 4684 3150 
+L 1459 2003 
+L 4684 863 
+L 4684 294 
+L 678 1747 
+L 678 2266 
+L 4684 3719 
+L 4684 3150 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-21" d="M 678 3150 
+L 678 3719 
+L 4684 2266 
+L 4684 1747 
+L 678 294 
+L 678 863 
+L 3897 2003 
+L 678 3150 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-56"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(52.09375 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(113.625 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(177 0)"/>
+      <use xlink:href="#DejaVuSans-13af" transform="translate(240.484375 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(303.46875 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(331.25 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(392.78125 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(424.5625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(485.84375 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(549.21875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(612.703125 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(644.484375 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(683.6875 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(747.0625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(808.59375 0)"/>
+      <use xlink:href="#DejaVuSans-37" transform="translate(840.375 0)"/>
+      <use xlink:href="#DejaVuSans-26" transform="translate(895.59375 0)"/>
+      <use xlink:href="#DejaVuSans-33" transform="translate(965.421875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(1025.71875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1057.5 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(1109.59375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(1148.796875 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(1210.078125 0)"/>
+      <use xlink:href="#DejaVuSans-4e" transform="translate(1265.0625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(1322.96875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(1354.75 0)"/>
+      <use xlink:href="#DejaVuSans-4e" transform="translate(1393.765625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(1448.109375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(1509.640625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(1549 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(1612.375 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(1673.90625 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(1701.6875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(1740.703125 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(1772.484375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1831.671875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(1883.765625 0)"/>
+      <use xlink:href="#DejaVuSans-37" transform="translate(1915.546875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(1960.078125 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(2021.359375 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2049.140625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(2110.328125 0)"/>
+      <use xlink:href="#DejaVuSans-a" transform="translate(2173.703125 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(2201.1875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2253.28125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2285.0625 0)"/>
+      <use xlink:href="#DejaVuSans-5a" transform="translate(2346.25 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(2428.03125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2491.40625 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(2523.1875 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2578.171875 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(2639.359375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(2702.84375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2764.375 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(2796.15625 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(2835.171875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(2898.546875 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(2950.640625 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(3012.171875 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(3053.28125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(3092.296875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(3124.078125 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(3155.859375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(3187.640625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(3219.421875 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(3251.203125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(3278.984375 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(3340.171875 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(3401.359375 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(3464.84375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(3528.328125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(3589.609375 0)"/>
+      <use xlink:href="#DejaVuSans-4e" transform="translate(3644.59375 0)"/>
+      <use xlink:href="#DejaVuSans-f" transform="translate(3702.5 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(3734.28125 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(3766.0625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(3818.15625 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(3879.4375 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(3976.84375 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(4040.328125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(4068.109375 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(4129.640625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(4193.125 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(4224.90625 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(4260.109375 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(4299.015625 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(4360.203125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(4457.609375 0)"/>
+      <use xlink:href="#DejaVuSans-12" transform="translate(4489.390625 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(4523.078125 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(4586.5625 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(4625.46875 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(4686.65625 0)"/>
+      <use xlink:href="#DejaVuSans-12" transform="translate(4741.640625 0)"/>
+      <use xlink:href="#DejaVuSans-1f" transform="translate(4775.328125 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(4859.125 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(4922.609375 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(4950.390625 0)"/>
+      <use xlink:href="#DejaVuSans-21" transform="translate(5013.875 0)"/>
+      <use xlink:href="#DejaVuSans-12" transform="translate(5097.671875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(5131.359375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(5183.453125 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(5222.65625 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(5283.9375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2"/>
+   <g id="patch_3">
+    <path d="M 45.861328 122.866125 
+L 388.845377 122.866125 
+L 388.845377 27.106125 
+L 45.861328 27.106125 
+z
+" clip-path="url(#p7d07f739ed)" style="fill: #e07a3f"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 388.845377 122.866125 
+L 447.621328 122.866125 
+L 447.621328 27.106125 
+L 388.845377 27.106125 
+z
+" clip-path="url(#p7d07f739ed)" style="fill: #2f6df6"/>
+   </g>
+   <g id="text_2">
+    <!-- kernel  85% -->
+    <g style="fill: #ffffff" transform="translate(184.191634 77.584172) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-Bold-4e" d="M 538 4863 
+L 1656 4863 
+L 1656 2216 
+L 2944 3500 
+L 4244 3500 
+L 2534 1894 
+L 4378 0 
+L 3022 0 
+L 1656 1459 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-48" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-55" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-51" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-4f" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-3" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-1b" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-18" d="M 678 4666 
+L 3669 4666 
+L 3669 3781 
+L 1638 3781 
+L 1638 3059 
+Q 1775 3097 1914 3117 
+Q 2053 3138 2203 3138 
+Q 3056 3138 3531 2711 
+Q 4006 2284 4006 1522 
+Q 4006 766 3489 337 
+Q 2972 -91 2053 -91 
+Q 1656 -91 1267 -14 
+Q 878 63 494 219 
+L 494 1166 
+Q 875 947 1217 837 
+Q 1559 728 1863 728 
+Q 2300 728 2551 942 
+Q 2803 1156 2803 1522 
+Q 2803 1891 2551 2103 
+Q 2300 2316 1863 2316 
+Q 1603 2316 1309 2248 
+Q 1016 2181 678 2041 
+L 678 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-8" d="M 4959 1925 
+Q 4738 1925 4616 1733 
+Q 4494 1541 4494 1184 
+Q 4494 825 4614 633 
+Q 4734 441 4959 441 
+Q 5184 441 5303 633 
+Q 5422 825 5422 1184 
+Q 5422 1541 5301 1733 
+Q 5181 1925 4959 1925 
+z
+M 4959 2450 
+Q 5541 2450 5875 2112 
+Q 6209 1775 6209 1184 
+Q 6209 594 5875 251 
+Q 5541 -91 4959 -91 
+Q 4378 -91 4042 251 
+Q 3706 594 3706 1184 
+Q 3706 1772 4042 2111 
+Q 4378 2450 4959 2450 
+z
+M 2094 -91 
+L 1403 -91 
+L 4319 4750 
+L 5013 4750 
+L 2094 -91 
+z
+M 1453 4750 
+Q 2034 4750 2367 4411 
+Q 2700 4072 2700 3481 
+Q 2700 2891 2367 2550 
+Q 2034 2209 1453 2209 
+Q 872 2209 539 2550 
+Q 206 2891 206 3481 
+Q 206 4072 539 4411 
+Q 872 4750 1453 4750 
+z
+M 1453 4225 
+Q 1228 4225 1106 4031 
+Q 984 3838 984 3481 
+Q 984 3122 1106 2926 
+Q 1228 2731 1453 2731 
+Q 1678 2731 1798 2926 
+Q 1919 3122 1919 3481 
+Q 1919 3838 1797 4031 
+Q 1675 4225 1453 4225 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-4e"/>
+     <use xlink:href="#DejaVuSans-Bold-48" transform="translate(63.8125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-55" transform="translate(131.640625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-51" transform="translate(180.953125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-48" transform="translate(252.140625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4f" transform="translate(319.96875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(354.25 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(389.0625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-1b" transform="translate(423.875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-18" transform="translate(493.453125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-8" transform="translate(563.03125 0)"/>
+    </g>
+   </g>
+   <g id="text_3">
+    <!-- 15% -->
+    <g style="fill: #ffffff" transform="translate(406.265384 77.583781) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-Bold-14" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-14"/>
+     <use xlink:href="#DejaVuSans-Bold-18" transform="translate(69.578125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-8" transform="translate(139.15625 0)"/>
+    </g>
+   </g>
+   <g id="text_4">
+    <!-- Where a serving worker's CPU goes -->
+    <g style="fill: #1b2733" transform="translate(126.507891 16.318125) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-Bold-3a" d="M 191 4666 
+L 1344 4666 
+L 2150 1275 
+L 2950 4666 
+L 4109 4666 
+L 4909 1275 
+L 5716 4666 
+L 6859 4666 
+L 5759 0 
+L 4372 0 
+L 3525 3547 
+L 2688 0 
+L 1300 0 
+L 191 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-4b" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1625 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-44" d="M 2106 1575 
+Q 1756 1575 1579 1456 
+Q 1403 1338 1403 1106 
+Q 1403 894 1545 773 
+Q 1688 653 1941 653 
+Q 2256 653 2472 879 
+Q 2688 1106 2688 1447 
+L 2688 1575 
+L 2106 1575 
+z
+M 3816 1997 
+L 3816 0 
+L 2688 0 
+L 2688 519 
+Q 2463 200 2181 54 
+Q 1900 -91 1497 -91 
+Q 953 -91 614 226 
+Q 275 544 275 1050 
+Q 275 1666 698 1953 
+Q 1122 2241 2028 2241 
+L 2688 2241 
+L 2688 2328 
+Q 2688 2594 2478 2717 
+Q 2269 2841 1825 2841 
+Q 1466 2841 1156 2769 
+Q 847 2697 581 2553 
+L 581 3406 
+Q 941 3494 1303 3539 
+Q 1666 3584 2028 3584 
+Q 2975 3584 3395 3211 
+Q 3816 2838 3816 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-56" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-59" d="M 97 3500 
+L 1216 3500 
+L 2088 1081 
+L 2956 3500 
+L 4078 3500 
+L 2700 0 
+L 1472 0 
+L 97 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-4c" d="M 538 3500 
+L 1656 3500 
+L 1656 0 
+L 538 0 
+L 538 3500 
+z
+M 538 4863 
+L 1656 4863 
+L 1656 3950 
+L 538 3950 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-4a" d="M 2919 594 
+Q 2688 288 2409 144 
+Q 2131 0 1766 0 
+Q 1125 0 706 504 
+Q 288 1009 288 1791 
+Q 288 2575 706 3076 
+Q 1125 3578 1766 3578 
+Q 2131 3578 2409 3434 
+Q 2688 3291 2919 2981 
+L 2919 3500 
+L 4044 3500 
+L 4044 353 
+Q 4044 -491 3511 -936 
+Q 2978 -1381 1966 -1381 
+Q 1638 -1381 1331 -1331 
+Q 1025 -1281 716 -1178 
+L 716 -306 
+Q 1009 -475 1290 -558 
+Q 1572 -641 1856 -641 
+Q 2406 -641 2662 -400 
+Q 2919 -159 2919 353 
+L 2919 594 
+z
+M 2181 2772 
+Q 1834 2772 1640 2515 
+Q 1447 2259 1447 1791 
+Q 1447 1309 1634 1061 
+Q 1822 813 2181 813 
+Q 2531 813 2725 1069 
+Q 2919 1325 2919 1791 
+Q 2919 2259 2725 2515 
+Q 2531 2772 2181 2772 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-5a" d="M 225 3500 
+L 1313 3500 
+L 1900 1088 
+L 2491 3500 
+L 3425 3500 
+L 4013 1113 
+L 4603 3500 
+L 5691 3500 
+L 4769 0 
+L 3547 0 
+L 2956 2406 
+L 2369 0 
+L 1147 0 
+L 225 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-52" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-a" d="M 1350 4666 
+L 1350 2931 
+L 609 2931 
+L 609 4666 
+L 1350 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-26" d="M 4288 256 
+Q 3956 84 3597 -3 
+Q 3238 -91 2847 -91 
+Q 1681 -91 1000 561 
+Q 319 1213 319 2328 
+Q 319 3447 1000 4098 
+Q 1681 4750 2847 4750 
+Q 3238 4750 3597 4662 
+Q 3956 4575 4288 4403 
+L 4288 3438 
+Q 3953 3666 3628 3772 
+Q 3303 3878 2944 3878 
+Q 2300 3878 1931 3465 
+Q 1563 3053 1563 2328 
+Q 1563 1606 1931 1193 
+Q 2300 781 2944 781 
+Q 3303 781 3628 887 
+Q 3953 994 4288 1222 
+L 4288 256 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-33" d="M 588 4666 
+L 2584 4666 
+Q 3475 4666 3951 4270 
+Q 4428 3875 4428 3144 
+Q 4428 2409 3951 2014 
+Q 3475 1619 2584 1619 
+L 1791 1619 
+L 1791 0 
+L 588 0 
+L 588 4666 
+z
+M 1791 3794 
+L 1791 2491 
+L 2456 2491 
+Q 2806 2491 2997 2661 
+Q 3188 2831 3188 3144 
+Q 3188 3456 2997 3625 
+Q 2806 3794 2456 3794 
+L 1791 3794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-38" d="M 588 4666 
+L 1791 4666 
+L 1791 1869 
+Q 1791 1291 1980 1042 
+Q 2169 794 2597 794 
+Q 3028 794 3217 1042 
+Q 3406 1291 3406 1869 
+L 3406 4666 
+L 4609 4666 
+L 4609 1869 
+Q 4609 878 4112 393 
+Q 3616 -91 2597 -91 
+Q 1581 -91 1084 393 
+Q 588 878 588 1869 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-3a"/>
+     <use xlink:href="#DejaVuSans-Bold-4b" transform="translate(110.296875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-48" transform="translate(181.484375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-55" transform="translate(249.3125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-48" transform="translate(298.625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(366.453125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-44" transform="translate(401.265625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(468.75 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-56" transform="translate(503.5625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-48" transform="translate(563.078125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-55" transform="translate(630.90625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-59" transform="translate(680.21875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4c" transform="translate(745.40625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-51" transform="translate(779.6875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4a" transform="translate(850.875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(922.453125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-5a" transform="translate(957.265625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-52" transform="translate(1049.65625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-55" transform="translate(1118.359375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4e" transform="translate(1167.671875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-48" transform="translate(1231.484375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-55" transform="translate(1299.3125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-a" transform="translate(1348.625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-56" transform="translate(1379.234375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(1438.75 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-26" transform="translate(1473.5625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(1546.953125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(1620.25 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(1701.453125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4a" transform="translate(1736.265625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-52" transform="translate(1807.84375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-48" transform="translate(1876.546875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-56" transform="translate(1944.375 0)"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p7d07f739ed">
+   <rect x="45.861328" y="22.318125" width="401.76" height="105.336"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/bench/ring-scaling.svg
+++ b/docs/assets/bench/ring-scaling.svg
@@ -1,0 +1,1810 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="462.806094pt" height="318.542828pt" viewBox="0 0 462.806094 318.542828" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 318.542828 
+L 462.806094 318.542828 
+L 462.806094 0 
+L 0 0 
+L 0 318.542828 
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 53.846094 179.371028 
+L 455.606094 179.371028 
+L 455.606094 22.318125 
+L 53.846094 22.318125 
+L 53.846094 179.371028 
+z
+" style="fill: none"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 95.927675 179.371028 
+L 95.927675 22.318125 
+" clip-path="url(#pd323f5bb14)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="mfafd3f774d" d="M 0 0 
+L 0 3.5 
+" style="stroke: #8a94a6; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mfafd3f774d" x="95.927675" y="179.371028" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 201.793287 179.371028 
+L 201.793287 22.318125 
+" clip-path="url(#pd323f5bb14)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mfafd3f774d" x="201.793287" y="179.371028" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 307.6589 179.371028 
+L 307.6589 22.318125 
+" clip-path="url(#pd323f5bb14)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mfafd3f774d" x="307.6589" y="179.371028" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 413.524513 179.371028 
+L 413.524513 22.318125 
+" clip-path="url(#pd323f5bb14)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mfafd3f774d" x="413.524513" y="179.371028" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_9">
+      <path d="M 53.846094 179.371028 
+L 455.606094 179.371028 
+" clip-path="url(#pd323f5bb14)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <defs>
+       <path id="m07b9d8374b" d="M 0 0 
+L -3.5 0 
+" style="stroke: #8a94a6; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m07b9d8374b" x="53.846094" y="179.371028" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0K -->
+      <g style="fill: #8a94a6" transform="translate(33.925781 183.169856) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-13" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2e" d="M 628 4666 
+L 1259 4666 
+L 1259 2694 
+L 3353 4666 
+L 4166 4666 
+L 1850 2491 
+L 4331 0 
+L 3500 0 
+L 1259 2247 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_11">
+      <path d="M 53.846094 145.383129 
+L 455.606094 145.383129 
+" clip-path="url(#pd323f5bb14)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m07b9d8374b" x="53.846094" y="145.383129" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 50K -->
+      <g style="fill: #8a94a6" transform="translate(27.563281 149.181957) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-18" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-18"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_13">
+      <path d="M 53.846094 111.395229 
+L 455.606094 111.395229 
+" clip-path="url(#pd323f5bb14)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m07b9d8374b" x="53.846094" y="111.395229" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 100K -->
+      <g style="fill: #8a94a6" transform="translate(21.200781 115.194058) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_15">
+      <path d="M 53.846094 77.40733 
+L 455.606094 77.40733 
+" clip-path="url(#pd323f5bb14)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m07b9d8374b" x="53.846094" y="77.40733" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 150K -->
+      <g style="fill: #8a94a6" transform="translate(21.200781 81.206158) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_17">
+      <path d="M 53.846094 43.419431 
+L 455.606094 43.419431 
+" clip-path="url(#pd323f5bb14)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m07b9d8374b" x="53.846094" y="43.419431" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 200K -->
+      <g style="fill: #8a94a6" transform="translate(21.200781 47.218259) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-2e" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_6">
+     <!-- reads/s -->
+     <g style="fill: #1b2733" transform="translate(14.798438 118.998483) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-12" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-55"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(38.90625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(100.4375 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(161.71875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(225.203125 0)"/>
+      <use xlink:href="#DejaVuSans-12" transform="translate(277.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(310.984375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 53.846094 179.371028 
+L 53.846094 22.318125 
+" style="fill: none; stroke: #8a94a6; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 53.846094 179.371028 
+L 455.606094 179.371028 
+" style="fill: none; stroke: #8a94a6; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_19">
+    <path d="M 95.927675 144.215305 
+L 201.793287 130.491671 
+L 307.6589 85.466541 
+L 413.524513 50.63914 
+" clip-path="url(#pd323f5bb14)" style="fill: none; stroke: #2f6df6; stroke-width: 2.2; stroke-linecap: square"/>
+    <defs>
+     <path id="m62e3f529fb" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+" style="stroke: #2f6df6"/>
+    </defs>
+    <g clip-path="url(#pd323f5bb14)">
+     <use xlink:href="#m62e3f529fb" x="95.927675" y="144.215305" style="fill: #2f6df6; stroke: #2f6df6"/>
+     <use xlink:href="#m62e3f529fb" x="201.793287" y="130.491671" style="fill: #2f6df6; stroke: #2f6df6"/>
+     <use xlink:href="#m62e3f529fb" x="307.6589" y="85.466541" style="fill: #2f6df6; stroke: #2f6df6"/>
+     <use xlink:href="#m62e3f529fb" x="413.524513" y="50.63914" style="fill: #2f6df6; stroke: #2f6df6"/>
+    </g>
+   </g>
+   <g id="text_7">
+    <!-- 51,718 -->
+    <g style="fill: #1b2733" transform="translate(80.181894 136.215305) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-f" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-1a" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-1b" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-18"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(159.03125 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(286.28125 0)"/>
+    </g>
+   </g>
+   <g id="text_8">
+    <!-- 71,907 -->
+    <g style="fill: #1b2733" transform="translate(186.047506 122.491671) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-1c" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-1a"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(159.03125 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(286.28125 0)"/>
+    </g>
+   </g>
+   <g id="text_9">
+    <!-- 138,144 -->
+    <g style="fill: #1b2733" transform="translate(289.049994 77.466541) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-16" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-17" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-14"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(190.875 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(286.28125 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(349.90625 0)"/>
+    </g>
+   </g>
+   <g id="text_10">
+    <!-- 189,379 -->
+    <g style="fill: #1b2733" transform="translate(394.915606 42.63914) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-14"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(190.875 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(286.28125 0)"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(349.90625 0)"/>
+    </g>
+   </g>
+   <g id="text_11">
+    <!-- Throughput scales with rings; CPU stops short of the cap -->
+    <g style="fill: #1b2733" transform="translate(61.313281 16.318125) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-Bold-37" d="M 31 4666 
+L 4331 4666 
+L 4331 3756 
+L 2784 3756 
+L 2784 0 
+L 1581 0 
+L 1581 3756 
+L 31 3756 
+L 31 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-4b" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1625 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-55" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-52" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-58" d="M 500 1363 
+L 500 3500 
+L 1625 3500 
+L 1625 3150 
+Q 1625 2866 1622 2436 
+Q 1619 2006 1619 1863 
+Q 1619 1441 1641 1255 
+Q 1663 1069 1716 984 
+Q 1784 875 1895 815 
+Q 2006 756 2150 756 
+Q 2500 756 2700 1025 
+Q 2900 1294 2900 1772 
+L 2900 3500 
+L 4019 3500 
+L 4019 0 
+L 2900 0 
+L 2900 506 
+Q 2647 200 2364 54 
+Q 2081 -91 1741 -91 
+Q 1134 -91 817 281 
+Q 500 653 500 1363 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-4a" d="M 2919 594 
+Q 2688 288 2409 144 
+Q 2131 0 1766 0 
+Q 1125 0 706 504 
+Q 288 1009 288 1791 
+Q 288 2575 706 3076 
+Q 1125 3578 1766 3578 
+Q 2131 3578 2409 3434 
+Q 2688 3291 2919 2981 
+L 2919 3500 
+L 4044 3500 
+L 4044 353 
+Q 4044 -491 3511 -936 
+Q 2978 -1381 1966 -1381 
+Q 1638 -1381 1331 -1331 
+Q 1025 -1281 716 -1178 
+L 716 -306 
+Q 1009 -475 1290 -558 
+Q 1572 -641 1856 -641 
+Q 2406 -641 2662 -400 
+Q 2919 -159 2919 353 
+L 2919 594 
+z
+M 2181 2772 
+Q 1834 2772 1640 2515 
+Q 1447 2259 1447 1791 
+Q 1447 1309 1634 1061 
+Q 1822 813 2181 813 
+Q 2531 813 2725 1069 
+Q 2919 1325 2919 1791 
+Q 2919 2259 2725 2515 
+Q 2531 2772 2181 2772 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-53" d="M 1656 506 
+L 1656 -1331 
+L 538 -1331 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+z
+M 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-57" d="M 1759 4494 
+L 1759 3500 
+L 2913 3500 
+L 2913 2700 
+L 1759 2700 
+L 1759 1216 
+Q 1759 972 1856 886 
+Q 1953 800 2241 800 
+L 2816 800 
+L 2816 0 
+L 1856 0 
+Q 1194 0 917 276 
+Q 641 553 641 1216 
+L 641 2700 
+L 84 2700 
+L 84 3500 
+L 641 3500 
+L 641 4494 
+L 1759 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-3" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-56" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-46" d="M 3366 3391 
+L 3366 2478 
+Q 3138 2634 2908 2709 
+Q 2678 2784 2431 2784 
+Q 1963 2784 1702 2511 
+Q 1441 2238 1441 1747 
+Q 1441 1256 1702 982 
+Q 1963 709 2431 709 
+Q 2694 709 2930 787 
+Q 3166 866 3366 1019 
+L 3366 103 
+Q 3103 6 2833 -42 
+Q 2563 -91 2291 -91 
+Q 1344 -91 809 395 
+Q 275 881 275 1747 
+Q 275 2613 809 3098 
+Q 1344 3584 2291 3584 
+Q 2566 3584 2833 3536 
+Q 3100 3488 3366 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-44" d="M 2106 1575 
+Q 1756 1575 1579 1456 
+Q 1403 1338 1403 1106 
+Q 1403 894 1545 773 
+Q 1688 653 1941 653 
+Q 2256 653 2472 879 
+Q 2688 1106 2688 1447 
+L 2688 1575 
+L 2106 1575 
+z
+M 3816 1997 
+L 3816 0 
+L 2688 0 
+L 2688 519 
+Q 2463 200 2181 54 
+Q 1900 -91 1497 -91 
+Q 953 -91 614 226 
+Q 275 544 275 1050 
+Q 275 1666 698 1953 
+Q 1122 2241 2028 2241 
+L 2688 2241 
+L 2688 2328 
+Q 2688 2594 2478 2717 
+Q 2269 2841 1825 2841 
+Q 1466 2841 1156 2769 
+Q 847 2697 581 2553 
+L 581 3406 
+Q 941 3494 1303 3539 
+Q 1666 3584 2028 3584 
+Q 2975 3584 3395 3211 
+Q 3816 2838 3816 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-4f" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-48" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-5a" d="M 225 3500 
+L 1313 3500 
+L 1900 1088 
+L 2491 3500 
+L 3425 3500 
+L 4013 1113 
+L 4603 3500 
+L 5691 3500 
+L 4769 0 
+L 3547 0 
+L 2956 2406 
+L 2369 0 
+L 1147 0 
+L 225 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-4c" d="M 538 3500 
+L 1656 3500 
+L 1656 0 
+L 538 0 
+L 538 3500 
+z
+M 538 4863 
+L 1656 4863 
+L 1656 3950 
+L 538 3950 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-51" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-1e" d="M 716 1209 
+L 1844 1209 
+L 1844 256 
+L 1069 -909 
+L 403 -909 
+L 716 256 
+L 716 1209 
+z
+M 716 3500 
+L 1844 3500 
+L 1844 2291 
+L 716 2291 
+L 716 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-26" d="M 4288 256 
+Q 3956 84 3597 -3 
+Q 3238 -91 2847 -91 
+Q 1681 -91 1000 561 
+Q 319 1213 319 2328 
+Q 319 3447 1000 4098 
+Q 1681 4750 2847 4750 
+Q 3238 4750 3597 4662 
+Q 3956 4575 4288 4403 
+L 4288 3438 
+Q 3953 3666 3628 3772 
+Q 3303 3878 2944 3878 
+Q 2300 3878 1931 3465 
+Q 1563 3053 1563 2328 
+Q 1563 1606 1931 1193 
+Q 2300 781 2944 781 
+Q 3303 781 3628 887 
+Q 3953 994 4288 1222 
+L 4288 256 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-33" d="M 588 4666 
+L 2584 4666 
+Q 3475 4666 3951 4270 
+Q 4428 3875 4428 3144 
+Q 4428 2409 3951 2014 
+Q 3475 1619 2584 1619 
+L 1791 1619 
+L 1791 0 
+L 588 0 
+L 588 4666 
+z
+M 1791 3794 
+L 1791 2491 
+L 2456 2491 
+Q 2806 2491 2997 2661 
+Q 3188 2831 3188 3144 
+Q 3188 3456 2997 3625 
+Q 2806 3794 2456 3794 
+L 1791 3794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-38" d="M 588 4666 
+L 1791 4666 
+L 1791 1869 
+Q 1791 1291 1980 1042 
+Q 2169 794 2597 794 
+Q 3028 794 3217 1042 
+Q 3406 1291 3406 1869 
+L 3406 4666 
+L 4609 4666 
+L 4609 1869 
+Q 4609 878 4112 393 
+Q 3616 -91 2597 -91 
+Q 1581 -91 1084 393 
+Q 588 878 588 1869 
+L 588 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-49" d="M 2841 4863 
+L 2841 4128 
+L 2222 4128 
+Q 1984 4128 1890 4042 
+Q 1797 3956 1797 3744 
+L 1797 3500 
+L 2753 3500 
+L 2753 2700 
+L 1797 2700 
+L 1797 0 
+L 678 0 
+L 678 2700 
+L 122 2700 
+L 122 3500 
+L 678 3500 
+L 678 3744 
+Q 678 4316 997 4589 
+Q 1316 4863 1984 4863 
+L 2841 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-37"/>
+     <use xlink:href="#DejaVuSans-Bold-4b" transform="translate(68.21875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-55" transform="translate(139.40625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-52" transform="translate(188.71875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-58" transform="translate(257.421875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4a" transform="translate(328.609375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4b" transform="translate(400.1875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-53" transform="translate(471.375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-58" transform="translate(542.953125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-57" transform="translate(614.140625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(661.9375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-56" transform="translate(696.75 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-46" transform="translate(756.265625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-44" transform="translate(815.546875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4f" transform="translate(883.03125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-48" transform="translate(917.3125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-56" transform="translate(985.140625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(1044.65625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-5a" transform="translate(1079.46875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4c" transform="translate(1171.859375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-57" transform="translate(1206.140625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4b" transform="translate(1253.9375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(1325.125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-55" transform="translate(1359.9375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4c" transform="translate(1409.25 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-51" transform="translate(1443.53125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4a" transform="translate(1514.71875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-56" transform="translate(1586.296875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-1e" transform="translate(1645.8125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(1685.796875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-26" transform="translate(1720.609375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(1794 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(1867.296875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(1948.5 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-56" transform="translate(1983.3125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-57" transform="translate(2042.828125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-52" transform="translate(2090.625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-53" transform="translate(2159.328125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-56" transform="translate(2230.90625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(2290.421875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-56" transform="translate(2325.234375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4b" transform="translate(2384.75 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-52" transform="translate(2455.9375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-55" transform="translate(2524.640625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-57" transform="translate(2573.953125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(2621.75 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-52" transform="translate(2656.5625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-49" transform="translate(2725.265625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(2768.765625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-57" transform="translate(2803.578125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4b" transform="translate(2851.375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-48" transform="translate(2922.5625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(2990.390625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-46" transform="translate(3025.203125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-44" transform="translate(3084.484375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-53" transform="translate(3151.96875 0)"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_5">
+    <path d="M 53.846094 277.342125 
+L 455.606094 277.342125 
+L 455.606094 202.555028 
+L 53.846094 202.555028 
+L 53.846094 277.342125 
+z
+" style="fill: none"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_5">
+     <g id="line2d_20">
+      <path d="M 95.927675 277.342125 
+L 95.927675 202.555028 
+" clip-path="url(#pb410ce0b08)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#mfafd3f774d" x="95.927675" y="277.342125" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 1 -->
+      <g style="fill: #8a94a6" transform="translate(92.746425 291.939781) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_22">
+      <path d="M 201.793287 277.342125 
+L 201.793287 202.555028 
+" clip-path="url(#pb410ce0b08)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#mfafd3f774d" x="201.793287" y="277.342125" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 2 -->
+      <g style="fill: #8a94a6" transform="translate(198.612037 291.939781) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_24">
+      <path d="M 307.6589 277.342125 
+L 307.6589 202.555028 
+" clip-path="url(#pb410ce0b08)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#mfafd3f774d" x="307.6589" y="277.342125" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 4 -->
+      <g style="fill: #8a94a6" transform="translate(304.47765 291.939781) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_26">
+      <path d="M 413.524513 277.342125 
+L 413.524513 202.555028 
+" clip-path="url(#pb410ce0b08)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#mfafd3f774d" x="413.524513" y="277.342125" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 8 -->
+      <g style="fill: #8a94a6" transform="translate(410.343263 291.939781) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-1b"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_16">
+     <!-- io_uring rings  ·  64 connections, depth 16  ·  peak leaves 2 of 8 cores idle -->
+     <g style="fill: #8a94a6" transform="translate(88.112188 309.180719) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-42" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4a" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4e" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-59" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-49" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-4c"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(27.78125 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(88.96875 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(138.96875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(202.34375 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(243.453125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(271.234375 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(334.609375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(398.09375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(429.875 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(470.984375 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(498.765625 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(562.140625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(625.625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(677.71875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(709.5 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(741.28125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(773.0625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(804.84375 0)"/>
+      <use xlink:href="#DejaVuSans-19" transform="translate(836.625 0)"/>
+      <use xlink:href="#DejaVuSans-17" transform="translate(900.25 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(963.875 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(995.65625 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(1050.640625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(1111.828125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(1175.203125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(1238.578125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(1300.109375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(1355.09375 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(1394.296875 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(1422.078125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(1483.265625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1546.640625 0)"/>
+      <use xlink:href="#DejaVuSans-f" transform="translate(1598.734375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(1630.515625 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(1662.296875 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(1725.78125 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(1787.3125 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(1850.796875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(1890 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(1953.375 0)"/>
+      <use xlink:href="#DejaVuSans-14" transform="translate(1985.15625 0)"/>
+      <use xlink:href="#DejaVuSans-19" transform="translate(2048.78125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2112.40625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2144.1875 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(2175.96875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2207.75 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2239.53125 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(2271.3125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(2334.796875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(2396.328125 0)"/>
+      <use xlink:href="#DejaVuSans-4e" transform="translate(2457.609375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2515.515625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(2547.296875 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(2575.078125 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(2636.609375 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(2697.890625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(2757.078125 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(2818.609375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2870.703125 0)"/>
+      <use xlink:href="#DejaVuSans-15" transform="translate(2902.484375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2966.109375 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2997.890625 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(3059.078125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(3094.28125 0)"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(3126.0625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(3189.6875 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(3221.46875 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(3276.453125 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(3337.640625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(3376.546875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(3438.078125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(3490.171875 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(3521.953125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(3549.734375 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(3613.21875 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(3641 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_6">
+     <g id="line2d_28">
+      <path d="M 53.846094 277.342125 
+L 455.606094 277.342125 
+" clip-path="url(#pb410ce0b08)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m07b9d8374b" x="53.846094" y="277.342125" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 0 -->
+      <g style="fill: #8a94a6" transform="translate(40.483594 281.140953) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_30">
+      <path d="M 53.846094 238.390512 
+L 455.606094 238.390512 
+" clip-path="url(#pb410ce0b08)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m07b9d8374b" x="53.846094" y="238.390512" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 5 -->
+      <g style="fill: #8a94a6" transform="translate(40.483594 242.18934) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-18"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_19">
+     <!-- cores used -->
+     <g style="fill: #1b2733" transform="translate(34.08125 266.997014) rotate(-90) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-46"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(54.984375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(116.171875 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(155.078125 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(216.609375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(268.703125 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(300.484375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(363.859375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(415.953125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(477.484375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 53.846094 277.342125 
+L 53.846094 202.555028 
+" style="fill: none; stroke: #8a94a6; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 53.846094 277.342125 
+L 455.606094 277.342125 
+" style="fill: none; stroke: #8a94a6; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 72.107912 277.342125 
+L 119.747438 277.342125 
+L 119.747438 269.551802 
+L 72.107912 269.551802 
+z
+" clip-path="url(#pb410ce0b08)" style="fill: #8a94a6"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 177.973525 277.342125 
+L 225.61305 277.342125 
+L 225.61305 261.839383 
+L 177.973525 261.839383 
+z
+" clip-path="url(#pb410ce0b08)" style="fill: #8a94a6"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 283.839137 277.342125 
+L 331.478663 277.342125 
+L 331.478663 246.336641 
+L 283.839137 246.336641 
+z
+" clip-path="url(#pb410ce0b08)" style="fill: #8a94a6"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 389.70475 277.342125 
+L 437.344276 277.342125 
+L 437.344276 232.859383 
+L 389.70475 232.859383 
+z
+" clip-path="url(#pb410ce0b08)" style="fill: #8a94a6"/>
+   </g>
+   <g id="text_20">
+    <!-- 1.00 -->
+    <g style="fill: #1b2733" transform="translate(86.464784 265.551802) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-14"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 1.99 -->
+    <g style="fill: #1b2733" transform="translate(192.330397 257.839383) scale(0.085 -0.085)">
+     <use xlink:href="#DejaVuSans-14"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(159.03125 0)"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 3.98 -->
+    <g style="fill: #1b2733" transform="translate(298.196009 242.336641) scale(0.085 -0.085)">
+     <use xlink:href="#DejaVuSans-16"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(159.03125 0)"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 5.71 -->
+    <g style="fill: #1b2733" transform="translate(404.061622 228.859383) scale(0.085 -0.085)">
+     <use xlink:href="#DejaVuSans-18"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(159.03125 0)"/>
+    </g>
+   </g>
+   <g id="line2d_32">
+    <path d="M 53.846094 215.019544 
+L 455.606094 215.019544 
+" clip-path="url(#pb410ce0b08)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #d1495b; stroke-width: 1.4"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pd323f5bb14">
+   <rect x="53.846094" y="22.318125" width="401.76" height="157.052903"/>
+  </clipPath>
+  <clipPath id="pb410ce0b08">
+   <rect x="53.846094" y="202.555028" width="401.76" height="74.787097"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/bench/throughput-ceilings.svg
+++ b/docs/assets/bench/throughput-ceilings.svg
@@ -1,0 +1,1522 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="558.617344pt" height="265.103609pt" viewBox="0 0 558.617344 265.103609" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 265.103609 
+L 558.617344 265.103609 
+L 558.617344 0 
+L 0 0 
+L 0 265.103609 
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 78.428672 221.902125 
+L 480.188672 221.902125 
+L 480.188672 22.318125 
+L 78.428672 22.318125 
+L 78.428672 221.902125 
+z
+" style="fill: none"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 157.563217 221.902125 
+L 157.563217 22.318125 
+" clip-path="url(#pddf3f87696)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="mfafd3f774d" d="M 0 0 
+L 0 3.5 
+" style="stroke: #8a94a6; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mfafd3f774d" x="157.563217" y="221.902125" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- loopback -->
+      <g style="fill: #8a94a6" transform="translate(134.998374 236.500563) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-45" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4e" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-4f"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(27.78125 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(88.96875 0)"/>
+       <use xlink:href="#DejaVuSans-53" transform="translate(150.15625 0)"/>
+       <use xlink:href="#DejaVuSans-45" transform="translate(213.640625 0)"/>
+       <use xlink:href="#DejaVuSans-44" transform="translate(277.125 0)"/>
+       <use xlink:href="#DejaVuSans-46" transform="translate(338.40625 0)"/>
+       <use xlink:href="#DejaVuSans-4e" transform="translate(393.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 401.054126 221.902125 
+L 401.054126 22.318125 
+" clip-path="url(#pddf3f87696)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mfafd3f774d" x="401.054126" y="221.902125" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- cross-node -->
+      <g style="fill: #8a94a6" transform="translate(373.808033 236.500563) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-10" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-46"/>
+       <use xlink:href="#DejaVuSans-55" transform="translate(54.984375 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(93.890625 0)"/>
+       <use xlink:href="#DejaVuSans-56" transform="translate(155.078125 0)"/>
+       <use xlink:href="#DejaVuSans-56" transform="translate(207.171875 0)"/>
+       <use xlink:href="#DejaVuSans-10" transform="translate(259.265625 0)"/>
+       <use xlink:href="#DejaVuSans-51" transform="translate(295.34375 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(358.71875 0)"/>
+       <use xlink:href="#DejaVuSans-47" transform="translate(419.90625 0)"/>
+       <use xlink:href="#DejaVuSans-48" transform="translate(483.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_3">
+     <!-- 32 connections, depth 16, 64 KiB ranges  ·  cross-node reaches 27% of local at equal connections, and saturates the link -->
+     <g style="fill: #8a94a6" transform="translate(7.2 255.7415) scale(0.09 -0.09)">
+      <defs>
+       <path id="DejaVuSans-16" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-f" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-17" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2e" d="M 628 4666 
+L 1259 4666 
+L 1259 2694 
+L 3353 4666 
+L 4166 4666 
+L 1850 2491 
+L 4331 0 
+L 3500 0 
+L 1259 2247 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-25" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4a" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 684 2619 
+L 1344 2619 
+L 1344 1825 
+L 684 1825 
+L 684 2619 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-1a" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-8" d="M 4653 2053 
+Q 4381 2053 4226 1822 
+Q 4072 1591 4072 1178 
+Q 4072 772 4226 539 
+Q 4381 306 4653 306 
+Q 4919 306 5073 539 
+Q 5228 772 5228 1178 
+Q 5228 1588 5073 1820 
+Q 4919 2053 4653 2053 
+z
+M 4653 2450 
+Q 5147 2450 5437 2106 
+Q 5728 1763 5728 1178 
+Q 5728 594 5436 251 
+Q 5144 -91 4653 -91 
+Q 4153 -91 3862 251 
+Q 3572 594 3572 1178 
+Q 3572 1766 3864 2108 
+Q 4156 2450 4653 2450 
+z
+M 1428 4353 
+Q 1159 4353 1004 4120 
+Q 850 3888 850 3481 
+Q 850 3069 1003 2837 
+Q 1156 2606 1428 2606 
+Q 1700 2606 1854 2837 
+Q 2009 3069 2009 3481 
+Q 2009 3884 1853 4118 
+Q 1697 4353 1428 4353 
+z
+M 4250 4750 
+L 4750 4750 
+L 1831 -91 
+L 1331 -91 
+L 4250 4750 
+z
+M 1428 4750 
+Q 1922 4750 2215 4408 
+Q 2509 4066 2509 3481 
+Q 2509 2891 2217 2550 
+Q 1925 2209 1428 2209 
+Q 931 2209 642 2551 
+Q 353 2894 353 3481 
+Q 353 4063 643 4406 
+Q 934 4750 1428 4750 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-49" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-54" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-16"/>
+      <use xlink:href="#DejaVuSans-15" transform="translate(63.625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(127.25 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(159.03125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(214.015625 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(275.203125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(338.578125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(401.953125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(463.484375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(518.46875 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(557.671875 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(585.453125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(646.640625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(710.015625 0)"/>
+      <use xlink:href="#DejaVuSans-f" transform="translate(762.109375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(793.890625 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(825.671875 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(889.15625 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(950.6875 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(1014.171875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(1053.375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(1116.75 0)"/>
+      <use xlink:href="#DejaVuSans-14" transform="translate(1148.53125 0)"/>
+      <use xlink:href="#DejaVuSans-19" transform="translate(1212.15625 0)"/>
+      <use xlink:href="#DejaVuSans-f" transform="translate(1275.78125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(1307.5625 0)"/>
+      <use xlink:href="#DejaVuSans-19" transform="translate(1339.34375 0)"/>
+      <use xlink:href="#DejaVuSans-17" transform="translate(1402.96875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(1466.59375 0)"/>
+      <use xlink:href="#DejaVuSans-2e" transform="translate(1498.375 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(1563.953125 0)"/>
+      <use xlink:href="#DejaVuSans-25" transform="translate(1591.734375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(1660.34375 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(1692.125 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(1733.234375 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(1794.515625 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(1857.890625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(1921.375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1982.90625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2035 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2066.78125 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(2098.5625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2130.34375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2162.125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(2193.90625 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(2248.890625 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2287.796875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(2348.984375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(2401.078125 0)"/>
+      <use xlink:href="#DejaVuSans-10" transform="translate(2453.171875 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(2489.25 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(2552.625 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(2613.8125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(2677.296875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(2738.828125 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(2770.609375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(2809.515625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(2871.046875 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(2932.328125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(2987.3125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(3050.6875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(3112.21875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(3164.3125 0)"/>
+      <use xlink:href="#DejaVuSans-15" transform="translate(3196.09375 0)"/>
+      <use xlink:href="#DejaVuSans-1a" transform="translate(3259.71875 0)"/>
+      <use xlink:href="#DejaVuSans-8" transform="translate(3323.34375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(3418.359375 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(3450.140625 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(3511.328125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(3546.53125 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(3578.3125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(3606.09375 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(3667.28125 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(3722.265625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(3783.546875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(3811.328125 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(3843.109375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(3904.390625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(3943.59375 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(3975.375 0)"/>
+      <use xlink:href="#DejaVuSans-54" transform="translate(4036.90625 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(4100.390625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(4163.765625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(4225.046875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(4252.828125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(4284.609375 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(4339.59375 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(4400.78125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(4464.15625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(4527.53125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(4589.0625 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(4644.046875 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(4683.25 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(4711.03125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(4772.21875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(4835.59375 0)"/>
+      <use xlink:href="#DejaVuSans-f" transform="translate(4887.6875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(4919.46875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(4951.25 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(5012.53125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(5075.90625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(5139.390625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(5171.171875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(5223.265625 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(5284.546875 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(5323.75 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(5387.125 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(5428.234375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(5489.515625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(5528.71875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(5590.25 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(5642.34375 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(5674.125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(5713.328125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(5776.703125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(5838.234375 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(5870.015625 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(5897.796875 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(5925.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4e" transform="translate(5988.953125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_5">
+      <path d="M 78.428672 221.902125 
+L 480.188672 221.902125 
+" clip-path="url(#pddf3f87696)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <defs>
+       <path id="m07b9d8374b" d="M 0 0 
+L -3.5 0 
+" style="stroke: #8a94a6; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m07b9d8374b" x="78.428672" y="221.902125" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 0 -->
+      <g style="fill: #8a94a6" transform="translate(65.066172 225.700953) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-13" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_7">
+      <path d="M 78.428672 186.343402 
+L 480.188672 186.343402 
+" clip-path="url(#pddf3f87696)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m07b9d8374b" x="78.428672" y="186.343402" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 20 -->
+      <g style="fill: #8a94a6" transform="translate(58.703672 190.14223) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_9">
+      <path d="M 78.428672 150.784679 
+L 480.188672 150.784679 
+" clip-path="url(#pddf3f87696)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m07b9d8374b" x="78.428672" y="150.784679" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 40 -->
+      <g style="fill: #8a94a6" transform="translate(58.703672 154.583507) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_11">
+      <path d="M 78.428672 115.225956 
+L 480.188672 115.225956 
+" clip-path="url(#pddf3f87696)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m07b9d8374b" x="78.428672" y="115.225956" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 60 -->
+      <g style="fill: #8a94a6" transform="translate(58.703672 119.024784) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-19"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_13">
+      <path d="M 78.428672 79.667233 
+L 480.188672 79.667233 
+" clip-path="url(#pddf3f87696)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m07b9d8374b" x="78.428672" y="79.667233" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 80 -->
+      <g style="fill: #8a94a6" transform="translate(58.703672 83.466061) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1b" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-1b"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_15">
+      <path d="M 78.428672 44.10851 
+L 480.188672 44.10851 
+" clip-path="url(#pddf3f87696)" style="fill: none; stroke: #e6e9ef; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m07b9d8374b" x="78.428672" y="44.10851" style="fill: #8a94a6; stroke: #8a94a6; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 100 -->
+      <g style="fill: #8a94a6" transform="translate(52.341172 47.907339) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_10">
+     <!-- throughput (Gbps) -->
+     <g style="fill: #1b2733" transform="translate(45.938828 168.376531) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-b" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2a" d="M 3809 666 
+L 3809 1919 
+L 2778 1919 
+L 2778 2438 
+L 4434 2438 
+L 4434 434 
+Q 4069 175 3628 42 
+Q 3188 -91 2688 -91 
+Q 1594 -91 976 548 
+Q 359 1188 359 2328 
+Q 359 3472 976 4111 
+Q 1594 4750 2688 4750 
+Q 3144 4750 3555 4637 
+Q 3966 4525 4313 4306 
+L 4313 3634 
+Q 3963 3931 3569 4081 
+Q 3175 4231 2741 4231 
+Q 1884 4231 1454 3753 
+Q 1025 3275 1025 2328 
+Q 1025 1384 1454 906 
+Q 1884 428 2741 428 
+Q 3075 428 3337 486 
+Q 3600 544 3809 666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-57"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(39.203125 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(102.578125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(141.484375 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(202.671875 0)"/>
+      <use xlink:href="#DejaVuSans-4a" transform="translate(266.046875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(329.53125 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(392.90625 0)"/>
+      <use xlink:href="#DejaVuSans-58" transform="translate(456.390625 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(519.765625 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(558.96875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(590.75 0)"/>
+      <use xlink:href="#DejaVuSans-2a" transform="translate(629.765625 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(707.25 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(770.734375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(834.21875 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(886.3125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 78.428672 221.902125 
+L 78.428672 22.318125 
+" style="fill: none; stroke: #8a94a6; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 78.428672 221.902125 
+L 480.188672 221.902125 
+" style="fill: none; stroke: #8a94a6; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 96.69049 221.902125 
+L 218.435945 221.902125 
+L 218.435945 65.977125 
+L 96.69049 65.977125 
+z
+" clip-path="url(#pddf3f87696)" style="fill: #2f6df6"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 340.181399 221.902125 
+L 461.926854 221.902125 
+L 461.926854 180.298419 
+L 340.181399 180.298419 
+z
+" clip-path="url(#pddf3f87696)" style="fill: #9db8fb"/>
+   </g>
+   <g id="text_11">
+    <!-- 87.7 Gbps -->
+    <g style="fill: #1b2733" transform="translate(134.56892 50.175367) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-1b"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(159.03125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-2a" transform="translate(254.4375 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(331.921875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(395.40625 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(458.890625 0)"/>
+    </g>
+    <!-- 167,278 rps -->
+    <g style="fill: #1b2733" transform="translate(130.473217 60.977125) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-14"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(190.875 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(286.28125 0)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(349.90625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(413.53125 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(445.3125 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(486.421875 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(549.90625 0)"/>
+    </g>
+   </g>
+   <g id="text_12">
+    <!-- 23.4 Gbps -->
+    <g style="fill: #1b2733" transform="translate(378.05983 164.496661) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-15"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(159.03125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-2a" transform="translate(254.4375 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(331.921875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(395.40625 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(458.890625 0)"/>
+    </g>
+    <!-- 44,662 rps -->
+    <g style="fill: #1b2733" transform="translate(376.827251 175.298419) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-17"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(159.03125 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(286.28125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(349.90625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(381.6875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(422.796875 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(486.28125 0)"/>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- The worker outruns the network -->
+    <g style="fill: #1b2733" transform="translate(169.672734 16.318125) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-Bold-37" d="M 31 4666 
+L 4331 4666 
+L 4331 3756 
+L 2784 3756 
+L 2784 0 
+L 1581 0 
+L 1581 3756 
+L 31 3756 
+L 31 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-4b" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1625 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-48" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-3" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-5a" d="M 225 3500 
+L 1313 3500 
+L 1900 1088 
+L 2491 3500 
+L 3425 3500 
+L 4013 1113 
+L 4603 3500 
+L 5691 3500 
+L 4769 0 
+L 3547 0 
+L 2956 2406 
+L 2369 0 
+L 1147 0 
+L 225 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-52" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-55" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-4e" d="M 538 4863 
+L 1656 4863 
+L 1656 2216 
+L 2944 3500 
+L 4244 3500 
+L 2534 1894 
+L 4378 0 
+L 3022 0 
+L 1656 1459 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-58" d="M 500 1363 
+L 500 3500 
+L 1625 3500 
+L 1625 3150 
+Q 1625 2866 1622 2436 
+Q 1619 2006 1619 1863 
+Q 1619 1441 1641 1255 
+Q 1663 1069 1716 984 
+Q 1784 875 1895 815 
+Q 2006 756 2150 756 
+Q 2500 756 2700 1025 
+Q 2900 1294 2900 1772 
+L 2900 3500 
+L 4019 3500 
+L 4019 0 
+L 2900 0 
+L 2900 506 
+Q 2647 200 2364 54 
+Q 2081 -91 1741 -91 
+Q 1134 -91 817 281 
+Q 500 653 500 1363 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-57" d="M 1759 4494 
+L 1759 3500 
+L 2913 3500 
+L 2913 2700 
+L 1759 2700 
+L 1759 1216 
+Q 1759 972 1856 886 
+Q 1953 800 2241 800 
+L 2816 800 
+L 2816 0 
+L 1856 0 
+Q 1194 0 917 276 
+Q 641 553 641 1216 
+L 641 2700 
+L 84 2700 
+L 84 3500 
+L 641 3500 
+L 641 4494 
+L 1759 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-51" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-56" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-37"/>
+     <use xlink:href="#DejaVuSans-Bold-4b" transform="translate(68.21875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-48" transform="translate(139.40625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(207.234375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-5a" transform="translate(242.046875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-52" transform="translate(334.4375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-55" transform="translate(403.140625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4e" transform="translate(452.453125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-48" transform="translate(516.265625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-55" transform="translate(584.09375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(633.40625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-52" transform="translate(668.21875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-58" transform="translate(736.921875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-57" transform="translate(808.109375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-55" transform="translate(855.90625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-58" transform="translate(905.21875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-51" transform="translate(976.40625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-56" transform="translate(1047.59375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(1107.109375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-57" transform="translate(1141.921875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4b" transform="translate(1189.71875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-48" transform="translate(1260.90625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-3" transform="translate(1328.734375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-51" transform="translate(1363.546875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-48" transform="translate(1434.734375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-57" transform="translate(1502.5625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-5a" transform="translate(1550.359375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-52" transform="translate(1642.75 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-55" transform="translate(1711.453125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-4e" transform="translate(1760.765625 0)"/>
+    </g>
+   </g>
+   <g id="line2d_17">
+    <path d="M 78.428672 177.453721 
+L 480.188672 177.453721 
+" clip-path="url(#pddf3f87696)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #d1495b; stroke-width: 1.5"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pddf3f87696">
+   <rect x="78.428672" y="22.318125" width="401.76" height="199.584"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/scripts/bench_charts.py
+++ b/scripts/bench_charts.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["matplotlib>=3.8"]
+# ///
+"""Render the data-plane benchmark charts used in the README and docs.
+
+The measurements live in `bench/data/dataplane.json`, not in this file. This
+script only draws them, so a re-measurement means editing the JSON and re-running
+`just bench-charts` — the numbers in the docs and the numbers in the charts
+cannot drift apart because they have one source.
+
+Charts are written as SVG (crisp at any zoom, diffable as text, and rendered by
+both GitHub and mdbook):
+
+  docs/assets/bench/throughput-ceilings.svg   loopback vs cross-node, vs the NIC
+  docs/assets/bench/ring-scaling.svg          throughput and CPU across rings
+  docs/assets/bench/cpu-split.svg             kernel vs user time on the worker
+
+Run it with uv and there is nothing to install:
+
+    just bench-charts          # or: uv run scripts/bench_charts.py
+
+matplotlib is declared inline (PEP 723) so uv builds an ephemeral environment on
+demand rather than requiring a project-wide dependency for a docs-only tool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+import matplotlib
+
+# Select the non-interactive backend before importing pyplot: these two imports
+# are deliberately not at the top of the file, because pyplot picks a backend at
+# import time and would otherwise fail on a machine with no display.
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.ticker import FuncFormatter
+
+REPO = Path(__file__).resolve().parent.parent
+DATA = REPO / "bench" / "data" / "dataplane.json"
+OUT_DIR = REPO / "docs" / "assets" / "bench"
+
+# A small deliberate palette rather than matplotlib's default cycle: one accent
+# for "what Talon does", one muted tone for "what the hardware allows", and red
+# reserved for the limit that binds. Colours are distinguishable in greyscale
+# and pass contrast checks on both light and dark GitHub themes.
+INK = "#1b2733"
+MUTED = "#8a94a6"
+ACCENT = "#2f6df6"
+ACCENT_DIM = "#9db8fb"
+LIMIT = "#d1495b"
+KERNEL = "#e07a3f"
+
+
+def style() -> None:
+    """Apply a common look: no chartjunk, labels over legends where possible."""
+    plt.rcParams.update(
+        {
+            # Byte-reproducible output: without this matplotlib gives clip paths
+            # random ids, so re-rendering unchanged data would still diff.
+            "svg.hashsalt": "talon-bench-charts",
+            "figure.dpi": 130,
+            "savefig.bbox": "tight",
+            "savefig.transparent": True,
+            "font.size": 10,
+            "text.color": INK,
+            "axes.edgecolor": MUTED,
+            "axes.labelcolor": INK,
+            "axes.titlesize": 12,
+            "axes.titleweight": "bold",
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+            "xtick.color": MUTED,
+            "ytick.color": MUTED,
+            "axes.grid": True,
+            "grid.color": "#e6e9ef",
+            "grid.linewidth": 0.8,
+            "axes.axisbelow": True,
+        }
+    )
+
+
+def gbps(rps: int, range_bytes: int) -> float:
+    return rps * range_bytes * 8 / 1e9
+
+
+def save(fig, name: str) -> Path:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    path = OUT_DIR / name
+    # metadata Date=None keeps the output byte-reproducible: matplotlib otherwise
+    # stamps the render time into the SVG, so every run would look like a change
+    # to git and --check could never pass.
+    fig.savefig(path, format="svg", metadata={"Date": None})
+    plt.close(fig)
+    return path
+
+
+def chart_ceilings(d: dict) -> Path:
+    """The headline: local ceiling, what the network delivers, and the NIC line.
+
+    Drawn as throughput in Gbps rather than rps so the NIC line rate can share
+    the axis — that shared axis is the whole point of the chart.
+    """
+    block = d["loopback_vs_network"]
+    rows = block["rows"]
+    nic = block["nic_line_rate_gbps"]
+    labels = [r["path"] for r in rows]
+    values = [r["gbps"] for r in rows]
+
+    fig, ax = plt.subplots(figsize=(7.2, 3.6))
+    bars = ax.bar(labels, values, width=0.5, color=[ACCENT, ACCENT_DIM], zorder=3)
+
+    ax.axhline(nic, color=LIMIT, linestyle="--", linewidth=1.5, zorder=4)
+    ax.annotate(
+        f"25 GbE line rate — {nic:g} Gbps",
+        xy=(1.42, nic),
+        xytext=(0, 6),
+        textcoords="offset points",
+        ha="right",
+        color=LIMIT,
+        fontsize=9,
+        fontweight="bold",
+    )
+
+    for bar, row in zip(bars, rows):
+        ax.annotate(
+            f"{row['gbps']:.1f} Gbps\n{row['rps']:,} rps",
+            xy=(bar.get_x() + bar.get_width() / 2, bar.get_height()),
+            xytext=(0, 5),
+            textcoords="offset points",
+            ha="center",
+            fontsize=9,
+            color=INK,
+        )
+
+    share = rows[1]["gbps"] / rows[0]["gbps"] * 100
+    ax.set_title("The worker outruns the network")
+    ax.set_ylabel("throughput (Gbps)")
+    ax.set_ylim(0, max(values) * 1.28)
+    ax.set_xlabel(
+        f"{block['connections']} connections, depth {block['depth']}, 64 KiB ranges"
+        f"  ·  cross-node reaches {share:.0f}% of local at equal connections,"
+        " and saturates the link",
+        fontsize=9,
+        color=MUTED,
+        labelpad=10,
+    )
+    return save(fig, "throughput-ceilings.svg")
+
+
+def chart_ring_scaling(d: dict) -> Path:
+    """Throughput against rings, with the CPU actually used underneath.
+
+    Two series on one figure because the interesting fact is the relationship:
+    throughput keeps climbing while CPU stops short of the 8-core cap, which is
+    what "the kernel binds before the cores run out" looks like.
+    """
+    block = d["ring_scaling_depth16"]
+    rows = block["rows"]
+    rings = [r["rings"] for r in rows]
+    rps = [r["rps"] for r in rows]
+    cores = [r["cpu_cores"] for r in rows]
+    x = range(len(rings))
+
+    fig, (ax, ax2) = plt.subplots(
+        2, 1, figsize=(7.2, 4.6), sharex=True, height_ratios=[2.1, 1]
+    )
+
+    ax.plot(x, rps, marker="o", color=ACCENT, linewidth=2.2, zorder=3)
+    for xi, r in zip(x, rows):
+        ax.annotate(
+            f"{r['rps']:,}",
+            xy=(xi, r["rps"]),
+            xytext=(0, 8),
+            textcoords="offset points",
+            ha="center",
+            fontsize=9,
+        )
+    ax.set_ylabel("reads/s")
+    ax.set_title("Throughput scales with rings; CPU stops short of the cap")
+    ax.set_ylim(0, max(rps) * 1.22)
+    ax.yaxis.set_major_formatter(FuncFormatter(lambda v, _: f"{v/1000:.0f}K"))
+
+    ax2.bar(x, cores, width=0.45, color=MUTED, zorder=3)
+    ax2.axhline(8, color=LIMIT, linestyle="--", linewidth=1.4, zorder=4)
+    ax2.annotate(
+        "8-core cgroup cap",
+        xy=(len(rings) - 1 + 0.42, 8),
+        xytext=(0, 4),
+        textcoords="offset points",
+        ha="right",
+        color=LIMIT,
+        fontsize=8.5,
+        fontweight="bold",
+    )
+    for xi, c in zip(x, cores):
+        ax2.annotate(
+            f"{c:.2f}",
+            xy=(xi, c),
+            xytext=(0, 4),
+            textcoords="offset points",
+            ha="center",
+            fontsize=8.5,
+            color=INK,
+        )
+    ax2.set_ylabel("cores used")
+    ax2.set_ylim(0, 9.6)
+    ax2.set_xticks(list(x), [str(r) for r in rings])
+    ax2.set_xlabel(
+        f"io_uring rings  ·  {block['connections']} connections, depth {block['depth']}"
+        "  ·  peak leaves 2 of 8 cores idle",
+        fontsize=9,
+        color=MUTED,
+        labelpad=8,
+    )
+    return save(fig, "ring-scaling.svg")
+
+
+def chart_cpu_split(d: dict) -> Path:
+    """Where the worker's CPU goes. One stacked bar; the ratio is the message."""
+    block = d["cpu_split_loopback"]
+    kernel, user = block["kernel_ticks"], block["user_ticks"]
+    total = kernel + user
+    k_pct, u_pct = kernel / total * 100, user / total * 100
+
+    fig, ax = plt.subplots(figsize=(7.2, 1.9))
+    ax.barh([0], [k_pct], color=KERNEL, zorder=3, height=0.5)
+    ax.barh([0], [u_pct], left=[k_pct], color=ACCENT, zorder=3, height=0.5)
+
+    ax.text(
+        k_pct / 2,
+        0,
+        f"kernel  {k_pct:.0f}%",
+        ha="center",
+        va="center",
+        color="white",
+        fontweight="bold",
+        fontsize=10,
+    )
+    ax.text(
+        k_pct + u_pct / 2,
+        0,
+        f"{u_pct:.0f}%",
+        ha="center",
+        va="center",
+        color="white",
+        fontweight="bold",
+        fontsize=10,
+    )
+
+    ax.set_title("Where a serving worker's CPU goes")
+    ax.set_xlim(0, 100)
+    ax.set_yticks([])
+    ax.set_xlabel(
+        "sendfile and the TCP stack (kernel) vs Talon's own code (user)"
+        "  ·  loopback, sampled from /proc/<pid>/stat",
+        fontsize=9,
+        color=MUTED,
+        labelpad=8,
+    )
+    ax.grid(False)
+    for side in ("left", "bottom"):
+        ax.spines[side].set_visible(False)
+    ax.set_xticks([])
+    return save(fig, "cpu-split.svg")
+
+
+CHART_NAMES = ("throughput-ceilings.svg", "ring-scaling.svg", "cpu-split.svg")
+
+
+def render(data: dict) -> list[Path]:
+    return [chart_ceilings(data), chart_ring_scaling(data), chart_cpu_split(data)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail if any chart would change (for CI drift detection)",
+    )
+    args = parser.parse_args()
+
+    if not DATA.exists():
+        print(f"error: missing measurements at {DATA}", file=sys.stderr)
+        return 2
+    data = json.loads(DATA.read_text())
+
+    style()
+
+    if args.check:
+        # Render into a scratch directory and compare. Writing to the real paths
+        # first would repair whatever drift we are trying to detect, so a stale
+        # tree would pass on the second run and CI would never fail.
+        global OUT_DIR
+        committed = {}
+        for name in CHART_NAMES:
+            p = OUT_DIR / name
+            committed[name] = p.read_bytes() if p.exists() else None
+
+        with tempfile.TemporaryDirectory() as tmp:
+            real_out, OUT_DIR = OUT_DIR, Path(tmp)
+            try:
+                fresh = {p.name: p.read_bytes() for p in render(data)}
+            finally:
+                OUT_DIR = real_out
+
+        stale = [n for n in CHART_NAMES if committed.get(n) != fresh.get(n)]
+        if stale:
+            print(
+                "error: charts are stale, run `just bench-charts` and commit:\n  "
+                + "\n  ".join(stale),
+                file=sys.stderr,
+            )
+            return 1
+        print("charts up to date")
+        return 0
+
+    for p in render(data):
+        print(f"wrote {p.relative_to(REPO)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The measured numbers were readable only as markdown tables. This adds charts — and **generates** them rather than drawing them, so they cannot drift from the prose.

## What is added

**`bench/data/dataplane.json`** — the measurements as structured data, the single source of truth for both the charts and the tables on the page. To record a new measurement you edit the JSON and re-run; you never edit an SVG.

**`scripts/bench_charts.py`** — renders three SVGs with matplotlib:

| chart | shows |
|---|---|
| `throughput-ceilings.svg` | loopback vs cross-node, with the 25 GbE line rate drawn across both — the shared axis is the point |
| `ring-scaling.svg` | throughput climbing across 1/2/4/8 rings with CPU used underneath, against the 8-core cap |
| `cpu-split.svg` | 85% kernel vs 15% Talon, as one stacked bar |

The ceilings chart leads the README; all three appear in `BENCHMARKS.md` beside the tables they visualise.

**`just bench-charts`** (and `--check`) joins the existing `just bench` / `bench-save` / `bench-check` surface.

## Why `--check` is trustworthy

Two things had to be fixed for a drift check to mean anything, and both were caught by testing the guard rather than assuming it worked:

1. **Byte-reproducibility.** matplotlib stamps a render timestamp into the SVG and gives clip paths random ids, so two identical runs diffed. Fixed with `metadata={"Date": None}` and a pinned `svg.hashsalt`. An unchanged run now produces no diff.

2. **`--check` must not repair what it detects.** The first version rendered to the committed paths and then compared — so it overwrote the stale files, and a stale tree passed on the second run. It now renders to a scratch directory. Verified end to end: unchanged data exits 0; a mutated value exits 1, names the stale chart, and leaves the files untouched.

Dependencies are declared inline (PEP 723), so `uv` builds a throwaway environment on demand and matplotlib never becomes a project dependency for a docs-only tool.

Charts were visually reviewed (rasterised and inspected), not just diffed. Two axis labels were corrected during review to name which configuration they describe, since the loopback peak and the paired 32-connection figure have different denominators.

Docs and tooling only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)