### PR TITLE
doc(gateway): publish deployment and benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,13 @@ jobs:
           file: deploy/docker/fuse.Dockerfile
           push: false
           cache-from: type=gha,scope=fuse
+      - name: Build gateway image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/docker/gateway.Dockerfile
+          push: false
+          cache-from: type=gha,scope=gateway
 
   helm:
     name: helm chart

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -10,7 +10,7 @@ name: Release images
 # guaranteed its own sha-* image. A version tag (vX.Y.Z) additionally
 # publishes semver and major.minor tags; `latest` tracks main only, so a tag
 # publish racing a main publish can never leave `latest` mixed across the
-# three images. Pull requests do NOT run this workflow — the docker-build job
+# images. Pull requests do NOT run this workflow — the docker-build job
 # in ci.yml already smoke-builds every image (no push).
 
 on:
@@ -46,6 +46,8 @@ jobs:
             dockerfile: deploy/docker/worker.Dockerfile
           - image: fuse
             dockerfile: deploy/docker/fuse.Dockerfile
+          - image: gateway
+            dockerfile: deploy/docker/gateway.Dockerfile
     steps:
       - uses: actions/checkout@v4
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -110,6 +110,15 @@ Notes on running it:
   refuses to turn error frames into latency numbers and prints the first error
   verbatim.
 
+## Object-store gateway
+
+`just gateway-bench` measures the bounded HTTP runtime around controlled
+cache-client, worker, and origin delays, then streams a large object to a slow
+consumer while sampling RSS. Results and interpretation are in the
+[gateway benchmark reference](docs/reference/object-store-gateway-benchmarks.md).
+The harness emits JSON Lines and is a regression floor, not a cloud capacity
+claim.
+
 ## Where the serve path actually saturates
 
 The sweep above compares data planes against each other. It does not answer a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,6 +2677,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-subscriber",
  "url",
 ]
 

--- a/Justfile
+++ b/Justfile
@@ -85,6 +85,10 @@ bench-save NAME="main":
 bench-check *ARGS:
     python3 scripts/bench.py check {{ARGS}}
 
+# Measure bounded HTTP gateway overhead and slow-consumer memory behavior.
+gateway-bench:
+    cargo run --release -p talon-gateway --example gateway_benchmark
+
 # Print the current committed baseline.
 bench-baseline NAME="main":
     @cat bench/baselines/{{NAME}}.json

--- a/crates/talon-gateway/Cargo.toml
+++ b/crates/talon-gateway/Cargo.toml
@@ -25,6 +25,7 @@ tokio.workspace = true
 tower.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 url.workspace = true
 
 [dev-dependencies]

