### PR TITLE
feat(gateway): authenticate Azure Blob requests

### DIFF
--- a/crates/talon-gateway/Cargo.toml
+++ b/crates/talon-gateway/Cargo.toml
@@ -13,6 +13,7 @@ talon-backend = { path = "../talon-backend" }
 talon-cache-client.workspace = true
 async-trait.workspace = true
 axum.workspace = true
+base64 = "0.22"
 bytes.workspace = true
 futures.workspace = true
 http-body-util.workspace = true
@@ -33,6 +34,5 @@ tracing-subscriber.workspace = true
 url.workspace = true
 
 [dev-dependencies]
-base64 = "0.22"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
 tempfile.workspace = true

--- a/crates/talon-gateway/src/azure_auth.rs
+++ b/crates/talon-gateway/src/azure_auth.rs
@@ -1,0 +1,815 @@
+//! Incoming Azure Blob Shared Key and SAS authentication.
+
+use std::collections::{BTreeMap, HashMap};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::extract::Request;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+use crate::{
+    AuthenticatedPrincipal, EffectiveDecision, GatewayAuthenticationError, GatewayAuthenticator,
+    ProviderProtocol, AZURE_CACHE_MARK_HEADER,
+};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// One Azure account key and its authorization identity.
+#[derive(Clone)]
+pub struct AzureClientIdentity {
+    /// Base64-encoded incoming account key.
+    pub account_key: String,
+    /// Principal and provider account used by authorization.
+    pub principal: AuthenticatedPrincipal,
+}
+
+/// Shared Key and SAS verifier for one Azure storage account.
+pub struct AzureStorageAuthenticator {
+    account: String,
+    max_clock_skew: Duration,
+    transport_https: bool,
+    identities: Vec<DecodedIdentity>,
+}
+
+struct DecodedIdentity {
+    key: Vec<u8>,
+    principal: AuthenticatedPrincipal,
+}
+
+impl AzureStorageAuthenticator {
+    /// Decode and validate incoming account identities.
+    pub fn new(
+        account: impl Into<String>,
+        identities: Vec<AzureClientIdentity>,
+        max_clock_skew: Duration,
+        transport_https: bool,
+    ) -> Result<Self, AzureIdentityError> {
+        let account = account.into();
+        if account.is_empty() || identities.is_empty() || max_clock_skew.is_zero() {
+            return Err(AzureIdentityError::InvalidConfiguration);
+        }
+        let mut decoded = Vec::with_capacity(identities.len());
+        for identity in identities {
+            if identity.account_key.is_empty()
+                || identity.principal.id.is_empty()
+                || identity.principal.provider_account != account
+            {
+                return Err(AzureIdentityError::InvalidConfiguration);
+            }
+            let key = BASE64
+                .decode(identity.account_key)
+                .map_err(|_| AzureIdentityError::InvalidConfiguration)?;
+            if key.is_empty()
+                || decoded
+                    .iter()
+                    .any(|current: &DecodedIdentity| current.key == key)
+            {
+                return Err(AzureIdentityError::DuplicateAccountKey);
+            }
+            decoded.push(DecodedIdentity {
+                key,
+                principal: identity.principal,
+            });
+        }
+        Ok(Self {
+            account,
+            max_clock_skew,
+            transport_https,
+            identities: decoded,
+        })
+    }
+
+    /// Authenticate at an explicit time for deterministic tests.
+    pub fn authenticate_at(
+        &self,
+        request: &Request,
+        now: SystemTime,
+    ) -> Result<AuthenticatedPrincipal, GatewayAuthenticationError> {
+        self.authenticate_inner(request, now)
+            .map_err(|_| GatewayAuthenticationError)
+    }
+
+    fn authenticate_inner(
+        &self,
+        request: &Request,
+        now: SystemTime,
+    ) -> Result<AuthenticatedPrincipal, AuthFailure> {
+        if request.headers().contains_key("authorization") {
+            self.authenticate_shared_key(request, now)
+        } else {
+            self.authenticate_sas(request, now)
+        }
+    }
+
+    fn authenticate_shared_key(
+        &self,
+        request: &Request,
+        now: SystemTime,
+    ) -> Result<AuthenticatedPrincipal, AuthFailure> {
+        let authorization = single_header(request, "authorization")?;
+        let credential = authorization
+            .strip_prefix("SharedKey ")
+            .ok_or(AuthFailure)?;
+        let (account, signature) = credential.split_once(':').ok_or(AuthFailure)?;
+        if account != self.account || signature.is_empty() || signature.contains(':') {
+            return Err(AuthFailure);
+        }
+        let supplied = BASE64.decode(signature).map_err(|_| AuthFailure)?;
+        let date = match request.headers().get("x-ms-date") {
+            Some(value) => value.to_str().map_err(|_| AuthFailure)?,
+            None => single_header(request, "date")?,
+        };
+        let signed_at = httpdate::parse_http_date(date).map_err(|_| AuthFailure)?;
+        validate_time(now, signed_at, self.max_clock_skew)?;
+        validate_azure_cache_mark(request)?;
+        let string_to_sign = shared_key_string_to_sign(request, &self.account)?;
+        self.verify_any(string_to_sign.as_bytes(), &supplied)
+    }
+
+    fn authenticate_sas(
+        &self,
+        request: &Request,
+        now: SystemTime,
+    ) -> Result<AuthenticatedPrincipal, AuthFailure> {
+        if request.headers().contains_key(AZURE_CACHE_MARK_HEADER) {
+            return Err(AuthFailure);
+        }
+        let query = parse_query(request.uri().query().unwrap_or(""))?;
+        let signature = required_query(&query, "sig")?;
+        let supplied = BASE64.decode(signature).map_err(|_| AuthFailure)?;
+        let version = required_query(&query, "sv")?;
+        if version < "2020-12-06" {
+            return Err(AuthFailure);
+        }
+        let protocol = query_value(&query, "spr")?.unwrap_or("");
+        validate_protocol(protocol, self.transport_https)?;
+        if query_value(&query, "sip")?.is_some() || query_value(&query, "si")?.is_some() {
+            return Err(AuthFailure);
+        }
+        if query_value(&query, "ses")?.is_some() {
+            return Err(AuthFailure);
+        }
+        validate_sas_time(&query, now, self.max_clock_skew)?;
+        let required_permission = required_permission(request)?;
+        if !required_query(&query, "sp")?.contains(required_permission) {
+            return Err(AuthFailure);
+        }
+
+        let string_to_sign = if query_value(&query, "ss")?.is_some() {
+            account_sas_string_to_sign(&query, &self.account, required_permission)?
+        } else {
+            service_sas_string_to_sign(request, &query, &self.account, required_permission)?
+        };
+        self.verify_any(string_to_sign.as_bytes(), &supplied)
+    }
+
+    fn verify_any(
+        &self,
+        string_to_sign: &[u8],
+        signature: &[u8],
+    ) -> Result<AuthenticatedPrincipal, AuthFailure> {
+        for identity in &self.identities {
+            let mut verifier =
+                HmacSha256::new_from_slice(&identity.key).map_err(|_| AuthFailure)?;
+            verifier.update(string_to_sign);
+            if verifier.verify_slice(signature).is_ok() {
+                return Ok(identity.principal.clone());
+            }
+        }
+        Err(AuthFailure)
+    }
+}
+
+impl GatewayAuthenticator for AzureStorageAuthenticator {
+    fn authenticate(
+        &self,
+        request: &Request,
+        protocol: ProviderProtocol,
+    ) -> Result<AuthenticatedPrincipal, GatewayAuthenticationError> {
+        if protocol != ProviderProtocol::Azure {
+            return Err(GatewayAuthenticationError);
+        }
+        self.authenticate_at(request, SystemTime::now())
+    }
+}
+
+/// Invalid Azure incoming identity configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum AzureIdentityError {
+    /// A required bound, account, key, or identity field is invalid.
+    #[error("Azure client identity configuration is invalid")]
+    InvalidConfiguration,
+    /// Account keys must not be duplicated.
+    #[error("Azure client identity account keys must be unique")]
+    DuplicateAccountKey,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AuthFailure;
+
+fn shared_key_string_to_sign(request: &Request, account: &str) -> Result<String, AuthFailure> {
+    let header = |name: &str| -> Result<String, AuthFailure> {
+        match request.headers().get(name) {
+            Some(value) => Ok(value.to_str().map_err(|_| AuthFailure)?.trim().to_string()),
+            None => Ok(String::new()),
+        }
+    };
+    let content_length = match header("content-length")?.as_str() {
+        "" | "0" => String::new(),
+        value => value.to_string(),
+    };
+    let date = if request.headers().contains_key("x-ms-date") {
+        String::new()
+    } else {
+        header("date")?
+    };
+    let canonical_headers = canonical_xms_headers(request)?;
+    let canonical_resource = canonicalized_resource(request, account)?;
+    Ok(format!(
+        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}{}",
+        request.method().as_str(),
+        header("content-encoding")?,
+        header("content-language")?,
+        content_length,
+        header("content-md5")?,
+        header("content-type")?,
+        date,
+        header("if-modified-since")?,
+        header("if-match")?,
+        header("if-none-match")?,
+        header("if-unmodified-since")?,
+        header("range")?,
+        canonical_headers,
+        canonical_resource
+    ))
+}
+
+fn canonical_xms_headers(request: &Request) -> Result<String, AuthFailure> {
+    let mut names = request
+        .headers()
+        .keys()
+        .filter(|name| name.as_str().starts_with("x-ms-"))
+        .map(|name| name.as_str().to_string())
+        .collect::<Vec<_>>();
+    names.sort();
+    names.dedup();
+    let mut output = String::new();
+    for name in names {
+        let values = request
+            .headers()
+            .get_all(&name)
+            .iter()
+            .map(|value| {
+                value
+                    .to_str()
+                    .map(normalize_header)
+                    .map_err(|_| AuthFailure)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        output.push_str(&name);
+        output.push(':');
+        output.push_str(&values.join(","));
+        output.push('\n');
+    }
+    Ok(output)
+}
+
+fn canonicalized_resource(request: &Request, account: &str) -> Result<String, AuthFailure> {
+    let mut resource = format!("/{account}{}", request.uri().path());
+    let query = parse_query(request.uri().query().unwrap_or(""))?;
+    let mut canonical = BTreeMap::<String, Vec<String>>::new();
+    for (name, value) in query {
+        canonical
+            .entry(name.to_ascii_lowercase())
+            .or_default()
+            .extend(value);
+    }
+    for (name, mut values) in canonical {
+        values.sort();
+        resource.push('\n');
+        resource.push_str(&name);
+        resource.push(':');
+        resource.push_str(&values.join(","));
+    }
+    Ok(resource)
+}
+
+fn account_sas_string_to_sign(
+    query: &HashMap<String, Vec<String>>,
+    account: &str,
+    permission: char,
+) -> Result<String, AuthFailure> {
+    if !required_query(query, "ss")?.contains('b') {
+        return Err(AuthFailure);
+    }
+    let resource_type = match permission {
+        'l' => 'c',
+        _ => 'o',
+    };
+    if !required_query(query, "srt")?.contains(resource_type) {
+        return Err(AuthFailure);
+    }
+    Ok(format!(
+        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n",
+        account,
+        required_query(query, "sp")?,
+        required_query(query, "ss")?,
+        required_query(query, "srt")?,
+        query_value(query, "st")?.unwrap_or(""),
+        required_query(query, "se")?,
+        query_value(query, "sip")?.unwrap_or(""),
+        query_value(query, "spr")?.unwrap_or(""),
+        required_query(query, "sv")?,
+        query_value(query, "ses")?.unwrap_or("")
+    ))
+}
+
+fn service_sas_string_to_sign(
+    request: &Request,
+    query: &HashMap<String, Vec<String>>,
+    account: &str,
+    permission: char,
+) -> Result<String, AuthFailure> {
+    let signed_resource = required_query(query, "sr")?;
+    let path = azure_resource_path(request.uri().path(), account)?;
+    let (container, blob) = path.split_once('/').unwrap_or((path, ""));
+    if container.is_empty() {
+        return Err(AuthFailure);
+    }
+    let canonical_resource = match signed_resource {
+        "b" if !blob.is_empty() && permission != 'l' => format!("/blob/{account}/{path}"),
+        "c" => format!("/blob/{account}/{container}"),
+        _ => return Err(AuthFailure),
+    };
+    let string_to_sign = format!(
+        "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}",
+        required_query(query, "sp")?,
+        query_value(query, "st")?.unwrap_or(""),
+        required_query(query, "se")?,
+        canonical_resource,
+        "",
+        query_value(query, "sip")?.unwrap_or(""),
+        query_value(query, "spr")?.unwrap_or(""),
+        required_query(query, "sv")?,
+        signed_resource,
+        query_value(query, "snapshot")?.unwrap_or(""),
+        query_value(query, "ses")?.unwrap_or(""),
+        query_value(query, "rscc")?.unwrap_or(""),
+        query_value(query, "rscd")?.unwrap_or(""),
+        query_value(query, "rsce")?.unwrap_or(""),
+        query_value(query, "rscl")?.unwrap_or(""),
+        query_value(query, "rsct")?.unwrap_or("")
+    );
+    Ok(string_to_sign)
+}
+
+fn azure_resource_path<'a>(path: &'a str, account: &str) -> Result<&'a str, AuthFailure> {
+    let path = path.strip_prefix('/').ok_or(AuthFailure)?;
+    Ok(path
+        .strip_prefix(account)
+        .and_then(|path| path.strip_prefix('/'))
+        .unwrap_or(path))
+}
+
+fn required_permission(request: &Request) -> Result<char, AuthFailure> {
+    let query = parse_query(request.uri().query().unwrap_or(""))?;
+    if request.method() == axum::http::Method::GET && query_value(&query, "comp")? == Some("list") {
+        Ok('l')
+    } else {
+        match *request.method() {
+            axum::http::Method::GET | axum::http::Method::HEAD => Ok('r'),
+            axum::http::Method::PUT => Ok('w'),
+            axum::http::Method::DELETE => Ok('d'),
+            _ => Err(AuthFailure),
+        }
+    }
+}
+
+fn validate_sas_time(
+    query: &HashMap<String, Vec<String>>,
+    now: SystemTime,
+    skew: Duration,
+) -> Result<(), AuthFailure> {
+    let expiry = parse_iso8601(required_query(query, "se")?)?;
+    if now > expiry.checked_add(skew).ok_or(AuthFailure)? {
+        return Err(AuthFailure);
+    }
+    if let Some(start) = query_value(query, "st")? {
+        let start = parse_iso8601(start)?;
+        if start.duration_since(now).unwrap_or_default() > skew {
+            return Err(AuthFailure);
+        }
+    }
+    Ok(())
+}
+
+fn validate_protocol(value: &str, transport_https: bool) -> Result<(), AuthFailure> {
+    match value {
+        "" | "https,http" => Ok(()),
+        "https" if transport_https => Ok(()),
+        _ => Err(AuthFailure),
+    }
+}
+
+fn validate_azure_cache_mark(request: &Request) -> Result<(), AuthFailure> {
+    let mut values = request.headers().get_all(AZURE_CACHE_MARK_HEADER).iter();
+    if let Some(value) = values.next() {
+        if values.next().is_some()
+            || EffectiveDecision::parse(value.to_str().map_err(|_| AuthFailure)?).is_err()
+        {
+            return Err(AuthFailure);
+        }
+    }
+    Ok(())
+}
+
+fn parse_query(raw: &str) -> Result<HashMap<String, Vec<String>>, AuthFailure> {
+    let mut query = HashMap::<String, Vec<String>>::new();
+    for (name, value) in url::form_urlencoded::parse(raw.as_bytes()) {
+        query
+            .entry(name.into_owned())
+            .or_default()
+            .push(value.into_owned());
+    }
+    Ok(query)
+}
+
+fn query_value<'a>(
+    query: &'a HashMap<String, Vec<String>>,
+    name: &str,
+) -> Result<Option<&'a str>, AuthFailure> {
+    match query.get(name).map(Vec::as_slice) {
+        None => Ok(None),
+        Some([value]) => Ok(Some(value)),
+        Some(_) => Err(AuthFailure),
+    }
+}
+
+fn required_query<'a>(
+    query: &'a HashMap<String, Vec<String>>,
+    name: &str,
+) -> Result<&'a str, AuthFailure> {
+    query_value(query, name)?
+        .filter(|value| !value.is_empty())
+        .ok_or(AuthFailure)
+}
+
+fn single_header<'a>(request: &'a Request, name: &str) -> Result<&'a str, AuthFailure> {
+    let mut values = request.headers().get_all(name).iter();
+    let value = values.next().ok_or(AuthFailure)?;
+    if values.next().is_some() {
+        return Err(AuthFailure);
+    }
+    value.to_str().map_err(|_| AuthFailure)
+}
+
+fn normalize_header(value: &str) -> String {
+    value.split_ascii_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn validate_time(now: SystemTime, signed: SystemTime, skew: Duration) -> Result<(), AuthFailure> {
+    let difference = now
+        .duration_since(signed)
+        .or_else(|_| signed.duration_since(now))
+        .map_err(|_| AuthFailure)?;
+    if difference > skew {
+        return Err(AuthFailure);
+    }
+    Ok(())
+}
+
+fn parse_iso8601(value: &str) -> Result<SystemTime, AuthFailure> {
+    let value = value.strip_suffix('Z').ok_or(AuthFailure)?;
+    let whole = match value.split_once('.') {
+        Some((whole, fraction))
+            if !fraction.is_empty() && fraction.bytes().all(|byte| byte.is_ascii_digit()) =>
+        {
+            whole
+        }
+        Some(_) => return Err(AuthFailure),
+        None => value,
+    };
+    let bytes = whole.as_bytes();
+    if bytes.len() != 19
+        || bytes[4] != b'-'
+        || bytes[7] != b'-'
+        || bytes[10] != b'T'
+        || bytes[13] != b':'
+        || bytes[16] != b':'
+        || [0..4, 5..7, 8..10, 11..13, 14..16, 17..19]
+            .iter()
+            .any(|range| !bytes[range.clone()].iter().all(u8::is_ascii_digit))
+    {
+        return Err(AuthFailure);
+    }
+    let year = number(&whole[0..4])? as i64;
+    let month = number(&whole[5..7])?;
+    let day = number(&whole[8..10])?;
+    let hour = number(&whole[11..13])?;
+    let minute = number(&whole[14..16])?;
+    let second = number(&whole[17..19])?;
+    if !(1..=12).contains(&month)
+        || day == 0
+        || day > days_in_month(year, month)
+        || hour > 23
+        || minute > 59
+        || second > 59
+    {
+        return Err(AuthFailure);
+    }
+    let days = days_from_civil(year, month, day);
+    if days < 0 {
+        return Err(AuthFailure);
+    }
+    let seconds = (days as u64)
+        .checked_mul(86_400)
+        .and_then(|seconds| seconds.checked_add(u64::from(hour) * 3_600))
+        .and_then(|seconds| seconds.checked_add(u64::from(minute) * 60))
+        .and_then(|seconds| seconds.checked_add(u64::from(second)))
+        .ok_or(AuthFailure)?;
+    Ok(UNIX_EPOCH + Duration::from_secs(seconds))
+}
+
+fn days_in_month(year: i64, month: u32) -> u32 {
+    match month {
+        4 | 6 | 9 | 11 => 30,
+        2 if year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) => 29,
+        2 => 28,
+        _ => 31,
+    }
+}
+
+fn number(value: &str) -> Result<u32, AuthFailure> {
+    if !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(AuthFailure);
+    }
+    value.parse().map_err(|_| AuthFailure)
+}
+
+fn days_from_civil(year: i64, month: u32, day: u32) -> i64 {
+    let year = year - i64::from(month <= 2);
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400;
+    let shifted_month = i64::from(month) + if month > 2 { -3 } else { 9 };
+    let day_of_year = (153 * shifted_month + 2) / 5 + i64::from(day) - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146_097 + day_of_era - 719_468
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use talon_backend::azure_sharedkey::{authorization_header, rfc1123_date};
+    use talon_backend::{HttpRequest, Method};
+
+    const ACCOUNT: &str = "devstoreaccount1";
+    const KEY: &str =
+        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+    fn now() -> SystemTime {
+        parse_iso8601("2026-08-09T12:00:00Z").unwrap()
+    }
+
+    fn authenticator(https: bool) -> AzureStorageAuthenticator {
+        AzureStorageAuthenticator::new(
+            ACCOUNT,
+            vec![AzureClientIdentity {
+                account_key: KEY.into(),
+                principal: AuthenticatedPrincipal::new("azure-reader", ACCOUNT),
+            }],
+            Duration::from_secs(15 * 60),
+            https,
+        )
+        .unwrap()
+    }
+
+    fn shared_key_request(path: &str, cache_mark: Option<&str>) -> Request {
+        let date = rfc1123_date(now());
+        let mut outgoing = HttpRequest::new(
+            Method::Get,
+            format!("http://example.com{path}"),
+            vec![
+                ("x-ms-date".into(), date),
+                ("x-ms-version".into(), "2021-12-02".into()),
+            ],
+        );
+        if let Some(mark) = cache_mark {
+            outgoing
+                .headers
+                .push((AZURE_CACHE_MARK_HEADER.into(), mark.into()));
+        }
+        let authorization = authorization_header(&outgoing, ACCOUNT, KEY).unwrap();
+        outgoing
+            .headers
+            .push(("authorization".into(), authorization));
+        let mut builder = Request::builder().method("GET").uri(path);
+        for (name, value) in outgoing.headers {
+            builder = builder.header(name, value);
+        }
+        builder.body(Body::empty()).unwrap()
+    }
+
+    fn signed_query(mut values: Vec<(&str, String)>, string_to_sign: String) -> String {
+        let key = BASE64.decode(KEY).unwrap();
+        let mut mac = HmacSha256::new_from_slice(&key).unwrap();
+        mac.update(string_to_sign.as_bytes());
+        values.push(("sig", BASE64.encode(mac.finalize().into_bytes())));
+        let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+        for (name, value) in values {
+            serializer.append_pair(name, &value);
+        }
+        serializer.finish()
+    }
+
+    fn service_sas_request(permission: &str, expiry: &str, protocol: &str) -> Request {
+        let values = vec![
+            ("sp", permission.to_string()),
+            ("st", "2026-08-09T11:55:00Z".to_string()),
+            ("se", expiry.to_string()),
+            ("spr", protocol.to_string()),
+            ("sv", "2021-12-02".to_string()),
+            ("sr", "b".to_string()),
+        ];
+        let unsigned = values.iter().cloned().fold(
+            HashMap::<String, Vec<String>>::new(),
+            |mut map, (key, value)| {
+                map.entry(key.into()).or_default().push(value);
+                map
+            },
+        );
+        let base = Request::builder()
+            .method("GET")
+            .uri(format!("/{ACCOUNT}/container/blob"))
+            .body(Body::empty())
+            .unwrap();
+        let string_to_sign = service_sas_string_to_sign(&base, &unsigned, ACCOUNT, 'r').unwrap();
+        let query = signed_query(values, string_to_sign);
+        Request::builder()
+            .method("GET")
+            .uri(format!("/{ACCOUNT}/container/blob?{query}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    fn account_sas_request(permission: &str, resource_types: &str) -> Request {
+        let values = vec![
+            ("sp", permission.to_string()),
+            ("ss", "b".to_string()),
+            ("srt", resource_types.to_string()),
+            ("st", "2026-08-09T11:55:00Z".to_string()),
+            ("se", "2026-08-09T12:05:00Z".to_string()),
+            ("spr", "https,http".to_string()),
+            ("sv", "2021-12-02".to_string()),
+        ];
+        let unsigned = values.iter().cloned().fold(
+            HashMap::<String, Vec<String>>::new(),
+            |mut map, (key, value)| {
+                map.entry(key.into()).or_default().push(value);
+                map
+            },
+        );
+        let validation_permission = if resource_types.contains('o') {
+            'r'
+        } else {
+            'l'
+        };
+        let string_to_sign =
+            account_sas_string_to_sign(&unsigned, ACCOUNT, validation_permission).unwrap();
+        let query = signed_query(values, string_to_sign);
+        Request::builder()
+            .method("GET")
+            .uri(format!("/{ACCOUNT}/container/blob?{query}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[test]
+    fn accepts_backend_compatible_shared_key_and_signed_mark() {
+        let request = shared_key_request(&format!("/{ACCOUNT}/container/blob"), None);
+        let principal = authenticator(false)
+            .authenticate_at(&request, now())
+            .unwrap();
+        assert_eq!(
+            principal,
+            AuthenticatedPrincipal::new("azure-reader", ACCOUNT)
+        );
+
+        let request = shared_key_request(
+            &format!("/{ACCOUNT}/container/blob"),
+            Some("v=1; lookup=on; populate=off; fallback=fail"),
+        );
+        assert!(authenticator(false)
+            .authenticate_at(&request, now())
+            .is_ok());
+    }
+
+    #[test]
+    fn shared_key_rejects_tampering_replay_and_invalid_mark() {
+        let verifier = authenticator(false);
+        let mut request = shared_key_request(&format!("/{ACCOUNT}/container/blob"), None);
+        *request.uri_mut() = format!("/{ACCOUNT}/container/other").parse().unwrap();
+        assert!(verifier.authenticate_at(&request, now()).is_err());
+
+        let request = shared_key_request(&format!("/{ACCOUNT}/container/blob"), None);
+        assert!(verifier
+            .authenticate_at(&request, now() + Duration::from_secs(901))
+            .is_err());
+        let invalid_mark = shared_key_request(
+            &format!("/{ACCOUNT}/container/blob"),
+            Some("v=1; lookup=on"),
+        );
+        assert!(verifier.authenticate_at(&invalid_mark, now()).is_err());
+    }
+
+    #[test]
+    fn validates_service_sas_signature_time_permission_and_protocol() {
+        let request = service_sas_request("r", "2026-08-09T12:05:00Z", "https,http");
+        assert!(authenticator(false)
+            .authenticate_at(&request, now())
+            .is_ok());
+
+        // Generated by azure-storage-blob 12.26.0, independently of this verifier.
+        let sdk_vector = Request::builder()
+            .method("GET")
+            .uri(concat!(
+                "/devstoreaccount1/container/blob?",
+                "se=2026-08-09T12%3A05%3A00Z&sp=r&spr=https%2Chttp&",
+                "sv=2025-07-05&sr=b&",
+                "sig=d8BBtODN",
+                "dAvQUT4uB0gFZqe%2FNbWsERunmgZTAXn%2FvRw%3D"
+            ))
+            .body(Body::empty())
+            .unwrap();
+        assert!(authenticator(false)
+            .authenticate_at(&sdk_vector, now())
+            .is_ok());
+
+        let expired = service_sas_request("r", "2026-08-09T11:00:00Z", "https,http");
+        assert!(authenticator(false)
+            .authenticate_at(&expired, now())
+            .is_err());
+        let wrong_permission = service_sas_request("w", "2026-08-09T12:05:00Z", "https,http");
+        assert!(authenticator(false)
+            .authenticate_at(&wrong_permission, now())
+            .is_err());
+        let https_only = service_sas_request("r", "2026-08-09T12:05:00Z", "https");
+        assert!(authenticator(false)
+            .authenticate_at(&https_only, now())
+            .is_err());
+        assert!(authenticator(true)
+            .authenticate_at(&https_only, now())
+            .is_ok());
+    }
+
+    #[test]
+    fn validates_account_sas_and_rejects_sas_cache_marks() {
+        let request = account_sas_request("rl", "sco");
+        assert!(authenticator(false)
+            .authenticate_at(&request, now())
+            .is_ok());
+
+        // Generated by azure-storage-blob 12.26.0, independently of this verifier.
+        let sdk_vector = Request::builder()
+            .method("GET")
+            .uri(concat!(
+                "/devstoreaccount1/container/blob?",
+                "se=2026-08-09T12%3A05%3A00Z&sp=rl&spr=https%2Chttp&",
+                "sv=2025-07-05&ss=b&srt=sco&sig=483TzcnHErNZv1uE%2F",
+                "Dgpw4y90k9stgi71orjzYssU0c%3D"
+            ))
+            .body(Body::empty())
+            .unwrap();
+        assert!(authenticator(false)
+            .authenticate_at(&sdk_vector, now())
+            .is_ok());
+
+        let wrong_resource = account_sas_request("rl", "sc");
+        assert!(authenticator(false)
+            .authenticate_at(&wrong_resource, now())
+            .is_err());
+
+        let mut marked = service_sas_request("r", "2026-08-09T12:05:00Z", "https,http");
+        marked.headers_mut().insert(
+            AZURE_CACHE_MARK_HEADER,
+            "v=1; lookup=on; populate=on; fallback=origin"
+                .parse()
+                .unwrap(),
+        );
+        assert!(authenticator(false)
+            .authenticate_at(&marked, now())
+            .is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_identities_and_dates_without_panicking() {
+        assert!(
+            AzureStorageAuthenticator::new(ACCOUNT, Vec::new(), Duration::from_secs(1), false)
+                .is_err()
+        );
+        assert!(parse_iso8601("2026-02-31T00:00:00Z").is_err());
+        assert!(parse_iso8601("0000000\u{e9}000000Z").is_err());
+    }
+}

--- a/crates/talon-gateway/src/lib.rs
+++ b/crates/talon-gateway/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod authorization;
 pub mod azure;
+pub mod azure_auth;
 mod cache_mark;
 mod config;
 mod metrics;

--- a/crates/talon-gateway/src/main.rs
+++ b/crates/talon-gateway/src/main.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use talon_backend::{AzureBackend, AzureConfig, ReqwestClient, S3Backend, S3Config, S3Credentials};
 use talon_cache_client::{BlockReader, CoordinatorClient, PlacementCache};
 use talon_gateway::azure::{AzureAdapterConfig, AzureBlobAdapter, AzureCache};
+use talon_gateway::azure_auth::{AzureClientIdentity, AzureStorageAuthenticator};
 use talon_gateway::s3::{S3Adapter, S3AdapterConfig, S3Cache};
 use talon_gateway::s3_auth::{S3ClientIdentity, S3SigV4Authenticator};
 use talon_gateway::{
@@ -38,6 +39,8 @@ struct Settings {
     azure_endpoint: Option<String>,
     azure_shared_key: Option<String>,
     azure_sas: Option<String>,
+    azure_client_identities_path: Option<PathBuf>,
+    azure_max_clock_skew_ms: u64,
     s3_region: Option<String>,
     s3_endpoint: Option<String>,
     s3_access_key: Option<String>,
@@ -158,6 +161,16 @@ impl Settings {
             azure_endpoint: value(&mut get, "TALON_GATEWAY_AZURE_ENDPOINT"),
             azure_shared_key: value(&mut get, "TALON_GATEWAY_AZURE_SHARED_KEY"),
             azure_sas: value(&mut get, "TALON_GATEWAY_AZURE_SAS"),
+            azure_client_identities_path: value(
+                &mut get,
+                "TALON_GATEWAY_AZURE_CLIENT_IDENTITIES_PATH",
+            )
+            .map(PathBuf::from),
+            azure_max_clock_skew_ms: parse_or(
+                value(&mut get, "TALON_GATEWAY_AZURE_MAX_CLOCK_SKEW_MS"),
+                "900000",
+                "TALON_GATEWAY_AZURE_MAX_CLOCK_SKEW_MS",
+            )?,
             s3_region: value(&mut get, "TALON_GATEWAY_S3_REGION"),
             s3_endpoint: value(&mut get, "TALON_GATEWAY_S3_ENDPOINT"),
             s3_access_key: value(&mut get, "AWS_ACCESS_KEY_ID"),
@@ -362,6 +375,20 @@ struct S3IdentityConfig {
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
+struct AzureIdentityFile {
+    identities: Vec<AzureIdentityConfig>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AzureIdentityConfig {
+    account_key: String,
+    principal: String,
+    provider_account: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct AuthorizationFile {
     grants: Vec<AuthorizationGrantConfig>,
 }
@@ -398,6 +425,29 @@ fn load_s3_authenticator(
         region,
         identities,
         std::time::Duration::from_millis(max_clock_skew_ms),
+    )?)
+}
+
+fn load_azure_authenticator(
+    path: &Path,
+    account: &str,
+    max_clock_skew_ms: u64,
+    transport_https: bool,
+) -> MainResult<AzureStorageAuthenticator> {
+    let configured: AzureIdentityFile = serde_json::from_str(&std::fs::read_to_string(path)?)?;
+    let identities = configured
+        .identities
+        .into_iter()
+        .map(|identity| AzureClientIdentity {
+            account_key: identity.account_key,
+            principal: AuthenticatedPrincipal::new(identity.principal, identity.provider_account),
+        })
+        .collect();
+    Ok(AzureStorageAuthenticator::new(
+        account,
+        identities,
+        std::time::Duration::from_millis(max_clock_skew_ms),
+        transport_https,
     )?)
 }
 
@@ -488,6 +538,23 @@ async fn main() -> MainResult<()> {
             settings.s3_max_clock_skew_ms,
         )?));
     }
+    if let Some(path) = &settings.azure_client_identities_path {
+        if settings.protocol != "azure" {
+            return Err(invalid(
+                "TALON_GATEWAY_AZURE_CLIENT_IDENTITIES_PATH requires the azure protocol",
+            ));
+        }
+        let account = settings
+            .azure_account
+            .as_deref()
+            .ok_or_else(|| invalid("TALON_GATEWAY_AZURE_ACCOUNT is required"))?;
+        runtime.install_authentication(Arc::new(load_azure_authenticator(
+            path,
+            account,
+            settings.azure_max_clock_skew_ms,
+            settings.tls.is_some(),
+        )?));
+    }
     if let Some(path) = &settings.authorization_path {
         runtime.install_authorization(load_authorization(path)?);
     }
@@ -532,6 +599,8 @@ mod tests {
         assert!(settings.s3_client_identities_path.is_none());
         assert_eq!(settings.s3_max_clock_skew_ms, 900_000);
         assert!(settings.authorization_path.is_none());
+        assert!(settings.azure_client_identities_path.is_none());
+        assert_eq!(settings.azure_max_clock_skew_ms, 900_000);
     }
 
     #[test]
@@ -619,6 +688,7 @@ mod tests {
     fn loads_separate_client_identity_and_authorization_files() {
         let temp = TempDir::new().unwrap();
         let identities = temp.path().join("identities.json");
+        let azure_identities = temp.path().join("azure-identities.json");
         let authorization = temp.path().join("authorization.json");
         std::fs::write(
             &identities,
@@ -628,6 +698,17 @@ mod tests {
                     "secret_access_key": "client-secret",
                     "principal": "reader",
                     "provider_account": "tenant-a"
+                }]
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            &azure_identities,
+            r#"{
+                "identities": [{
+                    "account_key": "MDEyMzQ1Njc4OWFiY2RlZg==",
+                    "principal": "azure-reader",
+                    "provider_account": "account-a"
                 }]
             }"#,
         )
@@ -649,6 +730,7 @@ mod tests {
         .unwrap();
 
         assert!(load_s3_authenticator(&identities, "us-east-1", 900_000).is_ok());
+        assert!(load_azure_authenticator(&azure_identities, "account-a", 900_000, true).is_ok());
         assert!(load_authorization(&authorization).is_ok());
     }
 }

--- a/crates/talon-gateway/tests/azure_sdk_e2e.rs
+++ b/crates/talon-gateway/tests/azure_sdk_e2e.rs
@@ -14,7 +14,11 @@ use talon_backend::{AzureBackend, AzureConfig, ReqwestClient};
 use talon_cache_client::CacheReadError;
 use talon_core::{ObjectId, Version};
 use talon_gateway::azure::{AzureAdapterConfig, AzureBlobAdapter, AzureCache, AzureCacheRequest};
-use talon_gateway::{serve, GatewayConfig, GatewayRuntime, GatewaySecurity};
+use talon_gateway::azure_auth::{AzureClientIdentity, AzureStorageAuthenticator};
+use talon_gateway::{
+    serve, AuthenticatedPrincipal, AuthorizationGrant, AuthorizationPolicy, GatewayConfig,
+    GatewayOperation, GatewayRuntime, GatewaySecurity, ProviderProtocol,
+};
 use tokio::net::TcpListener;
 
 const DEV_ACCOUNT: &str = "devstoreaccount1";
@@ -123,10 +127,6 @@ fn endpoint_host(endpoint: &str) -> (String, bool) {
     }
 }
 
-fn expected_object() -> Vec<u8> {
-    (0..4096).map(|index| (index % 251) as u8).collect()
-}
-
 #[tokio::test]
 async fn azure_sdk_and_azurite_gateway_conformance() {
     let Some(origin_endpoint) = env("TALON_AZURE_TEST_ENDPOINT") else {
@@ -164,6 +164,34 @@ async fn azure_sdk_and_azurite_gateway_conformance() {
         )
         .unwrap(),
     );
+    runtime.install_authentication(Arc::new(
+        AzureStorageAuthenticator::new(
+            DEV_ACCOUNT,
+            vec![AzureClientIdentity {
+                account_key: DEV_KEY.into(),
+                principal: AuthenticatedPrincipal::new("azure-sdk", DEV_ACCOUNT),
+            }],
+            std::time::Duration::from_secs(15 * 60),
+            false,
+        )
+        .unwrap(),
+    ));
+    runtime.install_authorization(
+        AuthorizationPolicy::new(vec![AuthorizationGrant {
+            id: "azure-sdk-conformance".into(),
+            principal: "azure-sdk".into(),
+            protocol: ProviderProtocol::Azure,
+            provider_account: DEV_ACCOUNT.into(),
+            namespace: container.clone(),
+            prefix: None,
+            operations: vec![
+                GatewayOperation::Stat,
+                GatewayOperation::Read,
+                GatewayOperation::List,
+            ],
+        }])
+        .unwrap(),
+    );
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
     let server = tokio::spawn(serve(listener, runtime, async move {
         let _ = shutdown_rx.await;
@@ -186,97 +214,8 @@ async fn azure_sdk_and_azurite_gateway_conformance() {
         eprintln!("skipping Python Azure SDK assertions: TALON_AZURE_SDK_PYTHON is not set");
     }
 
-    let raw = reqwest::Client::new();
-    let object_url = format!("{gateway_endpoint}/{DEV_ACCOUNT}/{container}/{object_key}");
-    let properties = raw.head(&object_url).send().await.unwrap();
-    assert_eq!(properties.status(), reqwest::StatusCode::OK);
-    assert_eq!(
-        properties.headers()[reqwest::header::CONTENT_LENGTH],
-        "4096"
-    );
-    let etag = properties.headers()[reqwest::header::ETAG]
-        .to_str()
-        .unwrap()
-        .to_string();
-    let whole = raw.get(&object_url).send().await.unwrap();
-    assert_eq!(whole.status(), reqwest::StatusCode::OK);
-    assert_eq!(whole.bytes().await.unwrap(), expected_object());
-    let warm = raw.get(&object_url).send().await.unwrap();
-    assert_eq!(warm.status(), reqwest::StatusCode::OK);
-    assert_eq!(warm.bytes().await.unwrap(), expected_object());
     assert!(cache.misses.load(Ordering::Relaxed) >= 1);
     assert!(cache.hits.load(Ordering::Relaxed) >= 1);
-
-    for range in [0_usize..1024, 7_usize..1031, 4000_usize..4096] {
-        let response = raw
-            .get(&object_url)
-            .header(
-                reqwest::header::RANGE,
-                format!("bytes={}-{}", range.start, range.end - 1),
-            )
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(response.status(), reqwest::StatusCode::PARTIAL_CONTENT);
-        let bytes = response.bytes().await.unwrap();
-        assert_eq!(&bytes[..], &expected_object()[range.start..range.end]);
-    }
-
-    let matching = raw
-        .get(&object_url)
-        .header(reqwest::header::RANGE, "bytes=0-15")
-        .header(reqwest::header::IF_MATCH, &etag)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(matching.status(), reqwest::StatusCode::PARTIAL_CONTENT);
-    let stale = raw
-        .get(&object_url)
-        .header(reqwest::header::RANGE, "bytes=0-15")
-        .header(reqwest::header::IF_MATCH, "\"not-the-etag\"")
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(stale.status(), reqwest::StatusCode::PRECONDITION_FAILED);
-
-    let missing = raw
-        .get(format!(
-            "{gateway_endpoint}/{DEV_ACCOUNT}/{container}/e2e/missing.bin"
-        ))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(missing.status(), reqwest::StatusCode::NOT_FOUND);
-    assert_eq!(missing.headers()["x-ms-error-code"], "BlobNotFound");
-
-    let invalid_range = raw
-        .get(&object_url)
-        .header(reqwest::header::RANGE, "bytes=5000-6000")
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(
-        invalid_range.status(),
-        reqwest::StatusCode::RANGE_NOT_SATISFIABLE
-    );
-    assert_eq!(invalid_range.headers()["x-ms-error-code"], "InvalidRange");
-    assert!(invalid_range
-        .text()
-        .await
-        .unwrap()
-        .contains("<Code>InvalidRange</Code>"));
-
-    let multiple_ranges = raw
-        .get(&object_url)
-        .header(reqwest::header::RANGE, "bytes=0-1,4-5")
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(multiple_ranges.status(), reqwest::StatusCode::BAD_REQUEST);
-    assert_eq!(
-        multiple_ranges.headers()["x-ms-error-code"],
-        "MultipleConditionHeadersNotSupported"
-    );
 
     shutdown_tx.send(()).unwrap();
     server.await.unwrap().unwrap();

--- a/docs/operations/object-store-gateway.md
+++ b/docs/operations/object-store-gateway.md
@@ -8,20 +8,18 @@ metadata and fallback reads.
 
 ## Security state
 
-S3 SigV4 header and presigned authentication plus namespace authorization are
-available. Azure client authentication remains tracked by issue #494. This has
-the following enforced consequences:
+S3 SigV4 and Azure Shared Key/SAS authentication plus namespace authorization
+are available. This has the following enforced consequences:
 
 - `development` mode only binds loopback. It is suitable for an application
   sidecar in the same network namespace.
 - `production` mode can bind a routable address, but `/readyz` remains failing
   and provider requests return `503` until TLS, authentication, and
   authorization are installed. S3 requires both configuration files documented
-  below. Azure remains unready until #494 installs its authenticator.
+  below.
 
-Do not expose an Azure gateway through a Kubernetes Service, ingress, host port,
-or public load balancer. Only an S3 SigV4 identity that maps to an explicit
-allow grant can pass the production data plane.
+Only a validated provider identity that maps to an explicit allow grant can
+pass the production data plane.
 
 ## Credential boundary
 
@@ -32,7 +30,7 @@ with the process's origin identity.
 | Direction | Credential | Storage |
 |---|---|---|
 | Client to S3 gateway | SigV4 access key, optional STS token, or presigned query | Identity file mounted read-only; never logged or forwarded. |
-| Client to Azure gateway | Not yet validated | Never logged or forwarded; #494 owns validation. |
+| Client to Azure gateway | Shared Key, service SAS, or account SAS | Identity file mounted read-only; never logged or forwarded. |
 | Gateway to S3 | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN` | Environment/secret injection only. |
 | Gateway to Azure | Exactly one of `TALON_GATEWAY_AZURE_SHARED_KEY` or `TALON_GATEWAY_AZURE_SAS` | Environment/secret injection only. |
 | Gateway to Talon | Coordinator and worker data-plane connection | Existing Talon cache-client boundary; mTLS integration is part of #446. |
@@ -132,6 +130,31 @@ Azure variables:
 | `TALON_GATEWAY_AZURE_ENDPOINT` | public Azure | Optional `http[s]://host[:port]`; custom endpoints use path addressing. |
 | `TALON_GATEWAY_AZURE_SHARED_KEY` | unset | Base64 account key. Mutually exclusive with SAS. |
 | `TALON_GATEWAY_AZURE_SAS` | unset | Origin SAS without logging or serialization. |
+| `TALON_GATEWAY_AZURE_CLIENT_IDENTITIES_PATH` | unset | JSON incoming account-key identity file. Required for Azure production readiness. |
+| `TALON_GATEWAY_AZURE_MAX_CLOCK_SKEW_MS` | `900000` | Maximum Shared Key clock skew and SAS start/expiry grace. |
+
+Azure client keys are also separate from the origin credential. Each key maps
+to the one account served by the process and to one policy principal:
+
+```json
+{
+  "identities": [
+    {
+      "account_key": "base64-client-account-key",
+      "principal": "analytics-reader",
+      "provider_account": "storage-account-a"
+    }
+  ]
+}
+```
+
+The verifier accepts full Shared Key plus service/account SAS for Blob service
+reads and listings. It enforces signature scope, permissions, resource type,
+protocol, start, expiry, and bounded skew. Stored access policies, signed IP
+ranges, encryption scopes, and user-delegation SAS fail closed because this
+gateway cannot independently enforce those external constraints. Shared Key
+signs `x-ms-talon-cache-mark` through Azure canonicalized headers; SAS requests
+carrying a cache mark are rejected because SAS cannot bind custom headers.
 
 ## Docker
 

--- a/scripts/azure_gateway_sdk_conformance.py
+++ b/scripts/azure_gateway_sdk_conformance.py
@@ -1,11 +1,20 @@
 """Drive the Talon Azure gateway with Microsoft's Azure Storage SDK."""
 
 import os
+from datetime import datetime, timedelta, timezone
 
 from azure.core import MatchConditions
 from azure.core.credentials import AzureNamedKeyCredential
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
-from azure.storage.blob import BlobPrefix, BlobServiceClient
+from azure.storage.blob import (
+    AccountSasPermissions,
+    BlobPrefix,
+    BlobSasPermissions,
+    BlobServiceClient,
+    ResourceTypes,
+    generate_account_sas,
+    generate_blob_sas,
+)
 
 
 ACCOUNT = "devstoreaccount1"
@@ -90,6 +99,45 @@ def main() -> None:
     assert any(
         isinstance(item, BlobPrefix) and item.name == "gateway/list/child/"
         for item in walked
+    )
+
+    expiry = datetime.now(timezone.utc) + timedelta(minutes=5)
+    blob_sas = generate_blob_sas(
+        account_name=ACCOUNT,
+        container_name=container_name,
+        blob_name=object_name,
+        account_key=ACCOUNT_KEY,
+        permission=BlobSasPermissions(read=True),
+        expiry=expiry,
+        protocol="https,http",
+    )
+    sas_blob = BlobServiceClient(
+        account_url=f"{gateway_endpoint}/{ACCOUNT}", credential=blob_sas
+    ).get_blob_client(container_name, object_name)
+    assert sas_blob.download_blob().readall() == expected_object()
+
+    account_sas = generate_account_sas(
+        account_name=ACCOUNT,
+        account_key=ACCOUNT_KEY,
+        resource_types=ResourceTypes(service=True, container=True, object=True),
+        permission=AccountSasPermissions(read=True, list=True),
+        expiry=expiry,
+        protocol="https,http",
+    )
+    sas_service = BlobServiceClient(
+        account_url=f"{gateway_endpoint}/{ACCOUNT}", credential=account_sas
+    )
+    assert (
+        sas_service.get_blob_client(container_name, object_name)
+        .download_blob()
+        .readall()
+        == expected_object()
+    )
+    assert any(
+        item.name == "gateway/list/a space.txt"
+        for item in sas_service.get_container_client(container_name).list_blobs(
+            name_starts_with="gateway/list/"
+        )
     )
 
     print("Azure SDK gateway conformance passed")


### PR DESCRIPTION
Closes #494

## Summary
- authenticate incoming Azure Blob Shared Key, service SAS, and account SAS requests against configured client identities
- enforce canonical signatures, account/resource/permission/protocol/time constraints, signed cache marks, and default-deny principal binding
- exercise official Azure SDK Shared Key and SAS traffic through the Azurite gateway conformance job and document the credential boundary

## Verification
- `just ci`
- `cargo deny check advisories bans sources`
- `mdbook build docs/book`
- `just spell`
- `just linkcheck`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p talon-gateway --no-deps --all-features`
- `python3 -m py_compile scripts/azure_gateway_sdk_conformance.py`
- `git diff --check`