### PR TITLE
test(gateway): add S3 SDK and LocalStack conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,7 @@ jobs:
           fi
 
   s3-e2e:
-    name: s3 backend e2e (localstack)
+    name: s3 backend and gateway e2e (localstack)
     runs-on: ubuntu-latest
     # Exercises the real S3Backend (SigV4 signing + path-style endpoint) against
     # LocalStack, reading bytes an object actually contains. The test skips when
@@ -368,10 +368,16 @@ jobs:
       TALON_S3_TEST_BUCKET: talon-e2e
       TALON_S3_TEST_KEY: e2e/object.bin
       TALON_S3_TEST_REGION: us-east-1
+      TALON_S3_SDK_PYTHON: python
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Install S3 client libraries
+        run: python -m pip install boto3==1.40.0 minio==7.2.16
       - name: Seed the bucket with a deterministic object
         run: |
           # 4096 bytes where byte i == i % 251 (matches the test's expectation).
@@ -382,8 +388,10 @@ jobs:
           aws --endpoint-url http://127.0.0.1:4566 s3 mb s3://talon-e2e
           aws --endpoint-url http://127.0.0.1:4566 s3 cp /tmp/object.bin s3://talon-e2e/e2e/object.bin
       - uses: Swatinem/rust-cache@v2
-      - name: Run the S3 e2e test
+      - name: Run the S3 backend e2e test
         run: cargo test -p talon-backend --test s3_e2e --locked -- --nocapture
+      - name: Run the S3 SDK gateway conformance test
+        run: cargo test -p talon-gateway --test s3_sdk_e2e --locked -- --nocapture
 
   gcs-e2e:
     name: gcs backend e2e (fake-gcs)

--- a/crates/talon-gateway/src/s3.rs
+++ b/crates/talon-gateway/src/s3.rs
@@ -682,6 +682,26 @@ impl S3RequestError {
         }
     }
 
+    fn not_found() -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            code: "NoSuchKey",
+            message: "The specified key does not exist".into(),
+            failure: FailureReason::NotFound,
+            content_range: None,
+        }
+    }
+
+    fn precondition_failed() -> Self {
+        Self {
+            status: StatusCode::PRECONDITION_FAILED,
+            code: "PreconditionFailed",
+            message: "At least one precondition failed".into(),
+            failure: FailureReason::Precondition,
+            content_range: None,
+        }
+    }
+
     fn origin_unavailable(message: impl Into<String>) -> Self {
         let _ = message.into();
         Self {
@@ -898,6 +918,12 @@ impl S3Adapter {
             .head(&object, &conditions)
             .await
             .map_err(S3RequestError::origin_unavailable)?;
+        if metadata.status == 404 {
+            return Err(S3RequestError::not_found());
+        }
+        if metadata.status == 412 {
+            return Err(S3RequestError::precondition_failed());
+        }
         if !(200..300).contains(&metadata.status) {
             return Ok(raw_response(
                 metadata,
@@ -1071,6 +1097,8 @@ impl S3Adapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Mutex;
 
     use axum::body::to_bytes;
@@ -1090,8 +1118,54 @@ mod tests {
                 Err(CacheReadError::Unavailable(message)) => {
                     Err(CacheReadError::Unavailable(message.clone()))
                 }
+                Err(CacheReadError::Timeout(message)) => {
+                    Err(CacheReadError::Timeout(message.clone()))
+                }
+                Err(CacheReadError::Protocol(message)) => {
+                    Err(CacheReadError::Protocol(message.clone()))
+                }
                 _ => unreachable!("test cache response"),
             }
+        }
+    }
+
+    struct DropSignal(Arc<AtomicBool>);
+
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    struct DemandCache {
+        polls: Arc<AtomicUsize>,
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl DemandCache {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                polls: Arc::new(AtomicUsize::new(0)),
+                dropped: Arc::new(AtomicBool::new(false)),
+            })
+        }
+    }
+
+    impl S3Cache for DemandCache {
+        fn stream(&self, _request: S3CacheRequest<'_>) -> Result<CacheStream, CacheReadError> {
+            let chunks = VecDeque::from([Bytes::from_static(b"abc"), Bytes::from_static(b"def")]);
+            let polls = Arc::clone(&self.polls);
+            let guard = DropSignal(Arc::clone(&self.dropped));
+            Ok(Box::pin(futures::stream::unfold(
+                (chunks, guard),
+                move |(mut chunks, guard)| {
+                    let polls = Arc::clone(&polls);
+                    async move {
+                        polls.fetch_add(1, Ordering::SeqCst);
+                        chunks.pop_front().map(|chunk| (Ok(chunk), (chunks, guard)))
+                    }
+                },
+            )))
         }
     }
 
@@ -1168,6 +1242,40 @@ mod tests {
                 headers: vec![("content-type".into(), "application/xml".into())],
                 body: Bytes::from_static(b"<ListBucketResult/>"),
             })
+        }
+    }
+
+    struct UnavailableOrigin;
+
+    #[async_trait]
+    impl S3Origin for UnavailableOrigin {
+        async fn head(
+            &self,
+            _object: &ObjectId,
+            _conditions: &[(String, String)],
+        ) -> Result<HttpResponse, String> {
+            Err("connect failed at https://s3.example/?secret=credential".into())
+        }
+
+        async fn get(
+            &self,
+            _object: &ObjectId,
+            _range: Option<(u64, u64)>,
+            _conditions: &[(String, String)],
+        ) -> Result<HttpStreamResponse, String> {
+            unreachable!("HEAD failure must stop GET dispatch")
+        }
+
+        async fn list(
+            &self,
+            _bucket: &str,
+            _prefix: &str,
+            _delimiter: Option<&str>,
+            _continuation_token: Option<&str>,
+            _max_keys: u32,
+            _encoding_type: Option<&str>,
+        ) -> Result<HttpResponse, String> {
+            unreachable!("test only dispatches object reads")
         }
     }
 
