### PR TITLE
feat(gateway): add namespace authorization policy

### DIFF
--- a/crates/talon-gateway/src/authorization.rs
+++ b/crates/talon-gateway/src/authorization.rs
@@ -1,0 +1,320 @@
+//! Default-deny principal and object namespace authorization.
+
+use std::collections::HashSet;
+use std::sync::{Arc, RwLock};
+
+use talon_core::Backend;
+
+use crate::{GatewayAccess, GatewayOperation, GatewayTarget, ProviderProtocol};
+
+/// Identity established by a trusted provider authenticator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthenticatedPrincipal {
+    /// Stable policy identity. This value is never emitted in metrics or audit logs.
+    pub id: String,
+    /// Provider tenant or storage account established from the credential.
+    pub provider_account: String,
+}
+
+impl AuthenticatedPrincipal {
+    /// Construct a trusted principal for insertion into request extensions.
+    pub fn new(id: impl Into<String>, provider_account: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            provider_account: provider_account.into(),
+        }
+    }
+}
+
+/// One allow-only policy grant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorizationGrant {
+    /// Unique operator-facing identifier used only for configuration errors.
+    pub id: String,
+    /// Authenticated principal identity.
+    pub principal: String,
+    /// Object-store protocol.
+    pub protocol: ProviderProtocol,
+    /// Provider tenant or storage account.
+    pub provider_account: String,
+    /// Exact bucket or container.
+    pub namespace: String,
+    /// Optional literal object or listing prefix.
+    pub prefix: Option<String>,
+    /// Allowed operations.
+    pub operations: Vec<GatewayOperation>,
+}
+
+#[derive(Debug)]
+struct CompiledPolicy {
+    grants: Vec<AuthorizationGrant>,
+}
+
+/// Atomically reloadable authorization policy. Invalid reloads retain the last good policy.
+#[derive(Debug, Clone)]
+pub struct AuthorizationPolicy {
+    current: Arc<RwLock<Arc<CompiledPolicy>>>,
+}
+
+impl AuthorizationPolicy {
+    /// Compile an initial policy. An empty policy is valid and denies every request.
+    pub fn new(grants: Vec<AuthorizationGrant>) -> Result<Self, AuthorizationPolicyError> {
+        let compiled = Arc::new(compile(grants)?);
+        Ok(Self {
+            current: Arc::new(RwLock::new(compiled)),
+        })
+    }
+
+    /// Compile and atomically publish a replacement policy.
+    pub fn reload(&self, grants: Vec<AuthorizationGrant>) -> Result<(), AuthorizationPolicyError> {
+        let compiled = Arc::new(compile(grants)?);
+        *self.current.write().unwrap() = compiled;
+        Ok(())
+    }
+
+    pub(crate) fn allows(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        protocol: ProviderProtocol,
+        access: &GatewayAccess,
+    ) -> bool {
+        if access
+            .provider_account
+            .as_deref()
+            .is_some_and(|account| account != principal.provider_account)
+        {
+            return false;
+        }
+        let (backend, namespace, requested_prefix) = target_parts(&access.target);
+        if backend != protocol_backend(protocol) {
+            return false;
+        }
+        let current = self.current.read().unwrap().clone();
+        current.grants.iter().any(|grant| {
+            grant.principal == principal.id
+                && grant.protocol == protocol
+                && grant.provider_account == principal.provider_account
+                && grant.namespace == namespace
+                && grant.operations.contains(&access.operation)
+                && prefix_contains(grant.prefix.as_deref(), requested_prefix)
+        })
+    }
+}
+
+fn target_parts(target: &GatewayTarget) -> (Backend, &str, Option<&str>) {
+    match target {
+        GatewayTarget::Object(object) => (
+            object.backend,
+            object.bucket.as_str(),
+            Some(object.object_path.as_str()),
+        ),
+        GatewayTarget::Namespace {
+            backend,
+            namespace,
+            prefix,
+        } => (*backend, namespace.as_str(), prefix.as_deref()),
+    }
+}
+
+fn protocol_backend(protocol: ProviderProtocol) -> Backend {
+    match protocol {
+        ProviderProtocol::S3 => Backend::S3,
+        ProviderProtocol::Azure => Backend::Azure,
+    }
+}
+
+fn prefix_contains(grant: Option<&str>, requested: Option<&str>) -> bool {
+    match (grant, requested) {
+        (None, _) => true,
+        (Some(_), None) => false,
+        (Some(grant), Some(requested)) => requested.starts_with(grant),
+    }
+}
+
+fn compile(grants: Vec<AuthorizationGrant>) -> Result<CompiledPolicy, AuthorizationPolicyError> {
+    let mut ids = HashSet::new();
+    let mut selectors = HashSet::new();
+    for grant in &grants {
+        if grant.id.is_empty()
+            || grant.principal.is_empty()
+            || grant.provider_account.is_empty()
+            || grant.namespace.is_empty()
+            || grant.operations.is_empty()
+        {
+            return Err(AuthorizationPolicyError::InvalidGrant(grant.id.clone()));
+        }
+        if !ids.insert(grant.id.clone()) {
+            return Err(AuthorizationPolicyError::DuplicateGrantId(grant.id.clone()));
+        }
+        if grant.prefix.as_deref().is_some_and(invalid_prefix) {
+            return Err(AuthorizationPolicyError::InvalidGrant(grant.id.clone()));
+        }
+        let mut operations = HashSet::new();
+        for operation in &grant.operations {
+            if *operation == GatewayOperation::Unsupported || !operations.insert(*operation) {
+                return Err(AuthorizationPolicyError::InvalidGrant(grant.id.clone()));
+            }
+            let selector = (
+                grant.principal.clone(),
+                grant.protocol,
+                grant.provider_account.clone(),
+                grant.namespace.clone(),
+                grant.prefix.clone(),
+                *operation,
+            );
+            if !selectors.insert(selector) {
+                return Err(AuthorizationPolicyError::AmbiguousGrant(grant.id.clone()));
+            }
+        }
+    }
+    Ok(CompiledPolicy { grants })
+}
+
+fn invalid_prefix(prefix: &str) -> bool {
+    prefix.is_empty()
+}
+
+/// Policy compilation error. Resource values are deliberately absent from display text.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum AuthorizationPolicyError {
+    /// A grant is empty, unsupported, duplicated internally, or has an unsafe prefix.
+    #[error("authorization grant {0:?} is invalid")]
+    InvalidGrant(String),
+    /// Grant identifiers must be unique.
+    #[error("authorization grant id {0:?} is duplicated")]
+    DuplicateGrantId(String),
+    /// Two grants contain the same selector and operation.
+    #[error("authorization grant {0:?} is ambiguous")]
+    AmbiguousGrant(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use talon_core::ObjectId;
+
+    fn grant(prefix: Option<&str>) -> AuthorizationGrant {
+        AuthorizationGrant {
+            id: "reader".into(),
+            principal: "principal-a".into(),
+            protocol: ProviderProtocol::S3,
+            provider_account: "account-a".into(),
+            namespace: "bucket-a".into(),
+            prefix: prefix.map(str::to_string),
+            operations: vec![GatewayOperation::Read, GatewayOperation::List],
+        }
+    }
+
+    fn access(namespace: &str, key: &str, operation: GatewayOperation) -> GatewayAccess {
+        GatewayAccess {
+            operation,
+            provider_account: None,
+            target: GatewayTarget::Object(ObjectId::new(Backend::S3, namespace, key)),
+        }
+    }
+
+    fn list_access(prefix: Option<&str>) -> GatewayAccess {
+        GatewayAccess {
+            operation: GatewayOperation::List,
+            provider_account: None,
+            target: GatewayTarget::Namespace {
+                backend: Backend::S3,
+                namespace: "bucket-a".into(),
+                prefix: prefix.map(str::to_string),
+            },
+        }
+    }
+
+    #[test]
+    fn policy_is_default_deny_and_tenant_scoped() {
+        let policy = AuthorizationPolicy::new(vec![grant(Some("tenant/"))]).unwrap();
+        let principal = AuthenticatedPrincipal::new("principal-a", "account-a");
+        assert!(policy.allows(
+            &principal,
+            ProviderProtocol::S3,
+            &access("bucket-a", "tenant/object", GatewayOperation::Read)
+        ));
+        assert!(!policy.allows(
+            &principal,
+            ProviderProtocol::S3,
+            &access("bucket-b", "tenant/object", GatewayOperation::Read)
+        ));
+        assert!(!policy.allows(
+            &AuthenticatedPrincipal::new("principal-b", "account-a"),
+            ProviderProtocol::S3,
+            &access("bucket-a", "tenant/object", GatewayOperation::Read)
+        ));
+        assert!(!AuthorizationPolicy::new(Vec::new()).unwrap().allows(
+            &principal,
+            ProviderProtocol::S3,
+            &access("bucket-a", "tenant/object", GatewayOperation::Read)
+        ));
+    }
+
+    #[test]
+    fn prefix_and_operation_boundaries_are_exact() {
+        let policy = AuthorizationPolicy::new(vec![grant(Some("tenant/"))]).unwrap();
+        let principal = AuthenticatedPrincipal::new("principal-a", "account-a");
+        assert!(!policy.allows(
+            &principal,
+            ProviderProtocol::S3,
+            &access("bucket-a", "tenant-other", GatewayOperation::Read)
+        ));
+        assert!(!policy.allows(
+            &principal,
+            ProviderProtocol::S3,
+            &access("bucket-a", "tenant/object", GatewayOperation::Delete)
+        ));
+        assert!(policy.allows(
+            &principal,
+            ProviderProtocol::S3,
+            &list_access(Some("tenant/nested"))
+        ));
+        assert!(!policy.allows(&principal, ProviderProtocol::S3, &list_access(None)));
+    }
+
+    #[test]
+    fn invalid_reload_retains_last_good_policy() {
+        let policy = AuthorizationPolicy::new(vec![grant(None)]).unwrap();
+        let principal = AuthenticatedPrincipal::new("principal-a", "account-a");
+        let access = access("bucket-a", "object", GatewayOperation::Read);
+        let mut invalid = grant(None);
+        invalid.operations.clear();
+        assert!(policy.reload(vec![invalid]).is_err());
+        assert!(policy.allows(&principal, ProviderProtocol::S3, &access));
+
+        let mut replacement = grant(None);
+        replacement.principal = "principal-b".into();
+        policy.reload(vec![replacement]).unwrap();
+        assert!(!policy.allows(&principal, ProviderProtocol::S3, &access));
+    }
+
+    #[test]
+    fn configured_provider_account_must_match_authenticated_account() {
+        let policy = AuthorizationPolicy::new(vec![grant(None)]).unwrap();
+        let mut access = access("bucket-a", "object", GatewayOperation::Read);
+        access.provider_account = Some("account-b".into());
+        assert!(!policy.allows(
+            &AuthenticatedPrincipal::new("principal-a", "account-a"),
+            ProviderProtocol::S3,
+            &access
+        ));
+    }
+
+    #[test]
+    fn duplicate_ids_and_selectors_are_rejected() {
+        let first = grant(None);
+        let mut duplicate_id = grant(Some("other/"));
+        assert!(matches!(
+            AuthorizationPolicy::new(vec![first.clone(), duplicate_id.clone()]),
+            Err(AuthorizationPolicyError::DuplicateGrantId(_))
+        ));
+
+        duplicate_id.id = "second".into();
+        duplicate_id.prefix = first.prefix.clone();
+        assert!(matches!(
+            AuthorizationPolicy::new(vec![first, duplicate_id]),
+            Err(AuthorizationPolicyError::AmbiguousGrant(_))
+        ));
+    }
+}

