### PR TITLE
feat(gateway): add bounded shared HTTP runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2654,6 +2654,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "talon-gateway"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "bytes",
+ "futures",
+ "http-body-util",
+ "serde",
+ "serde_json",
+ "talon-core",
+ "thiserror 2.0.19",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
 name = "talon-metadata"
 version = "0.1.0"
 dependencies = [
@@ -3076,6 +3095,7 @@ dependencies = [
  "http-body",
  "mime",
  "pin-project-lite",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/talon-core",
     "crates/talon-cache-client",
+    "crates/talon-gateway",
     "crates/talon-coordinator",
     "crates/talon-worker",
     "crates/talon-fuse",
@@ -53,6 +54,9 @@ divan = "0.1"
 # needs to stay off the ring; it requires an explicitly attached thread pool.
 monoio = { version = "0.2.4", features = ["sync"] }
 axum = "0.8"
+tower = { version = "0.5", features = ["limit", "util"] }
+tower-http = { version = "0.6", features = ["timeout"] }
+http-body-util = "0.1"
 serde_yaml = "0.9"
 # Kubernetes client for the Lease-based ClusterStateStore backend (feature
 # "kubernetes"). rustls avoids a system OpenSSL build dependency. k8s-openapi is

--- a/crates/talon-gateway/Cargo.toml
+++ b/crates/talon-gateway/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "talon-gateway"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Shared bounded HTTP runtime for Talon object-store gateways"
+
+[dependencies]
+talon-core.workspace = true
+async-trait.workspace = true
+axum.workspace = true
+futures.workspace = true
+http-body-util.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tower.workspace = true
+tower-http.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+bytes.workspace = true

--- a/crates/talon-gateway/src/config.rs
+++ b/crates/talon-gateway/src/config.rs
@@ -1,0 +1,132 @@
+//! Runtime limits and fail-closed deployment mode.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+/// Whether a gateway is an explicitly local development process or production.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GatewayMode {
+    /// Unauthenticated mode, accepted only on a loopback listener.
+    Development,
+    /// Public data-plane mode; readiness requires TLS, authn, and authz.
+    Production,
+}
+
+/// Security components installed by the production security layer.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct GatewaySecurity {
+    /// Client connections are protected by TLS.
+    pub tls: bool,
+    /// Provider credentials are authenticated before dispatch.
+    pub authentication: bool,
+    /// The authenticated principal is checked against a policy.
+    pub authorization: bool,
+}
+
+impl GatewaySecurity {
+    pub(crate) fn production_ready(self) -> bool {
+        self.tls && self.authentication && self.authorization
+    }
+}
+
+/// Shared HTTP server limits.
+#[derive(Debug, Clone)]
+pub struct GatewayConfig {
+    /// Listener address used to enforce loopback-only development mode.
+    pub bind: SocketAddr,
+    /// Deployment security mode.
+    pub mode: GatewayMode,
+    /// Maximum raw request-target length.
+    pub max_request_target_bytes: usize,
+    /// Maximum number of request headers.
+    pub max_header_count: usize,
+    /// Maximum aggregate request header name/value bytes.
+    pub max_header_bytes: usize,
+    /// Maximum request body bytes, including chunked bodies.
+    pub max_body_bytes: usize,
+    /// Maximum active provider requests. Operational endpoints are exempt.
+    pub max_concurrency: usize,
+    /// Deadline for adapter dispatch before response headers exist.
+    pub request_deadline: Duration,
+    /// Maximum wait between request or response body frames.
+    pub body_idle_timeout: Duration,
+    /// Time allowed for active requests after shutdown begins.
+    pub graceful_shutdown_timeout: Duration,
+}
+
+impl Default for GatewayConfig {
+    fn default() -> Self {
+        Self {
+            bind: "127.0.0.1:8080".parse().expect("literal socket address"),
+            mode: GatewayMode::Development,
+            max_request_target_bytes: 16 * 1024,
+            max_header_count: 100,
+            max_header_bytes: 64 * 1024,
+            max_body_bytes: 16 * 1024 * 1024,
+            max_concurrency: 1_024,
+            request_deadline: Duration::from_secs(30),
+            body_idle_timeout: Duration::from_secs(30),
+            graceful_shutdown_timeout: Duration::from_secs(30),
+        }
+    }
+}
+
+impl GatewayConfig {
+    /// Reject unsafe development listeners and zero-valued limits.
+    pub fn validate(&self) -> Result<(), GatewayConfigError> {
+        if self.mode == GatewayMode::Development && !self.bind.ip().is_loopback() {
+            return Err(GatewayConfigError::DevelopmentRequiresLoopback);
+        }
+        if self.max_request_target_bytes == 0
+            || self.max_header_count == 0
+            || self.max_header_bytes == 0
+            || self.max_body_bytes == 0
+            || self.max_concurrency == 0
+            || self.request_deadline.is_zero()
+            || self.body_idle_timeout.is_zero()
+            || self.graceful_shutdown_timeout.is_zero()
+        {
+            return Err(GatewayConfigError::ZeroLimit);
+        }
+        Ok(())
+    }
+}
+
+/// Invalid shared gateway configuration.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum GatewayConfigError {
+    /// Development mode would expose an unauthenticated public listener.
+    #[error("unauthenticated development mode requires a loopback bind address")]
+    DevelopmentRequiresLoopback,
+    /// A resource or time bound was disabled.
+    #[error("gateway limits and timeouts must be greater than zero")]
+    ZeroLimit,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn development_mode_is_loopback_only() {
+        let mut config = GatewayConfig {
+            bind: "0.0.0.0:8080".parse().unwrap(),
+            ..GatewayConfig::default()
+        };
+        assert_eq!(
+            config.validate(),
+            Err(GatewayConfigError::DevelopmentRequiresLoopback)
+        );
+        config.mode = GatewayMode::Production;
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn every_limit_is_nonzero() {
+        let config = GatewayConfig {
+            max_concurrency: 0,
+            ..GatewayConfig::default()
+        };
+        assert_eq!(config.validate(), Err(GatewayConfigError::ZeroLimit));
+    }
+}