--- a/crates/talon-gateway/examples/gateway_benchmark.rs
+++ b/crates/talon-gateway/examples/gateway_benchmark.rs
@@ -1,0 +1,203 @@
+//! Reproducible loopback benchmark for shared gateway overhead and backpressure.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use axum::body::Body;
+use axum::extract::Request;
+use bytes::Bytes;
+use futures::StreamExt;
+use serde_json::json;
+use talon_gateway::{
+    serve, GatewayAdapter, GatewayConfig, GatewayOperation, GatewayRequestContext, GatewayResponse,
+    GatewayRuntime, GatewaySecurity, ProviderProtocol,
+};
+use tokio::net::TcpListener;
+
+const DEFAULT_REQUESTS: usize = 2_000;
+const DEFAULT_LARGE_OBJECT_BYTES: usize = 64 * 1024 * 1024;
+const STREAM_CHUNK_BYTES: usize = 64 * 1024;
+
+struct BenchmarkAdapter;
+
+#[async_trait]
+impl GatewayAdapter for BenchmarkAdapter {
+    fn protocol(&self) -> ProviderProtocol {
+        ProviderProtocol::S3
+    }
+
+    async fn handle(&self, request: Request, _context: GatewayRequestContext) -> GatewayResponse {
+        let delay = match request.uri().path() {
+            "/cache" => Duration::from_micros(100),
+            "/worker" => Duration::from_millis(1),
+            "/origin" => Duration::from_millis(5),
+            _ => Duration::ZERO,
+        };
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
+        let body = if request.uri().path() == "/large" {
+            let bytes = std::env::var("TALON_GATEWAY_BENCH_OBJECT_BYTES")
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(DEFAULT_LARGE_OBJECT_BYTES);
+            let chunks = bytes.div_ceil(STREAM_CHUNK_BYTES);
+            let chunk = Bytes::from(vec![0x5a; STREAM_CHUNK_BYTES]);
+            let stream = futures::stream::unfold(0usize, move |index| {
+                let chunk = chunk.clone();
+                async move {
+                    (index < chunks).then(|| {
+                        let remaining = bytes.saturating_sub(index * STREAM_CHUNK_BYTES);
+                        let frame = if remaining < chunk.len() {
+                            chunk.slice(..remaining)
+                        } else {
+                            chunk
+                        };
+                        (Ok::<_, std::io::Error>(frame), index + 1)
+                    })
+                }
+            });
+            Body::from_stream(stream)
+        } else {
+            Body::empty()
+        };
+        GatewayResponse::new(axum::response::Response::new(body), GatewayOperation::Read)
+    }
+}
+
+fn percentile(samples: &mut [u64], percent: usize) -> u64 {
+    samples.sort_unstable();
+    samples[(samples.len() - 1) * percent / 100]
+}
+
+async fn phase(client: &reqwest::Client, base: &str, name: &str, injected_us: u64, count: usize) {
+    for _ in 0..100 {
+        client
+            .get(format!("{base}/{name}"))
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+    }
+    let mut samples = Vec::with_capacity(count);
+    for _ in 0..count {
+        let started = Instant::now();
+        client
+            .get(format!("{base}/{name}"))
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+        samples.push(started.elapsed().as_nanos().min(u64::MAX as u128) as u64);
+    }
+    let p50 = percentile(&mut samples, 50);
+    let p99 = percentile(&mut samples, 99);
+    println!(
+        "{}",
+        json!({
+            "kind": "phase",
+            "phase": name,
+            "requests": count,
+            "injected_us": injected_us,
+            "p50_ns": p50,
+            "p99_ns": p99,
+            "p50_over_injected_ns": p50.saturating_sub(injected_us * 1_000),
+        })
+    );
+}
+
+#[cfg(target_os = "linux")]
+fn rss_bytes() -> Option<u64> {
+    std::fs::read_to_string("/proc/self/status")
+        .ok()?
+        .lines()
+        .find_map(|line| line.strip_prefix("VmRSS:"))?
+        .split_whitespace()
+        .next()?
+        .parse::<u64>()
+        .ok()
+        .map(|kib| kib * 1024)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn rss_bytes() -> Option<u64> {
+    None
+}
+
+async fn slow_stream(client: &reqwest::Client, base: &str) {
+    let baseline = rss_bytes();
+    let mut response = client
+        .get(format!("{base}/large"))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .bytes_stream();
+    let started = Instant::now();
+    let mut bytes = 0u64;
+    let mut peak = baseline;
+    while let Some(chunk) = response.next().await {
+        bytes += chunk.unwrap().len() as u64;
+        peak = peak.max(rss_bytes());
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+    let elapsed = started.elapsed();
+    println!(
+        "{}",
+        json!({
+            "kind": "slow_stream",
+            "object_bytes": bytes,
+            "chunk_bytes": STREAM_CHUNK_BYTES,
+            "client_delay_ms": 1,
+            "elapsed_ms": elapsed.as_millis(),
+            "throughput_mib_s": bytes as f64 / elapsed.as_secs_f64() / 1024.0 / 1024.0,
+            "baseline_rss_bytes": baseline,
+            "peak_rss_bytes": peak,
+            "peak_rss_delta_bytes": peak.zip(baseline).map(|(peak, base)| peak.saturating_sub(base)),
+        })
+    );
+}
+
+#[tokio::main]
+async fn main() {
+    let count = std::env::var("TALON_GATEWAY_BENCH_REQUESTS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(DEFAULT_REQUESTS);
+    assert!(count > 0, "TALON_GATEWAY_BENCH_REQUESTS must be positive");
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let runtime = Arc::new(
+        GatewayRuntime::new(
+            GatewayConfig {
+                bind: address,
+                ..GatewayConfig::default()
+            },
+            Arc::new(BenchmarkAdapter),
+            GatewaySecurity::default(),
+        )
+        .unwrap(),
+    );
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(serve(listener, runtime, async move {
+        let _ = shutdown_rx.await;
+    }));
+    let base = format!("http://{address}");
+    let client = reqwest::Client::builder()
+        .pool_max_idle_per_host(1)
+        .build()
+        .unwrap();
+
+    phase(&client, &base, "empty", 0, count).await;
+    phase(&client, &base, "cache", 100, count).await;
+    phase(&client, &base, "worker", 1_000, count).await;
+    phase(&client, &base, "origin", 5_000, count).await;
+    slow_stream(&client, &base).await;
+
+    shutdown_tx.send(()).unwrap();
+    server.await.unwrap().unwrap();
+}

--- a/crates/talon-gateway/src/main.rs
+++ b/crates/talon-gateway/src/main.rs
@@ -1,0 +1,429 @@
+//! Environment-configured Talon object-store gateway process.
+
+use std::io::{Error, ErrorKind};
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use talon_backend::{AzureBackend, AzureConfig, ReqwestClient, S3Backend, S3Config, S3Credentials};
+use talon_cache_client::{BlockReader, CoordinatorClient, PlacementCache};
+use talon_gateway::azure::{AzureAdapterConfig, AzureBlobAdapter, AzureCache};
+use talon_gateway::s3::{S3Adapter, S3AdapterConfig, S3Cache};
+use talon_gateway::{
+    serve, GatewayAdapter, GatewayConfig, GatewayMode, GatewayRoute, GatewayRuntime,
+    GatewaySecurity,
+};
+use tokio::net::TcpListener;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+type MainResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+struct Settings {
+    protocol: String,
+    bind: SocketAddr,
+    mode: GatewayMode,
+    coordinator: String,
+    block_size: u32,
+    transfer_chunk_bytes: u32,
+    placement_ttl_ms: u64,
+    replicas: u8,
+    route: GatewayRoute,
+    incoming_path_style: bool,
+    endpoint_suffix: Option<String>,
+    azure_account: Option<String>,
+    azure_endpoint: Option<String>,
+    azure_shared_key: Option<String>,
+    azure_sas: Option<String>,
+    s3_region: Option<String>,
+    s3_endpoint: Option<String>,
+    s3_access_key: Option<String>,
+    s3_secret_key: Option<String>,
+    s3_session_token: Option<String>,
+}
+
+impl Settings {
+    fn from_env() -> MainResult<Self> {
+        Self::from_lookup(|name| std::env::var(name).ok())
+    }
+
+    fn from_lookup(mut get: impl FnMut(&str) -> Option<String>) -> MainResult<Self> {
+        let value = |get: &mut dyn FnMut(&str) -> Option<String>, name: &str| {
+            get(name).filter(|value| !value.is_empty())
+        };
+        let protocol = value(&mut get, "TALON_GATEWAY_PROTOCOL")
+            .unwrap_or_else(|| "s3".to_string())
+            .to_ascii_lowercase();
+        if !matches!(protocol.as_str(), "s3" | "azure") {
+            return Err(invalid("TALON_GATEWAY_PROTOCOL must be s3 or azure"));
+        }
+        let bind = parse_or(
+            value(&mut get, "TALON_GATEWAY_BIND"),
+            "127.0.0.1:8080",
+            "TALON_GATEWAY_BIND",
+        )?;
+        let mode = match value(&mut get, "TALON_GATEWAY_MODE").as_deref() {
+            None | Some("development") => GatewayMode::Development,
+            Some("production") => GatewayMode::Production,
+            Some(_) => {
+                return Err(invalid(
+                    "TALON_GATEWAY_MODE must be development or production",
+                ))
+            }
+        };
+        let coordinator = required(&mut get, "TALON_COORDINATOR_ADDR")?;
+        let block_size = parse_or(
+            value(&mut get, "TALON_GATEWAY_BLOCK_SIZE"),
+            "268435456",
+            "TALON_GATEWAY_BLOCK_SIZE",
+        )?;
+        let transfer_chunk_bytes = parse_or(
+            value(&mut get, "TALON_GATEWAY_TRANSFER_CHUNK_BYTES"),
+            "1048576",
+            "TALON_GATEWAY_TRANSFER_CHUNK_BYTES",
+        )?;
+        let placement_ttl_ms = parse_or(
+            value(&mut get, "TALON_GATEWAY_PLACEMENT_TTL_MS"),
+            "5000",
+            "TALON_GATEWAY_PLACEMENT_TTL_MS",
+        )?;
+        let replicas = parse_or(
+            value(&mut get, "TALON_GATEWAY_REPLICAS"),
+            "1",
+            "TALON_GATEWAY_REPLICAS",
+        )?;
+        let route = match value(&mut get, "TALON_GATEWAY_ROUTE").as_deref() {
+            None | Some("cache") => GatewayRoute::Cache,
+            Some("cache-only") => GatewayRoute::CacheOnly,
+            Some("origin") => GatewayRoute::Origin,
+            Some(_) => {
+                return Err(invalid(
+                    "TALON_GATEWAY_ROUTE must be cache, cache-only, or origin",
+                ))
+            }
+        };
+        let incoming_path_style = parse_bool(
+            value(&mut get, "TALON_GATEWAY_PATH_STYLE").as_deref(),
+            false,
+            "TALON_GATEWAY_PATH_STYLE",
+        )?;
+
+        Ok(Self {
+            protocol,
+            bind,
+            mode,
+            coordinator,
+            block_size,
+            transfer_chunk_bytes,
+            placement_ttl_ms,
+            replicas,
+            route,
+            incoming_path_style,
+            endpoint_suffix: value(&mut get, "TALON_GATEWAY_ENDPOINT_SUFFIX"),
+            azure_account: value(&mut get, "TALON_GATEWAY_AZURE_ACCOUNT"),
+            azure_endpoint: value(&mut get, "TALON_GATEWAY_AZURE_ENDPOINT"),
+            azure_shared_key: value(&mut get, "TALON_GATEWAY_AZURE_SHARED_KEY"),
+            azure_sas: value(&mut get, "TALON_GATEWAY_AZURE_SAS"),
+            s3_region: value(&mut get, "TALON_GATEWAY_S3_REGION"),
+            s3_endpoint: value(&mut get, "TALON_GATEWAY_S3_ENDPOINT"),
+            s3_access_key: value(&mut get, "AWS_ACCESS_KEY_ID"),
+            s3_secret_key: value(&mut get, "AWS_SECRET_ACCESS_KEY"),
+            s3_session_token: value(&mut get, "AWS_SESSION_TOKEN"),
+        })
+    }
+}
+
+fn invalid(message: impl Into<String>) -> Box<dyn std::error::Error + Send + Sync> {
+    Box::new(Error::new(ErrorKind::InvalidInput, message.into()))
+}
+
+fn required(get: &mut dyn FnMut(&str) -> Option<String>, name: &str) -> MainResult<String> {
+    get(name)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| invalid(format!("{name} is required")))
+}
+
+fn parse_or<T: std::str::FromStr>(
+    value: Option<String>,
+    default: &str,
+    name: &str,
+) -> MainResult<T> {
+    value
+        .as_deref()
+        .unwrap_or(default)
+        .parse()
+        .map_err(|_| invalid(format!("{name} is invalid")))
+}
+
+fn parse_bool(value: Option<&str>, default: bool, name: &str) -> MainResult<bool> {
+    match value {
+        None => Ok(default),
+        Some("1" | "true" | "yes") => Ok(true),
+        Some("0" | "false" | "no") => Ok(false),
+        Some(_) => Err(invalid(format!("{name} must be true or false"))),
+    }
+}
+
+fn split_endpoint(endpoint: &str) -> (String, bool) {
+    if let Some(host) = endpoint.strip_prefix("http://") {
+        (host.to_string(), false)
+    } else {
+        (
+            endpoint
+                .strip_prefix("https://")
+                .unwrap_or(endpoint)
+                .to_string(),
+            true,
+        )
+    }
+}
+
+fn cache_reader(settings: &Settings) -> Arc<BlockReader> {
+    Arc::new(BlockReader::new(
+        CoordinatorClient::new(&settings.coordinator),
+        Arc::new(PlacementCache::new(settings.placement_ttl_ms)),
+        settings.replicas,
+    ))
+}
+
+fn azure_adapter(settings: &Settings) -> MainResult<Arc<dyn GatewayAdapter>> {
+    let account = settings
+        .azure_account
+        .clone()
+        .ok_or_else(|| invalid("TALON_GATEWAY_AZURE_ACCOUNT is required"))?;
+    if settings.azure_shared_key.is_some() && settings.azure_sas.is_some() {
+        return Err(invalid(
+            "set only one of TALON_GATEWAY_AZURE_SHARED_KEY or TALON_GATEWAY_AZURE_SAS",
+        ));
+    }
+    if settings.azure_shared_key.is_none() && settings.azure_sas.is_none() {
+        return Err(invalid("an Azure shared key or SAS credential is required"));
+    }
+    let mut origin_config = match settings.azure_endpoint.as_deref() {
+        Some(endpoint) => {
+            let (host, tls) = split_endpoint(endpoint);
+            AzureConfig::emulator(&account, host, tls)
+        }
+        None => AzureConfig::new(&account),
+    };
+    if settings.azure_endpoint.is_none() {
+        if let Some(suffix) = &settings.endpoint_suffix {
+            origin_config.endpoint_suffix.clone_from(suffix);
+        }
+    }
+    let http = Arc::new(ReqwestClient::new());
+    let origin = match settings.azure_shared_key.as_deref() {
+        Some(key) => Arc::new(AzureBackend::with_shared_key(origin_config, key, http)),
+        None => Arc::new(AzureBackend::new(
+            origin_config,
+            settings
+                .azure_sas
+                .as_deref()
+                .map(|token| token.trim_start_matches('?').to_string()),
+            http,
+        )),
+    };
+    let mut config = if settings.incoming_path_style {
+        AzureAdapterConfig::path_style(&account)
+    } else {
+        AzureAdapterConfig::public_cloud(&account)
+    };
+    if let Some(suffix) = &settings.endpoint_suffix {
+        config.endpoint_suffix.clone_from(suffix);
+    }
+    config.block_size = settings.block_size;
+    config.transfer_chunk_bytes = settings.transfer_chunk_bytes;
+    config.default_route = settings.route;
+    let cache = cache_reader(settings);
+    Ok(Arc::new(AzureBlobAdapter::new(
+        config,
+        cache as Arc<dyn AzureCache>,
+        origin,
+    )?))
+}
+
+fn s3_adapter(settings: &Settings) -> MainResult<Arc<dyn GatewayAdapter>> {
+    let region = settings
+        .s3_region
+        .clone()
+        .unwrap_or_else(|| "us-east-1".to_string());
+    let access_key = settings
+        .s3_access_key
+        .clone()
+        .ok_or_else(|| invalid("AWS_ACCESS_KEY_ID is required"))?;
+    let secret_key = settings
+        .s3_secret_key
+        .clone()
+        .ok_or_else(|| invalid("AWS_SECRET_ACCESS_KEY is required"))?;
+    let origin_config = match settings.s3_endpoint.as_deref() {
+        Some(endpoint) => {
+            let (host, tls) = split_endpoint(endpoint);
+            S3Config {
+                region: region.clone(),
+                endpoint: host,
+                path_style: true,
+                tls,
+            }
+        }
+        None => S3Config::aws(&region),
+    };
+    let origin = Arc::new(S3Backend::new(
+        origin_config,
+        S3Credentials {
+            access_key_id: access_key,
+            secret_access_key: secret_key,
+            session_token: settings.s3_session_token.clone(),
+        },
+        Arc::new(ReqwestClient::new()),
+    ));
+    let mut config = if settings.incoming_path_style {
+        S3AdapterConfig::path_style(
+            settings
+                .endpoint_suffix
+                .clone()
+                .unwrap_or_else(|| "localhost".to_string()),
+        )
+    } else {
+        S3AdapterConfig::aws(&region)
+    };
+    if let Some(suffix) = &settings.endpoint_suffix {
+        config.endpoint_suffix.clone_from(suffix);
+    }
+    config.block_size = settings.block_size;
+    config.transfer_chunk_bytes = settings.transfer_chunk_bytes;
+    config.default_route = settings.route;
+    let cache = cache_reader(settings);
+    Ok(Arc::new(S3Adapter::new(
+        config,
+        cache as Arc<dyn S3Cache>,
+        origin,
+    )?))
+}
+
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        let mut terminate =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .expect("install SIGTERM handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {},
+            _ = terminate.recv() => {},
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
+#[tokio::main]
+async fn main() -> MainResult<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .init();
+    let settings = Settings::from_env()?;
+    let adapter = match settings.protocol.as_str() {
+        "azure" => azure_adapter(&settings)?,
+        "s3" => s3_adapter(&settings)?,
+        _ => unreachable!("validated protocol"),
+    };
+    let runtime = Arc::new(GatewayRuntime::new(
+        GatewayConfig {
+            bind: settings.bind,
+            mode: settings.mode,
+            ..GatewayConfig::default()
+        },
+        adapter,
+        GatewaySecurity::default(),
+    )?);
+    let listener = TcpListener::bind(settings.bind).await?;
+    info!(
+        bind = %settings.bind,
+        protocol = %settings.protocol,
+        mode = ?settings.mode,
+        route = ?settings.route,
+        "starting object-store gateway"
+    );
+    serve(listener, runtime, shutdown_signal()).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn settings(values: &[(&str, &str)]) -> MainResult<Settings> {
+        let values = values
+            .iter()
+            .map(|(name, value)| (name.to_string(), value.to_string()))
+            .collect::<HashMap<_, _>>();
+        Settings::from_lookup(|name| values.get(name).cloned())
+    }
+
+    #[test]
+    fn defaults_are_loopback_bounded_and_cache_routed() {
+        let settings = settings(&[("TALON_COORDINATOR_ADDR", "coordinator:7411")]).unwrap();
+        assert_eq!(settings.protocol, "s3");
+        assert!(settings.bind.ip().is_loopback());
+        assert_eq!(settings.mode, GatewayMode::Development);
+        assert_eq!(settings.route, GatewayRoute::Cache);
+        assert!(!settings.incoming_path_style);
+    }
+
+    #[test]
+    fn rejects_bad_modes_protocols_and_booleans() {
+        assert!(settings(&[
+            ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
+            ("TALON_GATEWAY_PROTOCOL", "gcs"),
+        ])
+        .is_err());
+        assert!(settings(&[
+            ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
+            ("TALON_GATEWAY_MODE", "unsafe"),
+        ])
+        .is_err());
+        assert!(settings(&[
+            ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
+            ("TALON_GATEWAY_PATH_STYLE", "maybe"),
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn endpoint_scheme_selects_transport_without_retaining_the_scheme() {
+        assert_eq!(
+            split_endpoint("http://minio:9000"),
+            ("minio:9000".into(), false)
+        );
+        assert_eq!(
+            split_endpoint("https://blob.example"),
+            ("blob.example".into(), true)
+        );
+        assert_eq!(split_endpoint("s3.example"), ("s3.example".into(), true));
+    }
+
+    #[test]
+    fn provider_credentials_are_required_and_mutually_exclusive() {
+        let s3 = settings(&[("TALON_COORDINATOR_ADDR", "coordinator:7411")]).unwrap();
+        assert!(s3_adapter(&s3).is_err());
+
+        let azure = settings(&[
+            ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
+            ("TALON_GATEWAY_PROTOCOL", "azure"),
+            ("TALON_GATEWAY_AZURE_ACCOUNT", "account"),
+        ])
+        .unwrap();
+        assert!(azure_adapter(&azure).is_err());
+
+        let both = settings(&[
+            ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
+            ("TALON_GATEWAY_PROTOCOL", "azure"),
+            ("TALON_GATEWAY_AZURE_ACCOUNT", "account"),
+            ("TALON_GATEWAY_AZURE_SHARED_KEY", "key"),
+            ("TALON_GATEWAY_AZURE_SAS", "sas"),
+        ])
+        .unwrap();
+        assert!(azure_adapter(&both).is_err());
+    }
+}

--- a/deploy/docker/gateway.Dockerfile
+++ b/deploy/docker/gateway.Dockerfile
@@ -1,0 +1,42 @@
+# Talon object-store gateway image.
+#
+# The runtime is intentionally suitable for loopback sidecars only until #446
+# installs provider authentication, authorization, and TLS.
+
+FROM rust:1.96.1-bookworm AS chef
+
+RUN cargo install cargo-chef --locked --version 0.1.77
+WORKDIR /src
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS build
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=planner /src/recipe.json recipe.json
+RUN cargo chef cook --release --locked --recipe-path recipe.json \
+    --package talon-gateway
+COPY . .
+RUN cargo build --release --locked -p talon-gateway --bin talon-gateway \
+    && strip target/release/talon-gateway
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --uid 10001 --user-group --home-dir /nonexistent \
+       --no-create-home talon
+COPY --from=build /src/target/release/talon-gateway /usr/local/bin/talon-gateway
+
+USER 10001:10001
+ENV TALON_GATEWAY_BIND=127.0.0.1:8080 \
+    TALON_GATEWAY_MODE=development \
+    TALON_GATEWAY_ROUTE=cache \
+    RUST_LOG=info
+EXPOSE 8080
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:8080/healthz || exit 1
+ENTRYPOINT ["talon-gateway"]

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -5,6 +5,11 @@ stateless replicas behind one Service, with a user-selected shared-state
 backend. Pick **exactly one** coordinator Deployment (Kubernetes Lease *or*
 external etcd); deploying both is a misconfiguration.
 
+The object-store gateway has loopback-only sidecar templates for
+[S3](gateway-s3-sidecar.yaml) and [Azure Blob](gateway-azure-sidecar.yaml).
+They intentionally have no Service until incoming provider authentication and
+authorization are implemented in issue #446.
+
 ## Files
 
 | File | Purpose |
@@ -17,6 +22,8 @@ external etcd); deploying both is a misconfiguration.
 | `rbac.yaml` | Least-privilege namespaced Lease RBAC. **Kubernetes backend only.** |
 | `etcd-secret.example.yaml` | Template Secret for etcd endpoints/credentials/TLS and the optional management token. **etcd backend only.** |
 | `servicemonitor.yaml` | Prometheus Operator ServiceMonitor (or use the pod scrape annotations). |
+| `gateway-s3-sidecar.yaml` | Loopback-only S3 gateway sidecar template. |
+| `gateway-azure-sidecar.yaml` | Loopback-only Azure Blob gateway sidecar template. |
 
 ## Quick start — Kubernetes Lease backend
 

--- a/deploy/kubernetes/gateway-azure-sidecar.yaml
+++ b/deploy/kubernetes/gateway-azure-sidecar.yaml
@@ -1,0 +1,71 @@
+# Loopback-only Azure Blob gateway sidecar template. The application container
+# uses http://127.0.0.1:8080/<account>. Do not add a Service before #446.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: talon-gateway-azure
+type: Opaque
+stringData:
+  account-key: replace-me
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: application-with-talon-azure
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: application-with-talon-azure
+  template:
+    metadata:
+      labels:
+        app: application-with-talon-azure
+    spec:
+      containers:
+        - name: application
+          image: replace-with-your-application
+          env:
+            - name: AZURE_STORAGE_BLOB_ENDPOINT
+              value: http://127.0.0.1:8080/replace-account
+        - name: talon-gateway
+          image: ghcr.io/milvus-io/talon-gateway:latest
+          env:
+            - name: TALON_GATEWAY_PROTOCOL
+              value: azure
+            - name: TALON_GATEWAY_BIND
+              value: 127.0.0.1:8080
+            - name: TALON_GATEWAY_MODE
+              value: development
+            - name: TALON_GATEWAY_PATH_STYLE
+              value: "true"
+            - name: TALON_COORDINATOR_ADDR
+              value: talon-coordinator:7411
+            - name: TALON_GATEWAY_AZURE_ACCOUNT
+              value: replace-account
+            - name: TALON_GATEWAY_AZURE_SHARED_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: talon-gateway-azure
+                  key: account-key
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          readinessProbe:
+            exec:
+              command: ["curl", "-fsS", "http://127.0.0.1:8080/readyz"]
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["curl", "-fsS", "http://127.0.0.1:8080/healthz"]
+            periodSeconds: 10

--- a/deploy/kubernetes/gateway-s3-sidecar.yaml
+++ b/deploy/kubernetes/gateway-s3-sidecar.yaml
@@ -1,0 +1,78 @@
+# Loopback-only S3 gateway sidecar template. The application container shares
+# the Pod network namespace and uses http://127.0.0.1:8080. Do not add a Service
+# before #446 installs incoming SigV4 authentication and bucket authorization.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: talon-gateway-s3
+type: Opaque
+stringData:
+  access-key-id: replace-me
+  secret-access-key: replace-me
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: application-with-talon-s3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: application-with-talon-s3
+  template:
+    metadata:
+      labels:
+        app: application-with-talon-s3
+    spec:
+      containers:
+        - name: application
+          image: replace-with-your-application
+          env:
+            - name: AWS_ENDPOINT_URL_S3
+              value: http://127.0.0.1:8080
+        - name: talon-gateway
+          image: ghcr.io/milvus-io/talon-gateway:latest
+          env:
+            - name: TALON_GATEWAY_PROTOCOL
+              value: s3
+            - name: TALON_GATEWAY_BIND
+              value: 127.0.0.1:8080
+            - name: TALON_GATEWAY_MODE
+              value: development
+            - name: TALON_GATEWAY_PATH_STYLE
+              value: "true"
+            - name: TALON_COORDINATOR_ADDR
+              value: talon-coordinator:7411
+            - name: TALON_GATEWAY_S3_REGION
+              value: us-east-1
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: talon-gateway-s3
+                  key: access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: talon-gateway-s3
+                  key: secret-access-key
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          readinessProbe:
+            exec:
+              command: ["curl", "-fsS", "http://127.0.0.1:8080/readyz"]
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["curl", "-fsS", "http://127.0.0.1:8080/healthz"]
+            periodSeconds: 10

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -28,6 +28,7 @@
 - [Cloud backends (S3/GCS/Azure)](./operations/cloud-backends.md)
 - [Security hardening](./operations/security.md)
 - [Latency lab](./testing/latency-lab.md)
+- [Object-store gateway deployment](./operations/object-store-gateway.md)
 
 # Client SDKs
 
@@ -42,6 +43,7 @@
 - [REST API reference](./reference/rest-api.md)
 - [Wire protocol reference](./reference/wire-protocol.md)
 - [Object-store gateway compatibility](./reference/object-store-gateway-compatibility.md)
+- [Object-store gateway benchmarks](./reference/object-store-gateway-benchmarks.md)
 
 # Explanation
 

--- a/docs/book/src/operations/object-store-gateway.md
+++ b/docs/book/src/operations/object-store-gateway.md
@@ -1,0 +1,1 @@
+{{#include ../../../operations/object-store-gateway.md}}

--- a/docs/book/src/reference/object-store-gateway-benchmarks.md
+++ b/docs/book/src/reference/object-store-gateway-benchmarks.md
@@ -1,0 +1,1 @@
+{{#include ../../../reference/object-store-gateway-benchmarks.md}}

--- a/docs/operations/object-store-gateway.md
+++ b/docs/operations/object-store-gateway.md
@@ -1,0 +1,126 @@
+# Object-store gateway deployment
+
+`talon-gateway` exposes the read-only compatibility surface documented in the
+[compatibility matrix](../reference/object-store-gateway-compatibility.md). One
+process serves either S3 or Azure Blob, connects to a Talon coordinator and
+worker fleet for cached bytes, and uses a separately scoped origin identity for
+metadata and fallback reads.
+
+## Security state
+
+Incoming provider authentication and authorization are tracked by issue #446
+and are not implemented. This has two enforced consequences:
+
+- `development` mode only binds loopback. It is suitable for an application
+  sidecar in the same network namespace.
+- `production` mode can bind a routable address, but `/readyz` remains failing
+  and provider requests return `503` until TLS, authentication, and
+  authorization are installed.
+
+Do not add a Kubernetes Service, ingress, host port, or public load balancer to
+the current gateway. A client signature or SAS token is parsed only as protocol
+input; it is not yet proof of identity.
+
+## Credential boundary
+
+The gateway never forwards incoming `Authorization`, SAS, or presigned query
+credentials to a rewritten origin request. It builds a new request and signs it
+with the process's origin identity.
+
+| Direction | Credential | Storage |
+|---|---|---|
+| Client to gateway | Not yet validated | Never logged or forwarded; #446 owns validation. |
+| Gateway to S3 | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN` | Environment/secret injection only. |
+| Gateway to Azure | Exactly one of `TALON_GATEWAY_AZURE_SHARED_KEY` or `TALON_GATEWAY_AZURE_SAS` | Environment/secret injection only. |
+| Gateway to Talon | Coordinator and worker data-plane connection | Existing Talon cache-client boundary; mTLS integration is part of #446. |
+
+Use an origin identity limited to read metadata, object ranges, and bounded
+listing on the namespaces assigned to that gateway. Do not grant write or
+account administration permissions.
+
+## Configuration
+
+Common variables:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `TALON_GATEWAY_PROTOCOL` | `s3` | `s3` or `azure`. |
+| `TALON_GATEWAY_BIND` | `127.0.0.1:8080` | Listener; development mode rejects non-loopback addresses. |
+| `TALON_GATEWAY_MODE` | `development` | `development` or fail-closed `production`. |
+| `TALON_COORDINATOR_ADDR` | required | Talon coordinator control address. |
+| `TALON_GATEWAY_ROUTE` | `cache` | `cache`, `cache-only`, or direct `origin`. |
+| `TALON_GATEWAY_PATH_STYLE` | `false` | Accept `/bucket/key` or `/account/container/blob`. |
+| `TALON_GATEWAY_ENDPOINT_SUFFIX` | provider default | Virtual-host suffix accepted from clients. |
+| `TALON_GATEWAY_BLOCK_SIZE` | `268435456` | Must match worker cache granularity. |
+| `TALON_GATEWAY_TRANSFER_CHUNK_BYTES` | `1048576` | Maximum cache body frame. |
+| `TALON_GATEWAY_PLACEMENT_TTL_MS` | `5000` | Client-side placement freshness. |
+| `TALON_GATEWAY_REPLICAS` | `1` | Ordered worker replicas attempted by the cache client. |
+
+S3 variables:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `TALON_GATEWAY_S3_REGION` | `us-east-1` | Origin signing region. |
+| `TALON_GATEWAY_S3_ENDPOINT` | AWS regional endpoint | Optional `http[s]://host[:port]`; custom endpoints use path addressing. |
+| `AWS_ACCESS_KEY_ID` | required | Scoped origin access key. |
+| `AWS_SECRET_ACCESS_KEY` | required | Scoped origin secret. |
+| `AWS_SESSION_TOKEN` | unset | Optional STS token. |
+
+Azure variables:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `TALON_GATEWAY_AZURE_ACCOUNT` | required | The single account served by the process. |
+| `TALON_GATEWAY_AZURE_ENDPOINT` | public Azure | Optional `http[s]://host[:port]`; custom endpoints use path addressing. |
+| `TALON_GATEWAY_AZURE_SHARED_KEY` | unset | Base64 account key. Mutually exclusive with SAS. |
+| `TALON_GATEWAY_AZURE_SAS` | unset | Origin SAS without logging or serialization. |
+
+## Docker
+
+Build the non-root image:
+
+```sh
+docker build -f deploy/docker/gateway.Dockerfile -t talon-gateway .
+```
+
+Loopback mode requires host networking when the client runs on the Docker host.
+Keep secrets in an env file with restrictive permissions:
+
+```sh
+docker run --rm --network host --env-file /run/secrets/talon-s3.env \
+  -e TALON_GATEWAY_PROTOCOL=s3 \
+  -e TALON_COORDINATOR_ADDR=127.0.0.1:7411 \
+  -e TALON_GATEWAY_PATH_STYLE=true talon-gateway
+```
+
+For Azure, set `TALON_GATEWAY_PROTOCOL=azure`, the account, and exactly one
+Azure origin credential in the env file.
+
+## Kubernetes
+
+Use the gateway only as a sidecar. The application reaches
+`127.0.0.1:8080`, while no Service selects the gateway port:
+
+- [S3 sidecar template](https://github.com/milvus-io/talon/blob/main/deploy/kubernetes/gateway-s3-sidecar.yaml)
+- [Azure sidecar template](https://github.com/milvus-io/talon/blob/main/deploy/kubernetes/gateway-azure-sidecar.yaml)
+
+Replace placeholder images and Secrets before applying. The templates run as a
+fixed non-root UID, drop all capabilities, use a read-only root filesystem, and
+probe loopback with `exec` because kubelet HTTP probes target the Pod IP.
+
+## Failure runbook
+
+| Symptom | Meaning | Action |
+|---|---|---|
+| `/healthz` fails | Process/runtime failure. | Restart and inspect bounded gateway logs. |
+| `/readyz` reports security reasons | Production security is incomplete. | Do not route traffic; complete #446. |
+| `503` with `ServerBusy` or `ServiceUnavailable` | Origin unavailable, or cache fallback also unavailable. | Check origin reachability and scoped credentials; correlate `x-talon-request-id`. |
+| `504` / timeout error | Worker or request deadline elapsed. | Check worker saturation, placement freshness, and network latency. |
+| `412` | Origin ETag changed or a client condition failed. | Re-resolve metadata; do not retry stale cached bytes. |
+| `404` | Origin-authoritative object absence. | Verify namespace and key; cache does not override this result. |
+| `416` | Unsatisfiable or multi-range request. | Send one valid byte range. |
+| Cache errors increase while reads succeed | Infrastructure fallback is active. | Repair coordinator/workers before origin load becomes sustained. |
+
+Metrics use bounded labels only. Use request IDs for individual incidents;
+object names, credentials, and origin URLs are deliberately absent from labels
+and error bodies.

--- a/docs/reference/object-store-gateway-benchmarks.md
+++ b/docs/reference/object-store-gateway-benchmarks.md
@@ -1,0 +1,66 @@
+# Object-store gateway benchmarks
+
+The shared gateway has a deterministic loopback harness:
+
+```sh
+just gateway-bench
+```
+
+It emits JSON Lines so runs can be archived without scraping a presentation
+table. `TALON_GATEWAY_BENCH_REQUESTS` controls phase samples and
+`TALON_GATEWAY_BENCH_OBJECT_BYTES` controls the slow-stream object size.
+
+## What is separated
+
+The harness drives the real HTTP parser, limits, middleware, request IDs,
+metrics observation, Axum dispatch, and streaming body runtime. The current
+loopback-only mode has a no-op incoming authentication boundary; #446 will add
+the authentication phase to this same measurement.
+
+Controlled delays model boundaries outside the shared runtime:
+
+| Phase | Injected delay | Interpretation |
+|---|---:|---|
+| `empty` | 0 | HTTP parse, middleware, no-op auth boundary, adapter dispatch, response. |
+| `cache` | 100 us | Cache-client call plus runtime; sub-millisecond Tokio timers may round upward. |
+| `worker` | 1 ms | Cache client and modeled worker round trip. |
+| `origin` | 5 ms | Modeled direct-origin metadata/body latency. |
+
+These are regression measurements, not claims about a real worker or cloud
+service. Provider compatibility is measured separately by the Azurite and
+LocalStack SDK CI jobs.
+
+## Recorded run
+
+Run on the Agent Console devbox on 2026-08-09, release build, one warm HTTP/1.1
+connection, 100 warmups and 1,000 measured serial requests per phase:
+
+| Phase | p50 | p99 | p50 above injected delay |
+|---|---:|---:|---:|
+| `empty` | 117 us | 171 us | 117 us |
+| `cache` | 1.216 ms | 2.273 ms | 1.116 ms |
+| `worker` | 2.223 ms | 2.329 ms | 1.223 ms |
+| `origin` | 6.235 ms | 6.342 ms | 1.235 ms |
+
+The 100 us modeled cache delay rounds to a scheduler tick on this host. The
+useful comparison is the stable `empty` floor and the roughly 1.2 ms timer plus
+runtime cost around delayed phases, not the absolute cloud latency.
+
+## Slow client and large object
+
+The same run streamed 64 MiB in 64 KiB frames while the client paused 1 ms
+after every received frame:
+
+| Metric | Result |
+|---|---:|
+| Elapsed | 2.478 s |
+| Throughput | 25.82 MiB/s |
+| Baseline RSS | 6,406,144 bytes |
+| Peak RSS | 7,102,464 bytes |
+| Peak RSS increase | 696,320 bytes |
+
+The client intentionally determines throughput. The result of interest is that
+a 64 MiB object increased process RSS by less than 0.7 MiB: the response stream
+remained demand-driven instead of buffering the object. Repeat on the target
+kernel and allocator before setting pod memory limits; RSS numbers are not
+portable capacity guarantees.

--- a/docs/reference/object-store-gateway-compatibility.md
+++ b/docs/reference/object-store-gateway-compatibility.md
@@ -67,3 +67,7 @@ boto3 and the MinIO SDK. It covers cold and warm reads, exact ranges, URL
 encoding, conditions, presigned URLs, listing pagination and delimiters, and
 standard errors. Arrow-compatible signed HEAD and ranged GET fixtures run in
 the same test.
+
+See the [deployment and failure runbook](../operations/object-store-gateway.md)
+and [gateway benchmark results](object-store-gateway-benchmarks.md) for the
+operational boundary around this matrix.


### PR DESCRIPTION
## Summary

- add the environment-configured `talon-gateway` process and non-root container image
- publish loopback-only S3 and Azure sidecar examples with a fail-closed production boundary
- document configuration, credentials, compatibility, failure handling, and synthetic gateway benchmarks
- smoke-build the image in CI and include it in release image publishing

## Verification

- `cargo fmt --all`
- `just ci`
- `cargo test -p talon-gateway --all-targets`
- `cargo clippy -p talon-gateway --all-targets --all-features -- -D warnings`
- `cargo test -p talon-observability deploy::tests --all-features`
- `mdbook build docs/book`
- `just spell`
- `just linkcheck`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --all-features`
- `cargo deny check advisories bans sources`
- `just gateway-bench`
- development and production readiness smoke tests

Closes #478
