### PR TITLE
test(gateway): add Azure SDK and Azurite conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,7 +424,7 @@ jobs:
         run: cargo test -p talon-backend --test gcs_e2e --locked -- --nocapture
 
   azure-e2e:
-    name: azure backend e2e (azurite)
+    name: azure backend and gateway e2e (azurite)
     runs-on: ubuntu-latest
     # Exercises the real AzureBackend (Shared Key signing + path-style endpoint)
     # against Azurite, reading bytes an object actually contains. The test skips
@@ -436,12 +436,18 @@ jobs:
       TALON_AZURE_TEST_ENDPOINT: http://127.0.0.1:10000
       TALON_AZURE_TEST_CONTAINER: talon-e2e
       TALON_AZURE_TEST_KEY: e2e/object.bin
+      TALON_AZURE_SDK_PYTHON: python
       # Azurite's well-known dev connection string (public emulator values).
       AZURE_STORAGE_CONNECTION_STRING: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Install the official Azure Storage SDK
+        run: python -m pip install azure-storage-blob==12.26.0
       - name: Start Azurite and seed a deterministic object
         run: |
           docker run -d --name azurite -p 10000:10000 \
@@ -458,8 +464,10 @@ jobs:
           az storage blob upload --container-name talon-e2e \
             --name e2e/object.bin --file /tmp/object.bin --overwrite
       - uses: Swatinem/rust-cache@v2
-      - name: Run the Azure e2e test
+      - name: Run the Azure backend e2e test
         run: cargo test -p talon-backend --test azure_e2e --locked -- --nocapture
+      - name: Run the Azure SDK gateway conformance test
+        run: cargo test -p talon-gateway --test azure_sdk_e2e --locked -- --nocapture
 
   python-client:
     name: python client

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,6 +2558,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -2665,6 +2666,7 @@ dependencies = [
  "http-body-util",
  "httpdate",
  "percent-encoding",
+ "reqwest",
  "serde",
  "serde_json",
  "talon-backend",

--- a/crates/talon-backend/Cargo.toml
+++ b/crates/talon-backend/Cargo.toml
@@ -17,6 +17,7 @@ futures.workspace = true
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
 tokio = { workspace = true, features = ["time"] }
 tokio-util.workspace = true
+url.workspace = true
 sha2 = "0.10"
 hmac = "0.12"
 base64 = "0.22"

--- a/crates/talon-backend/src/azure_sharedkey.rs
+++ b/crates/talon-backend/src/azure_sharedkey.rs
@@ -7,9 +7,8 @@
 //! `Authorization: SharedKey <account>:<signature>` header value.
 //!
 //! Only what the blob backend needs is implemented: the full `SharedKey` scheme
-//! (not `SharedKeyLite`), header-based signing, and requests that carry no query
-//! string (so the canonicalized resource is just `/account/path`). Signing is a
-//! pure function of the request + account + key, unit-testable offline.
+//! (not `SharedKeyLite`) and header-based signing. Signing is a pure function of
+//! the request + account + key, unit-testable offline.
 //!
 //! Reference: <https://learn.microsoft.com/rest/api/storageservices/authorize-with-shared-key>
 
@@ -66,15 +65,24 @@ fn method_str(m: Method) -> &'static str {
     }
 }
 