@@ -1276,6 +1384,78 @@ mod tests {
             to_bytes(response.response.into_body(), 16).await.unwrap(),
             "abcdef"
         );
+    }
+
+    #[tokio::test]
+    async fn timeout_falls_back_but_protocol_failure_is_terminal() {
+        let timeout = adapter(
+            MockCache {
+                response: Err(CacheReadError::Timeout("slow worker".into())),
+            },
+            MockOrigin::new(),
+        )
+        .handle(request(axum::http::Method::GET, "/bucket/key"), context())
+        .await;
+        assert_eq!(timeout.response.status(), StatusCode::OK);
+        assert_eq!(timeout.outcome, GatewayOutcome::Fallback);
+
+        let protocol = adapter(
+            MockCache {
+                response: Err(CacheReadError::Protocol("bad frame".into())),
+            },
+            MockOrigin::new(),
+        )
+        .handle(request(axum::http::Method::GET, "/bucket/key"), context())
+        .await;
+        assert_eq!(
+            protocol.response.status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+        assert_eq!(protocol.outcome, GatewayOutcome::Failed);
+    }
+
+    #[tokio::test]
+    async fn cache_stream_respects_backpressure_and_cancellation() {
+        let cache = DemandCache::new();
+        let response = S3Adapter::new(
+            S3AdapterConfig::path_style("localhost"),
+            Arc::clone(&cache) as Arc<dyn S3Cache>,
+            MockOrigin::new(),
+        )
+        .unwrap()
+        .handle(request(axum::http::Method::GET, "/bucket/key"), context())
+        .await;
+
+        assert_eq!(cache.polls.load(Ordering::SeqCst), 1);
+        tokio::task::yield_now().await;
+        assert_eq!(cache.polls.load(Ordering::SeqCst), 1);
+        let mut body = response.response.into_body().into_data_stream();
+        assert_eq!(
+            body.next().await.unwrap().unwrap(),
+            Bytes::from_static(b"abc")
+        );
+        assert_eq!(cache.polls.load(Ordering::SeqCst), 1);
+        drop(body);
+        assert!(cache.dropped.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn origin_outage_returns_a_sanitized_s3_error() {
+        let response = S3Adapter::new(
+            S3AdapterConfig::path_style("localhost"),
+            Arc::new(MockCache {
+                response: Ok(Vec::new()),
+            }),
+            Arc::new(UnavailableOrigin),
+        )
+        .unwrap()
+        .handle(request(axum::http::Method::GET, "/bucket/key"), context())
+        .await;
+
+        assert_eq!(response.response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = to_bytes(response.response.into_body(), 4096).await.unwrap();
+        assert!(!body.windows(6).any(|window| window == b"secret"));
+        assert!(!body.windows(10).any(|window| window == b"credential"));
     }
 
     #[tokio::test]

--- a/crates/talon-gateway/tests/s3_sdk_e2e.rs
+++ b/crates/talon-gateway/tests/s3_sdk_e2e.rs
@@ -1,0 +1,233 @@
+//! S3 gateway conformance against LocalStack and real client libraries.
+//!
+//! The test is skipped unless `TALON_S3_TEST_ENDPOINT` is set. CI supplies a
+//! real LocalStack service; the gateway listens on an ephemeral loopback port.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use bytes::Bytes;
+use futures::{Stream, StreamExt};
+use talon_backend::{ReqwestClient, S3Backend, S3Config, S3Credentials};
+use talon_cache_client::CacheReadError;
+use talon_core::{ObjectId, Version};
+use talon_gateway::s3::{S3Adapter, S3AdapterConfig, S3Cache, S3CacheRequest};
+use talon_gateway::{serve, GatewayConfig, GatewayRuntime, GatewaySecurity};
+use tokio::net::TcpListener;
+
+type CacheKey = (ObjectId, Version, u64, u64);
+type CacheBody = Pin<Box<dyn Stream<Item = Result<Bytes, CacheReadError>> + Send>>;
+
+struct ReadThroughCache {
+    origin: Arc<S3Backend>,
+    entries: Arc<Mutex<HashMap<CacheKey, Bytes>>>,
+    hits: Arc<AtomicUsize>,
+    misses: Arc<AtomicUsize>,
+}
+
+impl ReadThroughCache {
+    fn new(origin: Arc<S3Backend>) -> Arc<Self> {
+        Arc::new(Self {
+            origin,
+            entries: Arc::new(Mutex::new(HashMap::new())),
+            hits: Arc::new(AtomicUsize::new(0)),
+            misses: Arc::new(AtomicUsize::new(0)),
+        })
+    }
+}
+
+impl S3Cache for ReadThroughCache {
+    fn stream(&self, request: S3CacheRequest<'_>) -> Result<CacheBody, CacheReadError> {
+        let key = (
+            request.object.clone(),
+            request.version.clone(),
+            request.offset,
+            request.len,
+        );
+        if let Some(body) = self.entries.lock().unwrap().get(&key).cloned() {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            return Ok(Box::pin(futures::stream::once(async move { Ok(body) })));
+        }
+
+        self.misses.fetch_add(1, Ordering::Relaxed);
+        let origin = Arc::clone(&self.origin);
+        let entries = Arc::clone(&self.entries);
+        let object = request.object.clone();
+        let version = request.version.to_string();
+        let offset = request.offset;
+        let len = request.len;
+        Ok(Box::pin(futures::stream::once(async move {
+            let end = offset
+                .checked_add(len)
+                .and_then(|value| value.checked_sub(1))
+                .ok_or_else(|| CacheReadError::InvalidRequest("invalid cache range".into()))?;
+            let conditions = vec![("if-match".to_string(), format!("\"{version}\""))];
+            let mut response = origin
+                .execute_get_stream_raw(&object, Some((offset, end)), &conditions)
+                .await
+                .map_err(CacheReadError::Origin)?;
+            if response.status == 412 {
+                return Err(CacheReadError::VersionMismatch(
+                    "origin version changed".into(),
+                ));
+            }
+            if response.status != 206 {
+                return Err(CacheReadError::Origin(format!(
+                    "origin returned HTTP {}",
+                    response.status
+                )));
+            }
+            let mut body = Vec::with_capacity(len as usize);
+            while let Some(chunk) = response.body.next().await {
+                body.extend_from_slice(&chunk.map_err(CacheReadError::Origin)?);
+                if body.len() as u64 > len {
+                    return Err(CacheReadError::Protocol(
+                        "origin returned more bytes than requested".into(),
+                    ));
+                }
+            }
+            if body.len() as u64 != len {
+                return Err(CacheReadError::Protocol(format!(
+                    "origin returned {} bytes, expected {len}",
+                    body.len()
+                )));
+            }
+            let body = Bytes::from(body);
+            entries.lock().unwrap().insert(key, body.clone());
+            Ok(body)
+        })))
+    }
+}
+
+fn env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+fn endpoint_host(endpoint: &str) -> (String, bool) {
+    if let Some(host) = endpoint.strip_prefix("http://") {
+        (host.to_string(), false)
+    } else {
+        (
+            endpoint
+                .strip_prefix("https://")
+                .unwrap_or(endpoint)
+                .to_string(),
+            true,
+        )
+    }
+}
+
+fn expected_object() -> Vec<u8> {
+    (0..4096).map(|index| (index % 251) as u8).collect()
+}
+
+#[tokio::test]
+async fn s3_sdks_and_localstack_gateway_conformance() {
+    let Some(origin_endpoint) = env("TALON_S3_TEST_ENDPOINT") else {
+        eprintln!("skipping S3 gateway e2e: TALON_S3_TEST_ENDPOINT is not set");
+        return;
+    };
+    let bucket = env("TALON_S3_TEST_BUCKET").expect("TALON_S3_TEST_BUCKET must be set");
+    let object_key = env("TALON_S3_TEST_KEY").unwrap_or_else(|| "e2e/object.bin".to_string());
+    let region = env("TALON_S3_TEST_REGION").unwrap_or_else(|| "us-east-1".to_string());
+    let access_key = env("AWS_ACCESS_KEY_ID").expect("AWS_ACCESS_KEY_ID must be set");
+    let secret_key = env("AWS_SECRET_ACCESS_KEY").expect("AWS_SECRET_ACCESS_KEY must be set");
+    let (host, tls) = endpoint_host(&origin_endpoint);
+    let origin = Arc::new(S3Backend::new(
+        S3Config {
+            region: region.clone(),
+            endpoint: host,
+            path_style: true,
+            tls,
+        },
+        S3Credentials {
+            access_key_id: access_key,
+            secret_access_key: secret_key,
+            session_token: None,
+        },
+        Arc::new(ReqwestClient::new()),
+    ));
+    let cache = ReadThroughCache::new(Arc::clone(&origin));
+    let adapter = Arc::new(
+        S3Adapter::new(
+            S3AdapterConfig::path_style("localhost"),
+            Arc::clone(&cache) as Arc<dyn S3Cache>,
+            origin,
+        )
+        .unwrap(),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let runtime = Arc::new(
+        GatewayRuntime::new(
+            GatewayConfig {
+                bind: address,
+                ..GatewayConfig::default()
+            },
+            adapter,
+            GatewaySecurity::default(),
+        )
+        .unwrap(),
+    );
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(serve(listener, runtime, async move {
+        let _ = shutdown_rx.await;
+    }));
+    let gateway_endpoint = format!("http://{address}");
+
+    if let Some(python) = env("TALON_S3_SDK_PYTHON") {
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../scripts/s3_gateway_sdk_conformance.py");
+        let status = tokio::process::Command::new(python)
+            .arg(script)
+            .env("TALON_S3_GATEWAY_ENDPOINT", &gateway_endpoint)
+            .env("TALON_S3_TEST_BUCKET", &bucket)
+            .env("TALON_S3_TEST_KEY", &object_key)
+            .env("TALON_S3_TEST_REGION", &region)
+            .status()
+            .await
+            .unwrap();
+        assert!(status.success(), "S3 SDK conformance process failed");
+    } else {
+        eprintln!("skipping Python S3 SDK assertions: TALON_S3_SDK_PYTHON is not set");
+    }
+
+    // Arrow's S3 filesystem uses signed HEAD and exact ranged GET requests.
+    // Authentication is intentionally deferred to #446, but these fixtures
+    // prove that its headers do not alter parsing or leak to the origin signer.
+    let raw = reqwest::Client::new();
+    let object_url = format!("{gateway_endpoint}/{bucket}/{object_key}");
+    let properties = raw
+        .head(&object_url)
+        .header("x-amz-date", "20260809T000000Z")
+        .header("x-amz-content-sha256", "UNSIGNED-PAYLOAD")
+        .header(
+            reqwest::header::AUTHORIZATION,
+            "AWS4-HMAC-SHA256 Credential=arrow/20260809/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-date, Signature=fixture",
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(properties.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        properties.headers()[reqwest::header::CONTENT_LENGTH],
+        "4096"
+    );
+
+    let range = raw
+        .get(&object_url)
+        .header(reqwest::header::RANGE, "bytes=7-1030")
+        .header("x-amz-checksum-mode", "ENABLED")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(range.status(), reqwest::StatusCode::PARTIAL_CONTENT);
+    assert_eq!(range.bytes().await.unwrap(), &expected_object()[7..1031]);
+    assert!(cache.misses.load(Ordering::Relaxed) >= 1);
+    assert!(cache.hits.load(Ordering::Relaxed) >= 1);
+
+    shutdown_tx.send(()).unwrap();
+    server.await.unwrap().unwrap();
+}

--- a/docs/reference/object-store-gateway-compatibility.md
+++ b/docs/reference/object-store-gateway-compatibility.md
@@ -61,6 +61,9 @@ Full incoming SigV4 authentication and bucket authorization remain blocked on
 issue #446, so production exposure stays fail-closed.
 
 The S3 adapter emits S3 XML errors and gateway request IDs. Cache fallback and
-streaming behavior match the Azure adapter rules above. Official SDK and
-S3-compatible service conformance is tracked separately from the protocol
-adapter implementation.
+streaming behavior match the Azure adapter rules above. The `s3 backend and
+gateway e2e (localstack)` CI job runs the backend plus the gateway through
+boto3 and the MinIO SDK. It covers cold and warm reads, exact ranges, URL
+encoding, conditions, presigned URLs, listing pagination and delimiters, and
+standard errors. Arrow-compatible signed HEAD and ranged GET fixtures run in
+the same test.

--- a/scripts/s3_gateway_sdk_conformance.py
+++ b/scripts/s3_gateway_sdk_conformance.py
@@ -1,0 +1,134 @@
+"""Drive the Talon S3 gateway with boto3 and the MinIO Python SDK."""
+
+import os
+import urllib.request
+from urllib.parse import urlparse
+
+import boto3
+from botocore.client import Config
+from botocore.exceptions import ClientError
+from minio import Minio
+
+
+def expected_object() -> bytes:
+    return bytes(index % 251 for index in range(4096))
+
+
+def read_minio(response) -> bytes:
+    try:
+        return response.read()
+    finally:
+        response.close()
+        response.release_conn()
+
+
+def main() -> None:
+    gateway_endpoint = os.environ["TALON_S3_GATEWAY_ENDPOINT"].rstrip("/")
+    origin_endpoint = os.environ["TALON_S3_TEST_ENDPOINT"].rstrip("/")
+    bucket = os.environ["TALON_S3_TEST_BUCKET"]
+    object_name = os.environ["TALON_S3_TEST_KEY"]
+    region = os.environ.get("TALON_S3_TEST_REGION", "us-east-1")
+    access_key = os.environ["AWS_ACCESS_KEY_ID"]
+    secret_key = os.environ["AWS_SECRET_ACCESS_KEY"]
+    config = Config(
+        region_name=region,
+        signature_version="s3v4",
+        retries={"max_attempts": 0},
+        s3={"addressing_style": "path"},
+    )
+
+    origin = boto3.client(
+        "s3",
+        endpoint_url=origin_endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        config=config,
+    )
+    origin.put_object(Bucket=bucket, Key="gateway/list/a space.txt", Body=b"a")
+    origin.put_object(Bucket=bucket, Key="gateway/list/child/b.txt", Body=b"b")
+
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=gateway_endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        config=config,
+    )
+    properties = s3.head_object(Bucket=bucket, Key=object_name)
+    etag = properties["ETag"]
+    assert properties["ContentLength"] == 4096
+    assert s3.get_object(Bucket=bucket, Key=object_name)["Body"].read() == expected_object()
+    assert s3.get_object(Bucket=bucket, Key=object_name)["Body"].read() == expected_object()
+
+    for start, end in [(0, 1023), (7, 1030), (4000, 4095)]:
+        body = s3.get_object(
+            Bucket=bucket, Key=object_name, Range=f"bytes={start}-{end}"
+        )["Body"].read()
+        assert body == expected_object()[start : end + 1]
+
+    s3.head_object(Bucket=bucket, Key=object_name, IfMatch=etag)
+    try:
+        s3.get_object(Bucket=bucket, Key=object_name, IfMatch='"not-the-etag"')
+        raise AssertionError("stale ETag unexpectedly succeeded")
+    except ClientError as error:
+        assert error.response["ResponseMetadata"]["HTTPStatusCode"] == 412
+        assert error.response["Error"]["Code"] == "PreconditionFailed"
+
+    try:
+        s3.get_object(Bucket=bucket, Key="e2e/missing.bin")
+        raise AssertionError("missing object unexpectedly succeeded")
+    except ClientError as error:
+        assert error.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+        assert error.response["Error"]["Code"] == "NoSuchKey"
+
+    assert (
+        s3.get_object(Bucket=bucket, Key="gateway/list/a space.txt")["Body"].read()
+        == b"a"
+    )
+    first = s3.list_objects_v2(Bucket=bucket, Prefix="gateway/list/", MaxKeys=1)
+    assert first["IsTruncated"]
+    second = s3.list_objects_v2(
+        Bucket=bucket,
+        Prefix="gateway/list/",
+        ContinuationToken=first["NextContinuationToken"],
+    )
+    names = {item["Key"] for item in first.get("Contents", []) + second.get("Contents", [])}
+    assert "gateway/list/a space.txt" in names
+    walked = s3.list_objects_v2(
+        Bucket=bucket, Prefix="gateway/list/", Delimiter="/"
+    )
+    assert any(item["Key"] == "gateway/list/a space.txt" for item in walked["Contents"])
+    assert any(
+        item["Prefix"] == "gateway/list/child/"
+        for item in walked["CommonPrefixes"]
+    )
+
+    presigned = s3.generate_presigned_url(
+        "get_object", Params={"Bucket": bucket, "Key": object_name}, ExpiresIn=60
+    )
+    with urllib.request.urlopen(presigned) as response:
+        assert response.read() == expected_object()
+
+    parsed = urlparse(gateway_endpoint)
+    minio = Minio(
+        parsed.netloc,
+        access_key=access_key,
+        secret_key=secret_key,
+        secure=parsed.scheme == "https",
+        region=region,
+    )
+    assert minio.stat_object(bucket, object_name).size == 4096
+    assert read_minio(minio.get_object(bucket, object_name)) == expected_object()
+    assert read_minio(minio.get_object(bucket, object_name, offset=7, length=1024)) == expected_object()[7:1031]
+    minio_names = {
+        item.object_name
+        for item in minio.list_objects(bucket, prefix="gateway/list/", recursive=True)
+    }
+    assert "gateway/list/a space.txt" in minio_names
+    assert "gateway/list/child/b.txt" in minio_names
+
+    print("S3 SDK gateway conformance passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- drive the in-process S3 gateway through boto3 and the MinIO SDK against LocalStack
- cover cold and warm reads, exact ranges, conditions, standard errors, presigned URLs, and paginated listings
- add Arrow-compatible signed HEAD and ranged GET fixtures
- verify timeout fallback, terminal protocol errors, outage sanitization, cancellation, and backpressure
- wire the suite into CI and update the compatibility matrix

## Verification
- `cargo fmt --all && just ci && git diff --check`
- `cargo clippy -p talon-gateway --all-targets --all-features -- -D warnings`
- `python3 -m py_compile scripts/s3_gateway_sdk_conformance.py`
- `mdbook build docs/book`
- `just spell`
- `just linkcheck`

Closes #477