### PR TITLE
feat(client): stream bounded ranges with typed failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,6 +2563,8 @@ dependencies = [
 name = "talon-cache-client"
 version = "0.1.0"
 dependencies = [
+ "bytes",
+ "futures",
  "talon-core",
  "talon-transport",
  "tempfile",

--- a/crates/talon-cache-client/Cargo.toml
+++ b/crates/talon-cache-client/Cargo.toml
@@ -10,6 +10,8 @@ description = "Reusable coordinator and worker data-plane client for Talon"
 [dependencies]
 talon-core.workspace = true
 talon-transport.workspace = true
+bytes.workspace = true
+futures.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/talon-cache-client/src/block_reader.rs
+++ b/crates/talon-cache-client/src/block_reader.rs
@@ -33,6 +33,23 @@ use crate::pool::ConnectionPool;
 use crate::read_plan::plan_read;
 use crate::worker_client::{WorkerClient, WorkerError};
 
+pub(crate) enum DetailedBlockReadError {
+    Block(BlockReadError),
+    Worker(WorkerError),
+}
+
+impl From<BlockReadError> for DetailedBlockReadError {
+    fn from(error: BlockReadError) -> Self {
+        Self::Block(error)
+    }
+}
+
+struct ReplicaFailure {
+    reason: RefreshReason,
+    error: WorkerError,
+    retryable: bool,
+}
+
 /// Errors from a block read.
 #[derive(Debug, thiserror::Error)]
 pub enum BlockReadError {
@@ -154,6 +171,28 @@ impl BlockReader {
         len: u32,
         now_ms: u64,
     ) -> Result<Vec<u8>, BlockReadError> {
+        match self
+            .read_block_detailed(block, offset_in_block, len, now_ms)
+            .await
+        {
+            Ok(bytes) => Ok(bytes),
+            Err(DetailedBlockReadError::Block(error)) => Err(error),
+            Err(DetailedBlockReadError::Worker(_)) => Err(BlockReadError::AllReplicasFailed),
+        }
+    }
+
+    /// Read one block slice while preserving the last worker failure.
+    ///
+    /// The public FUSE-compatible API intentionally retains its historical
+    /// `AllReplicasFailed` result. Streaming protocol frontends need the typed
+    /// final failure to make a deterministic fallback decision.
+    pub(crate) async fn read_block_detailed(
+        &self,
+        block: &BlockId,
+        offset_in_block: u32,
+        len: u32,
+        now_ms: u64,
+    ) -> Result<Vec<u8>, DetailedBlockReadError> {
         let cached = match self.cache.get(block, now_ms) {
             Some(c) => {
                 self.stats.record_cache_hit();
@@ -175,11 +214,14 @@ impl BlockReader {
                 self.stats.add_bytes_served(bytes.len() as u64);
                 return Ok(bytes);
             }
-            Err(reason) => {
+            Err(failure) => {
+                if !failure.retryable {
+                    return Err(DetailedBlockReadError::Worker(failure.error));
+                }
                 // Every cached replica failed; drop the stale placement and do a
                 // single membership refresh before giving up.
-                tracing::debug!(%block, ?reason, "all cached replicas failed; refreshing placement");
-                self.cache.invalidate(block, reason);
+                tracing::debug!(%block, reason = ?failure.reason, "all cached replicas failed; refreshing placement");
+                self.cache.invalidate(block, failure.reason);
                 self.stats.record_coordinator_refresh();
             }
         }
@@ -188,7 +230,7 @@ impl BlockReader {
         let bytes = self
             .try_replicas(block, &fresh.replicas, abs_offset, len)
             .await
-            .map_err(|_| BlockReadError::AllReplicasFailed)?;
+            .map_err(|failure| DetailedBlockReadError::Worker(failure.error))?;
         self.stats.add_bytes_served(bytes.len() as u64);
         Ok(bytes)
     }
@@ -205,11 +247,18 @@ impl BlockReader {
         replicas: &[String],
         abs_offset: u64,
         len: u32,
-    ) -> Result<Vec<u8>, RefreshReason> {
+    ) -> Result<Vec<u8>, ReplicaFailure> {
         if replicas.is_empty() {
-            return Err(RefreshReason::WrongOwner);
+            return Err(ReplicaFailure {
+                reason: RefreshReason::WrongOwner,
+                error: WorkerError::Remote(talon_transport::DataPlaneError {
+                    code: talon_transport::DataErrorCode::Internal,
+                    message: "placement contained no worker addresses".into(),
+                }),
+                retryable: true,
+            });
         }
-        let mut last = RefreshReason::WrongOwner;
+        let mut last = None;
         for addr in replicas {
             let worker = WorkerClient::with_pool(addr.clone(), Arc::clone(&self.worker_pool));
             self.stats.record_worker_fetch();
@@ -218,22 +267,39 @@ impl BlockReader {
                 .await
             {
                 Ok(bytes) if bytes.len() as u64 == u64::from(len) => return Ok(bytes),
-                Ok(_) => {
+                Ok(bytes) => {
                     self.stats.record_worker_failure();
-                    last = RefreshReason::WrongOwner;
+                    last = Some(ReplicaFailure {
+                        reason: RefreshReason::WrongOwner,
+                        error: WorkerError::RangeLengthMismatch {
+                            expected: u64::from(len),
+                            actual: bytes.len() as u64,
+                        },
+                        retryable: true,
+                    });
                 }
                 Err(e) => {
                     self.stats.record_worker_failure();
-                    last = match e {
+                    let reason = match &e {
                         WorkerError::Io(_) => RefreshReason::ConnectFailure,
                         // A framing/encode error is not a placement problem, but
                         // treat it as a wrong-owner refresh so we still recover.
                         _ => RefreshReason::WrongOwner,
                     };
+                    let retryable = replica_retryable(&e);
+                    let failure = ReplicaFailure {
+                        reason,
+                        error: e,
+                        retryable,
+                    };
+                    if !retryable {
+                        return Err(failure);
+                    }
+                    last = Some(failure);
                 }
             }
         }
-        Err(last)
+        Err(last.expect("non-empty replica list records a failure"))
     }
 
     /// Reconcile the cache against an observed placement version.
@@ -400,6 +466,19 @@ impl BlockReader {
                 }
             }
         }
+    }
+}
+
+fn replica_retryable(error: &WorkerError) -> bool {
+    match error {
+        WorkerError::Remote(error) => !matches!(
+            error.code,
+            talon_transport::DataErrorCode::InvalidRequest
+                | talon_transport::DataErrorCode::NotFound
+                | talon_transport::DataErrorCode::VersionMismatch
+                | talon_transport::DataErrorCode::Origin
+        ),
+        _ => true,
     }
 }
 

--- a/crates/talon-cache-client/src/lib.rs
+++ b/crates/talon-cache-client/src/lib.rs
@@ -11,6 +11,7 @@ pub mod membership_cache;
 pub mod metrics;
 pub mod placement_cache;
 pub mod pool;
+pub mod range_stream;
 pub mod read_plan;
 pub mod worker_client;
 
@@ -21,5 +22,6 @@ pub use coordinator_client::{
 pub use metrics::{ReadStats, ReadStatsSnapshot};
 pub use placement_cache::{Cached, PlacementCache, RefreshReason};
 pub use pool::{ConnectionPool, DEFAULT_CONNECT_TIMEOUT, DEFAULT_REQUEST_TIMEOUT};
+pub use range_stream::{CacheReadError, RangeChunkStream, DEFAULT_TRANSFER_CHUNK_BYTES};
 pub use read_plan::{plan_read, BlockSegment};
 pub use worker_client::{WorkerClient, WorkerError, WriteClient};

--- a/crates/talon-cache-client/src/range_stream.rs
+++ b/crates/talon-cache-client/src/range_stream.rs
@@ -1,0 +1,483 @@
+//! Demand-driven, bounded-memory range streaming.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use futures::{Stream, StreamExt};
+use talon_core::{BlockId, ObjectId, Version};
+use talon_transport::DataErrorCode;
+
+use crate::block_reader::{BlockReadError, DetailedBlockReadError};
+use crate::coordinator_client::CoordinatorError;
+use crate::worker_client::WorkerError;
+use crate::{BlockReader, FileView};
+
+/// Default maximum bytes held by one in-flight worker response.
+pub const DEFAULT_TRANSFER_CHUNK_BYTES: u32 = 4 * 1024 * 1024;
+
+/// A typed cache-read failure suitable for an HTTP routing decision.
+#[derive(Debug, thiserror::Error)]
+pub enum CacheReadError {
+    /// The requested range or stream configuration is invalid.
+    #[error("invalid cache request: {0}")]
+    InvalidRequest(String),
+    /// The authoritative object does not exist.
+    #[error("object not found: {0}")]
+    NotFound(String),
+    /// The block is absent and the selected route disabled origin fill.
+    #[error("cache miss: {0}")]
+    CacheMiss(String),
+    /// Cache infrastructure is unavailable.
+    #[error("cache unavailable: {0}")]
+    Unavailable(String),
+    /// Cache infrastructure exceeded its deadline.
+    #[error("cache timeout: {0}")]
+    Timeout(String),
+    /// The source version changed during the read.
+    #[error("source version mismatch: {0}")]
+    VersionMismatch(String),
+    /// The authoritative origin failed while a worker was filling the cache.
+    #[error("origin failure: {0}")]
+    Origin(String),
+    /// A wire/framing invariant was violated.
+    #[error("cache protocol failure: {0}")]
+    Protocol(String),
+    /// An explicitly typed worker-internal failure.
+    #[error("cache internal failure: {0}")]
+    Internal(String),
+    /// A legacy worker returned only an unclassified string.
+    #[error("unclassified legacy worker failure: {0}")]
+    Unknown(String),
+}
+
+impl CacheReadError {
+    /// Whether direct-origin fallback may safely hide this cache-path failure.
+    ///
+    /// Policy must still opt into fallback. Correctness, origin, protocol, and
+    /// legacy-unknown failures remain visible rather than being guessed from
+    /// diagnostic text.
+    pub fn fallback_eligible(&self) -> bool {
+        matches!(self, Self::Unavailable(_) | Self::Timeout(_))
+    }
+}
+
+impl From<WorkerError> for CacheReadError {
+    fn from(error: WorkerError) -> Self {
+        match error {
+            WorkerError::Io(error) if error.kind() == std::io::ErrorKind::TimedOut => {
+                Self::Timeout(error.to_string())
+            }
+            WorkerError::Io(error) => Self::Unavailable(error.to_string()),
+            WorkerError::Remote(error) => match error.code {
+                DataErrorCode::Unknown => Self::Unknown(error.message),
+                DataErrorCode::InvalidRequest => Self::InvalidRequest(error.message),
+                DataErrorCode::NotFound => Self::NotFound(error.message),
+                DataErrorCode::CacheMiss => Self::CacheMiss(error.message),
+                DataErrorCode::Unavailable => Self::Unavailable(error.message),
+                DataErrorCode::Timeout => Self::Timeout(error.message),
+                DataErrorCode::VersionMismatch => Self::VersionMismatch(error.message),
+                DataErrorCode::Origin => Self::Origin(error.message),
+                DataErrorCode::Internal => Self::Internal(error.message),
+            },
+            other => Self::Protocol(other.to_string()),
+        }
+    }
+}
+
+impl From<CoordinatorError> for CacheReadError {
+    fn from(error: CoordinatorError) -> Self {
+        match error {
+            CoordinatorError::Io(error) if error.kind() == std::io::ErrorKind::TimedOut => {
+                Self::Timeout(error.to_string())
+            }
+            CoordinatorError::Io(error) => Self::Unavailable(error.to_string()),
+            other => Self::Protocol(other.to_string()),
+        }
+    }
+}
+
+impl From<DetailedBlockReadError> for CacheReadError {
+    fn from(error: DetailedBlockReadError) -> Self {
+        match error {
+            DetailedBlockReadError::Worker(error) => error.into(),
+            DetailedBlockReadError::Block(BlockReadError::Coordinator(error)) => error.into(),
+            DetailedBlockReadError::Block(BlockReadError::Worker(error)) => error.into(),
+            DetailedBlockReadError::Block(error) => Self::Unavailable(error.to_string()),
+        }
+    }
+}
+
+struct StreamState {
+    reader: BlockReader,
+    object: ObjectId,
+    version: Version,
+    block_size: u32,
+    position: u64,
+    end: u64,
+    chunk_size: u32,
+    now_ms: u64,
+}
+
+/// A cache range body that starts at most one bounded worker request per poll.
+pub struct RangeChunkStream {
+    inner: Pin<Box<dyn Stream<Item = Result<Bytes, CacheReadError>> + Send>>,
+}
+
+impl Stream for RangeChunkStream {
+    type Item = Result<Bytes, CacheReadError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+
+impl BlockReader {
+    /// Stream `[offset, offset + len)` in chunks bounded by both the Talon block
+    /// boundary and `chunk_size`.
+    ///
+    /// No worker request starts until the consumer polls the stream. A slow
+    /// consumer therefore applies backpressure naturally, and dropping the
+    /// stream drops its in-flight worker socket rather than leaving detached
+    /// cache work behind.
+    pub fn stream_range(
+        &self,
+        file: &FileView<'_>,
+        offset: u64,
+        len: u64,
+        chunk_size: u32,
+        now_ms: u64,
+    ) -> Result<RangeChunkStream, CacheReadError> {
+        if file.block_size == 0 {
+            return Err(CacheReadError::InvalidRequest(
+                "block size must be greater than zero".into(),
+            ));
+        }
+        if chunk_size == 0 {
+            return Err(CacheReadError::InvalidRequest(
+                "transfer chunk size must be greater than zero".into(),
+            ));
+        }
+        let requested_end = offset.checked_add(len).ok_or_else(|| {
+            CacheReadError::InvalidRequest("range offset+len overflows u64".into())
+        })?;
+        let state = StreamState {
+            reader: self.clone(),
+            object: file.object.clone(),
+            version: file.version.clone(),
+            block_size: file.block_size,
+            position: offset.min(file.size),
+            end: requested_end.min(file.size),
+            chunk_size,
+            now_ms,
+        };
+        let stream = futures::stream::try_unfold(state, |mut state| async move {
+            if state.position >= state.end {
+                return Ok(None);
+            }
+            let block_size = u64::from(state.block_size);
+            let block_start = (state.position / block_size) * block_size;
+            let offset_in_block = (state.position - block_start) as u32;
+            let block_remaining = block_size - u64::from(offset_in_block);
+            let remaining = state.end - state.position;
+            let take = remaining
+                .min(block_remaining)
+                .min(u64::from(state.chunk_size)) as u32;
+            let block = BlockId::new(
+                state.object.clone(),
+                block_start,
+                state.block_size,
+                state.version.clone(),
+            );
+            let bytes = state
+                .reader
+                .read_block_detailed(&block, offset_in_block, take, state.now_ms)
+                .await
+                .map_err(CacheReadError::from)?;
+            if bytes.len() != take as usize {
+                return Err(CacheReadError::Protocol(format!(
+                    "worker returned {} bytes for a {take}-byte chunk",
+                    bytes.len()
+                )));
+            }
+            state.position += u64::from(take);
+            Ok(Some((Bytes::from(bytes), state)))
+        });
+        Ok(RangeChunkStream {
+            inner: stream.boxed(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use talon_core::{Backend, NodeId, NodeInfo, NodeRole};
+    use talon_transport::frame::{FrameHeader, HEADER_LEN};
+    use talon_transport::{
+        decode_request, encode_typed_error, response_header_ok, ControlMessage, DataPlaneError,
+    };
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    async fn coordinator(worker_addr: String) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            loop {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let worker_addr = worker_addr.clone();
+                tokio::spawn(async move {
+                    loop {
+                        let mut header = [0; HEADER_LEN];
+                        if socket.read_exact(&mut header).await.is_err() {
+                            return;
+                        }
+                        let header = FrameHeader::decode(&header).unwrap();
+                        let mut body = vec![0; header.length as usize];
+                        socket.read_exact(&mut body).await.unwrap();
+                        let mut frame = header.encode().to_vec();
+                        frame.extend_from_slice(&body);
+                        let reply = match talon_transport::decode(&frame).unwrap().1 {
+                            ControlMessage::MembershipQuery {} => ControlMessage::MembershipList {
+                                nodes: vec![NodeInfo {
+                                    id: NodeId("w1".into()),
+                                    address: worker_addr.clone(),
+                                    role: NodeRole::Worker,
+                                }],
+                            },
+                            other => panic!("unexpected control request: {other:?}"),
+                        };
+                        socket
+                            .write_all(&talon_transport::encode(0, &reply).unwrap())
+                            .await
+                            .unwrap();
+                    }
+                });
+            }
+        });
+        addr
+    }
+
+    async fn byte_worker(requests: Arc<AtomicUsize>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            loop {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let requests = Arc::clone(&requests);
+                tokio::spawn(async move {
+                    loop {
+                        let mut header = [0; HEADER_LEN];
+                        if socket.read_exact(&mut header).await.is_err() {
+                            return;
+                        }
+                        let header = FrameHeader::decode(&header).unwrap();
+                        let mut body = vec![0; header.length as usize];
+                        socket.read_exact(&mut body).await.unwrap();
+                        let mut frame = header.encode().to_vec();
+                        frame.extend_from_slice(&body);
+                        let request = decode_request(&frame).unwrap().1;
+                        requests.fetch_add(1, Ordering::SeqCst);
+                        let bytes: Vec<u8> = (request.offset..request.offset + request.len)
+                            .map(|value| value as u8)
+                            .collect();
+                        socket
+                            .write_all(&response_header_ok(0, bytes.len() as u32))
+                            .await
+                            .unwrap();
+                        socket.write_all(&bytes).await.unwrap();
+                    }
+                });
+            }
+        });
+        addr
+    }
+
+    fn file<'a>(object: &'a ObjectId, version: &'a Version) -> FileView<'a> {
+        FileView {
+            object,
+            block_size: 8,
+            version,
+            size: 10,
+        }
+    }
+
+    #[tokio::test]
+    async fn polling_drives_one_bounded_chunk_at_a_time() {
+        let requests = Arc::new(AtomicUsize::new(0));
+        let worker = byte_worker(Arc::clone(&requests)).await;
+        let coordinator = coordinator(worker).await;
+        let reader = BlockReader::new(
+            crate::CoordinatorClient::new(coordinator),
+            Arc::new(crate::PlacementCache::new(60_000)),
+            1,
+        );
+        let object = ObjectId::new(Backend::S3, "bucket", "object");
+        let version = Version::new("v1");
+        let mut stream = reader
+            .stream_range(&file(&object, &version), 0, 10, 3, 0)
+            .unwrap();
+
+        assert_eq!(requests.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            stream.next().await.unwrap().unwrap(),
+            Bytes::from_static(&[0, 1, 2])
+        );
+        assert_eq!(requests.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            stream.next().await.unwrap().unwrap(),
+            Bytes::from_static(&[3, 4, 5])
+        );
+        assert_eq!(requests.load(Ordering::SeqCst), 2);
+
+        let rest = stream.map(|chunk| chunk.unwrap()).collect::<Vec<_>>().await;
+        assert_eq!(
+            rest,
+            vec![Bytes::from_static(&[6, 7]), Bytes::from_static(&[8, 9])]
+        );
+        assert_eq!(requests.load(Ordering::SeqCst), 4);
+    }
+
+    #[test]
+    fn only_infrastructure_failures_allow_fallback() {
+        assert!(CacheReadError::Unavailable("down".into()).fallback_eligible());
+        assert!(CacheReadError::Timeout("slow".into()).fallback_eligible());
+        assert!(!CacheReadError::NotFound("missing".into()).fallback_eligible());
+        assert!(!CacheReadError::Protocol("bad frame".into()).fallback_eligible());
+        assert!(!CacheReadError::Unknown("legacy text".into()).fallback_eligible());
+    }
+
+    #[test]
+    fn typed_worker_errors_map_without_reading_messages() {
+        let error = WorkerError::Remote(DataPlaneError {
+            code: DataErrorCode::VersionMismatch,
+            message: "arbitrary diagnostic".into(),
+        });
+        assert!(matches!(
+            CacheReadError::from(error),
+            CacheReadError::VersionMismatch(_)
+        ));
+
+        let error = WorkerError::Remote(DataPlaneError {
+            code: DataErrorCode::Unavailable,
+            message: "does not contain the word unavailable".into(),
+        });
+        assert!(CacheReadError::from(error).fallback_eligible());
+
+        let error = WorkerError::Io(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "deadline elapsed",
+        ));
+        assert!(matches!(
+            CacheReadError::from(error),
+            CacheReadError::Timeout(_)
+        ));
+    }
+
+    #[test]
+    fn invalid_ranges_fail_before_creating_a_stream() {
+        let reader = BlockReader::new(
+            crate::CoordinatorClient::new("127.0.0.1:1"),
+            Arc::new(crate::PlacementCache::new(1)),
+            1,
+        );
+        let object = ObjectId::new(Backend::S3, "bucket", "object");
+        let version = Version::new("v1");
+        assert!(matches!(
+            reader.stream_range(&file(&object, &version), 0, 1, 0, 0),
+            Err(CacheReadError::InvalidRequest(_))
+        ));
+        assert!(matches!(
+            reader.stream_range(&file(&object, &version), u64::MAX, 2, 1, 0),
+            Err(CacheReadError::InvalidRequest(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn typed_remote_failure_reaches_the_stream() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let worker = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut header = [0; HEADER_LEN];
+            socket.read_exact(&mut header).await.unwrap();
+            let header = FrameHeader::decode(&header).unwrap();
+            let mut body = vec![0; header.length as usize];
+            socket.read_exact(&mut body).await.unwrap();
+            socket
+                .write_all(&encode_typed_error(
+                    header.request_id,
+                    DataErrorCode::NotFound,
+                    "gone",
+                ))
+                .await
+                .unwrap();
+        });
+        let coordinator = coordinator(worker).await;
+        let reader = BlockReader::new(
+            crate::CoordinatorClient::new(coordinator),
+            Arc::new(crate::PlacementCache::new(60_000)),
+            1,
+        );
+        let object = ObjectId::new(Backend::S3, "bucket", "object");
+        let version = Version::new("v1");
+        let mut stream = reader
+            .stream_range(&file(&object, &version), 0, 1, 1, 0)
+            .unwrap();
+        assert!(matches!(
+            stream.next().await.unwrap(),
+            Err(CacheReadError::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn dropping_stream_cancels_the_in_flight_worker_request() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let worker = listener.local_addr().unwrap().to_string();
+        let (request_seen_tx, request_seen_rx) = tokio::sync::oneshot::channel();
+        let (eof_tx, eof_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut header = [0; HEADER_LEN];
+            socket.read_exact(&mut header).await.unwrap();
+            let header = FrameHeader::decode(&header).unwrap();
+            let mut body = vec![0; header.length as usize];
+            socket.read_exact(&mut body).await.unwrap();
+            request_seen_tx.send(()).unwrap();
+            let mut byte = [0; 1];
+            let closed = socket.read(&mut byte).await.unwrap() == 0;
+            eof_tx.send(closed).unwrap();
+        });
+        let coordinator = coordinator(worker).await;
+        let reader = BlockReader::new(
+            crate::CoordinatorClient::new(coordinator),
+            Arc::new(crate::PlacementCache::new(60_000)),
+            1,
+        );
+        let object = ObjectId::new(Backend::S3, "bucket", "object");
+        let version = Version::new("v1");
+        let mut stream = reader
+            .stream_range(&file(&object, &version), 0, 1, 1, 0)
+            .unwrap();
+
+        {
+            let next = stream.next();
+            tokio::pin!(next);
+            tokio::select! {
+                result = &mut next => panic!("stalled worker unexpectedly replied: {result:?}"),
+                result = request_seen_rx => result.unwrap(),
+            }
+        }
+        drop(stream);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), eof_rx)
+                .await
+                .unwrap()
+                .unwrap()
+        );
+    }
+}

--- a/crates/talon-cache-client/src/worker_client.rs
+++ b/crates/talon-cache-client/src/worker_client.rs
@@ -5,7 +5,7 @@
 //! single [`MsgType::GetRange`] frame whose body is a bincode
 //! [`RangeRequest`] (object + `[offset, len)`), and a reply that is a
 //! `GetRange` frame carrying the **raw range bytes** — or, if the
-//! [`Flags::ERROR`] bit is set, a UTF-8 error string.
+//! [`Flags::ERROR`] bit is set, a typed error envelope (or a legacy string).
 //!
 //! The response body is raw (no bincode envelope) precisely so a production
 //! worker can `sendfile` the range straight from a file into the socket; this
@@ -20,8 +20,8 @@ use std::time::Duration;
 use talon_core::{ObjectId, RequestId, Version};
 use talon_transport::frame::{FrameHeader, MsgType, HEADER_LEN};
 use talon_transport::{
-    encode_delete, encode_put_header, encode_request, DeleteRequest, Flags, PutRequest,
-    RangeRequest, MAX_CONTROL_PAYLOAD_LEN,
+    decode_error_payload, encode_delete, encode_put_header, encode_request, DataPlaneError,
+    DeleteRequest, Flags, PutRequest, RangeRequest, MAX_CONTROL_PAYLOAD_LEN,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -59,9 +59,9 @@ pub enum WorkerError {
         /// Maximum accepted payload size for this reply.
         cap: u32,
     },
-    /// The worker set the ERROR flag and returned this message.
+    /// The worker set the ERROR flag and returned this typed or legacy error.
     #[error("worker error: {0}")]
-    Remote(String),
+    Remote(DataPlaneError),
 }
 
 /// A thin data-plane client bound to one worker address.
@@ -101,8 +101,9 @@ impl WorkerClient {
     ///
     /// Returns the raw range bytes on success. A worker-side error (block not
     /// present, backend failure, etc.) surfaces as [`WorkerError::Remote`] with
-    /// the worker's message, which the caller can use to trigger a placement
-    /// refresh or replica fallback.
+    /// a stable code when the worker supports typed errors. Legacy string-only
+    /// replies remain [`talon_transport::DataErrorCode::Unknown`] and must not
+    /// be classified by matching their text.
     ///
     /// Uses a pooled connection when one is warm; the connection is returned to
     /// the pool only after a fully successful exchange, so a broken socket is
@@ -487,9 +488,7 @@ async fn read_version_reply(stream: &mut TcpStream) -> Result<Version, WorkerErr
     let mut body = vec![0u8; header.length as usize];
     stream.read_exact(&mut body).await?;
     if header.flags.contains(Flags::ERROR) {
-        return Err(WorkerError::Remote(
-            String::from_utf8_lossy(&body).into_owned(),
-        ));
+        return Err(WorkerError::Remote(decode_error_payload(&body)));
     }
     Ok(Version::new(String::from_utf8_lossy(&body).into_owned()))
 }
@@ -498,7 +497,7 @@ async fn read_version_reply(stream: &mut TcpStream) -> Result<Version, WorkerErr
 ///
 /// A successful reply must advertise exactly `expected_len` before its buffer is
 /// allocated. If the header carries [`Flags::ERROR`], the body is instead a
-/// UTF-8 message capped at [`MAX_CONTROL_PAYLOAD_LEN`] and returned as
+/// typed or legacy message capped at [`MAX_CONTROL_PAYLOAD_LEN`] and returned as
 /// [`WorkerError::Remote`].
 async fn read_range_reply(
     stream: &mut TcpStream,
@@ -526,8 +525,7 @@ async fn read_range_reply(
     let mut body = vec![0u8; header.length as usize];
     stream.read_exact(&mut body).await?;
     if header.flags.contains(Flags::ERROR) {
-        let msg = String::from_utf8_lossy(&body).into_owned();
-        return Err(WorkerError::Remote(msg));
+        return Err(WorkerError::Remote(decode_error_payload(&body)));
     }
     Ok(body)
 }
@@ -661,7 +659,10 @@ mod tests {
         let client = WorkerClient::new(addr);
         let err = client.fetch_range(&object(), 0, 16).await.unwrap_err();
         match err {
-            WorkerError::Remote(m) => assert_eq!(m, "block not present"),
+            WorkerError::Remote(error) => {
+                assert_eq!(error.code, talon_transport::DataErrorCode::Unknown);
+                assert_eq!(error.message, "block not present");
+            }
             other => panic!("expected Remote, got {other:?}"),
         }
     }
@@ -964,7 +965,10 @@ mod tests {
         let client = WriteClient::new(addr);
         let err = client.put_object(&object(), b"x").await.unwrap_err();
         match err {
-            WorkerError::Remote(m) => assert_eq!(m, "backend PUT failed"),
+            WorkerError::Remote(error) => {
+                assert_eq!(error.code, talon_transport::DataErrorCode::Unknown);
+                assert_eq!(error.message, "backend PUT failed");
+            }
             other => panic!("expected Remote, got {other:?}"),
         }
     }

--- a/crates/talon-transport/src/data.rs
+++ b/crates/talon-transport/src/data.rs
@@ -16,6 +16,54 @@ use talon_core::ObjectId;
 
 use crate::frame::{Flags, FrameError, FrameHeader, MsgType, HEADER_LEN};
 
+const ERROR_ENVELOPE_MAGIC: &[u8; 4] = b"TLE1";
+
+/// Stable machine-readable classification for a data-plane failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DataErrorCode {
+    /// A legacy or otherwise unclassified failure.
+    Unknown,
+    /// The request could not be parsed or names an invalid range.
+    InvalidRequest,
+    /// The requested object does not exist at the origin.
+    NotFound,
+    /// The requested block is absent and origin fetch was disabled.
+    CacheMiss,
+    /// The worker or one of its required services is unavailable.
+    Unavailable,
+    /// The operation exceeded its deadline.
+    Timeout,
+    /// The source object changed relative to the requested version.
+    VersionMismatch,
+    /// The authoritative origin returned an operation failure.
+    Origin,
+    /// The worker encountered an internal or protocol failure.
+    Internal,
+}
+
+/// A decoded data-plane error, including legacy string-only replies.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataPlaneError {
+    /// Stable error class. Legacy replies use [`DataErrorCode::Unknown`].
+    pub code: DataErrorCode,
+    /// Human-readable diagnostic text; never use it for control flow.
+    pub message: String,
+}
+
+impl std::fmt::Display for DataPlaneError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for DataPlaneError {}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ErrorEnvelope {
+    code: DataErrorCode,
+    message: String,
+}
+
 /// A client→worker request to read `[offset, offset+len)` of an object.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RangeRequest {
@@ -188,6 +236,55 @@ pub fn encode_error(request_id: u32, message: &str) -> Vec<u8> {
     buf
 }
 
+/// Build a typed error response understood by new clients.
+///
+/// The `ERROR` frame shape is unchanged. A short magic prefix distinguishes
+/// the bincode envelope from legacy UTF-8 error payloads, so rolling upgrades
+/// remain fail-closed in both directions.
+pub fn encode_typed_error(
+    request_id: u32,
+    code: DataErrorCode,
+    message: impl Into<String>,
+) -> Vec<u8> {
+    let envelope = ErrorEnvelope {
+        code,
+        message: message.into(),
+    };
+    let encoded = bincode::serialize(&envelope).expect("error envelope is serializable");
+    let mut body = Vec::with_capacity(ERROR_ENVELOPE_MAGIC.len() + encoded.len());
+    body.extend_from_slice(ERROR_ENVELOPE_MAGIC);
+    body.extend_from_slice(&encoded);
+    let mut header = FrameHeader::new(MsgType::GetRange, request_id, body.len() as u32);
+    header.flags = Flags(Flags::ERROR);
+    let mut out = Vec::with_capacity(HEADER_LEN + body.len());
+    out.extend_from_slice(&header.encode());
+    out.extend_from_slice(&body);
+    out
+}
+
+/// Decode a typed or legacy error-frame payload.
+///
+/// A malformed typed envelope is classified as [`DataErrorCode::Internal`]
+/// rather than falling back to lossy string matching.
+pub fn decode_error_payload(body: &[u8]) -> DataPlaneError {
+    let Some(encoded) = body.strip_prefix(ERROR_ENVELOPE_MAGIC) else {
+        return DataPlaneError {
+            code: DataErrorCode::Unknown,
+            message: String::from_utf8_lossy(body).into_owned(),
+        };
+    };
+    match bincode::deserialize::<ErrorEnvelope>(encoded) {
+        Ok(envelope) => DataPlaneError {
+            code: envelope.code,
+            message: envelope.message,
+        },
+        Err(error) => DataPlaneError {
+            code: DataErrorCode::Internal,
+            message: format!("malformed typed worker error: {error}"),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -237,6 +334,40 @@ mod tests {
         assert!(header.flags.contains(Flags::ERROR));
         assert_eq!(header.request_id, 7);
         assert_eq!(&buf[HEADER_LEN..], b"boom");
+    }
+
+    #[test]
+    fn typed_error_round_trips_with_a_stable_code() {
+        let buf = encode_typed_error(9, DataErrorCode::VersionMismatch, "object changed");
+        let header = FrameHeader::decode(&buf).unwrap();
+        assert!(header.flags.contains(Flags::ERROR));
+        assert_eq!(header.request_id, 9);
+        assert_eq!(
+            decode_error_payload(&buf[HEADER_LEN..]),
+            DataPlaneError {
+                code: DataErrorCode::VersionMismatch,
+                message: "object changed".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn legacy_error_is_unknown_without_string_classification() {
+        let buf = encode_error(4, "object not found: bucket/key");
+        assert_eq!(
+            decode_error_payload(&buf[HEADER_LEN..]),
+            DataPlaneError {
+                code: DataErrorCode::Unknown,
+                message: "object not found: bucket/key".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn malformed_typed_error_fails_closed_as_internal() {
+        let error = decode_error_payload(b"TLE1not-bincode");
+        assert_eq!(error.code, DataErrorCode::Internal);
+        assert!(error.message.contains("malformed typed worker error"));
     }
 
     #[test]

--- a/crates/talon-transport/src/lib.rs
+++ b/crates/talon-transport/src/lib.rs
@@ -23,9 +23,9 @@ pub use codec::{
     CONTROL_SCHEMA_VERSION, MIN_CONTROL_SCHEMA_VERSION,
 };
 pub use data::{
-    decode_delete, decode_put_header, decode_request, encode_delete, encode_error,
-    encode_put_header, encode_request, response_header_ok, DataError, DeleteRequest, PutRequest,
-    RangeRequest,
+    decode_delete, decode_error_payload, decode_put_header, decode_request, encode_delete,
+    encode_error, encode_put_header, encode_request, encode_typed_error, response_header_ok,
+    DataError, DataErrorCode, DataPlaneError, DeleteRequest, PutRequest, RangeRequest,
 };
 pub use frame::{Flags, FrameError, FrameHeader, MsgType, HEADER_LEN, MAGIC, PROTOCOL_VERSION};
 pub use limits::{

--- a/crates/talon-worker/src/data_error.rs
+++ b/crates/talon-worker/src/data_error.rs
@@ -1,0 +1,81 @@
+//! Stable data-plane error classification shared by both worker runtimes.
+
+use talon_core::Error;
+use talon_transport::{encode_typed_error, DataErrorCode};
+
+/// Encode an error returned by [`crate::WorkerRuntime`] for a range request.
+pub(crate) fn encode_runtime_error(request_id: u32, error: &anyhow::Error) -> Vec<u8> {
+    encode_typed_error(request_id, classify(error), error.to_string())
+}
+
+fn classify(error: &anyhow::Error) -> DataErrorCode {
+    if let Some(error) = error.downcast_ref::<Error>() {
+        return match error {
+            Error::NotFound(_) => DataErrorCode::NotFound,
+            Error::NodeUnavailable(_) => DataErrorCode::Unavailable,
+            Error::Backend(_) => DataErrorCode::Origin,
+            Error::VersionMismatch { .. } => DataErrorCode::VersionMismatch,
+            Error::Io(error) if error.kind() == std::io::ErrorKind::TimedOut => {
+                DataErrorCode::Timeout
+            }
+            Error::Io(_) => DataErrorCode::Unavailable,
+            Error::Unsupported(_) | Error::Serialization(_) | Error::Other(_) => {
+                DataErrorCode::Internal
+            }
+        };
+    }
+    if let Some(error) = error.downcast_ref::<std::io::Error>() {
+        return if error.kind() == std::io::ErrorKind::TimedOut {
+            DataErrorCode::Timeout
+        } else {
+            DataErrorCode::Unavailable
+        };
+    }
+    DataErrorCode::Internal
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use talon_transport::{decode_error_payload, FrameHeader, HEADER_LEN};
+
+    fn encoded_code(error: anyhow::Error) -> DataErrorCode {
+        let frame = encode_runtime_error(1, &error);
+        let header = FrameHeader::decode(&frame).unwrap();
+        decode_error_payload(&frame[HEADER_LEN..HEADER_LEN + header.length as usize]).code
+    }
+
+    #[test]
+    fn core_failures_have_stable_codes() {
+        assert_eq!(
+            encoded_code(Error::NotFound("x".into()).into()),
+            DataErrorCode::NotFound
+        );
+        assert_eq!(
+            encoded_code(
+                Error::VersionMismatch {
+                    expected: "a".into(),
+                    found: "b".into(),
+                }
+                .into()
+            ),
+            DataErrorCode::VersionMismatch
+        );
+        assert_eq!(
+            encoded_code(Error::Backend("origin failed".into()).into()),
+            DataErrorCode::Origin
+        );
+    }
+
+    #[test]
+    fn timeout_is_distinct_from_other_io() {
+        assert_eq!(
+            encoded_code(std::io::Error::new(std::io::ErrorKind::TimedOut, "slow").into()),
+            DataErrorCode::Timeout
+        );
+        assert_eq!(
+            encoded_code(std::io::Error::new(std::io::ErrorKind::ConnectionReset, "reset").into()),
+            DataErrorCode::Unavailable
+        );
+    }
+}

--- a/crates/talon-worker/src/lib.rs
+++ b/crates/talon-worker/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod block_store;
 pub mod capacity;
+mod data_error;
 pub mod eviction;
 pub mod flusher;
 pub mod index;

--- a/crates/talon-worker/src/tokio_conn.rs
+++ b/crates/talon-worker/src/tokio_conn.rs
@@ -26,10 +26,11 @@ use std::time::Instant;
 use talon_core::RequestId;
 use talon_transport::data;
 use talon_transport::frame::{MsgType, HEADER_LEN};
-use talon_transport::{codec, ControlMessage, FrameHeader};
+use talon_transport::{codec, ControlMessage, DataErrorCode, FrameHeader};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
+use crate::data_error::encode_runtime_error;
 use crate::{send_file_range, ServeOutcome, WorkerObservability, WorkerRuntime, DEFAULT_CHUNK};
 
 /// Serve data-plane range requests on one connection until EOF.
@@ -105,8 +106,9 @@ pub async fn handle_conn(
         // GetRange (plus the Put/Delete/Control handled above); other frames are
         // capped tightly by read_frame.
         if header.msg_type != MsgType::GetRange {
-            let err = data::encode_error(
+            let err = data::encode_typed_error(
                 header.request_id,
+                DataErrorCode::InvalidRequest,
                 "worker only serves GetRange/Put/Delete/StatObject/ListObjects",
             );
             stream.write_all(&err).await?;
@@ -123,7 +125,11 @@ pub async fn handle_conn(
         let (h, req) = match data::decode_request(&full) {
             Ok(v) => v,
             Err(e) => {
-                let err = data::encode_error(header.request_id, &format!("bad request: {e}"));
+                let err = data::encode_typed_error(
+                    header.request_id,
+                    DataErrorCode::InvalidRequest,
+                    format!("bad request: {e}"),
+                );
                 stream.write_all(&err).await?;
                 stream.flush().await?;
                 observability
@@ -134,7 +140,25 @@ pub async fn handle_conn(
         };
 
         if !observability.is_ready() {
-            let err = data::encode_error(h.request_id, "worker is not ready");
+            let err = data::encode_typed_error(
+                h.request_id,
+                DataErrorCode::Unavailable,
+                "worker is not ready",
+            );
+            stream.write_all(&err).await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+            continue;
+        }
+
+        if req.offset.checked_add(req.len).is_none() {
+            let err = data::encode_typed_error(
+                h.request_id,
+                DataErrorCode::InvalidRequest,
+                "range offset+len overflows u64",
+            );
             stream.write_all(&err).await?;
             stream.flush().await?;
             observability
@@ -188,7 +212,7 @@ pub async fn handle_conn(
                     error = %e,
                     "serving range failed"
                 );
-                let err = data::encode_error(h.request_id, &e.to_string());
+                let err = encode_runtime_error(h.request_id, &e);
                 stream.write_all(&err).await?;
                 stream.flush().await?;
                 observability

--- a/crates/talon-worker/src/uring_conn.rs
+++ b/crates/talon-worker/src/uring_conn.rs
@@ -61,7 +61,9 @@ use talon_core::{BlockHandle, RequestId};
 use talon_transport::data;
 use talon_transport::frame::{FrameHeader, MsgType, HEADER_LEN};
 use talon_transport::uring::{write_all, BufferedFrameReader};
+use talon_transport::DataErrorCode;
 
+use crate::data_error::encode_runtime_error;
 use crate::observability::WorkerObservability;
 use crate::runtime::{ServeOutcome, WorkerRuntime};
 use crate::{send_header_and_file_range, DEFAULT_CHUNK};
@@ -137,8 +139,9 @@ pub async fn handle_conn(
             // A data listener serves only GetRange/Put/Delete; anything else is
             // rejected before any per-request work.
             _ => {
-                let err = data::encode_error(
+                let err = data::encode_typed_error(
                     header.request_id,
+                    DataErrorCode::InvalidRequest,
                     "worker only serves GetRange/Put/Delete/StatObject/ListObjects",
                 );
                 write_all(&mut stream, err).await?;
@@ -152,7 +155,11 @@ pub async fn handle_conn(
         let (h, req) = match data::decode_request(&rejoin(&header, &payload)) {
             Ok(v) => v,
             Err(e) => {
-                let err = data::encode_error(header.request_id, &format!("bad request: {e}"));
+                let err = data::encode_typed_error(
+                    header.request_id,
+                    DataErrorCode::InvalidRequest,
+                    format!("bad request: {e}"),
+                );
                 write_all(&mut stream, err).await?;
                 observability
                     .metrics()
@@ -162,7 +169,24 @@ pub async fn handle_conn(
         };
 
         if !observability.is_ready() {
-            let err = data::encode_error(h.request_id, "worker is not ready");
+            let err = data::encode_typed_error(
+                h.request_id,
+                DataErrorCode::Unavailable,
+                "worker is not ready",
+            );
+            write_all(&mut stream, err).await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+            continue;
+        }
+
+        if req.offset.checked_add(req.len).is_none() {
+            let err = data::encode_typed_error(
+                h.request_id,
+                DataErrorCode::InvalidRequest,
+                "range offset+len overflows u64",
+            );
             write_all(&mut stream, err).await?;
             observability
                 .metrics()
@@ -207,7 +231,7 @@ pub async fn handle_conn(
                     error = %e,
                     "serving range failed"
                 );
-                let err = data::encode_error(h.request_id, &e.to_string());
+                let err = encode_runtime_error(h.request_id, &e);
                 write_all(&mut stream, err).await?;
                 observability
                     .metrics()


### PR DESCRIPTION
## Summary

- add demand-driven cache range streaming bounded by block and transfer chunk size
- add stable typed worker data-plane failures with legacy fail-closed decoding
- preserve replica retries while exposing deterministic gateway fallback eligibility
- cancel in-flight worker I/O when the response stream is dropped

## Verification

- `cargo test -p talon-transport -p talon-cache-client -p talon-worker --all-features --locked`
- `cargo clippy -p talon-transport -p talon-cache-client -p talon-worker --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --all-features`
- `just ci`

Closes #472