--- a/crates/talon-gateway/src/azure.rs
+++ b/crates/talon-gateway/src/azure.rs
@@ -15,8 +15,8 @@ use talon_cache_client::{BlockReader, CacheReadError, FileView, DEFAULT_TRANSFER
 use talon_core::{Backend, ObjectId, Version};
 
 use crate::{
-    FailureReason, GatewayAdapter, GatewayOperation, GatewayOutcome, GatewayRequestContext,
-    GatewayResponse, GatewayRoute, GatewayTarget, ProviderProtocol,
+    FailureReason, GatewayAccess, GatewayAdapter, GatewayOperation, GatewayOutcome,
+    GatewayRequestContext, GatewayResponse, GatewayRoute, GatewayTarget, ProviderProtocol,
 };
 
 const AZURE_API_VERSION: &str = "2021-12-02";
@@ -1397,6 +1397,15 @@ impl GatewayAdapter for AzureBlobAdapter {
         ProviderProtocol::Azure
     }
 
+    fn access(
+        &self,
+        request: &Request,
+        context: &GatewayRequestContext,
+    ) -> Result<GatewayAccess, Box<GatewayResponse>> {
+        self.classify_access(request)
+            .map_err(|error| Box::new(error_response(error, &context.request_id)))
+    }
+
     async fn handle(&self, request: Request, context: GatewayRequestContext) -> GatewayResponse {
         match self.handle_request(request, &context).await {
             Ok(response) => response,
@@ -1406,6 +1415,37 @@ impl GatewayAdapter for AzureBlobAdapter {
 }
 
 impl AzureBlobAdapter {
+    fn classify_access(&self, request: &Request) -> Result<GatewayAccess, AzureRequestError> {
+        let target = parse_target(request, &self.config)?;
+        let query = AzureQuery::parse(request.uri().query())?;
+        if request.method() == axum::http::Method::GET && target.blob.is_none() && query.is_list() {
+            return Ok(GatewayAccess {
+                operation: GatewayOperation::List,
+                provider_account: Some(self.config.account.clone()),
+                target: GatewayTarget::Namespace {
+                    backend: Backend::Azure,
+                    namespace: target.container,
+                    prefix: query.prefix,
+                },
+            });
+        }
+        let blob = target.blob.ok_or_else(|| {
+            AzureRequestError::invalid("InvalidUri", "request does not identify a blob")
+        })?;
+        let operation = match *request.method() {
+            axum::http::Method::HEAD => GatewayOperation::Stat,
+            axum::http::Method::GET => GatewayOperation::Read,
+            axum::http::Method::PUT => GatewayOperation::Write,
+            axum::http::Method::DELETE => GatewayOperation::Delete,
+            _ => GatewayOperation::Unsupported,
+        };
+        Ok(GatewayAccess {
+            operation,
+            provider_account: Some(self.config.account.clone()),
+            target: GatewayTarget::Object(ObjectId::new(Backend::Azure, target.container, blob)),
+        })
+    }
+
     async fn handle_request(
         &self,
         request: Request,

--- a/crates/talon-gateway/src/config.rs
+++ b/crates/talon-gateway/src/config.rs
@@ -19,7 +19,7 @@ pub struct GatewaySecurity {
     pub tls: bool,
     /// Provider credentials are authenticated before dispatch.
     pub authentication: bool,
-    /// The authenticated principal is checked against a policy.
+    /// The authenticated principal is checked against a policy. Runtime installation manages this bit.
     pub authorization: bool,
 }
 

--- a/crates/talon-gateway/src/lib.rs
+++ b/crates/talon-gateway/src/lib.rs
@@ -1,5 +1,6 @@
 //! Provider-neutral, bounded HTTP runtime shared by Talon's object-store gateways.
 
+mod authorization;
 pub mod azure;
 mod cache_mark;
 mod config;
@@ -9,6 +10,9 @@ mod runtime;
 pub mod s3;
 mod tls;
 
+pub use authorization::{
+    AuthenticatedPrincipal, AuthorizationGrant, AuthorizationPolicy, AuthorizationPolicyError,
+};
 pub use cache_mark::{
     CacheFallback, CacheLookup, CacheMarkError, CachePopulation, EffectiveDecision,
     AZURE_CACHE_MARK_HEADER, S3_CACHE_MARK_HEADER,
@@ -16,8 +20,8 @@ pub use cache_mark::{
 pub use config::{GatewayConfig, GatewayConfigError, GatewayMode, GatewaySecurity};
 pub use metrics::GatewayMetrics;
 pub use model::{
-    FailureReason, GatewayAdapter, GatewayOperation, GatewayOutcome, GatewayRequestContext,
-    GatewayResponse, GatewayRoute, GatewayTarget, ProviderProtocol,
+    FailureReason, GatewayAccess, GatewayAdapter, GatewayOperation, GatewayOutcome,
+    GatewayRequestContext, GatewayResponse, GatewayRoute, GatewayTarget, ProviderProtocol,
 };
 pub use runtime::{
     gateway_router, serve, serve_tls, GatewayReadiness, GatewayRuntime, GatewayTlsServeError,

--- a/crates/talon-gateway/src/metrics.rs
+++ b/crates/talon-gateway/src/metrics.rs
@@ -43,6 +43,16 @@ impl GatewayMetrics {
             .inc();
     }
 
+    pub(crate) fn record_authorization(&self, decision: &'static str) {
+        self.registry
+            .counter(
+                "talon_gateway_authorization_total",
+                "Gateway authorization decisions.",
+                labels(&[("decision", decision)]),
+            )
+            .inc();
+    }
+
     pub(crate) fn record_headers(&self, observation: RequestObservation) {
         let failure = observation.failure.map_or("none", FailureReason::label);
         let response_class = match observation.status / 100 {

--- a/crates/talon-gateway/src/model.rs
+++ b/crates/talon-gateway/src/model.rs
@@ -9,7 +9,7 @@ use axum::response::Response;
 use talon_core::{Backend, ObjectId};
 
 /// Object-store protocol served by one gateway process.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ProviderProtocol {
     /// Amazon S3-compatible HTTP API.
     S3,
@@ -27,7 +27,7 @@ impl ProviderProtocol {
 }
 
 /// Provider-neutral operation used by policy and bounded-cardinality metrics.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum GatewayOperation {
     /// Resolve object metadata.
     Stat,
@@ -180,6 +180,17 @@ pub struct GatewayRequestContext {
     pub started: Instant,
 }
 
+/// Provider-neutral resource and operation resolved without backend access.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayAccess {
+    /// Operation requested by the client.
+    pub operation: GatewayOperation,
+    /// Provider account fixed by the listener, when the protocol exposes one.
+    pub provider_account: Option<String>,
+    /// Canonical namespace and optional object or listing prefix.
+    pub target: GatewayTarget,
+}
+
 /// Adapter response plus provider-neutral accounting metadata.
 pub struct GatewayResponse {
     /// Provider-correct status, headers, and streaming body.
@@ -225,6 +236,24 @@ pub trait GatewayAdapter: Send + Sync + 'static {
     /// Protocol label for metrics and logs.
     fn protocol(&self) -> ProviderProtocol;
 
-    /// Parse, authorize, execute, and translate one provider request.
+    /// Resolve an authorization target without cache or origin access.
+    fn access(
+        &self,
+        _request: &Request,
+        _context: &GatewayRequestContext,
+    ) -> Result<GatewayAccess, Box<GatewayResponse>> {
+        let mut response = GatewayResponse::new(
+            Response::builder()
+                .status(501)
+                .body(Body::empty())
+                .expect("static response is valid"),
+            GatewayOperation::Unsupported,
+        );
+        response.outcome = GatewayOutcome::Failed;
+        response.failure = Some(FailureReason::Unsupported);
+        Err(Box::new(response))
+    }
+
+    /// Execute and translate one request after shared authorization.
     async fn handle(&self, request: Request, context: GatewayRequestContext) -> GatewayResponse;
 }

--- a/crates/talon-gateway/src/runtime.rs
+++ b/crates/talon-gateway/src/runtime.rs
@@ -19,6 +19,7 @@ use tokio::net::TcpListener;
 use tower::limit::ConcurrencyLimitLayer;
 use tower_http::timeout::TimeoutBody;
 
+use crate::authorization::{AuthenticatedPrincipal, AuthorizationPolicy};
 use crate::config::{GatewayConfig, GatewayConfigError, GatewayMode, GatewaySecurity};
 use crate::metrics::{GatewayMetrics, RequestObservation, ResponseObserver};
 use crate::model::{
@@ -59,8 +60,10 @@ impl GatewayReadiness {
     }
 
     /// Update installed production security components.
-    pub fn set_security(&self, security: GatewaySecurity) {
-        *self.security.write().unwrap() = security;
+    pub fn set_security(&self, mut security: GatewaySecurity) {
+        let mut current = self.security.write().unwrap();
+        security.authorization = current.authorization;
+        *current = security;
     }
 
     /// Update the TLS readiness bit from the installed listener state.
@@ -114,6 +117,7 @@ pub struct GatewayRuntime {
     adapter: Arc<dyn GatewayAdapter>,
     readiness: Arc<GatewayReadiness>,
     metrics: GatewayMetrics,
+    authorization: RwLock<Option<AuthorizationPolicy>>,
 }
 
 impl GatewayRuntime {
@@ -121,9 +125,10 @@ impl GatewayRuntime {
     pub fn new(
         config: GatewayConfig,
         adapter: Arc<dyn GatewayAdapter>,
-        security: GatewaySecurity,
+        mut security: GatewaySecurity,
     ) -> Result<Self, GatewayConfigError> {
         config.validate()?;
+        security.authorization = false;
         if config.mode == GatewayMode::Development {
             tracing::warn!(
                 bind = %config.bind,
@@ -135,6 +140,7 @@ impl GatewayRuntime {
             config,
             adapter,
             metrics: GatewayMetrics::new(),
+            authorization: RwLock::new(None),
         })
     }
 
@@ -146,6 +152,13 @@ impl GatewayRuntime {
     /// Shared metrics registry.
     pub fn metrics(&self) -> &GatewayMetrics {
         &self.metrics
+    }
+
+    /// Atomically install a compiled default-deny authorization policy.
+    pub fn install_authorization(&self, policy: AuthorizationPolicy) {
+        *self.authorization.write().unwrap() = Some(policy);
+        let mut security = self.readiness.security.write().unwrap();
+        security.authorization = true;
     }
 }
 
@@ -257,6 +270,46 @@ async fn adapter_handler(State(runtime): State<Arc<GatewayRuntime>>, request: Re
     let elapsed = context.started.elapsed();
     let remaining = runtime.config.request_deadline.saturating_sub(elapsed);
     let protocol = runtime.adapter.protocol();
+    let policy = runtime.authorization.read().unwrap().clone();
+    if let Some(policy) = policy {
+        let access = match runtime.adapter.access(&request, &context) {
+            Ok(access) => access,
+            Err(result) => return record_adapter_result(&runtime, protocol, &context, *result),
+        };
+        let principal = request.extensions().get::<AuthenticatedPrincipal>();
+        if principal.map_or(true, |principal| {
+            !policy.allows(principal, protocol, &access)
+        }) {
+            runtime.metrics.record_authorization("deny");
+            tracing::warn!(
+                request_id = context.request_id,
+                protocol = protocol.label(),
+                operation = access.operation.label(),
+                decision = "deny",
+                "gateway authorization decision"
+            );
+            let result = GatewayResponse {
+                response: (StatusCode::FORBIDDEN, "request is not authorized").into_response(),
+                operation: access.operation,
+                target: Some(access.target),
+                route: GatewayRoute::None,
+                outcome: GatewayOutcome::Failed,
+                failure: Some(FailureReason::Authorization),
+                requested_bytes: 0,
+                cache_bytes: 0,
+                origin_bytes: 0,
+            };
+            return record_adapter_result(&runtime, protocol, &context, result);
+        }
+        runtime.metrics.record_authorization("allow");
+        tracing::info!(
+            request_id = context.request_id,
+            protocol = protocol.label(),
+            operation = access.operation.label(),
+            decision = "allow",
+            "gateway authorization decision"
+        );
+    }
     let result =
         match tokio::time::timeout(remaining, runtime.adapter.handle(request, context.clone()))
             .await
@@ -279,6 +332,15 @@ async fn adapter_handler(State(runtime): State<Arc<GatewayRuntime>>, request: Re
             },
         };
 
+    record_adapter_result(&runtime, protocol, &context, result)
+}
+
+fn record_adapter_result(
+    runtime: &GatewayRuntime,
+    protocol: crate::ProviderProtocol,
+    context: &GatewayRequestContext,
+    result: GatewayResponse,
+) -> Response {
     let mut response = result.response;
     let status = response.status();
     runtime.metrics.record_headers(RequestObservation {
@@ -558,7 +620,10 @@ mod tests {
     use axum::body::to_bytes;
     use axum::http::Request as HttpRequest;
     use bytes::Bytes;
+    use talon_core::{Backend, ObjectId};
     use tower::ServiceExt;
+
+    use crate::{AuthorizationGrant, GatewayAccess, GatewayTarget};
 
     #[derive(Clone, Copy)]
     enum AdapterBehavior {
@@ -584,6 +649,22 @@ mod tests {
     impl GatewayAdapter for TestAdapter {
         fn protocol(&self) -> crate::ProviderProtocol {
             crate::ProviderProtocol::S3
+        }
+
+        fn access(
+            &self,
+            request: &Request,
+            _context: &GatewayRequestContext,
+        ) -> Result<GatewayAccess, Box<GatewayResponse>> {
+            Ok(GatewayAccess {
+                operation: GatewayOperation::Read,
+                provider_account: None,
+                target: GatewayTarget::Object(ObjectId::new(
+                    Backend::S3,
+                    "bucket-a",
+                    request.uri().path().trim_start_matches('/'),
+                )),
+            })
         }
 
         async fn handle(
@@ -641,18 +722,95 @@ mod tests {
             authentication: true,
             authorization: true,
         });
+        assert!(!runtime.readiness().is_ready());
+        runtime.install_authorization(
+            AuthorizationPolicy::new(vec![AuthorizationGrant {
+                id: "production-read".into(),
+                principal: "principal-a".into(),
+                protocol: crate::ProviderProtocol::S3,
+                provider_account: "account-a".into(),
+                namespace: "bucket-a".into(),
+                prefix: None,
+                operations: vec![GatewayOperation::Read],
+            }])
+            .unwrap(),
+        );
         let response = app
             .clone()
             .oneshot(HttpRequest::get("/readyz").body(Body::empty()).unwrap())
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        let response = app
-            .oneshot(HttpRequest::get("/object").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
+        let mut request = HttpRequest::get("/object").body(Body::empty()).unwrap();
+        request
+            .extensions_mut()
+            .insert(AuthenticatedPrincipal::new("principal-a", "account-a"));
+        let response = app.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(adapter.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn authorization_denies_before_dispatch_and_ignores_spoofed_headers() {
+        let adapter = TestAdapter::immediate();
+        let runtime = runtime_with(
+            GatewayConfig::default(),
+            adapter.clone(),
+            GatewaySecurity::default(),
+        );
+        runtime.install_authorization(
+            AuthorizationPolicy::new(vec![AuthorizationGrant {
+                id: "read-tenant".into(),
+                principal: "principal-a".into(),
+                protocol: crate::ProviderProtocol::S3,
+                provider_account: "account-a".into(),
+                namespace: "bucket-a".into(),
+                prefix: Some("tenant/".into()),
+                operations: vec![GatewayOperation::Read],
+            }])
+            .unwrap(),
+        );
+        let app = gateway_router(Arc::clone(&runtime));
+
+        let response = app
+            .clone()
+            .oneshot(
+                HttpRequest::get("/tenant/object-secret")
+                    .header("x-talon-principal", "principal-a")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(adapter.calls.load(Ordering::SeqCst), 0);
+
+        let mut wrong_tenant = HttpRequest::get("/tenant/object-secret")
+            .body(Body::empty())
+            .unwrap();
+        wrong_tenant
+            .extensions_mut()
+            .insert(AuthenticatedPrincipal::new("principal-a", "account-b"));
+        let response = app.clone().oneshot(wrong_tenant).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(adapter.calls.load(Ordering::SeqCst), 0);
+
+        let mut allowed = HttpRequest::get("/tenant/object-secret")
+            .body(Body::empty())
+            .unwrap();
+        allowed
+            .extensions_mut()
+            .insert(AuthenticatedPrincipal::new("principal-a", "account-a"));
+        let response = app.oneshot(allowed).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(adapter.calls.load(Ordering::SeqCst), 1);
+
+        let metrics = runtime.metrics().render();
+        assert!(metrics.contains("decision=\"deny\""));
+        assert!(metrics.contains("decision=\"allow\""));
+        assert!(!metrics.contains("object-secret"));
+        assert!(!metrics.contains("principal-a"));
+        assert!(!metrics.contains("account-a"));
     }
 
     #[tokio::test]

--- a/crates/talon-gateway/src/s3.rs
+++ b/crates/talon-gateway/src/s3.rs
@@ -15,8 +15,8 @@ use talon_cache_client::{BlockReader, CacheReadError, FileView, DEFAULT_TRANSFER
 use talon_core::{Backend, ObjectId, Version};
 
 use crate::{
-    FailureReason, GatewayAdapter, GatewayOperation, GatewayOutcome, GatewayRequestContext,
-    GatewayResponse, GatewayRoute, GatewayTarget, ProviderProtocol,
+    FailureReason, GatewayAccess, GatewayAdapter, GatewayOperation, GatewayOutcome,
+    GatewayRequestContext, GatewayResponse, GatewayRoute, GatewayTarget, ProviderProtocol,
 };
 
 const MAX_ERROR_BODY_BYTES: usize = 64 * 1024;
@@ -818,6 +818,15 @@ impl GatewayAdapter for S3Adapter {
         ProviderProtocol::S3
     }
 
+    fn access(
+        &self,
+        request: &Request,
+        context: &GatewayRequestContext,
+    ) -> Result<GatewayAccess, Box<GatewayResponse>> {
+        self.classify_access(request)
+            .map_err(|error| Box::new(error_response(error, &context.request_id)))
+    }
+
     async fn handle(&self, request: Request, context: GatewayRequestContext) -> GatewayResponse {
         match self.handle_request(request, &context).await {
             Ok(response) => response,
@@ -827,6 +836,38 @@ impl GatewayAdapter for S3Adapter {
 }
 
 impl S3Adapter {
+    fn classify_access(&self, request: &Request) -> Result<GatewayAccess, S3RequestError> {
+        let target = parse_target(request, &self.config)?;
+        let query = S3Query::parse(request.uri().query())?;
+        if request.method() == axum::http::Method::GET && target.key.is_none() && query.is_list_v2()
+        {
+            return Ok(GatewayAccess {
+                operation: GatewayOperation::List,
+                provider_account: None,
+                target: GatewayTarget::Namespace {
+                    backend: Backend::S3,
+                    namespace: target.bucket,
+                    prefix: query.prefix,
+                },
+            });
+        }
+        let key = target
+            .key
+            .ok_or_else(|| S3RequestError::invalid("InvalidURI", "request has no object key"))?;
+        let operation = match *request.method() {
+            axum::http::Method::HEAD => GatewayOperation::Stat,
+            axum::http::Method::GET => GatewayOperation::Read,
+            axum::http::Method::PUT | axum::http::Method::POST => GatewayOperation::Write,
+            axum::http::Method::DELETE => GatewayOperation::Delete,
+            _ => GatewayOperation::Unsupported,
+        };
+        Ok(GatewayAccess {
+            operation,
+            provider_account: None,
+            target: GatewayTarget::Object(ObjectId::new(Backend::S3, target.bucket, key)),
+        })
+    }
+
     async fn handle_request(
         &self,
         request: Request,

--- a/crates/talon-gateway/src/tls.rs
+++ b/crates/talon-gateway/src/tls.rs
@@ -240,8 +240,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        serve_tls, GatewayAdapter, GatewayConfig, GatewayMode, GatewayOperation,
-        GatewayRequestContext, GatewayResponse, GatewayRuntime, GatewaySecurity, ProviderProtocol,
+        serve_tls, AuthorizationPolicy, GatewayAdapter, GatewayConfig, GatewayMode,
+        GatewayOperation, GatewayRequestContext, GatewayResponse, GatewayRuntime, GatewaySecurity,
+        ProviderProtocol,
     };
 
     const CERT_DER: &[u8] =
@@ -313,6 +314,7 @@ mod tests {
             )
             .unwrap(),
         );
+        runtime.install_authorization(AuthorizationPolicy::new(Vec::new()).unwrap());
         assert!(!runtime.readiness().is_ready());
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
         let server_runtime = Arc::clone(&runtime);


### PR DESCRIPTION
Closes #492

## Summary

- add authenticated principal and allow-only account/namespace/literal-prefix/operation grants
- compile and atomically reload policies while retaining the last good policy on invalid reloads
- classify S3 and Azure access without backend calls and authorize before adapter dispatch
- keep production authorization readiness fail-closed until a policy is installed
- emit bounded allow/deny metrics and audit fields without principal, account, namespace, key, or credential values

## Verification

- `just ci`
- `cargo test -p talon-gateway --all-targets`
- `cargo clippy -p talon-gateway --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p talon-gateway --no-deps --all-features`
- `cargo deny check advisories bans sources`
- `mdbook build docs/book`
- `just spell`
- `just linkcheck`
- `git diff --check`
