### PR TITLE
feat(gateway): add client mTLS identities and security audit events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2685,6 +2685,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "x509-cert",
 ]
 
 [[package]]

--- a/crates/talon-gateway/Cargo.toml
+++ b/crates/talon-gateway/Cargo.toml
@@ -32,6 +32,7 @@ tower-http.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
+x509-cert.workspace = true
 
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }

--- a/crates/talon-gateway/src/audit.rs
+++ b/crates/talon-gateway/src/audit.rs
@@ -1,0 +1,150 @@
+//! Bounded, redacted security audit events.
+
+use sha2::{Digest, Sha256};
+
+use crate::{AuthenticatedPrincipal, GatewayAccess, GatewayTarget, ProviderProtocol};
+
+/// One authentication or authorization audit decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SecurityAuditEvent {
+    /// Opaque request correlation ID.
+    pub request_id: String,
+    /// Provider protocol.
+    pub protocol: ProviderProtocol,
+    /// Hash of the authenticated policy principal, or `anonymous`.
+    pub principal: String,
+    /// Bounded operation label.
+    pub operation: &'static str,
+    /// Hash of the provider account and scoped target, when parseable.
+    pub resource: Option<String>,
+    /// `allow` or `deny`.
+    pub decision: &'static str,
+    /// Stable bounded reason.
+    pub reason: &'static str,
+}
+
+impl SecurityAuditEvent {
+    pub(crate) fn new(
+        request_id: &str,
+        protocol: ProviderProtocol,
+        principal: Option<&AuthenticatedPrincipal>,
+        access: Option<&GatewayAccess>,
+        decision: &'static str,
+        reason: &'static str,
+    ) -> Self {
+        Self {
+            request_id: request_id.to_string(),
+            protocol,
+            principal: principal.map_or_else(|| "anonymous".into(), principal_hash),
+            operation: access.map_or("unsupported", |access| access.operation.label()),
+            resource: access.map(resource_hash),
+            decision,
+            reason,
+        }
+    }
+}
+
+/// Destination for security audit records.
+pub trait GatewayAuditSink: Send + Sync + 'static {
+    /// Record one bounded event. Implementations must not add request credentials or paths.
+    fn record(&self, event: SecurityAuditEvent);
+}
+
+pub(crate) struct TracingAuditSink;
+
+impl GatewayAuditSink for TracingAuditSink {
+    fn record(&self, event: SecurityAuditEvent) {
+        tracing::info!(
+            audit = true,
+            request_id = event.request_id,
+            protocol = event.protocol.label(),
+            principal = event.principal,
+            operation = event.operation,
+            resource = event.resource.as_deref().unwrap_or("unknown"),
+            decision = event.decision,
+            reason = event.reason,
+            "gateway security audit"
+        );
+    }
+}
+
+fn principal_hash(principal: &AuthenticatedPrincipal) -> String {
+    hash_parts(&[&principal.id, &principal.provider_account])
+}
+
+fn resource_hash(access: &GatewayAccess) -> String {
+    match &access.target {
+        GatewayTarget::Object(object) => hash_parts(&[
+            access.provider_account.as_deref().unwrap_or(""),
+            object.backend.prefix(),
+            &object.bucket,
+            &object.object_path,
+        ]),
+        GatewayTarget::Namespace {
+            backend,
+            namespace,
+            prefix,
+        } => hash_parts(&[
+            access.provider_account.as_deref().unwrap_or(""),
+            backend.prefix(),
+            namespace,
+            prefix.as_deref().unwrap_or(""),
+        ]),
+    }
+}
+
+fn hash_parts(parts: &[&str]) -> String {
+    let mut hash = Sha256::new();
+    for part in parts {
+        hash.update((part.len() as u64).to_be_bytes());
+        hash.update(part.as_bytes());
+    }
+    let digest = hash.finalize();
+    let mut output = String::with_capacity(32);
+    for byte in &digest[..16] {
+        use std::fmt::Write as _;
+        let _ = write!(output, "{byte:02x}");
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use talon_core::{Backend, ObjectId};
+
+    use super::*;
+    use crate::GatewayOperation;
+
+    #[test]
+    fn audit_identifiers_are_bounded_and_do_not_expose_inputs() {
+        let principal = AuthenticatedPrincipal::new("tenant-secret-name", "account-secret");
+        let access = GatewayAccess {
+            operation: GatewayOperation::Read,
+            provider_account: Some("account-secret".into()),
+            target: GatewayTarget::Object(ObjectId::new(
+                Backend::S3,
+                "private-bucket",
+                "customer/path.txt",
+            )),
+        };
+        let event = SecurityAuditEvent::new(
+            "request-id",
+            ProviderProtocol::S3,
+            Some(&principal),
+            Some(&access),
+            "allow",
+            "policy_allowed",
+        );
+        assert_eq!(event.principal.len(), 32);
+        assert_eq!(event.resource.as_ref().unwrap().len(), 32);
+        let rendered = format!("{event:?}");
+        for secret in [
+            "tenant-secret-name",
+            "account-secret",
+            "private-bucket",
+            "customer/path",
+        ] {
+            assert!(!rendered.contains(secret));
+        }
+    }
+}

--- a/crates/talon-gateway/src/lib.rs
+++ b/crates/talon-gateway/src/lib.rs
@@ -1,5 +1,6 @@
 //! Provider-neutral, bounded HTTP runtime shared by Talon's object-store gateways.
 
+mod audit;
 mod authorization;
 pub mod azure;
 pub mod azure_auth;
@@ -12,6 +13,7 @@ pub mod s3;
 pub mod s3_auth;
 mod tls;
 
+pub use audit::{GatewayAuditSink, SecurityAuditEvent};
 pub use authorization::{
     AuthenticatedPrincipal, AuthorizationGrant, AuthorizationPolicy, AuthorizationPolicyError,
     GatewayAuthenticationError, GatewayAuthenticator,
@@ -30,4 +32,7 @@ pub use runtime::{
     gateway_router, serve, serve_tls, GatewayReadiness, GatewayRuntime, GatewayTlsServeError,
     REQUEST_ID_HEADER,
 };
-pub use tls::{GatewayTlsConfig, GatewayTlsError, GatewayTlsListener};
+pub use tls::{
+    GatewayClientAuthConfig, GatewayClientAuthMode, GatewayConnectionInfo, GatewayMtlsIdentity,
+    GatewayTlsConfig, GatewayTlsError, GatewayTlsListener,
+};

--- a/crates/talon-gateway/src/main.rs
+++ b/crates/talon-gateway/src/main.rs
@@ -14,8 +14,9 @@ use talon_gateway::s3::{S3Adapter, S3AdapterConfig, S3Cache};
 use talon_gateway::s3_auth::{S3ClientIdentity, S3SigV4Authenticator};
 use talon_gateway::{
     serve, serve_tls, AuthenticatedPrincipal, AuthorizationGrant, AuthorizationPolicy,
-    GatewayAdapter, GatewayConfig, GatewayMode, GatewayOperation, GatewayRoute, GatewayRuntime,
-    GatewaySecurity, GatewayTlsConfig, ProviderProtocol,
+    GatewayAdapter, GatewayClientAuthConfig, GatewayClientAuthMode, GatewayConfig, GatewayMode,
+    GatewayMtlsIdentity, GatewayOperation, GatewayRoute, GatewayRuntime, GatewaySecurity,
+    GatewayTlsConfig, ProviderProtocol,
 };
 use tokio::net::TcpListener;
 use tracing::info;
@@ -119,8 +120,49 @@ impl Settings {
         )?;
         let tls_certificate = value(&mut get, "TALON_GATEWAY_TLS_CERT_PATH");
         let tls_private_key = value(&mut get, "TALON_GATEWAY_TLS_KEY_PATH");
+        let client_auth_mode =
+            value(&mut get, "TALON_GATEWAY_TLS_CLIENT_AUTH").unwrap_or_else(|| "off".into());
+        let client_ca = value(&mut get, "TALON_GATEWAY_TLS_CLIENT_CA_PATH");
+        let trust_domain = value(&mut get, "TALON_GATEWAY_TLS_TRUST_DOMAIN");
+        let mtls_identities = value(&mut get, "TALON_GATEWAY_MTLS_IDENTITIES_PATH");
+        let client_auth = match client_auth_mode.as_str() {
+            "off" if client_ca.is_none() && trust_domain.is_none() && mtls_identities.is_none() => {
+                None
+            }
+            "off" => return Err(invalid(
+                "mTLS client settings require TALON_GATEWAY_TLS_CLIENT_AUTH=optional or required",
+            )),
+            "optional" | "required" => {
+                let mode = if client_auth_mode == "optional" {
+                    GatewayClientAuthMode::Optional
+                } else {
+                    GatewayClientAuthMode::Required
+                };
+                let ca = client_ca.ok_or_else(|| {
+                    invalid("TALON_GATEWAY_TLS_CLIENT_CA_PATH is required for mTLS")
+                })?;
+                let trust_domain = trust_domain.ok_or_else(|| {
+                    invalid("TALON_GATEWAY_TLS_TRUST_DOMAIN is required for mTLS")
+                })?;
+                let identities = mtls_identities.ok_or_else(|| {
+                    invalid("TALON_GATEWAY_MTLS_IDENTITIES_PATH is required for mTLS")
+                })?;
+                Some(load_mtls_identities(
+                    Path::new(&identities),
+                    PathBuf::from(ca),
+                    mode,
+                    trust_domain,
+                )?)
+            }
+            _ => {
+                return Err(invalid(
+                    "TALON_GATEWAY_TLS_CLIENT_AUTH must be off, optional, or required",
+                ))
+            }
+        };
         let tls = match (tls_certificate, tls_private_key) {
-            (None, None) => None,
+            (None, None) if client_auth.is_none() => None,
+            (None, None) => return Err(invalid("mTLS requires gateway TLS certificate and key")),
             (Some(certificate_path), Some(private_key_path)) => Some(GatewayTlsConfig {
                 certificate_path: certificate_path.into(),
                 private_key_path: private_key_path.into(),
@@ -139,6 +181,7 @@ impl Settings {
                     "256",
                     "TALON_GATEWAY_TLS_MAX_HANDSHAKES",
                 )?,
+                client_auth,
             }),
             _ => return Err(invalid(
                 "TALON_GATEWAY_TLS_CERT_PATH and TALON_GATEWAY_TLS_KEY_PATH must be set together",
@@ -389,6 +432,20 @@ struct AzureIdentityConfig {
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
+struct MtlsIdentityFile {
+    identities: Vec<MtlsIdentityConfig>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MtlsIdentityConfig {
+    uri_san: String,
+    principal: String,
+    provider_account: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 struct AuthorizationFile {
     grants: Vec<AuthorizationGrantConfig>,
 }
@@ -486,6 +543,31 @@ fn load_authorization(path: &Path) -> MainResult<AuthorizationPolicy> {
         })
         .collect::<MainResult<Vec<_>>>()?;
     Ok(AuthorizationPolicy::new(grants)?)
+}
+
+fn load_mtls_identities(
+    path: &Path,
+    ca_certificate_path: PathBuf,
+    mode: GatewayClientAuthMode,
+    trust_domain: String,
+) -> MainResult<GatewayClientAuthConfig> {
+    let configured: MtlsIdentityFile = serde_json::from_str(&std::fs::read_to_string(path)?)?;
+    Ok(GatewayClientAuthConfig {
+        ca_certificate_path,
+        mode,
+        trust_domain,
+        identities: configured
+            .identities
+            .into_iter()
+            .map(|identity| GatewayMtlsIdentity {
+                uri_san: identity.uri_san,
+                principal: AuthenticatedPrincipal::new(
+                    identity.principal,
+                    identity.provider_account,
+                ),
+            })
+            .collect(),
+    })
 }
 
 async fn shutdown_signal() {
@@ -681,7 +763,53 @@ mod tests {
         assert_eq!(tls.reload_interval, std::time::Duration::from_millis(250));
         assert_eq!(tls.handshake_timeout, std::time::Duration::from_millis(900));
         assert_eq!(tls.max_concurrent_handshakes, 32);
+        assert!(tls.client_auth.is_none());
         assert!(!format!("{tls:?}").contains("/tls/key.pem"));
+    }
+
+    #[test]
+    fn mtls_settings_are_grouped_and_load_explicit_identity_mappings() {
+        let temp = TempDir::new().unwrap();
+        let identities = temp.path().join("mtls-identities.json");
+        std::fs::write(
+            &identities,
+            r#"{
+                "identities": [{
+                    "uri_san": "spiffe://cluster.example/talon/cluster-a/worker/worker-1",
+                    "principal": "worker-reader",
+                    "provider_account": "account-a"
+                }]
+            }"#,
+        )
+        .unwrap();
+        let identity_path = identities.to_str().unwrap();
+        let configured = settings(&[
+            ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
+            ("TALON_GATEWAY_TLS_CERT_PATH", "/tls/cert.pem"),
+            ("TALON_GATEWAY_TLS_KEY_PATH", "/tls/key.pem"),
+            ("TALON_GATEWAY_TLS_CLIENT_AUTH", "required"),
+            ("TALON_GATEWAY_TLS_CLIENT_CA_PATH", "/tls/client-ca.pem"),
+            ("TALON_GATEWAY_TLS_TRUST_DOMAIN", "cluster.example"),
+            ("TALON_GATEWAY_MTLS_IDENTITIES_PATH", identity_path),
+        ])
+        .unwrap();
+        let client_auth = configured.tls.unwrap().client_auth.unwrap();
+        assert_eq!(client_auth.mode, GatewayClientAuthMode::Required);
+        assert_eq!(client_auth.trust_domain, "cluster.example");
+        assert_eq!(client_auth.identities.len(), 1);
+        assert_eq!(client_auth.identities[0].principal.id, "worker-reader");
+
+        assert!(settings(&[
+            ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
+            ("TALON_GATEWAY_TLS_CLIENT_AUTH", "optional"),
+            ("TALON_GATEWAY_TLS_CLIENT_CA_PATH", "/tls/client-ca.pem"),
+        ])
+        .is_err());
+        assert!(settings(&[
+            ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
+            ("TALON_GATEWAY_TLS_CLIENT_CA_PATH", "/tls/client-ca.pem"),
+        ])
+        .is_err());
     }
 
     #[test]

--- a/crates/talon-gateway/src/runtime.rs
+++ b/crates/talon-gateway/src/runtime.rs
@@ -1,12 +1,11 @@
 //! Axum server, lifecycle middleware, operational endpoints, and limits.
 
 use std::future::{Future, IntoFuture};
-use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use axum::body::Body;
-use axum::extract::{Request, State};
+use axum::extract::{ConnectInfo, Request, State};
 use axum::http::{header, HeaderValue, StatusCode};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
@@ -19,6 +18,7 @@ use tokio::net::TcpListener;
 use tower::limit::ConcurrencyLimitLayer;
 use tower_http::timeout::TimeoutBody;
 
+use crate::audit::{GatewayAuditSink, SecurityAuditEvent, TracingAuditSink};
 use crate::authorization::{AuthenticatedPrincipal, AuthorizationPolicy, GatewayAuthenticator};
 use crate::config::{GatewayConfig, GatewayConfigError, GatewayMode, GatewaySecurity};
 use crate::metrics::{GatewayMetrics, RequestObservation, ResponseObserver};
@@ -26,7 +26,7 @@ use crate::model::{
     FailureReason, GatewayAdapter, GatewayOperation, GatewayOutcome, GatewayRequestContext,
     GatewayResponse, GatewayRoute,
 };
-use crate::tls::{GatewayTlsConfig, GatewayTlsError, GatewayTlsListener};
+use crate::tls::{GatewayConnectionInfo, GatewayTlsConfig, GatewayTlsError, GatewayTlsListener};
 
 /// Opaque request ID emitted by the shared core and translated by adapters.
 pub const REQUEST_ID_HEADER: &str = "x-talon-request-id";
@@ -120,6 +120,7 @@ pub struct GatewayRuntime {
     metrics: GatewayMetrics,
     authorization: RwLock<Option<AuthorizationPolicy>>,
     authentication: RwLock<Option<Arc<dyn GatewayAuthenticator>>>,
+    audit: RwLock<Arc<dyn GatewayAuditSink>>,
 }
 
 impl GatewayRuntime {
@@ -145,6 +146,7 @@ impl GatewayRuntime {
             metrics: GatewayMetrics::new(),
             authorization: RwLock::new(None),
             authentication: RwLock::new(None),
+            audit: RwLock::new(Arc::new(TracingAuditSink)),
         })
     }
 
@@ -170,6 +172,20 @@ impl GatewayRuntime {
         *self.authentication.write().unwrap() = Some(authenticator);
         let mut security = self.readiness.security.write().unwrap();
         security.authentication = true;
+    }
+
+    /// Install a security audit destination.
+    pub fn install_audit_sink(&self, sink: Arc<dyn GatewayAuditSink>) {
+        *self.audit.write().unwrap() = sink;
+    }
+
+    fn enable_mtls_authentication(&self) {
+        self.readiness.security.write().unwrap().authentication = true;
+    }
+
+    fn audit(&self, event: SecurityAuditEvent) {
+        let sink = self.audit.read().unwrap().clone();
+        sink.record(event);
     }
 }
 
@@ -201,42 +217,12 @@ pub async fn serve(
     runtime: Arc<GatewayRuntime>,
     shutdown: impl Future<Output = ()> + Send + 'static,
 ) -> std::io::Result<()> {
-    serve_listener(listener, runtime, shutdown).await
-}
-
-/// Serve HTTPS with reloadable TLS 1.3 material.
-pub async fn serve_tls(
-    listener: TcpListener,
-    runtime: Arc<GatewayRuntime>,
-    tls: GatewayTlsConfig,
-    shutdown: impl Future<Output = ()> + Send + 'static,
-) -> Result<(), GatewayTlsServeError> {
-    let listener = GatewayTlsListener::load(listener, tls, runtime.metrics().clone())?;
-    runtime.readiness.set_tls_ready(true);
-    serve_listener(listener, runtime, shutdown).await?;
-    Ok(())
-}
-
-async fn serve_listener<L>(
-    listener: L,
-    runtime: Arc<GatewayRuntime>,
-    shutdown: impl Future<Output = ()> + Send + 'static,
-) -> std::io::Result<()>
-where
-    L: axum::serve::Listener<Addr = SocketAddr>,
-{
-    let local = listener.local_addr()?;
-    if runtime.config.mode == GatewayMode::Development && !local.ip().is_loopback() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
-            "development gateway listener is not loopback",
-        ));
-    }
-
+    ensure_listener_allowed(&listener, &runtime)?;
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     let server = axum::serve(
         listener,
-        gateway_router(Arc::clone(&runtime)).into_make_service(),
+        gateway_router(Arc::clone(&runtime))
+            .into_make_service_with_connect_info::<GatewayConnectionInfo>(),
     )
     .with_graceful_shutdown(async move {
         let _ = shutdown_rx.await;
@@ -261,6 +247,67 @@ where
     }
 }
 
+/// Serve HTTPS with reloadable TLS 1.3 material.
+pub async fn serve_tls(
+    listener: TcpListener,
+    runtime: Arc<GatewayRuntime>,
+    tls: GatewayTlsConfig,
+    shutdown: impl Future<Output = ()> + Send + 'static,
+) -> Result<(), GatewayTlsServeError> {
+    ensure_listener_allowed(&listener, &runtime)?;
+    let mtls_required = tls
+        .client_auth
+        .as_ref()
+        .is_some_and(|config| config.mode == crate::GatewayClientAuthMode::Required);
+    let listener = GatewayTlsListener::load(listener, tls, runtime.metrics().clone())?;
+    runtime.readiness.set_tls_ready(true);
+    if mtls_required {
+        runtime.enable_mtls_authentication();
+    }
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let server = axum::serve(
+        listener,
+        gateway_router(Arc::clone(&runtime))
+            .into_make_service_with_connect_info::<GatewayConnectionInfo>(),
+    )
+    .with_graceful_shutdown(async move {
+        let _ = shutdown_rx.await;
+    })
+    .into_future();
+    tokio::pin!(server);
+    tokio::pin!(shutdown);
+
+    let result = tokio::select! {
+        result = &mut server => result,
+        () = &mut shutdown => {
+            runtime.readiness.begin_shutdown();
+            let _ = shutdown_tx.send(());
+            match tokio::time::timeout(runtime.config.graceful_shutdown_timeout, &mut server).await {
+                Ok(result) => result,
+                Err(_) => Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "gateway graceful shutdown timed out",
+                )),
+            }
+        }
+    };
+    result.map_err(GatewayTlsServeError::Io)
+}
+
+fn ensure_listener_allowed(
+    listener: &TcpListener,
+    runtime: &GatewayRuntime,
+) -> std::io::Result<()> {
+    let local = listener.local_addr()?;
+    if runtime.config.mode == GatewayMode::Development && !local.ip().is_loopback() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "development gateway listener is not loopback",
+        ));
+    }
+    Ok(())
+}
+
 /// HTTPS startup or serving failure.
 #[derive(Debug, thiserror::Error)]
 pub enum GatewayTlsServeError {
@@ -282,34 +329,67 @@ async fn adapter_handler(State(runtime): State<Arc<GatewayRuntime>>, request: Re
     let remaining = runtime.config.request_deadline.saturating_sub(elapsed);
     let protocol = runtime.adapter.protocol();
     let authenticator = runtime.authentication.read().unwrap().clone();
-    let authenticated = match authenticator {
-        Some(authenticator) => match authenticator.authenticate(&request, protocol) {
-            Ok(principal) => {
-                runtime.metrics.record_authentication("success");
-                Some(principal)
-            }
-            Err(_) => {
-                runtime.metrics.record_authentication("failure");
-                let result = GatewayResponse {
-                    response: (StatusCode::FORBIDDEN, "request authentication failed")
-                        .into_response(),
-                    operation: GatewayOperation::Unsupported,
-                    target: None,
-                    route: GatewayRoute::None,
-                    outcome: GatewayOutcome::Failed,
-                    failure: Some(FailureReason::Authentication),
-                    requested_bytes: 0,
-                    cache_bytes: 0,
-                    origin_bytes: 0,
-                };
-                return record_adapter_result(&runtime, protocol, &context, result);
-            }
-        },
-        None => request
-            .extensions()
-            .get::<AuthenticatedPrincipal>()
-            .cloned(),
+    let mtls_principal = request
+        .extensions()
+        .get::<ConnectInfo<GatewayConnectionInfo>>()
+        .and_then(|info| info.0.principal().cloned());
+    let direct_principal = request
+        .extensions()
+        .get::<AuthenticatedPrincipal>()
+        .cloned();
+    let credential_present = provider_credential_present(&request, protocol);
+    if credential_present && authenticator.is_none() && mtls_principal.is_some() {
+        return authentication_failure(
+            &runtime,
+            protocol,
+            &context,
+            &request,
+            mtls_principal.as_ref(),
+            "provider_authenticator_missing",
+        );
+    }
+    let credential_principal = authenticator.as_ref().and_then(|authenticator| {
+        credential_present.then(|| authenticator.authenticate(&request, protocol))
+    });
+    let authenticated = match (credential_principal, mtls_principal.clone()) {
+        (Some(Ok(credential)), Some(mtls)) if credential == mtls => Some(credential),
+        (Some(Ok(credential)), None) => Some(credential),
+        (None, Some(mtls)) => Some(mtls),
+        (None, None) if authenticator.is_none() => direct_principal,
+        (None, None) => {
+            return authentication_failure(
+                &runtime,
+                protocol,
+                &context,
+                &request,
+                None,
+                "missing_credentials",
+            );
+        }
+        (Some(Err(_)), _) => {
+            return authentication_failure(
+                &runtime,
+                protocol,
+                &context,
+                &request,
+                mtls_principal.as_ref(),
+                "provider_credential_rejected",
+            );
+        }
+        (Some(Ok(_)), Some(_)) => {
+            return authentication_failure(
+                &runtime,
+                protocol,
+                &context,
+                &request,
+                mtls_principal.as_ref(),
+                "identity_mismatch",
+            );
+        }
     };
+    if credential_present || mtls_principal.is_some() {
+        runtime.metrics.record_authentication("success");
+    }
     let policy = runtime.authorization.read().unwrap().clone();
     if let Some(policy) = policy {
         let access = match runtime.adapter.access(&request, &context) {
@@ -320,13 +400,18 @@ async fn adapter_handler(State(runtime): State<Arc<GatewayRuntime>>, request: Re
             !policy.allows(principal, protocol, &access)
         }) {
             runtime.metrics.record_authorization("deny");
-            tracing::warn!(
-                request_id = context.request_id,
-                protocol = protocol.label(),
-                operation = access.operation.label(),
-                decision = "deny",
-                "gateway authorization decision"
-            );
+            runtime.audit(SecurityAuditEvent::new(
+                &context.request_id,
+                protocol,
+                authenticated.as_ref(),
+                Some(&access),
+                "deny",
+                if authenticated.is_some() {
+                    "policy_denied"
+                } else {
+                    "missing_identity"
+                },
+            ));
             let result = GatewayResponse {
                 response: (StatusCode::FORBIDDEN, "request is not authorized").into_response(),
                 operation: access.operation,
@@ -341,13 +426,14 @@ async fn adapter_handler(State(runtime): State<Arc<GatewayRuntime>>, request: Re
             return record_adapter_result(&runtime, protocol, &context, result);
         }
         runtime.metrics.record_authorization("allow");
-        tracing::info!(
-            request_id = context.request_id,
-            protocol = protocol.label(),
-            operation = access.operation.label(),
-            decision = "allow",
-            "gateway authorization decision"
-        );
+        runtime.audit(SecurityAuditEvent::new(
+            &context.request_id,
+            protocol,
+            authenticated.as_ref(),
+            Some(&access),
+            "allow",
+            "policy_allowed",
+        ));
     }
     let result =
         match tokio::time::timeout(remaining, runtime.adapter.handle(request, context.clone()))
@@ -372,6 +458,56 @@ async fn adapter_handler(State(runtime): State<Arc<GatewayRuntime>>, request: Re
         };
 
     record_adapter_result(&runtime, protocol, &context, result)
+}
+
+fn provider_credential_present(request: &Request, protocol: crate::ProviderProtocol) -> bool {
+    if request.headers().contains_key(header::AUTHORIZATION) {
+        return true;
+    }
+    request.uri().query().is_some_and(|query| {
+        url::form_urlencoded::parse(query.as_bytes()).any(|(key, _)| match protocol {
+            crate::ProviderProtocol::S3 => {
+                key.eq_ignore_ascii_case("x-amz-algorithm")
+                    || key.eq_ignore_ascii_case("x-amz-signature")
+                    || key.eq_ignore_ascii_case("x-amz-credential")
+            }
+            crate::ProviderProtocol::Azure => key.eq_ignore_ascii_case("sig"),
+        })
+    })
+}
+
+fn authentication_failure(
+    runtime: &GatewayRuntime,
+    protocol: crate::ProviderProtocol,
+    context: &GatewayRequestContext,
+    request: &Request,
+    principal: Option<&AuthenticatedPrincipal>,
+    reason: &'static str,
+) -> Response {
+    runtime.metrics.record_authentication("failure");
+    let access = runtime.adapter.access(request, context).ok();
+    runtime.audit(SecurityAuditEvent::new(
+        &context.request_id,
+        protocol,
+        principal,
+        access.as_ref(),
+        "deny",
+        reason,
+    ));
+    let result = GatewayResponse {
+        response: (StatusCode::FORBIDDEN, "request authentication failed").into_response(),
+        operation: access
+            .as_ref()
+            .map_or(GatewayOperation::Unsupported, |access| access.operation),
+        target: access.map(|access| access.target),
+        route: GatewayRoute::None,
+        outcome: GatewayOutcome::Failed,
+        failure: Some(FailureReason::Authentication),
+        requested_bytes: 0,
+        cache_bytes: 0,
+        origin_bytes: 0,
+    };
+    record_adapter_result(runtime, protocol, context, result)
 }
 
 fn record_adapter_result(
@@ -654,6 +790,7 @@ async fn metrics_handler(State(runtime): State<Arc<GatewayRuntime>>) -> Response
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
 
     use async_trait::async_trait;
     use axum::body::to_bytes;
@@ -663,13 +800,22 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::{
-        AuthorizationGrant, GatewayAccess, GatewayAuthenticationError, GatewayAuthenticator,
-        GatewayTarget,
+        AuthorizationGrant, GatewayAccess, GatewayAuditSink, GatewayAuthenticationError,
+        GatewayAuthenticator, GatewayTarget, SecurityAuditEvent,
     };
 
     struct StaticAuthenticator;
 
     struct RejectingAuthenticator;
+
+    #[derive(Default)]
+    struct CapturingAuditSink(Mutex<Vec<SecurityAuditEvent>>);
+
+    impl GatewayAuditSink for CapturingAuditSink {
+        fn record(&self, event: SecurityAuditEvent) {
+            self.0.lock().unwrap().push(event);
+        }
+    }
 
     impl GatewayAuthenticator for StaticAuthenticator {
         fn authenticate(
@@ -812,7 +958,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        let mut request = HttpRequest::get("/object").body(Body::empty()).unwrap();
+        let mut request = HttpRequest::get("/object")
+            .header(header::AUTHORIZATION, "test")
+            .body(Body::empty())
+            .unwrap();
         request
             .extensions_mut()
             .insert(AuthenticatedPrincipal::new("principal-a", "account-a"));
@@ -841,6 +990,8 @@ mod tests {
             }])
             .unwrap(),
         );
+        let audit = Arc::new(CapturingAuditSink::default());
+        runtime.install_audit_sink(audit.clone());
         let app = gateway_router(Arc::clone(&runtime));
 
         let response = app
@@ -882,6 +1033,17 @@ mod tests {
         assert!(!metrics.contains("object-secret"));
         assert!(!metrics.contains("principal-a"));
         assert!(!metrics.contains("account-a"));
+        let events = audit.0.lock().unwrap();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].decision, "deny");
+        assert_eq!(events[1].decision, "deny");
+        assert_eq!(events[2].decision, "allow");
+        for event in events.iter() {
+            let rendered = format!("{event:?}");
+            assert!(!rendered.contains("object-secret"));
+            assert!(!rendered.contains("principal-a"));
+            assert!(!rendered.contains("account-a"));
+        }
     }
 
     #[tokio::test]
@@ -910,6 +1072,45 @@ mod tests {
         assert!(metrics.contains("result=\"failure\""));
         assert!(!metrics.contains("secret-object"));
         assert!(!metrics.contains("spoofed"));
+    }
+
+    #[tokio::test]
+    async fn provider_and_mtls_identity_mismatch_fails_before_dispatch() {
+        let adapter = TestAdapter::immediate();
+        let runtime = runtime_with(
+            GatewayConfig::default(),
+            adapter.clone(),
+            GatewaySecurity::default(),
+        );
+        runtime.install_authentication(Arc::new(StaticAuthenticator));
+        let audit = Arc::new(CapturingAuditSink::default());
+        runtime.install_audit_sink(audit.clone());
+        let app = gateway_router(runtime);
+        let mut request = HttpRequest::get("/secret-object")
+            .header(header::AUTHORIZATION, "test")
+            .body(Body::empty())
+            .unwrap();
+        request
+            .extensions_mut()
+            .insert(AuthenticatedPrincipal::new("provider-reader", "account-a"));
+        request
+            .extensions_mut()
+            .insert(ConnectInfo(GatewayConnectionInfo::authenticated(
+                "127.0.0.1:12345".parse().unwrap(),
+                AuthenticatedPrincipal::new("mtls-reader", "account-a"),
+            )));
+
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(adapter.calls.load(Ordering::SeqCst), 0);
+        let events = audit.0.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].reason, "identity_mismatch");
+        let rendered = format!("{:?}", events[0]);
+        assert!(!rendered.contains("provider-reader"));
+        assert!(!rendered.contains("mtls-reader"));
+        assert!(!rendered.contains("secret-object"));
     }
 
     #[tokio::test]