-/// Extract host + path from a URL (path keeps its leading `/`, query dropped).
-fn host_and_path(url: &str) -> (String, String) {
-    let after_scheme = url.split_once("://").map(|(_, r)| r).unwrap_or(url);
-    let (host, rest) = match after_scheme.split_once('/') {
-        Some((h, r)) => (h.to_string(), format!("/{r}")),
-        None => (after_scheme.to_string(), "/".to_string()),
-    };
-    let path = rest.split_once('?').map(|(p, _)| p).unwrap_or(&rest);
-    (host, path.to_string())
+fn canonicalized_resource(url: &str, account: &str) -> Result<String, String> {
+    let url = url::Url::parse(url).map_err(|error| format!("invalid Azure URL: {error}"))?;
+    let mut resource = format!("/{account}{}", url.path());
+    let mut query = std::collections::BTreeMap::<String, Vec<String>>::new();
+    for (name, value) in url.query_pairs() {
+        query
+            .entry(name.to_ascii_lowercase())
+            .or_default()
+            .push(value.into_owned());
+    }
+    for (name, mut values) in query {
+        values.sort();
+        resource.push('\n');
+        resource.push_str(&name);
+        resource.push(':');
+        resource.push_str(&values.join(","));
+    }
+    Ok(resource)
 }
 
 /// Compute the `Authorization: SharedKey ...` header value for `req`.
@@ -127,8 +135,7 @@ pub fn authorization_header(
     // result deliberately repeats the account (/devstoreaccount1/devstoreaccount1
     // /...) — that is exactly what Azurite signs against, so it must NOT be
     // stripped.
-    let (_host, path) = host_and_path(&req.url);
-    let canonical_resource = format!("/{account}{path}");
+    let canonical_resource = canonicalized_resource(&req.url, account)?;
 
     // The 20-line StringToSign (verb + standard headers + canonical headers +
     // canonical resource). Empty standard headers are blank lines.
@@ -260,10 +267,25 @@ mod tests {
 
     #[test]
     fn canonical_resource_uses_account_and_path() {
-        // Path-style emulator URL: host has a port, path is /account/container/blob.
-        let (host, path) = host_and_path("http://127.0.0.1:10000/devstoreaccount1/c/b");
-        assert_eq!(host, "127.0.0.1:10000");
-        assert_eq!(path, "/devstoreaccount1/c/b");
+        let resource = canonicalized_resource(
+            "http://127.0.0.1:10000/devstoreaccount1/c/b",
+            "devstoreaccount1",
+        )
+        .unwrap();
+        assert_eq!(resource, "/devstoreaccount1/devstoreaccount1/c/b");
+    }
+
+    #[test]
+    fn canonical_resource_sorts_and_decodes_query_parameters() {
+        let resource = canonicalized_resource(
+            "http://127.0.0.1:10000/devstoreaccount1/c?prefix=a%2Fb&comp=list&X=2&x=1",
+            "devstoreaccount1",
+        )
+        .unwrap();
+        assert_eq!(
+            resource,
+            "/devstoreaccount1/devstoreaccount1/c\ncomp:list\nprefix:a/b\nx:1,2"
+        );
     }
 
     #[test]

--- a/crates/talon-gateway/Cargo.toml
+++ b/crates/talon-gateway/Cargo.toml
@@ -26,3 +26,6 @@ tower.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
 url.workspace = true
+
+[dev-dependencies]
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }

--- a/crates/talon-gateway/src/azure.rs
+++ b/crates/talon-gateway/src/azure.rs
@@ -841,6 +841,7 @@ mod tests {
     enum CacheBehavior {
         Data(Vec<Bytes>),
         Unavailable,
+        Timeout,
     }
 
     struct MockCache {
@@ -867,6 +868,13 @@ mod tests {
                 request: Mutex::new(None),
             })
         }
+
+        fn timeout() -> Arc<Self> {
+            Arc::new(Self {
+                behavior: CacheBehavior::Timeout,
+                request: Mutex::new(None),
+            })
+        }
     }
 
     impl AzureCache for MockCache {
@@ -882,6 +890,7 @@ mod tests {
                     chunks.clone().into_iter().map(Ok),
                 ))),
                 CacheBehavior::Unavailable => Err(CacheReadError::Unavailable("down".into())),
+                CacheBehavior::Timeout => Err(CacheReadError::Timeout("slow worker".into())),
             }
         }
     }
@@ -941,6 +950,38 @@ mod tests {
         }
     }
 