--- a/crates/talon-gateway/src/lib.rs
+++ b/crates/talon-gateway/src/lib.rs
@@ -1,0 +1,14 @@
+//! Provider-neutral, bounded HTTP runtime shared by Talon's object-store gateways.
+
+mod config;
+mod metrics;
+mod model;
+mod runtime;
+
+pub use config::{GatewayConfig, GatewayConfigError, GatewayMode, GatewaySecurity};
+pub use metrics::GatewayMetrics;
+pub use model::{
+    FailureReason, GatewayAdapter, GatewayOperation, GatewayOutcome, GatewayRequestContext,
+    GatewayResponse, GatewayRoute, GatewayTarget, ProviderProtocol,
+};
+pub use runtime::{gateway_router, serve, GatewayReadiness, GatewayRuntime, REQUEST_ID_HEADER};

--- a/crates/talon-gateway/src/metrics.rs
+++ b/crates/talon-gateway/src/metrics.rs
@@ -1,0 +1,168 @@
+//! Low-cardinality gateway metrics.
+
+use std::time::Duration;
+
+use talon_core::metrics::{labels, Counter, Histogram, Metrics};
+
+use crate::model::{
+    FailureReason, GatewayOperation, GatewayOutcome, GatewayRoute, ProviderProtocol,
+};
+
+/// Metrics shared by all provider adapters.
+#[derive(Clone)]
+pub struct GatewayMetrics {
+    registry: Metrics,
+}
+
+impl Default for GatewayMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GatewayMetrics {
+    /// Create an empty gateway registry.
+    pub fn new() -> Self {
+        Self {
+            registry: Metrics::new(),
+        }
+    }
+
+    /// Render Prometheus text exposition.
+    pub fn render(&self) -> String {
+        self.registry.render()
+    }
+
+    pub(crate) fn record_headers(&self, observation: RequestObservation) {
+        let failure = observation.failure.map_or("none", FailureReason::label);
+        let response_class = match observation.status / 100 {
+            1 => "1xx",
+            2 => "2xx",
+            3 => "3xx",
+            4 => "4xx",
+            _ => "5xx",
+        };
+        self.registry
+            .counter(
+                "talon_gateway_requests_total",
+                "Gateway requests by bounded provider-neutral result dimensions.",
+                labels(&[
+                    ("protocol", observation.protocol.label()),
+                    ("operation", observation.operation.label()),
+                    ("route", observation.route.label()),
+                    ("outcome", observation.outcome.label()),
+                    ("response_class", response_class),
+                    ("failure", failure),
+                ]),
+            )
+            .inc();
+        self.byte_counter(observation.protocol, observation.operation, "requested")
+            .add(observation.requested_bytes);
+        self.byte_counter(observation.protocol, observation.operation, "cache")
+            .add(observation.cache_bytes);
+        self.byte_counter(observation.protocol, observation.operation, "origin")
+            .add(observation.origin_bytes);
+        self.latency_histogram(observation.protocol, observation.operation, "headers")
+            .observe(observation.headers_latency.as_secs_f64());
+    }
+
+    pub(crate) fn response_observer(
+        &self,
+        protocol: ProviderProtocol,
+        operation: GatewayOperation,
+    ) -> ResponseObserver {
+        ResponseObserver {
+            bytes: self.byte_counter(protocol, operation, "response"),
+            total_latency: self.latency_histogram(protocol, operation, "total"),
+        }
+    }
+
+    fn byte_counter(
+        &self,
+        protocol: ProviderProtocol,
+        operation: GatewayOperation,
+        source: &'static str,
+    ) -> Counter {
+        self.registry.counter(
+            "talon_gateway_bytes_total",
+            "Gateway bytes by bounded source dimension.",
+            labels(&[
+                ("protocol", protocol.label()),
+                ("operation", operation.label()),
+                ("source", source),
+            ]),
+        )
+    }
+
+    fn latency_histogram(
+        &self,
+        protocol: ProviderProtocol,
+        operation: GatewayOperation,
+        phase: &'static str,
+    ) -> Histogram {
+        self.registry.histogram(
+            "talon_gateway_request_duration_seconds",
+            "Gateway time to response headers and body completion.",
+            labels(&[
+                ("protocol", protocol.label()),
+                ("operation", operation.label()),
+                ("phase", phase),
+            ]),
+        )
+    }
+}
+
+pub(crate) struct RequestObservation {
+    pub protocol: ProviderProtocol,
+    pub operation: GatewayOperation,
+    pub route: GatewayRoute,
+    pub outcome: GatewayOutcome,
+    pub failure: Option<FailureReason>,
+    pub status: u16,
+    pub requested_bytes: u64,
+    pub cache_bytes: u64,
+    pub origin_bytes: u64,
+    pub headers_latency: Duration,
+}
+
+pub(crate) struct ResponseObserver {
+    bytes: Counter,
+    total_latency: Histogram,
+}
+
+impl ResponseObserver {
+    pub(crate) fn complete(self, bytes: u64, elapsed: Duration) {
+        self.bytes.add(bytes);
+        self.total_latency.observe(elapsed.as_secs_f64());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rendered_labels_never_include_targets_or_credentials() {
+        let metrics = GatewayMetrics::new();
+        metrics.record_headers(RequestObservation {
+            protocol: ProviderProtocol::Azure,
+            operation: GatewayOperation::Read,
+            route: GatewayRoute::Cache,
+            outcome: GatewayOutcome::Hit,
+            failure: None,
+            status: 206,
+            requested_bytes: 10,
+            cache_bytes: 10,
+            origin_bytes: 0,
+            headers_latency: Duration::from_millis(2),
+        });
+        metrics
+            .response_observer(ProviderProtocol::Azure, GatewayOperation::Read)
+            .complete(10, Duration::from_millis(3));
+        let rendered = metrics.render();
+        assert!(rendered.contains("protocol=\"azure\""));
+        assert!(rendered.contains("source=\"response\""));
+        assert!(!rendered.contains("object"));
+        assert!(!rendered.contains("credential"));
+    }
+}

--- a/crates/talon-gateway/src/model.rs
+++ b/crates/talon-gateway/src/model.rs
@@ -1,0 +1,230 @@
+//! Provider-neutral request and result contract.
+
+use std::time::Instant;
+
+use async_trait::async_trait;
+use axum::body::Body;
+use axum::extract::Request;
+use axum::response::Response;
+use talon_core::{Backend, ObjectId};
+
+/// Object-store protocol served by one gateway process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderProtocol {
+    /// Amazon S3-compatible HTTP API.
+    S3,
+    /// Azure Blob Storage-compatible HTTP API.
+    Azure,
+}
+
+impl ProviderProtocol {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::S3 => "s3",
+            Self::Azure => "azure",
+        }
+    }
+}
+
+/// Provider-neutral operation used by policy and bounded-cardinality metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GatewayOperation {
+    /// Resolve object metadata.
+    Stat,
+    /// Read a full object or one byte range.
+    Read,
+    /// List a namespace or prefix.
+    List,
+    /// Create or replace object data.
+    Write,
+    /// Delete object data.
+    Delete,
+    /// An operation intentionally outside the compatibility matrix.
+    Unsupported,
+}
+
+impl GatewayOperation {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Stat => "stat",
+            Self::Read => "read",
+            Self::List => "list",
+            Self::Write => "write",
+            Self::Delete => "delete",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
+/// Canonical target produced by a protocol adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GatewayTarget {
+    /// One canonical Talon object.
+    Object(ObjectId),
+    /// A provider namespace listing. Prefixes stay out of logs and metrics.
+    Namespace {
+        /// Canonical backend family.
+        backend: Backend,
+        /// Bucket or container.
+        namespace: String,
+        /// Optional provider prefix.
+        prefix: Option<String>,
+    },
+}
+
+/// Internal cache/origin route selected after authorization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GatewayRoute {
+    /// Use Talon and allow worker read-through population.
+    Cache,
+    /// Use Talon but never fetch missing bytes from the origin.
+    CacheOnly,
+    /// Bypass Talon and call the origin directly.
+    Origin,
+    /// No data route was selected, for validation/auth failures.
+    None,
+}
+
+impl GatewayRoute {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Cache => "cache",
+            Self::CacheOnly => "cache_only",
+            Self::Origin => "origin",
+            Self::None => "none",
+        }
+    }
+}
+
+/// Provider-neutral request outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GatewayOutcome {
+    /// Bytes came from an already resident cache entry.
+    Hit,
+    /// A worker filled missing bytes from the origin.
+    Fill,
+    /// The request intentionally bypassed Talon.
+    Bypass,
+    /// Cache infrastructure failed and policy allowed direct-origin fallback.
+    Fallback,
+    /// Cache-only routing found no resident bytes.
+    CacheOnlyMiss,
+    /// Metadata or a body completed without a cache classification.
+    Complete,
+    /// The request failed before completion.
+    Failed,
+}
+
+impl GatewayOutcome {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Hit => "hit",
+            Self::Fill => "fill",
+            Self::Bypass => "bypass",
+            Self::Fallback => "fallback",
+            Self::CacheOnlyMiss => "cache_only_miss",
+            Self::Complete => "complete",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// Stable failure dimensions. Diagnostic strings are deliberately excluded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureReason {
+    /// Request syntax or range was invalid.
+    InvalidRequest,
+    /// Client authentication failed.
+    Authentication,
+    /// The authenticated principal lacks permission.
+    Authorization,
+    /// The authoritative object does not exist.
+    NotFound,
+    /// A conditional request failed.
+    Precondition,
+    /// Cache infrastructure was unavailable.
+    CacheUnavailable,
+    /// A cache or origin deadline elapsed.
+    Timeout,
+    /// The origin returned an operation failure.
+    Origin,
+    /// A framing or internal invariant failed.
+    Internal,
+    /// The operation is not in the advertised compatibility matrix.
+    Unsupported,
+}
+
+impl FailureReason {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::InvalidRequest => "invalid_request",
+            Self::Authentication => "authentication",
+            Self::Authorization => "authorization",
+            Self::NotFound => "not_found",
+            Self::Precondition => "precondition",
+            Self::CacheUnavailable => "cache_unavailable",
+            Self::Timeout => "timeout",
+            Self::Origin => "origin",
+            Self::Internal => "internal",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
+/// Per-request context generated before provider parsing.
+#[derive(Debug, Clone)]
+pub struct GatewayRequestContext {
+    /// Stable opaque ID returned on every response.
+    pub request_id: String,
+    /// Monotonic request start used for latency accounting.
+    pub started: Instant,
+}
+
+/// Adapter response plus provider-neutral accounting metadata.
+pub struct GatewayResponse {
+    /// Provider-correct status, headers, and streaming body.
+    pub response: Response<Body>,
+    /// Parsed operation.
+    pub operation: GatewayOperation,
+    /// Canonical target, retained for policy but never used as a metric label.
+    pub target: Option<GatewayTarget>,
+    /// Selected route.
+    pub route: GatewayRoute,
+    /// Result classification.
+    pub outcome: GatewayOutcome,
+    /// Stable failure class, if any.
+    pub failure: Option<FailureReason>,
+    /// Bytes requested by the client, when known.
+    pub requested_bytes: u64,
+    /// Bytes read through Talon workers.
+    pub cache_bytes: u64,
+    /// Bytes read directly from the origin.
+    pub origin_bytes: u64,
+}
+
+impl GatewayResponse {
+    /// Construct a response with conservative, non-data defaults.
+    pub fn new(response: Response<Body>, operation: GatewayOperation) -> Self {
+        Self {
+            response,
+            operation,
+            target: None,
+            route: GatewayRoute::None,
+            outcome: GatewayOutcome::Complete,
+            failure: None,
+            requested_bytes: 0,
+            cache_bytes: 0,
+            origin_bytes: 0,
+        }
+    }
+}
+
+/// Protocol-specific parser/authenticator/response translator.
+#[async_trait]
+pub trait GatewayAdapter: Send + Sync + 'static {
+    /// Protocol label for metrics and logs.
+    fn protocol(&self) -> ProviderProtocol;
+
+    /// Parse, authorize, execute, and translate one provider request.
+    async fn handle(&self, request: Request, context: GatewayRequestContext) -> GatewayResponse;
+}