--- a/crates/talon-gateway/src/tls.rs
+++ b/crates/talon-gateway/src/tls.rs
@@ -1,26 +1,131 @@
 //! Reloadable TLS 1.3 listener for the public gateway data plane.
 
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::serve::Listener;
+use axum::extract::connect_info::Connected;
+use axum::serve::{IncomingStream, Listener};
 use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt};
 use rustls::pki_types::pem::PemObject;
-use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use rustls::ServerConfig;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, UnixTime};
+use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
+use rustls::{DigitallySignedStruct, RootCertStore, ServerConfig, SignatureScheme};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::watch;
 use tokio_rustls::server::TlsStream;
 use tokio_rustls::TlsAcceptor;
+use x509_cert::der::Decode;
+use x509_cert::ext::pkix::name::GeneralName;
+use x509_cert::ext::pkix::SubjectAltName;
+use x509_cert::Certificate;
 
 use crate::metrics::GatewayMetrics;
+use crate::AuthenticatedPrincipal;
 
-type AcceptedTls = (TlsStream<TcpStream>, std::net::SocketAddr);
+type AcceptedTls = (TlsStream<TcpStream>, GatewayConnectionInfo);
 type PendingHandshake = BoxFuture<'static, Option<AcceptedTls>>;
+
+/// Whether the listener requests or requires a client certificate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GatewayClientAuthMode {
+    /// Request a certificate but permit clients without one.
+    Optional,
+    /// Reject clients that do not provide a valid certificate.
+    Required,
+}
+
+/// One URI SAN to policy-principal mapping.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayMtlsIdentity {
+    /// Exact URI SAN accepted from the client certificate.
+    pub uri_san: String,
+    /// Principal used by the authorization policy.
+    pub principal: AuthenticatedPrincipal,
+}
+
+/// Client-certificate trust and identity configuration.
+#[derive(Clone, PartialEq, Eq)]
+pub struct GatewayClientAuthConfig {
+    /// PEM trust-anchor bundle. Overlapping roots permit rotation without outage.
+    pub ca_certificate_path: PathBuf,
+    /// Optional or required client-certificate mode.
+    pub mode: GatewayClientAuthMode,
+    /// Exact URI SAN trust domain.
+    pub trust_domain: String,
+    /// Explicit URI SAN mappings.
+    pub identities: Vec<GatewayMtlsIdentity>,
+}
+
+impl fmt::Debug for GatewayClientAuthConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GatewayClientAuthConfig")
+            .field("ca_certificate_path", &self.ca_certificate_path)
+            .field("mode", &self.mode)
+            .field("trust_domain", &self.trust_domain)
+            .field("identity_count", &self.identities.len())
+            .finish()
+    }
+}
+
+/// Peer metadata established by the listener before HTTP dispatch.
+#[derive(Clone)]
+pub struct GatewayConnectionInfo {
+    remote_addr: std::net::SocketAddr,
+    principal: Option<AuthenticatedPrincipal>,
+}
+
+impl fmt::Debug for GatewayConnectionInfo {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GatewayConnectionInfo")
+            .field("remote_addr", &self.remote_addr)
+            .field("authenticated", &self.principal.is_some())
+            .finish()
+    }
+}
+
+impl GatewayConnectionInfo {
+    /// Network peer address.
+    pub fn remote_addr(&self) -> std::net::SocketAddr {
+        self.remote_addr
+    }
+
+    pub(crate) fn principal(&self) -> Option<&AuthenticatedPrincipal> {
+        self.principal.as_ref()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn authenticated(
+        remote_addr: std::net::SocketAddr,
+        principal: AuthenticatedPrincipal,
+    ) -> Self {
+        Self {
+            remote_addr,
+            principal: Some(principal),
+        }
+    }
+}
+
+impl Connected<IncomingStream<'_, GatewayTlsListener>> for GatewayConnectionInfo {
+    fn connect_info(stream: IncomingStream<'_, GatewayTlsListener>) -> Self {
+        stream.remote_addr().clone()
+    }
+}
+
+impl Connected<IncomingStream<'_, TcpListener>> for GatewayConnectionInfo {
+    fn connect_info(stream: IncomingStream<'_, TcpListener>) -> Self {
+        Self {
+            remote_addr: *stream.remote_addr(),
+            principal: None,
+        }
+    }
+}
 
 /// File-backed public server TLS configuration.
 #[derive(Clone, PartialEq, Eq)]