+    struct DemandCache {
+        polls: Arc<AtomicUsize>,
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl DemandCache {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                polls: Arc::new(AtomicUsize::new(0)),
+                dropped: Arc::new(AtomicBool::new(false)),
+            })
+        }
+    }
+
+    impl AzureCache for DemandCache {
+        fn stream(&self, _request: AzureCacheRequest<'_>) -> Result<CacheStream, CacheReadError> {
+            let chunks = VecDeque::from([Bytes::from_static(b"abc"), Bytes::from_static(b"def")]);
+            let polls = Arc::clone(&self.polls);
+            let guard = DropSignal(Arc::clone(&self.dropped));
+            Ok(Box::pin(futures::stream::unfold(
+                (chunks, guard),
+                move |(mut chunks, guard)| {
+                    let polls = Arc::clone(&polls);
+                    async move {
+                        polls.fetch_add(1, Ordering::SeqCst);
+                        chunks.pop_front().map(|chunk| (Ok(chunk), (chunks, guard)))
+                    }
+                },
+            )))
+        }
+    }
+
     #[async_trait]
     impl AzureOrigin for MockOrigin {
         async fn head(
@@ -995,9 +1036,42 @@ mod tests {
         }
     }
 
+    struct UnavailableOrigin;
+
+    #[async_trait]
+    impl AzureOrigin for UnavailableOrigin {
+        async fn head(
+            &self,
+            _object: &ObjectId,
+            _conditions: &[(String, String)],
+        ) -> Result<HttpResponse, String> {
+            Err("connect failed at https://account.example/?sig=secret".into())
+        }
+
+        async fn get(
+            &self,
+            _object: &ObjectId,
+            _range: Option<(u64, u64)>,
+            _conditions: &[(String, String)],
+        ) -> Result<HttpStreamResponse, String> {
+            unreachable!("HEAD failure must stop GET dispatch")
+        }
+
+        async fn list(
+            &self,
+            _container: &str,
+            _prefix: &str,
+            _delimiter: Option<&str>,
+            _marker: Option<&str>,
+            _max_results: u32,
+        ) -> Result<HttpResponse, String> {
+            unreachable!("test only dispatches object reads")
+        }
+    }
+
     fn context() -> GatewayRequestContext {
         GatewayRequestContext {
-            request_id: "0011223344556677".into(),
+            request_id: "00112233-4455-4677-8899-aabbccddeeff".into(),
             started: std::time::Instant::now(),
         }
     }
@@ -1157,6 +1231,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cache_timeout_is_eligible_for_origin_fallback() {
+        let origin = MockOrigin::object(&[b"abc", b"def"]);
+        let response = adapter(
+            AzureAdapterConfig::public_cloud("acct"),
+            MockCache::timeout(),
+            origin,
+        )
+        .handle(
+            request(axum::http::Method::GET, "/container/blob"),
+            context(),
+        )
+        .await;
+
+        assert_eq!(response.response.status(), StatusCode::OK);
+        assert_eq!(response.outcome, GatewayOutcome::Fallback);
+    }
+
+    #[tokio::test]
+    async fn cache_stream_respects_backpressure_and_cancellation() {
+        let cache = DemandCache::new();
+        let response = adapter(
+            AzureAdapterConfig::public_cloud("acct"),
+            Arc::clone(&cache) as Arc<dyn AzureCache>,
+            MockOrigin::object(&[]),
+        )
+        .handle(
+            request(axum::http::Method::GET, "/container/blob"),
+            context(),
+        )
+        .await;
+
+        assert_eq!(cache.polls.load(Ordering::SeqCst), 1);
+        tokio::task::yield_now().await;
+        assert_eq!(cache.polls.load(Ordering::SeqCst), 1);
+        let mut body = response.response.into_body().into_data_stream();
+        assert_eq!(
+            body.next().await.unwrap().unwrap(),
+            Bytes::from_static(b"abc")
+        );
+        assert_eq!(cache.polls.load(Ordering::SeqCst), 1);
+        drop(body);
+        assert!(cache.dropped.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn origin_outage_returns_a_sanitized_azure_error() {
+        let response = adapter(
+            AzureAdapterConfig::public_cloud("acct"),
+            MockCache::data(&[]),
+            Arc::new(UnavailableOrigin),
+        )
+        .handle(
+            request(axum::http::Method::GET, "/container/blob"),
+            context(),
+        )
+        .await;
+
+        assert_eq!(response.response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.response.headers()["x-ms-error-code"], "ServerBusy");
+        let body = to_bytes(response.response.into_body(), 4096).await.unwrap();
+        assert!(!body.windows(6).any(|window| window == b"secret"));
+        assert!(!body.windows(4).any(|window| window == b"sig="));
+    }
+
+    #[tokio::test]
     async fn head_preserves_content_length_and_list_forwards_pagination() {
         let cache = MockCache::data(&[]);
         let origin = MockOrigin::object(&[]);
@@ -1174,7 +1313,7 @@ mod tests {
         assert_eq!(head.response.headers()[header::CONTENT_LENGTH], "6");
         assert_eq!(
             head.response.headers()["x-ms-request-id"],
-            "0011223344556677"
+            "00112233-4455-4677-8899-aabbccddeeff"
         );
 
         let list = adapter

--- a/crates/talon-gateway/src/runtime.rs
+++ b/crates/talon-gateway/src/runtime.rs
@@ -418,7 +418,8 @@ async fn request_lifecycle(
     next: Next,
 ) -> Response {
     let started = std::time::Instant::now();
-    let request_id = format!("{:016x}", NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed));
+    let sequence = NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed) & 0x0000_ffff_ffff_ffff;
+    let request_id = format!("00000000-0000-4000-8000-{sequence:012x}");
     let method = request.method().clone();
     let operational = matches!(request.uri().path(), "/healthz" | "/readyz" | "/metrics");
     let context = GatewayRequestContext {
@@ -895,7 +896,7 @@ mod tests {
             )
             .await
             .unwrap();
-        assert_eq!(response.headers()[REQUEST_ID_HEADER].as_bytes().len(), 16);
+        assert_eq!(response.headers()[REQUEST_ID_HEADER].as_bytes().len(), 36);
         let _ = to_bytes(response.into_body(), 4096).await.unwrap();
         let metrics = runtime.metrics().render();
         assert!(metrics.contains("protocol=\"s3\""));

--- a/crates/talon-gateway/tests/azure_sdk_e2e.rs
+++ b/crates/talon-gateway/tests/azure_sdk_e2e.rs
@@ -1,0 +1,283 @@
+//! Azure gateway conformance against Azurite and the official Azure SDK.
+//!
+//! The test is skipped unless `TALON_AZURE_TEST_ENDPOINT` is set. CI supplies
+//! a real Azurite service; the gateway itself listens on an ephemeral port.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use bytes::Bytes;
+use futures::{Stream, StreamExt};
+use talon_backend::{AzureBackend, AzureConfig, ReqwestClient};
+use talon_cache_client::CacheReadError;
+use talon_core::{ObjectId, Version};
+use talon_gateway::azure::{AzureAdapterConfig, AzureBlobAdapter, AzureCache, AzureCacheRequest};
+use talon_gateway::{serve, GatewayConfig, GatewayRuntime, GatewaySecurity};
+use tokio::net::TcpListener;
+
+const DEV_ACCOUNT: &str = "devstoreaccount1";
+const DEV_KEY: &str =
+    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+type CacheKey = (ObjectId, Version, u64, u64);
+type CacheBody = Pin<Box<dyn Stream<Item = Result<Bytes, CacheReadError>> + Send>>;
+
+struct ReadThroughCache {
+    origin: Arc<AzureBackend>,
+    entries: Arc<Mutex<HashMap<CacheKey, Bytes>>>,
+    hits: Arc<AtomicUsize>,
+    misses: Arc<AtomicUsize>,
+}
+
+impl ReadThroughCache {
+    fn new(origin: Arc<AzureBackend>) -> Arc<Self> {
+        Arc::new(Self {
+            origin,
+            entries: Arc::new(Mutex::new(HashMap::new())),
+            hits: Arc::new(AtomicUsize::new(0)),
+            misses: Arc::new(AtomicUsize::new(0)),
+        })
+    }
+}
+
+impl AzureCache for ReadThroughCache {
+    fn stream(&self, request: AzureCacheRequest<'_>) -> Result<CacheBody, CacheReadError> {
+        let key = (
+            request.object.clone(),
+            request.version.clone(),
+            request.offset,
+            request.len,
+        );
+        if let Some(body) = self.entries.lock().unwrap().get(&key).cloned() {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            return Ok(Box::pin(futures::stream::once(async move { Ok(body) })));
+        }
+
+        self.misses.fetch_add(1, Ordering::Relaxed);
+        let origin = Arc::clone(&self.origin);
+        let entries = Arc::clone(&self.entries);
+        let object = request.object.clone();
+        let version = request.version.to_string();
+        let offset = request.offset;
+        let len = request.len;
+        Ok(Box::pin(futures::stream::once(async move {
+            let end = offset
+                .checked_add(len)
+                .and_then(|value| value.checked_sub(1))
+                .ok_or_else(|| CacheReadError::InvalidRequest("invalid cache range".into()))?;
+            let conditions = vec![("if-match".to_string(), format!("\"{version}\""))];
+            let mut response = origin
+                .execute_get_stream_raw(&object, Some((offset, end)), &conditions)
+                .await
+                .map_err(CacheReadError::Origin)?;
+            if response.status == 412 {
+                return Err(CacheReadError::VersionMismatch(
+                    "origin version changed".into(),
+                ));
+            }
+            if response.status != 206 {
+                return Err(CacheReadError::Origin(format!(
+                    "origin returned HTTP {}",
+                    response.status
+                )));
+            }
+            let mut body = Vec::with_capacity(len as usize);
+            while let Some(chunk) = response.body.next().await {
+                body.extend_from_slice(&chunk.map_err(CacheReadError::Origin)?);
+                if body.len() as u64 > len {
+                    return Err(CacheReadError::Protocol(
+                        "origin returned more bytes than requested".into(),
+                    ));
+                }
+            }
+            if body.len() as u64 != len {
+                return Err(CacheReadError::Protocol(format!(
+                    "origin returned {} bytes, expected {len}",
+                    body.len()
+                )));
+            }
+            let body = Bytes::from(body);
+            entries.lock().unwrap().insert(key, body.clone());
+            Ok(body)
+        })))
+    }
+}
+
+fn env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+fn endpoint_host(endpoint: &str) -> (String, bool) {
+    if let Some(host) = endpoint.strip_prefix("http://") {
+        (host.to_string(), false)
+    } else {
+        (
+            endpoint
+                .strip_prefix("https://")
+                .unwrap_or(endpoint)
+                .to_string(),
+            true,
+        )
+    }
+}
+
+fn expected_object() -> Vec<u8> {
+    (0..4096).map(|index| (index % 251) as u8).collect()
+}
+
+#[tokio::test]
+async fn azure_sdk_and_azurite_gateway_conformance() {
+    let Some(origin_endpoint) = env("TALON_AZURE_TEST_ENDPOINT") else {
+        eprintln!("skipping Azure gateway e2e: TALON_AZURE_TEST_ENDPOINT is not set");
+        return;
+    };
+    let container =
+        env("TALON_AZURE_TEST_CONTAINER").expect("TALON_AZURE_TEST_CONTAINER must be set");
+    let object_key = env("TALON_AZURE_TEST_KEY").unwrap_or_else(|| "e2e/object.bin".to_string());
+    let (host, tls) = endpoint_host(&origin_endpoint);
+    let origin = Arc::new(AzureBackend::with_shared_key(
+        AzureConfig::emulator(DEV_ACCOUNT, host, tls),
+        DEV_KEY,
+        Arc::new(ReqwestClient::new()),
+    ));
+    let cache = ReadThroughCache::new(Arc::clone(&origin));
+    let adapter = Arc::new(
+        AzureBlobAdapter::new(
+            AzureAdapterConfig::path_style(DEV_ACCOUNT),
+            Arc::clone(&cache) as Arc<dyn AzureCache>,
+            origin,
+        )
+        .unwrap(),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let runtime = Arc::new(
+        GatewayRuntime::new(
+            GatewayConfig {
+                bind: address,
+                ..GatewayConfig::default()
+            },
+            adapter,
+            GatewaySecurity::default(),
+        )
+        .unwrap(),
+    );
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(serve(listener, runtime, async move {
+        let _ = shutdown_rx.await;
+    }));
+    let gateway_endpoint = format!("http://{address}");
+
+    if let Some(python) = env("TALON_AZURE_SDK_PYTHON") {
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../scripts/azure_gateway_sdk_conformance.py");
+        let status = tokio::process::Command::new(python)
+            .arg(script)
+            .env("TALON_AZURE_GATEWAY_ENDPOINT", &gateway_endpoint)
+            .env("TALON_AZURE_TEST_CONTAINER", &container)
+            .env("TALON_AZURE_TEST_KEY", &object_key)
+            .status()
+            .await
+            .unwrap();
+        assert!(status.success(), "Azure SDK conformance process failed");
+    } else {
+        eprintln!("skipping Python Azure SDK assertions: TALON_AZURE_SDK_PYTHON is not set");
+    }
+
+    let raw = reqwest::Client::new();
+    let object_url = format!("{gateway_endpoint}/{DEV_ACCOUNT}/{container}/{object_key}");
+    let properties = raw.head(&object_url).send().await.unwrap();
+    assert_eq!(properties.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        properties.headers()[reqwest::header::CONTENT_LENGTH],
+        "4096"
+    );
+    let etag = properties.headers()[reqwest::header::ETAG]
+        .to_str()
+        .unwrap()
+        .to_string();
+    let whole = raw.get(&object_url).send().await.unwrap();
+    assert_eq!(whole.status(), reqwest::StatusCode::OK);
+    assert_eq!(whole.bytes().await.unwrap(), expected_object());
+    let warm = raw.get(&object_url).send().await.unwrap();
+    assert_eq!(warm.status(), reqwest::StatusCode::OK);
+    assert_eq!(warm.bytes().await.unwrap(), expected_object());
+    assert!(cache.misses.load(Ordering::Relaxed) >= 1);
+    assert!(cache.hits.load(Ordering::Relaxed) >= 1);
+
+    for range in [0_usize..1024, 7_usize..1031, 4000_usize..4096] {
+        let response = raw
+            .get(&object_url)
+            .header(
+                reqwest::header::RANGE,
+                format!("bytes={}-{}", range.start, range.end - 1),
+            )
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::PARTIAL_CONTENT);
+        let bytes = response.bytes().await.unwrap();
+        assert_eq!(&bytes[..], &expected_object()[range.start..range.end]);
+    }
+
+    let matching = raw
+        .get(&object_url)
+        .header(reqwest::header::RANGE, "bytes=0-15")
+        .header(reqwest::header::IF_MATCH, &etag)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(matching.status(), reqwest::StatusCode::PARTIAL_CONTENT);
+    let stale = raw
+        .get(&object_url)
+        .header(reqwest::header::RANGE, "bytes=0-15")
+        .header(reqwest::header::IF_MATCH, "\"not-the-etag\"")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(stale.status(), reqwest::StatusCode::PRECONDITION_FAILED);
+
+    let missing = raw
+        .get(format!(
+            "{gateway_endpoint}/{DEV_ACCOUNT}/{container}/e2e/missing.bin"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
+    assert_eq!(missing.headers()["x-ms-error-code"], "BlobNotFound");
+
+    let invalid_range = raw
+        .get(&object_url)
+        .header(reqwest::header::RANGE, "bytes=5000-6000")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        invalid_range.status(),
+        reqwest::StatusCode::RANGE_NOT_SATISFIABLE
+    );
+    assert_eq!(invalid_range.headers()["x-ms-error-code"], "InvalidRange");
+    assert!(invalid_range
+        .text()
+        .await
+        .unwrap()
+        .contains("<Code>InvalidRange</Code>"));
+
+    let multiple_ranges = raw
+        .get(&object_url)
+        .header(reqwest::header::RANGE, "bytes=0-1,4-5")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(multiple_ranges.status(), reqwest::StatusCode::BAD_REQUEST);
+    assert_eq!(
+        multiple_ranges.headers()["x-ms-error-code"],
+        "MultipleConditionHeadersNotSupported"
+    );
+
+    shutdown_tx.send(()).unwrap();
+    server.await.unwrap().unwrap();
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -41,6 +41,7 @@
 - [Namespace authorization policy](./reference/namespace-policy.md)
 - [REST API reference](./reference/rest-api.md)
 - [Wire protocol reference](./reference/wire-protocol.md)
+- [Object-store gateway compatibility](./reference/object-store-gateway-compatibility.md)
 
 # Explanation
 

--- a/docs/book/src/reference/object-store-gateway-compatibility.md
+++ b/docs/book/src/reference/object-store-gateway-compatibility.md
@@ -1,0 +1,1 @@
+{{#include ../../../reference/object-store-gateway-compatibility.md}}

--- a/docs/reference/object-store-gateway-compatibility.md
+++ b/docs/reference/object-store-gateway-compatibility.md
@@ -1,0 +1,47 @@
+# Object-store gateway compatibility
+
+The gateway crate provides a bounded HTTP runtime and provider protocol
+adapters. This matrix describes behavior implemented and continuously tested;
+it does not imply that the production authentication and deployment work is
+complete.
+
+## Azure Blob Storage
+
+| Surface | Status | Authority and behavior |
+|---|---|---|
+| Get Blob Properties (`HEAD`) | Supported | Metadata and conditions are resolved by the configured origin identity. |
+| Get Blob (`GET`) | Supported | Bytes stream from Talon or the origin without whole-object buffering. |
+| One `Range` or `x-ms-range` | Supported | Closed, open-ended, suffix, aligned, unaligned, and EOF-clamped ranges are supported. |
+| Multiple ranges | Rejected | Returns `MultipleConditionHeadersNotSupported`; multipart responses are not approximated. |
+| List Blobs | Supported | `prefix`, `delimiter`, `marker`, and `maxresults` are forwarded to paginated origin listing. |
+| Conditional reads | Supported | ETag and date conditions remain origin-authoritative; `If-Range` controls range use. |
+| Virtual-host addressing | Supported | One configured public-cloud account per process. |
+| Azurite path addressing | Supported | `/account/container/blob` endpoint-override clients are accepted. |
+| Put, delete, copy, and block APIs | Not yet supported | Rejected explicitly until a write-through milestone preserves Azure commit semantics. |
+
+Azure responses include UUID-shaped `x-ms-request-id` values, gateway request
+correlation, Azure XML errors, and origin metadata. Blob names and listing
+parameters use strict percent decoding. Unsupported or malformed requests fail
+closed instead of being silently reinterpreted.
+
+Cache infrastructure unavailability and timeout may fall back to a conditional
+origin stream. Not-found, invalid range, version mismatch, authentication,
+authorization, protocol, and internal failures are terminal. Response streams
+are demand-driven; slow consumers do not trigger eager upstream reads, and
+disconnecting drops the upstream stream.
+
+The `azure backend and gateway e2e (azurite)` CI job runs both the backend
+contract and the gateway through the official Azure SDK against Azurite. It
+covers cold and warm reads, properties, full and ranged bytes, URL encoding,
+listing pagination and delimiter behavior, conditions, and Azure errors.
+
+Production exposure remains blocked until provider authentication and
+authorization are installed as tracked by issue #446. The protocol adapter is
+currently intended for conformance and integration work; executable packaging
+and deployment are tracked separately.
+
+## S3
+
+The S3 compatibility matrix will be added with the S3 adapter and conformance
+tasks. Existing `talon-backend` S3 support is an origin client, not an
+S3-compatible gateway endpoint.

--- a/scripts/azure_gateway_sdk_conformance.py
+++ b/scripts/azure_gateway_sdk_conformance.py
@@ -1,0 +1,99 @@
+"""Drive the Talon Azure gateway with Microsoft's Azure Storage SDK."""
+
+import os
+
+from azure.core import MatchConditions
+from azure.core.credentials import AzureNamedKeyCredential
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
+from azure.storage.blob import BlobPrefix, BlobServiceClient
+
+
+ACCOUNT = "devstoreaccount1"
+ACCOUNT_KEY = (
+    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/"
+    "K1SZFPTOtr/KBHBeksoGMGw=="
+)
+
+
+def expected_object() -> bytes:
+    return bytes(index % 251 for index in range(4096))
+
+
+def main() -> None:
+    gateway_endpoint = os.environ["TALON_AZURE_GATEWAY_ENDPOINT"].rstrip("/")
+    container_name = os.environ["TALON_AZURE_TEST_CONTAINER"]
+    object_name = os.environ["TALON_AZURE_TEST_KEY"]
+
+    origin = BlobServiceClient.from_connection_string(
+        os.environ["AZURE_STORAGE_CONNECTION_STRING"]
+    )
+    origin_container = origin.get_container_client(container_name)
+    origin_container.upload_blob("gateway/list/a space.txt", b"a", overwrite=True)
+    origin_container.upload_blob("gateway/list/child/b.txt", b"b", overwrite=True)
+
+    gateway = BlobServiceClient(
+        account_url=f"{gateway_endpoint}/{ACCOUNT}",
+        credential=AzureNamedKeyCredential(ACCOUNT, ACCOUNT_KEY),
+    )
+    container = gateway.get_container_client(container_name)
+    blob = container.get_blob_client(object_name)
+
+    properties = blob.get_blob_properties()
+    assert properties.size == 4096
+    assert blob.download_blob().readall() == expected_object()
+    assert blob.download_blob().readall() == expected_object()
+
+    for offset, length in [(0, 1024), (7, 1024), (4000, 96)]:
+        assert blob.download_blob(offset=offset, length=length).readall() == expected_object()[
+            offset : offset + length
+        ]
+
+    blob.get_blob_properties(
+        etag=properties.etag,
+        match_condition=MatchConditions.IfNotModified,
+    )
+    try:
+        blob.get_blob_properties(
+            etag='"not-the-etag"',
+            match_condition=MatchConditions.IfNotModified,
+        )
+        raise AssertionError("stale ETag unexpectedly succeeded")
+    except HttpResponseError as error:
+        assert error.status_code == 412
+
+    try:
+        container.get_blob_client("e2e/missing.bin").get_blob_properties()
+        raise AssertionError("missing blob unexpectedly succeeded")
+    except ResourceNotFoundError:
+        pass
+
+    assert (
+        container.get_blob_client("gateway/list/a space.txt")
+        .download_blob()
+        .readall()
+        == b"a"
+    )
+
+    pager = container.list_blobs(
+        name_starts_with="gateway/list/", results_per_page=1
+    ).by_page()
+    first_page = list(next(pager))
+    assert pager.continuation_token
+    second_page = list(next(pager))
+    names = {item.name for item in first_page + second_page}
+    assert "gateway/list/a space.txt" in names
+
+    walked = list(
+        container.walk_blobs(name_starts_with="gateway/list/", delimiter="/")
+    )
+    assert any(item.name == "gateway/list/a space.txt" for item in walked)
+    assert any(
+        isinstance(item, BlobPrefix) and item.name == "gateway/list/child/"
+        for item in walked
+    )
+
+    print("Azure SDK gateway conformance passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- exercise the Azure gateway with the official Azure Storage SDK against Azurite
- fix Shared Key query canonicalization and emit SDK-compatible UUID request IDs
- cover timeout fallback, outage sanitization, cancellation, and backpressure
- publish the Azure compatibility matrix and wire conformance into CI

## Verification
- `cargo fmt --all && just ci && git diff --check`
- `just spell`
- `just linkcheck`
- local Azurite 3.33.0 with `azure-storage-blob==12.26.0`
- `cargo deny check advisories bans sources`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- `mdbook build docs/book`

Closes #475