--- a/crates/talon-gateway/src/runtime.rs
+++ b/crates/talon-gateway/src/runtime.rs
@@ -1,0 +1,963 @@
+//! Axum server, lifecycle middleware, operational endpoints, and limits.
+
+use std::future::{Future, IntoFuture};
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use futures::StreamExt;
+use http_body_util::{BodyStream, Limited, StreamBody};
+use serde_json::json;
+use tokio::net::TcpListener;
+use tower::limit::ConcurrencyLimitLayer;
+use tower_http::timeout::TimeoutBody;
+
+use crate::config::{GatewayConfig, GatewayConfigError, GatewayMode, GatewaySecurity};
+use crate::metrics::{GatewayMetrics, RequestObservation, ResponseObserver};
+use crate::model::{
+    FailureReason, GatewayAdapter, GatewayOperation, GatewayOutcome, GatewayRequestContext,
+    GatewayResponse, GatewayRoute,
+};
+
+/// Opaque request ID emitted by the shared core and translated by adapters.
+pub const REQUEST_ID_HEADER: &str = "x-talon-request-id";
+
+static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Copy)]
+struct MetricsRecorded;
+
+/// Mutable dependency and security readiness shared with adapter binaries.
+pub struct GatewayReadiness {
+    mode: GatewayMode,
+    dependencies_ready: AtomicBool,
+    shutting_down: AtomicBool,
+    security: RwLock<GatewaySecurity>,
+}
+
+impl GatewayReadiness {
+    fn new(mode: GatewayMode, security: GatewaySecurity) -> Self {
+        Self {
+            mode,
+            dependencies_ready: AtomicBool::new(true),
+            shutting_down: AtomicBool::new(false),
+            security: RwLock::new(security),
+        }
+    }
+
+    /// Update whether coordinator/origin dependencies can serve requests.
+    pub fn set_dependencies_ready(&self, ready: bool) {
+        self.dependencies_ready.store(ready, Ordering::Release);
+    }
+
+    /// Update installed production security components.
+    pub fn set_security(&self, security: GatewaySecurity) {
+        *self.security.write().unwrap() = security;
+    }
+
+    /// Whether the process should receive provider traffic.
+    pub fn is_ready(&self) -> bool {
+        !self.shutting_down.load(Ordering::Acquire)
+            && self.dependencies_ready.load(Ordering::Acquire)
+            && (self.mode == GatewayMode::Development
+                || self.security.read().unwrap().production_ready())
+    }
+
+    fn is_live(&self) -> bool {
+        !self.shutting_down.load(Ordering::Acquire)
+    }
+
+    fn begin_shutdown(&self) {
+        self.shutting_down.store(true, Ordering::Release);
+    }
+
+    fn blocking_reasons(&self) -> Vec<&'static str> {
+        let mut reasons = Vec::new();
+        if self.shutting_down.load(Ordering::Acquire) {
+            reasons.push("shutting_down");
+        }
+        if !self.dependencies_ready.load(Ordering::Acquire) {
+            reasons.push("dependencies_not_ready");
+        }
+        if self.mode == GatewayMode::Production {
+            let security = *self.security.read().unwrap();
+            if !security.tls {
+                reasons.push("tls_not_configured");
+            }
+            if !security.authentication {
+                reasons.push("authentication_not_configured");
+            }
+            if !security.authorization {
+                reasons.push("authorization_not_configured");
+            }
+        }
+        reasons
+    }
+}
+
+/// Shared runtime state used by a protocol-specific binary.
+pub struct GatewayRuntime {
+    config: GatewayConfig,
+    adapter: Arc<dyn GatewayAdapter>,
+    readiness: Arc<GatewayReadiness>,
+    metrics: GatewayMetrics,
+}
+
+impl GatewayRuntime {
+    /// Validate configuration and construct a shared runtime.
+    pub fn new(
+        config: GatewayConfig,
+        adapter: Arc<dyn GatewayAdapter>,
+        security: GatewaySecurity,
+    ) -> Result<Self, GatewayConfigError> {
+        config.validate()?;
+        if config.mode == GatewayMode::Development {
+            tracing::warn!(
+                bind = %config.bind,
+                "gateway development mode is unauthenticated and loopback-only"
+            );
+        }
+        Ok(Self {
+            readiness: Arc::new(GatewayReadiness::new(config.mode, security)),
+            config,
+            adapter,
+            metrics: GatewayMetrics::new(),
+        })
+    }
+
+    /// Live readiness controls for dependency and security initialization.
+    pub fn readiness(&self) -> &Arc<GatewayReadiness> {
+        &self.readiness
+    }
+
+    /// Shared metrics registry.
+    pub fn metrics(&self) -> &GatewayMetrics {
+        &self.metrics
+    }
+}
+
+/// Build the complete provider and operational router.
+pub fn gateway_router(runtime: Arc<GatewayRuntime>) -> Router {
+    let data = Router::new()
+        .fallback(adapter_handler)
+        .layer(ConcurrencyLimitLayer::new(runtime.config.max_concurrency))
+        .layer(axum::middleware::from_fn_with_state(
+            Arc::clone(&runtime),
+            enforce_limits,
+        ));
+
+    Router::new()
+        .route("/healthz", get(health_handler))
+        .route("/readyz", get(readiness_handler))
+        .route("/metrics", get(metrics_handler))
+        .merge(data)
+        .layer(axum::middleware::from_fn_with_state(
+            Arc::clone(&runtime),
+            request_lifecycle,
+        ))
+        .with_state(runtime)
+}
+
+/// Serve until shutdown, then wait a bounded time for active responses.
+pub async fn serve(
+    listener: TcpListener,
+    runtime: Arc<GatewayRuntime>,
+    shutdown: impl Future<Output = ()> + Send + 'static,
+) -> std::io::Result<()> {
+    let local = listener.local_addr()?;
+    if runtime.config.mode == GatewayMode::Development && !local.ip().is_loopback() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "development gateway listener is not loopback",
+        ));
+    }
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server = axum::serve(
+        listener,
+        gateway_router(Arc::clone(&runtime)).into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(async move {
+        let _ = shutdown_rx.await;
+    })
+    .into_future();
+    tokio::pin!(server);
+    tokio::pin!(shutdown);
+
+    tokio::select! {
+        result = &mut server => result,
+        () = &mut shutdown => {
+            runtime.readiness.begin_shutdown();
+            let _ = shutdown_tx.send(());
+            match tokio::time::timeout(runtime.config.graceful_shutdown_timeout, &mut server).await {
+                Ok(result) => result,
+                Err(_) => Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "gateway graceful shutdown timed out",
+                )),
+            }
+        }
+    }
+}
+
+async fn adapter_handler(State(runtime): State<Arc<GatewayRuntime>>, request: Request) -> Response {
+    let context = request
+        .extensions()
+        .get::<GatewayRequestContext>()
+        .cloned()
+        .expect("lifecycle middleware installs request context");
+    let elapsed = context.started.elapsed();
+    let remaining = runtime.config.request_deadline.saturating_sub(elapsed);
+    let protocol = runtime.adapter.protocol();
+    let result =
+        match tokio::time::timeout(remaining, runtime.adapter.handle(request, context.clone()))
+            .await
+        {
+            Ok(result) => result,
+            Err(_) => GatewayResponse {
+                response: (
+                    StatusCode::GATEWAY_TIMEOUT,
+                    "gateway request deadline exceeded",
+                )
+                    .into_response(),
+                operation: GatewayOperation::Unsupported,
+                target: None,
+                route: GatewayRoute::None,
+                outcome: GatewayOutcome::Failed,
+                failure: Some(FailureReason::Timeout),
+                requested_bytes: 0,
+                cache_bytes: 0,
+                origin_bytes: 0,
+            },
+        };
+
+    let mut response = result.response;
+    let status = response.status();
+    runtime.metrics.record_headers(RequestObservation {
+        protocol,
+        operation: result.operation,
+        route: result.route,
+        outcome: result.outcome,
+        failure: result.failure,
+        status: status.as_u16(),
+        requested_bytes: result.requested_bytes,
+        cache_bytes: result.cache_bytes,
+        origin_bytes: result.origin_bytes,
+        headers_latency: context.started.elapsed(),
+    });
+    let observer = runtime
+        .metrics
+        .response_observer(protocol, result.operation);
+    response.extensions_mut().insert(MetricsRecorded);
+    observe_response_body(
+        response,
+        observer,
+        context.started,
+        runtime.config.request_deadline,
+    )
+}
+
+fn observe_response_body(
+    response: Response,
+    observer: ResponseObserver,
+    started: std::time::Instant,
+    request_deadline: std::time::Duration,
+) -> Response {
+    let (parts, body) = response.into_parts();
+    let frames = Box::pin(BodyStream::new(body));
+    let completion = ResponseCompletion {
+        observer: Some(observer),
+        bytes: 0,
+        started,
+    };
+    let stream = futures::stream::unfold(
+        (frames, completion, false),
+        move |(mut frames, mut completion, deadline_expired)| async move {
+            if deadline_expired {
+                return None;
+            }
+            let deadline = tokio::time::Instant::from_std(started + request_deadline);
+            let frame = if tokio::time::Instant::now() >= deadline {
+                None
+            } else {
+                tokio::select! {
+                    frame = frames.next() => Some(frame),
+                    () = tokio::time::sleep_until(deadline) => None,
+                }
+            };
+            match frame {
+                None => {
+                    completion.finish();
+                    let error = axum::Error::new(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "gateway response deadline exceeded",
+                    ));
+                    Some((Err(error), (frames, completion, true)))
+                }
+                Some(Some(Ok(frame))) => {
+                    if let Some(data) = frame.data_ref() {
+                        completion.bytes = completion.bytes.saturating_add(data.len() as u64);
+                    }
+                    Some((Ok::<_, axum::Error>(frame), (frames, completion, false)))
+                }
+                Some(Some(Err(error))) => {
+                    completion.finish();
+                    Some((Err(error), (frames, completion, true)))
+                }
+                Some(None) => {
+                    completion.finish();
+                    None
+                }
+            }
+        },
+    );
+    Response::from_parts(parts, Body::new(StreamBody::new(stream)))
+}
+
+struct ResponseCompletion {
+    observer: Option<ResponseObserver>,
+    bytes: u64,
+    started: std::time::Instant,
+}
+
+impl ResponseCompletion {
+    fn finish(&mut self) {
+        if let Some(observer) = self.observer.take() {
+            observer.complete(self.bytes, self.started.elapsed());
+        }
+    }
+}
+
+impl Drop for ResponseCompletion {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+async fn enforce_limits(
+    State(runtime): State<Arc<GatewayRuntime>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let target_len = request
+        .uri()
+        .path_and_query()
+        .map_or(0, |value| value.as_str().len());
+    if target_len > runtime.config.max_request_target_bytes {
+        return (
+            StatusCode::URI_TOO_LONG,
+            "request target exceeds gateway limit",
+        )
+            .into_response();
+    }
+    if request.headers().len() > runtime.config.max_header_count {
+        return (
+            StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
+            "request has too many headers",
+        )
+            .into_response();
+    }
+    let header_bytes = request
+        .headers()
+        .iter()
+        .try_fold(0usize, |total, (name, value)| {
+            total
+                .checked_add(name.as_str().len())?
+                .checked_add(value.as_bytes().len())
+        });
+    if match header_bytes {
+        Some(size) => size > runtime.config.max_header_bytes,
+        None => true,
+    } {
+        return (
+            StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
+            "request headers exceed gateway limit",
+        )
+            .into_response();
+    }
+    if request
+        .headers()
+        .get(header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .is_some_and(|length| length > runtime.config.max_body_bytes as u64)
+    {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "request body exceeds gateway limit",
+        )
+            .into_response();
+    }
+    if !runtime.readiness.is_ready() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "gateway is not ready to serve provider traffic",
+        )
+            .into_response();
+    }
+
+    let (parts, body) = request.into_parts();
+    let body = TimeoutBody::new(runtime.config.body_idle_timeout, body);
+    let body = Limited::new(body, runtime.config.max_body_bytes);
+    let response = next.run(Request::from_parts(parts, Body::new(body))).await;
+    let (parts, body) = response.into_parts();
+    let body = TimeoutBody::new(runtime.config.body_idle_timeout, body);
+    Response::from_parts(parts, Body::new(body))
+}
+
+async fn request_lifecycle(
+    State(runtime): State<Arc<GatewayRuntime>>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    let started = std::time::Instant::now();
+    let request_id = format!("{:016x}", NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed));
+    let method = request.method().clone();
+    let operational = matches!(request.uri().path(), "/healthz" | "/readyz" | "/metrics");
+    let context = GatewayRequestContext {
+        request_id: request_id.clone(),
+        started,
+    };
+    request.extensions_mut().insert(context);
+    let mut response = next.run(request).await;
+    if !operational && response.extensions().get::<MetricsRecorded>().is_none() {
+        let status = response.status();
+        let failure = match status {
+            StatusCode::REQUEST_TIMEOUT | StatusCode::GATEWAY_TIMEOUT => FailureReason::Timeout,
+            StatusCode::SERVICE_UNAVAILABLE => FailureReason::CacheUnavailable,
+            _ => FailureReason::InvalidRequest,
+        };
+        let protocol = runtime.adapter.protocol();
+        runtime.metrics.record_headers(RequestObservation {
+            protocol,
+            operation: GatewayOperation::Unsupported,
+            route: GatewayRoute::None,
+            outcome: GatewayOutcome::Failed,
+            failure: Some(failure),
+            status: status.as_u16(),
+            requested_bytes: 0,
+            cache_bytes: 0,
+            origin_bytes: 0,
+            headers_latency: started.elapsed(),
+        });
+        let observer = runtime
+            .metrics
+            .response_observer(protocol, GatewayOperation::Unsupported);
+        response =
+            observe_response_body(response, observer, started, runtime.config.request_deadline);
+    }
+    if let Ok(value) = HeaderValue::from_str(&request_id) {
+        response.headers_mut().insert(REQUEST_ID_HEADER, value);
+    }
+    tracing::info!(
+        request_id,
+        method = %method,
+        status = response.status().as_u16(),
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        protocol = runtime.adapter.protocol().label(),
+        "gateway request headers completed"
+    );
+    response
+}
+
+async fn health_handler(State(runtime): State<Arc<GatewayRuntime>>) -> Response {
+    let live = runtime.readiness.is_live();
+    (
+        if live {
+            StatusCode::OK
+        } else {
+            StatusCode::SERVICE_UNAVAILABLE
+        },
+        Json(json!({"live": live})),
+    )
+        .into_response()
+}
+
+async fn readiness_handler(State(runtime): State<Arc<GatewayRuntime>>) -> Response {
+    let ready = runtime.readiness.is_ready();
+    (
+        if ready {
+            StatusCode::OK
+        } else {
+            StatusCode::SERVICE_UNAVAILABLE
+        },
+        Json(json!({
+            "ready": ready,
+            "reasons": runtime.readiness.blocking_reasons(),
+        })),
+    )
+        .into_response()
+}
+
+async fn metrics_handler(State(runtime): State<Arc<GatewayRuntime>>) -> Response {
+    (
+        [(
+            header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        runtime.metrics.render(),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use axum::body::to_bytes;
+    use axum::http::Request as HttpRequest;
+    use bytes::Bytes;
+    use tower::ServiceExt;
+
+    #[derive(Clone, Copy)]
+    enum AdapterBehavior {
+        Immediate,
+        Pending,
+    }
+
+    struct TestAdapter {
+        calls: AtomicUsize,
+        behavior: AdapterBehavior,
+    }
+
+    impl TestAdapter {
+        fn immediate() -> Arc<Self> {
+            Arc::new(Self {
+                calls: AtomicUsize::new(0),
+                behavior: AdapterBehavior::Immediate,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl GatewayAdapter for TestAdapter {
+        fn protocol(&self) -> crate::ProviderProtocol {
+            crate::ProviderProtocol::S3
+        }
+
+        async fn handle(
+            &self,
+            _request: Request,
+            _context: GatewayRequestContext,
+        ) -> GatewayResponse {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            match self.behavior {
+                AdapterBehavior::Immediate => {
+                    GatewayResponse::new(Response::new(Body::from("ok")), GatewayOperation::Read)
+                }
+                AdapterBehavior::Pending => std::future::pending().await,
+            }
+        }
+    }
+
+    fn runtime_with(
+        mut config: GatewayConfig,
+        adapter: Arc<dyn GatewayAdapter>,
+        security: GatewaySecurity,
+    ) -> Arc<GatewayRuntime> {
+        config.bind = "127.0.0.1:0".parse().unwrap();
+        Arc::new(GatewayRuntime::new(config, adapter, security).unwrap())
+    }
+
+    #[tokio::test]
+    async fn production_readiness_fails_closed_until_every_security_layer_is_ready() {
+        let config = GatewayConfig {
+            mode: GatewayMode::Production,
+            ..GatewayConfig::default()
+        };
+        let adapter = TestAdapter::immediate();
+        let runtime = runtime_with(config, adapter.clone(), GatewaySecurity::default());
+        let app = gateway_router(Arc::clone(&runtime));
+
+        let response = app
+            .clone()
+            .oneshot(HttpRequest::get("/readyz").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(response.into_body(), 4096).await.unwrap();
+        assert!(body.windows(18).any(|part| part == b"tls_not_configured"));
+        let response = app
+            .clone()
+            .oneshot(HttpRequest::get("/object").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(adapter.calls.load(Ordering::SeqCst), 0);
+
+        runtime.readiness().set_security(GatewaySecurity {
+            tls: true,
+            authentication: true,
+            authorization: true,
+        });
+        let response = app
+            .clone()
+            .oneshot(HttpRequest::get("/readyz").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let response = app
+            .oneshot(HttpRequest::get("/object").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(adapter.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn oversized_metadata_and_bodies_fail_before_adapter_dispatch() {
+        let adapter = TestAdapter::immediate();
+        let config = GatewayConfig {
+            max_request_target_bytes: 8,
+            max_header_count: 1,
+            max_body_bytes: 4,
+            ..GatewayConfig::default()
+        };
+        let runtime = runtime_with(config, adapter.clone(), GatewaySecurity::default());
+        let app = gateway_router(runtime);
+
+        let response = app
+            .clone()
+            .oneshot(
+                HttpRequest::get("/too-long-target")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::URI_TOO_LONG);
+
+        let request = HttpRequest::get("/object")
+            .header("x-one", "1")
+            .header("x-two", "2")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE
+        );
+
+        let request = HttpRequest::post("/object")
+            .header(header::CONTENT_LENGTH, "5")
+            .body(Body::from("12345"))
+            .unwrap();
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(adapter.calls.load(Ordering::SeqCst), 0);
+    }
+
+    struct BodyReadingAdapter;
+
+    #[async_trait]
+    impl GatewayAdapter for BodyReadingAdapter {
+        fn protocol(&self) -> crate::ProviderProtocol {
+            crate::ProviderProtocol::Azure
+        }
+
+        async fn handle(
+            &self,
+            request: Request,
+            _context: GatewayRequestContext,
+        ) -> GatewayResponse {
+            let status = if to_bytes(request.into_body(), 1024).await.is_ok() {
+                StatusCode::OK
+            } else {
+                StatusCode::REQUEST_TIMEOUT
+            };
+            let mut response =
+                GatewayResponse::new(Response::new(Body::empty()), GatewayOperation::Write);
+            *response.response.status_mut() = status;
+            response
+        }
+    }
+
+    #[tokio::test]
+    async fn stalled_request_body_hits_the_idle_timeout() {
+        let config = GatewayConfig {
+            request_deadline: std::time::Duration::from_secs(1),
+            body_idle_timeout: std::time::Duration::from_millis(10),
+            ..GatewayConfig::default()
+        };
+        let app = gateway_router(runtime_with(
+            config,
+            Arc::new(BodyReadingAdapter),
+            GatewaySecurity::default(),
+        ));
+        let body = Body::from_stream(futures::stream::pending::<
+            Result<Bytes, std::convert::Infallible>,
+        >());
+        let response = app
+            .oneshot(HttpRequest::post("/object").body(body).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+    }
+
+    #[tokio::test]
+    async fn request_deadline_cancels_adapter_work() {
+        let adapter = Arc::new(TestAdapter {
+            calls: AtomicUsize::new(0),
+            behavior: AdapterBehavior::Pending,
+        });
+        let config = GatewayConfig {
+            request_deadline: std::time::Duration::from_millis(10),
+            ..GatewayConfig::default()
+        };
+        let app = gateway_router(runtime_with(
+            config,
+            adapter.clone(),
+            GatewaySecurity::default(),
+        ));
+        let response = app
+            .oneshot(HttpRequest::get("/object").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::GATEWAY_TIMEOUT);
+        assert_eq!(adapter.calls.load(Ordering::SeqCst), 1);
+    }
+
+    struct BlockingAdapter {
+        calls: AtomicUsize,
+        release: tokio::sync::Semaphore,
+    }
+
+    #[async_trait]
+    impl GatewayAdapter for BlockingAdapter {
+        fn protocol(&self) -> crate::ProviderProtocol {
+            crate::ProviderProtocol::S3
+        }
+
+        async fn handle(
+            &self,
+            _request: Request,
+            _context: GatewayRequestContext,
+        ) -> GatewayResponse {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let permit = self.release.acquire().await.unwrap();
+            permit.forget();
+            GatewayResponse::new(Response::new(Body::empty()), GatewayOperation::Read)
+        }
+    }
+
+    #[tokio::test]
+    async fn provider_concurrency_is_bounded_without_blocking_health_routes() {
+        let adapter = Arc::new(BlockingAdapter {
+            calls: AtomicUsize::new(0),
+            release: tokio::sync::Semaphore::new(0),
+        });
+        let config = GatewayConfig {
+            max_concurrency: 1,
+            ..GatewayConfig::default()
+        };
+        let app = gateway_router(runtime_with(
+            config,
+            adapter.clone(),
+            GatewaySecurity::default(),
+        ));
+        let first = tokio::spawn(
+            app.clone()
+                .oneshot(HttpRequest::get("/first").body(Body::empty()).unwrap()),
+        );
+        while adapter.calls.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+        let second = tokio::spawn(
+            app.clone()
+                .oneshot(HttpRequest::get("/second").body(Body::empty()).unwrap()),
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        assert_eq!(adapter.calls.load(Ordering::SeqCst), 1);
+
+        let health = app
+            .oneshot(HttpRequest::get("/healthz").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(health.status(), StatusCode::OK);
+        adapter.release.add_permits(2);
+        assert!(first.await.unwrap().is_ok());
+        assert!(second.await.unwrap().is_ok());
+    }
+
+    struct StreamingAdapter {
+        polls: Arc<AtomicUsize>,
+        dropped: Arc<AtomicBool>,
+    }
+
+    struct DropSignal(Arc<AtomicBool>);
+
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[async_trait]
+    impl GatewayAdapter for StreamingAdapter {
+        fn protocol(&self) -> crate::ProviderProtocol {
+            crate::ProviderProtocol::Azure
+        }
+
+        async fn handle(
+            &self,
+            _request: Request,
+            _context: GatewayRequestContext,
+        ) -> GatewayResponse {
+            let polls = Arc::clone(&self.polls);
+            let guard = DropSignal(Arc::clone(&self.dropped));
+            let stream = futures::stream::unfold((0u8, guard), move |(index, guard)| {
+                let polls = Arc::clone(&polls);
+                async move {
+                    polls.fetch_add(1, Ordering::SeqCst);
+                    Some((
+                        Ok::<_, std::convert::Infallible>(Bytes::from(vec![index])),
+                        (index + 1, guard),
+                    ))
+                }
+            });
+            GatewayResponse::new(
+                Response::new(Body::from_stream(stream)),
+                GatewayOperation::Read,
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn response_body_is_demand_driven_and_drop_cancels_it() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let dropped = Arc::new(AtomicBool::new(false));
+        let adapter = Arc::new(StreamingAdapter {
+            polls: Arc::clone(&polls),
+            dropped: Arc::clone(&dropped),
+        });
+        let app = gateway_router(runtime_with(
+            GatewayConfig::default(),
+            adapter,
+            GatewaySecurity::default(),
+        ));
+        let response = app
+            .oneshot(HttpRequest::get("/object").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(polls.load(Ordering::SeqCst), 0);
+        let mut body = response.into_body().into_data_stream();
+        assert_eq!(
+            body.next().await.unwrap().unwrap(),
+            Bytes::from_static(&[0])
+        );
+        assert_eq!(polls.load(Ordering::SeqCst), 1);
+        drop(body);
+        assert!(dropped.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn total_deadline_also_bounds_a_streaming_response() {
+        let adapter = Arc::new(StreamingAdapter {
+            polls: Arc::new(AtomicUsize::new(0)),
+            dropped: Arc::new(AtomicBool::new(false)),
+        });
+        let config = GatewayConfig {
+            request_deadline: std::time::Duration::from_millis(10),
+            ..GatewayConfig::default()
+        };
+        let response = gateway_router(runtime_with(config, adapter, GatewaySecurity::default()))
+            .oneshot(HttpRequest::get("/object").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let mut body = response.into_body().into_data_stream();
+        assert!(body.next().await.unwrap().is_ok());
+        tokio::time::sleep(std::time::Duration::from_millis(15)).await;
+        assert!(body.next().await.unwrap().is_err());
+        assert!(body.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn every_response_has_an_opaque_request_id_and_bounded_metrics() {
+        let runtime = runtime_with(
+            GatewayConfig::default(),
+            TestAdapter::immediate(),
+            GatewaySecurity::default(),
+        );
+        let response = gateway_router(Arc::clone(&runtime))
+            .oneshot(
+                HttpRequest::get("/secret-bucket/credential-like-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.headers()[REQUEST_ID_HEADER].as_bytes().len(), 16);
+        let _ = to_bytes(response.into_body(), 4096).await.unwrap();
+        let metrics = runtime.metrics().render();
+        assert!(metrics.contains("protocol=\"s3\""));
+        assert!(!metrics.contains("secret-bucket"));
+        assert!(!metrics.contains("credential-like-key"));
+    }
+
+    #[tokio::test]
+    async fn serve_stops_cleanly_after_shutdown_signal() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let runtime = runtime_with(
+            GatewayConfig::default(),
+            TestAdapter::immediate(),
+            GatewaySecurity::default(),
+        );
+        let readiness = Arc::clone(runtime.readiness());
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(serve(listener, runtime, async move {
+            let _ = shutdown_rx.await;
+        }));
+        shutdown_tx.send(()).unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert!(!readiness.is_live());
+        assert!(!readiness.is_ready());
+    }
+
+    #[tokio::test]
+    async fn maintained_http_parser_rejects_malformed_requests() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let runtime = runtime_with(
+            GatewayConfig::default(),
+            TestAdapter::immediate(),
+            GatewaySecurity::default(),
+        );
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(serve(listener, runtime, async move {
+            let _ = shutdown_rx.await;
+        }));
+
+        let mut client = tokio::net::TcpStream::connect(address).await.unwrap();
+        client
+            .write_all(b"not an HTTP request\r\n\r\n")
+            .await
+            .unwrap();
+        let mut response = [0; 512];
+        let read = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            client.read(&mut response),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(response[..read].starts_with(b"HTTP/1.1 400"));
+
+        shutdown_tx.send(()).unwrap();
+        task.await.unwrap().unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

- add the provider-neutral `talon-gateway` adapter, target, route, result, and failure contracts
- add an Axum streaming runtime with request-target, header, body, concurrency, idle, and total deadline limits
- add request IDs, structured lifecycle logging, low-cardinality byte/latency/result metrics, health/readiness, and bounded graceful shutdown
- keep unauthenticated development mode loopback-only and reject production traffic until TLS, authentication, and authorization are ready

## Verification

- `cargo test -p talon-gateway --all-features --locked`
- `cargo clippy -p talon-gateway --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --all-features`
- `just ci`

Closes #473