@@ -35,6 +140,8 @@ pub struct GatewayTlsConfig {
     pub handshake_timeout: Duration,
     /// Maximum accepted connections concurrently performing a TLS handshake.
     pub max_concurrent_handshakes: usize,
+    /// Optional incoming client-certificate authentication.
+    pub client_auth: Option<GatewayClientAuthConfig>,
 }
 
 impl fmt::Debug for GatewayTlsConfig {
@@ -46,6 +153,7 @@ impl fmt::Debug for GatewayTlsConfig {
             .field("reload_interval", &self.reload_interval)
             .field("handshake_timeout", &self.handshake_timeout)
             .field("max_concurrent_handshakes", &self.max_concurrent_handshakes)
+            .field("client_auth", &self.client_auth)
             .finish()
     }
 }
@@ -61,6 +169,9 @@ impl GatewayTlsConfig {
         }
         if self.max_concurrent_handshakes == 0 {
             return Err(GatewayTlsError::ZeroHandshakeLimit);
+        }
+        if let Some(client_auth) = &self.client_auth {
+            validate_client_auth(client_auth)?;
         }
         Ok(())
     }
@@ -90,12 +201,18 @@ pub enum GatewayTlsError {
     /// The key does not match the leaf certificate or rustls rejected it.
     #[error("gateway TLS certificate and private key are incompatible")]
     IncompatibleKey,
+    /// The client CA bundle could not be loaded.
+    #[error("gateway TLS client CA bundle is unreadable or invalid")]
+    InvalidClientCa,
+    /// Client identity mappings or trust domain are invalid.
+    #[error("gateway TLS client identity configuration is invalid")]
+    InvalidClientIdentity,
 }
 
 /// TLS listener that snapshots last-good material for each new connection.
 pub struct GatewayTlsListener {
     listener: TcpListener,
-    material: watch::Receiver<Arc<ServerConfig>>,
+    material: watch::Receiver<Arc<LoadedServerConfig>>,
     handshake_timeout: Duration,
     max_concurrent_handshakes: usize,
     handshakes: FuturesUnordered<PendingHandshake>,
@@ -126,7 +243,7 @@ impl GatewayTlsListener {
 
 impl Listener for GatewayTlsListener {
     type Io = TlsStream<TcpStream>;
-    type Addr = std::net::SocketAddr;
+    type Addr = GatewayConnectionInfo;
 
     async fn accept(&mut self) -> (Self::Io, Self::Addr) {
         loop {
@@ -144,9 +261,15 @@ impl Listener for GatewayTlsListener {
                         let timeout = self.handshake_timeout;
                         let metrics = self.metrics.clone();
                         self.handshakes.push(async move {
-                            let handshake = TlsAcceptor::from(material).accept(stream);
+                            let handshake = TlsAcceptor::from(Arc::new(material.server.clone())).accept(stream);
                             match tokio::time::timeout(timeout, handshake).await {
-                                Ok(Ok(stream)) => Some((stream, address)),
+                                Ok(Ok(stream)) => {
+                                    let principal = peer_principal(&stream, material.client_auth.as_ref());
+                                    Some((stream, GatewayConnectionInfo {
+                                        remote_addr: address,
+                                        principal,
+                                    }))
+                                }
                                 Ok(Err(_)) => {
                                     metrics.record_tls_event("handshake_failure");
                                     tracing::debug!("gateway TLS handshake rejected before HTTP dispatch");
@@ -175,13 +298,16 @@ impl Listener for GatewayTlsListener {
     }
 
     fn local_addr(&self) -> std::io::Result<Self::Addr> {
-        self.listener.local_addr()
+        Ok(GatewayConnectionInfo {
+            remote_addr: self.listener.local_addr()?,
+            principal: None,
+        })
     }
 }
 
 fn spawn_reload(
     config: GatewayTlsConfig,
-    sender: watch::Sender<Arc<ServerConfig>>,
+    sender: watch::Sender<Arc<LoadedServerConfig>>,
     metrics: GatewayMetrics,
 ) {
     tokio::spawn(async move {
@@ -208,7 +334,179 @@ fn spawn_reload(
     });
 }
 
-fn load_server_config(config: &GatewayTlsConfig) -> Result<ServerConfig, GatewayTlsError> {
+struct LoadedServerConfig {
+    server: ServerConfig,
+    client_auth: Option<GatewayClientAuthConfig>,
+}
+
+fn validate_client_auth(config: &GatewayClientAuthConfig) -> Result<(), GatewayTlsError> {
+    if config.trust_domain.is_empty() || config.identities.is_empty() {
+        return Err(GatewayTlsError::InvalidClientIdentity);
+    }
+    let mut uris = HashSet::new();
+    for identity in &config.identities {
+        if identity.principal.id.is_empty()
+            || identity.principal.provider_account.is_empty()
+            || !uris.insert(identity.uri_san.clone())
+            || !valid_workload_uri(&identity.uri_san, &config.trust_domain)
+        {
+            return Err(GatewayTlsError::InvalidClientIdentity);
+        }
+    }
+    Ok(())
+}
+
+fn valid_workload_uri(uri: &str, trust_domain: &str) -> bool {
+    url::Url::parse(uri).is_ok_and(|uri| {
+        uri.scheme() == "spiffe"
+            && uri.host_str() == Some(trust_domain)
+            && uri.port().is_none()
+            && uri.username().is_empty()
+            && uri.password().is_none()
+            && uri.path() != "/"
+            && !uri.path().is_empty()
+            && uri.query().is_none()
+            && uri.fragment().is_none()
+    })
+}
+
+fn client_verifier(
+    config: &GatewayClientAuthConfig,
+) -> Result<Arc<dyn ClientCertVerifier>, GatewayTlsError> {
+    validate_client_auth(config)?;
+    let mut roots = RootCertStore::empty();
+    let certificates = CertificateDer::pem_file_iter(&config.ca_certificate_path)
+        .map_err(|_| GatewayTlsError::InvalidClientCa)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| GatewayTlsError::InvalidClientCa)?;
+    if certificates.is_empty() {
+        return Err(GatewayTlsError::InvalidClientCa);
+    }
+    roots.add_parsable_certificates(certificates);
+    if roots.is_empty() {
+        return Err(GatewayTlsError::InvalidClientCa);
+    }
+    let builder = rustls::server::WebPkiClientVerifier::builder(Arc::new(roots));
+    let builder = if config.mode == GatewayClientAuthMode::Optional {
+        builder.allow_unauthenticated()
+    } else {
+        builder
+    };
+    let inner = builder
+        .build()
+        .map_err(|_| GatewayTlsError::InvalidClientCa)?;
+    Ok(Arc::new(GatewayClientVerifier {
+        inner,
+        trust_domain: config.trust_domain.clone(),
+        identities: identity_map(config),
+    }))
+}
+
+fn identity_map(config: &GatewayClientAuthConfig) -> HashMap<String, AuthenticatedPrincipal> {
+    config
+        .identities
+        .iter()
+        .map(|identity| (identity.uri_san.clone(), identity.principal.clone()))
+        .collect()
+}
+
+fn peer_principal(
+    stream: &TlsStream<TcpStream>,
+    config: Option<&GatewayClientAuthConfig>,
+) -> Option<AuthenticatedPrincipal> {
+    let config = config?;
+    let leaf = stream.get_ref().1.peer_certificates()?.first()?;
+    let uri = certificate_uri(leaf).ok()?;
+    identity_map(config).get(&uri).cloned()
+}
+
+fn certificate_uri(certificate: &CertificateDer<'_>) -> Result<String, GatewayTlsError> {
+    let certificate = Certificate::from_der(certificate.as_ref())
+        .map_err(|_| GatewayTlsError::InvalidClientIdentity)?;
+    let extension = certificate
+        .tbs_certificate
+        .extensions
+        .as_ref()
+        .and_then(|extensions| {
+            extensions
+                .iter()
+                .find(|extension| extension.extn_id.to_string() == "2.5.29.17")
+        })
+        .ok_or(GatewayTlsError::InvalidClientIdentity)?;
+    let san = SubjectAltName::from_der(extension.extn_value.as_bytes())
+        .map_err(|_| GatewayTlsError::InvalidClientIdentity)?;
+    let uris = san
+        .0
+        .iter()
+        .filter_map(|name| match name {
+            GeneralName::UniformResourceIdentifier(uri) => Some(uri.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    match uris.as_slice() {
+        [uri] => Ok((*uri).to_string()),
+        _ => Err(GatewayTlsError::InvalidClientIdentity),
+    }
+}
+
+#[derive(Debug)]
+struct GatewayClientVerifier {
+    inner: Arc<dyn ClientCertVerifier>,
+    trust_domain: String,
+    identities: HashMap<String, AuthenticatedPrincipal>,
+}
+
+impl ClientCertVerifier for GatewayClientVerifier {
+    fn client_auth_mandatory(&self) -> bool {
+        self.inner.client_auth_mandatory()
+    }
+
+    fn root_hint_subjects(&self) -> &[rustls::DistinguishedName] {
+        self.inner.root_hint_subjects()
+    }
+
+    fn verify_client_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        now: UnixTime,
+    ) -> Result<ClientCertVerified, rustls::Error> {
+        self.inner
+            .verify_client_cert(end_entity, intermediates, now)?;
+        let uri = certificate_uri(end_entity)
+            .map_err(|error| rustls::Error::General(error.to_string()))?;
+        if !valid_workload_uri(&uri, &self.trust_domain) || !self.identities.contains_key(&uri) {
+            return Err(rustls::Error::General(
+                "gateway TLS client identity is not authorized".into(),
+            ));
+        }
+        Ok(ClientCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        self.inner.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        self.inner.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.inner.supported_verify_schemes()
+    }
+}
+
+fn load_server_config(config: &GatewayTlsConfig) -> Result<LoadedServerConfig, GatewayTlsError> {
     let certificates = CertificateDer::pem_file_iter(&config.certificate_path)
         .map_err(|_| GatewayTlsError::InvalidCertificateChain)?
         .collect::<Result<Vec<_>, _>>()
@@ -218,12 +516,20 @@ fn load_server_config(config: &GatewayTlsConfig) -> Result<ServerConfig, Gateway
     }
     let key = PrivateKeyDer::from_pem_file(&config.private_key_path)
         .map_err(|_| GatewayTlsError::InvalidPrivateKey)?;
-    let mut server = ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
-        .with_no_client_auth()
+    let builder = ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13]);
+    let builder = if let Some(client_auth) = &config.client_auth {
+        builder.with_client_cert_verifier(client_verifier(client_auth)?)
+    } else {
+        builder.with_no_client_auth()
+    };
+    let mut server = builder
         .with_single_cert(certificates, key)
         .map_err(|_| GatewayTlsError::IncompatibleKey)?;
     server.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
-    Ok(server)
+    Ok(LoadedServerConfig {
+        server,
+        client_auth: config.client_auth.clone(),
+    })
 }
 
 #[cfg(test)]
@@ -236,20 +542,27 @@ mod tests {
     use axum::extract::Request;
     use base64::engine::general_purpose::STANDARD;
     use base64::Engine as _;
+    use talon_core::{Backend, ObjectId};
     use tempfile::TempDir;
 
     use super::*;
     use crate::{
-        serve_tls, AuthenticatedPrincipal, AuthorizationPolicy, GatewayAdapter,
-        GatewayAuthenticationError, GatewayAuthenticator, GatewayConfig, GatewayMode,
-        GatewayOperation, GatewayRequestContext, GatewayResponse, GatewayRuntime, GatewaySecurity,
-        ProviderProtocol,
+        serve_tls, AuthenticatedPrincipal, AuthorizationGrant, AuthorizationPolicy, GatewayAccess,
+        GatewayAdapter, GatewayAuthenticationError, GatewayAuthenticator, GatewayConfig,
+        GatewayMode, GatewayOperation, GatewayRequestContext, GatewayResponse, GatewayRuntime,
+        GatewaySecurity, GatewayTarget, ProviderProtocol,
     };
 
     const CERT_DER: &[u8] =
         include_bytes!("../../talon-transport/tests/fixtures/control_tls/coordinator.der");
     const KEY_DER: &[u8] =
         include_bytes!("../../talon-transport/tests/fixtures/control_tls/coordinator-key.der");
+    const CA_DER: &[u8] = include_bytes!("../../talon-transport/tests/fixtures/control_tls/ca.der");
+    const CLIENT_DER: &[u8] =
+        include_bytes!("../../talon-transport/tests/fixtures/control_tls/worker.der");
+    const CLIENT_KEY_DER: &[u8] =
+        include_bytes!("../../talon-transport/tests/fixtures/control_tls/worker-key.der");
+    const CLIENT_URI: &str = "spiffe://cluster.example/talon/cluster-a/worker/worker-1";
 
     struct Adapter;
 
@@ -269,6 +582,22 @@ mod tests {
     impl GatewayAdapter for Adapter {
         fn protocol(&self) -> ProviderProtocol {
             ProviderProtocol::S3
+        }
+
+        fn access(
+            &self,
+            _request: &Request,
+            _context: &GatewayRequestContext,
+        ) -> Result<GatewayAccess, Box<GatewayResponse>> {
+            Ok(GatewayAccess {
+                operation: GatewayOperation::Read,
+                provider_account: Some("account-a".into()),
+                target: GatewayTarget::Object(ObjectId::new(
+                    Backend::S3,
+                    "bucket-a",
+                    "tenant/object",
+                )),
+            })
         }
 
         async fn handle(
@@ -301,7 +630,157 @@ mod tests {
             reload_interval: Duration::from_millis(20),
             handshake_timeout: Duration::from_millis(200),
             max_concurrent_handshakes: 8,
+            client_auth: None,
         }
+    }
+
+    fn configure_client_auth(
+        root: &Path,
+        config: &mut GatewayTlsConfig,
+        mode: GatewayClientAuthMode,
+        uri_san: &str,
+    ) {
+        let ca_certificate_path = root.join("client-ca.pem");
+        fs::write(&ca_certificate_path, pem("CERTIFICATE", CA_DER)).unwrap();
+        config.client_auth = Some(GatewayClientAuthConfig {
+            ca_certificate_path,
+            mode,
+            trust_domain: "cluster.example".into(),
+            identities: vec![GatewayMtlsIdentity {
+                uri_san: uri_san.into(),
+                principal: AuthenticatedPrincipal::new("worker-reader", "account-a"),
+            }],
+        });
+    }
+
+    fn https_client(with_identity: bool) -> reqwest::Client {
+        let mut builder = reqwest::Client::builder().danger_accept_invalid_certs(true);
+        if with_identity {
+            let identity = format!(
+                "{}{}",
+                pem("CERTIFICATE", CLIENT_DER),
+                pem("PRIVATE KEY", CLIENT_KEY_DER)
+            );
+            builder = builder.identity(reqwest::Identity::from_pem(identity.as_bytes()).unwrap());
+        }
+        builder.build().unwrap()
+    }
+
+    fn mtls_runtime(address: std::net::SocketAddr) -> Arc<GatewayRuntime> {
+        let runtime = Arc::new(
+            GatewayRuntime::new(
+                GatewayConfig {
+                    bind: address,
+                    mode: GatewayMode::Production,
+                    ..GatewayConfig::default()
+                },
+                Arc::new(Adapter),
+                GatewaySecurity::default(),
+            )
+            .unwrap(),
+        );
+        runtime.install_authorization(
+            AuthorizationPolicy::new(vec![AuthorizationGrant {
+                id: "worker-read".into(),
+                principal: "worker-reader".into(),
+                protocol: ProviderProtocol::S3,
+                provider_account: "account-a".into(),
+                namespace: "bucket-a".into(),
+                prefix: Some("tenant/".into()),
+                operations: vec![GatewayOperation::Read],
+            }])
+            .unwrap(),
+        );
+        runtime
+    }
+
+    #[tokio::test]
+    async fn required_mtls_rejects_anonymous_and_dispatches_mapped_identity() {
+        let temp = TempDir::new().unwrap();
+        let mut tls = write_material(temp.path());
+        configure_client_auth(
+            temp.path(),
+            &mut tls,
+            GatewayClientAuthMode::Required,
+            CLIENT_URI,
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let runtime = mtls_runtime(address);
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let server_runtime = Arc::clone(&runtime);
+        let server = tokio::spawn(async move {
+            serve_tls(listener, server_runtime, tls, async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+        });
+
+        assert!(https_client(false)
+            .get(format!("https://{address}/tenant/object"))
+            .send()
+            .await
+            .is_err());
+        let response = https_client(true)
+            .get(format!("https://{address}/tenant/object"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert!(runtime.readiness().is_ready());
+
+        shutdown_tx.send(()).unwrap();
+        server.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn optional_mtls_accepts_anonymous_but_rejects_unmapped_certificates() {
+        let temp = TempDir::new().unwrap();
+        let mut optional = write_material(temp.path());
+        configure_client_auth(
+            temp.path(),
+            &mut optional,
+            GatewayClientAuthMode::Optional,
+            CLIENT_URI,
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let metrics = GatewayMetrics::new();
+        let mut tls = GatewayTlsListener::load(listener, optional, metrics).unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = tls.accept().await;
+            drop(stream);
+        });
+        assert!(https_client(false)
+            .get(format!("https://{address}"))
+            .send()
+            .await
+            .is_err());
+        server.await.unwrap();
+
+        let mut unmapped = write_material(temp.path());
+        configure_client_auth(
+            temp.path(),
+            &mut unmapped,
+            GatewayClientAuthMode::Required,
+            "spiffe://cluster.example/talon/cluster-a/worker/other",
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let metrics = GatewayMetrics::new();
+        let mut tls = GatewayTlsListener::load(listener, unmapped, metrics).unwrap();
+        let server = tokio::spawn(async move {
+            tokio::select! {
+                _ = tls.accept() => {},
+                _ = tokio::time::sleep(Duration::from_millis(500)) => {},
+            }
+        });
+        assert!(https_client(true)
+            .get(format!("https://{address}"))
+            .send()
+            .await
+            .is_err());
+        server.await.unwrap();
     }
 
     #[tokio::test]
@@ -367,14 +846,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalid_reload_retains_last_good_material_and_is_counted() {
+    async fn invalid_client_ca_reload_retains_last_good_material_and_is_counted() {
         let temp = TempDir::new().unwrap();
-        let config = write_material(temp.path());
+        let mut config = write_material(temp.path());
+        configure_client_auth(
+            temp.path(),
+            &mut config,
+            GatewayClientAuthMode::Required,
+            CLIENT_URI,
+        );
+        let client_ca_path = config
+            .client_auth
+            .as_ref()
+            .unwrap()
+            .ca_certificate_path
+            .clone();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let metrics = GatewayMetrics::new();
         let mut tls = GatewayTlsListener::load(listener, config.clone(), metrics.clone()).unwrap();
-        fs::write(&config.private_key_path, "not a private key").unwrap();
+        fs::write(&client_ca_path, "not a certificate").unwrap();
 
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {
@@ -387,7 +878,7 @@ mod tests {
         .await
         .unwrap();
 
-        fs::write(&config.private_key_path, pem("PRIVATE KEY", KEY_DER)).unwrap();
+        fs::write(&client_ca_path, pem("CERTIFICATE", CA_DER)).unwrap();
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {
                 if metrics.render().contains("event=\"reload_success\"") {
@@ -399,10 +890,7 @@ mod tests {
         .await
         .unwrap();
 
-        let client = reqwest::Client::builder()
-            .danger_accept_invalid_certs(true)
-            .build()
-            .unwrap();
+        let client = https_client(true);
         let server = tokio::spawn(async move {
             let (stream, _) = tls.accept().await;
             drop(stream);
@@ -435,5 +923,23 @@ mod tests {
         config.handshake_timeout = Duration::from_secs(1);
         config.max_concurrent_handshakes = 0;
         assert_eq!(config.validate(), Err(GatewayTlsError::ZeroHandshakeLimit));
+    }
+
+    #[test]
+    fn workload_uris_require_an_exact_portless_trust_domain_and_path() {
+        assert!(valid_workload_uri(CLIENT_URI, "cluster.example"));
+        assert!(!valid_workload_uri(CLIENT_URI, "other.example"));
+        assert!(!valid_workload_uri(
+            "spiffe://cluster.example:443/talon/worker",
+            "cluster.example"
+        ));
+        assert!(!valid_workload_uri(
+            "spiffe://cluster.example/",
+            "cluster.example"
+        ));
+        assert!(!valid_workload_uri(
+            "https://cluster.example/talon/worker",
+            "cluster.example"
+        ));
     }
 }

--- a/docs/operations/object-store-gateway.md
+++ b/docs/operations/object-store-gateway.md
@@ -8,8 +8,9 @@ metadata and fallback reads.
 
 ## Security state
 
-S3 SigV4 and Azure Shared Key/SAS authentication plus namespace authorization
-are available. This has the following enforced consequences:
+S3 SigV4, Azure Shared Key/SAS, and URI-SAN client-certificate authentication
+plus namespace authorization are available. This has the following enforced
+consequences:
 
 - `development` mode only binds loopback. It is suitable for an application
   sidecar in the same network namespace.
@@ -18,8 +19,9 @@ are available. This has the following enforced consequences:
   authorization are installed. S3 requires both configuration files documented
   below.
 
-Only a validated provider identity that maps to an explicit allow grant can
-pass the production data plane.
+Only a validated provider or mTLS identity that maps to an explicit allow grant
+can pass the production data plane. When both identity forms are present, both
+must map to exactly the same principal and provider account.
 
 ## Credential boundary
 
@@ -61,12 +63,45 @@ Common variables:
 | `TALON_GATEWAY_TLS_RELOAD_MS` | `5000` | Last-good certificate/key reload interval. |
 | `TALON_GATEWAY_TLS_HANDSHAKE_TIMEOUT_MS` | `10000` | Maximum TLS handshake time per connection. |
 | `TALON_GATEWAY_TLS_MAX_HANDSHAKES` | `256` | Maximum concurrent pre-HTTP TLS handshakes. |
+| `TALON_GATEWAY_TLS_CLIENT_AUTH` | `off` | `off`, `optional`, or `required` client-certificate mode. |
+| `TALON_GATEWAY_TLS_CLIENT_CA_PATH` | unset | PEM client trust-anchor bundle; required when client auth is enabled. |
+| `TALON_GATEWAY_TLS_TRUST_DOMAIN` | unset | Exact SPIFFE URI SAN trust domain. |
+| `TALON_GATEWAY_MTLS_IDENTITIES_PATH` | unset | JSON URI SAN to principal mapping file. |
 | `TALON_GATEWAY_AUTHORIZATION_PATH` | unset | JSON allow-grant file. Required for production readiness. |
 
 The listener permits TLS 1.3 only and advertises HTTP/2 and HTTP/1.1. A bad
 rotation increments `talon_gateway_tls_events_total{event="reload_failure"}`
 and retains the previous valid material. Plaintext and stalled handshakes are
 discarded before HTTP dispatch and counted with bounded event labels.
+
+Client authentication validates the certificate chain, validity period, and
+client-authentication usage. The leaf must contain exactly one URI SAN, use the
+configured `spiffe://` trust domain, and match an explicit mapping:
+
+```json
+{
+  "identities": [
+    {
+      "uri_san": "spiffe://cluster.example/talon/cluster-a/worker/worker-1",
+      "principal": "analytics-reader",
+      "provider_account": "tenant-a"
+    }
+  ]
+}
+```
+
+`required` mTLS can satisfy production authentication readiness without a
+provider identity file. `optional` only controls the TLS handshake and still
+requires a provider authenticator for readiness. A request with both a provider
+credential and client certificate is denied unless their mappings agree. CA
+bundles may contain old and new trust anchors during rotation; invalid reloads
+retain the complete last-good server and client-auth configuration.
+
+Authentication and authorization decisions emit `gateway security audit`
+events with request ID, protocol, operation, decision, and bounded reason.
+Principal and resource identifiers are truncated SHA-256 values; credentials,
+certificate contents, account names, buckets, containers, and object paths are
+not emitted.
 
 S3 variables:
 


### PR DESCRIPTION
## Summary

- add optional and required TLS client-certificate verification with exact SPIFFE URI SAN mappings
- combine provider credentials and mTLS identities with fail-closed principal matching
- emit bounded security audit events with hashed principal and resource identifiers
- reload server and client trust material atomically with last-good fallback
- document deployment settings, CA overlap rotation, and audit behavior

## Verification

- `just ci`
- `cargo deny check advisories bans sources`
- `mdbook build docs/book`
- `just spell`
- `just linkcheck`
- `git diff --check`

Closes #495