### PR TITLE
feat(gateway): pass through S3 object mutations

### DIFF
--- a/crates/talon-backend/src/delay.rs
+++ b/crates/talon-backend/src/delay.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 
-use crate::http::{HttpClient, HttpRequest, HttpResponse};
+use crate::http::{HttpClient, HttpRequest, HttpRequestBody, HttpResponse};
 
 /// Tunable latency model applied by [`DelayingHttpClient`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -141,6 +141,20 @@ impl HttpClient for DelayingHttpClient {
             tokio::time::sleep(delay).await;
         }
         Ok(resp)
+    }
+
+    async fn execute_body(
+        &self,
+        req: HttpRequest,
+        body: HttpRequestBody,
+        len: u64,
+    ) -> Result<HttpResponse, String> {
+        let response = self.inner.execute_body(req, body, len).await?;
+        let delay = self.delay_for(response.body.len());
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
+        Ok(response)
     }
 }
 

--- a/crates/talon-backend/src/http.rs
+++ b/crates/talon-backend/src/http.rs
@@ -95,6 +95,9 @@ pub struct HttpStreamResponse {
     pub body: Pin<Box<dyn Stream<Item = Result<Bytes, String>> + Send>>,
 }
 
+/// Single-use, demand-driven outgoing request body.
+pub type HttpRequestBody = Pin<Box<dyn Stream<Item = Result<Bytes, String>> + Send>>;
+
 impl HttpStreamResponse {
     /// Look up the first response header value (case-insensitive).
     pub fn header(&self, name: &str) -> Option<&str> {
@@ -273,6 +276,20 @@ pub trait HttpClient: Send + Sync {
     ) -> Result<HttpResponse, String> {
         let _ = (req, path, len);
         Err("HTTP client does not support streamed file bodies".to_string())
+    }
+
+    /// Execute a request with a single-use streaming body.
+    ///
+    /// Implementations must not retry or eagerly collect `body`. Exactly `len`
+    /// bytes must be forwarded before the origin response is accepted.
+    async fn execute_body(
+        &self,
+        req: HttpRequest,
+        body: HttpRequestBody,
+        len: u64,
+    ) -> Result<HttpResponse, String> {
+        let _ = (req, body, len);
+        Err("HTTP client does not support streamed request bodies".to_string())
     }
 }
 

--- a/crates/talon-backend/src/lib.rs
+++ b/crates/talon-backend/src/lib.rs
@@ -20,7 +20,9 @@ pub mod xml;
 pub use azure::{AzureBackend, AzureConfig};
 pub use delay::{DelayConfig, DelayingHttpClient};
 pub use gcs::{GcsBackend, GcsConfig};
-pub use http::{HttpClient, HttpRequest, HttpResponse, HttpStreamResponse, Method};
+pub use http::{
+    HttpClient, HttpRequest, HttpRequestBody, HttpResponse, HttpStreamResponse, Method,
+};
 pub use reqwest_client::ReqwestClient;
 pub use retry::{RetryConfig, RetryObserver, RetryingHttpClient};
 pub use s3::{S3Backend, S3Config, S3Credentials};

--- a/crates/talon-backend/src/reqwest_client.rs
+++ b/crates/talon-backend/src/reqwest_client.rs
@@ -17,7 +17,9 @@ use std::path::Path;
 use tokio::io::AsyncReadExt;
 use tokio_util::io::ReaderStream;
 
-use crate::http::{HttpClient, HttpRequest, HttpResponse, HttpStreamResponse, Method};
+use crate::http::{
+    HttpClient, HttpRequest, HttpRequestBody, HttpResponse, HttpStreamResponse, Method,
+};
 
 /// Cap on establishing a TCP+TLS connection. Independent of transfer size, so a
 /// slow connect always indicates a fault rather than a large object.
@@ -177,6 +179,46 @@ impl HttpClient for ReqwestClient {
             .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
             .collect();
         let body = resp.bytes().await.map_err(sanitize_error)?;
+        Ok(HttpResponse {
+            status,
+            headers,
+            body,
+        })
+    }
+
+    async fn execute_body(
+        &self,
+        req: HttpRequest,
+        body: HttpRequestBody,
+        len: u64,
+    ) -> Result<HttpResponse, String> {
+        let method = match req.method {
+            Method::Get => reqwest::Method::GET,
+            Method::Head => reqwest::Method::HEAD,
+            Method::Put => reqwest::Method::PUT,
+            Method::Delete => reqwest::Method::DELETE,
+        };
+        let mut builder = self.inner.request(method, &req.url);
+        for (key, value) in &req.headers {
+            builder = builder.header(key.as_str(), value.as_str());
+        }
+        let forwarded = body.map(|chunk| chunk.map_err(std::io::Error::other));
+        builder = builder
+            .header(reqwest::header::CONTENT_LENGTH, len)
+            .body(reqwest::Body::wrap_stream(forwarded));
+        let response = builder.send().await.map_err(sanitize_error)?;
+        let status = response.status().as_u16();
+        let headers = response
+            .headers()
+            .iter()
+            .map(|(key, value)| {
+                (
+                    key.as_str().to_string(),
+                    value.to_str().unwrap_or("").to_string(),
+                )
+            })
+            .collect();
+        let body = response.bytes().await.map_err(sanitize_error)?;
         Ok(HttpResponse {
             status,
             headers,

--- a/crates/talon-backend/src/retry.rs
+++ b/crates/talon-backend/src/retry.rs
@@ -49,7 +49,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 
-use crate::http::{HttpClient, HttpRequest, HttpResponse};
+use crate::http::{HttpClient, HttpRequest, HttpRequestBody, HttpResponse};
 
 /// Statuses worth another attempt: request timeout, throttling, and the
 /// transient server-side 5xx set. Deliberately excludes `501 Not Implemented`
@@ -317,6 +317,24 @@ impl HttpClient for RetryingHttpClient {
             attempt += 1;
         }
     }
+
+    async fn execute_body(
+        &self,
+        req: HttpRequest,
+        body: HttpRequestBody,
+        len: u64,
+    ) -> Result<HttpResponse, String> {
+        let timeout = self.config.attempt_timeout(len);
+        match tokio::time::timeout(timeout, self.inner.execute_body(req, body, len)).await {
+            Ok(result) => result,
+            Err(_) => {
+                if let Some(observer) = &self.observer {
+                    observer.on_timeout();
+                }
+                Err(format!("request timed out after {timeout:?}"))
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -379,6 +397,15 @@ mod tests {
                 Err(e) => Err(e.clone()),
             }
         }
+
+        async fn execute_body(
+            &self,
+            req: HttpRequest,
+            _body: HttpRequestBody,
+            _len: u64,
+        ) -> Result<HttpResponse, String> {
+            self.execute(req).await
+        }
     }
 
     /// A client that never responds, to exercise the deadline.
@@ -440,6 +467,22 @@ mod tests {
 
     fn client(inner: Arc<dyn HttpClient>) -> RetryingHttpClient {
         RetryingHttpClient::new(inner, RetryConfig::default(), 7)
+    }
+
+    #[tokio::test]
+    async fn single_use_stream_is_never_retried() {
+        let inner = ScriptedHttp::new(vec![Ok(503), Ok(200)]);
+        let body = futures::stream::once(async { Ok(bytes::Bytes::from_static(b"payload")) });
+        let response = client(Arc::clone(&inner) as Arc<dyn HttpClient>)
+            .execute_body(
+                HttpRequest::new(Method::Put, "https://origin/o".into(), Vec::new()),
+                Box::pin(body),
+                7,
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status, 503);
+        assert_eq!(inner.calls(), 1);
     }
 
     // ── classification ───────────────────────────────────────────────

--- a/crates/talon-backend/src/s3.rs
+++ b/crates/talon-backend/src/s3.rs
@@ -22,7 +22,9 @@ use talon_core::{
     BackendStore, Error, ListPage, ListedObject, ObjectId, ObjectStat, Result, Version,
 };
 
-use crate::http::{HttpClient, HttpRequest, HttpResponse, HttpStreamResponse, Method};
+use crate::http::{
+    HttpClient, HttpRequest, HttpRequestBody, HttpResponse, HttpStreamResponse, Method,
+};
 
 /// Percent-encode a query value.
 ///
@@ -351,6 +353,60 @@ impl S3Backend {
         self.http.execute(self.signed(request)).await
     }
 
+    /// Execute a single-use streaming PUT. The payload declaration is signed
+    /// by the scoped origin credential and the body is never retried here.
+    pub async fn execute_put_body_raw(
+        &self,
+        obj: &ObjectId,
+        headers: &[(String, String)],
+        body: HttpRequestBody,
+        len: u64,
+        payload_hash: &str,
+    ) -> std::result::Result<HttpResponse, String> {
+        let mut request = self.build_streamed_put(obj, len, None);
+        request.headers.extend_from_slice(headers);
+        let request = self.signed_with_payload_hash(request, payload_hash);
+        self.http.execute_body(request, body, len).await
+    }
+
+    /// Execute a PUT from a verified spool file without buffering it in memory.
+    pub async fn execute_put_file_raw(
+        &self,
+        obj: &ObjectId,
+        headers: &[(String, String)],
+        path: &Path,
+        len: u64,
+        payload_hash: &str,
+    ) -> std::result::Result<HttpResponse, String> {
+        let mut request = self.build_streamed_put(obj, len, None);
+        request.headers.extend_from_slice(headers);
+        let request = self.signed_with_payload_hash(request, payload_hash);
+        self.http.execute_file(request, path, len).await
+    }
+
+    /// Execute CopyObject. `headers` contains only adapter-validated copy and
+    /// metadata headers; incoming client credentials are never accepted here.
+    pub async fn execute_copy_raw(
+        &self,
+        obj: &ObjectId,
+        headers: &[(String, String)],
+    ) -> std::result::Result<HttpResponse, String> {
+        let mut request = self.build_streamed_put(obj, 0, None);
+        request.headers.extend_from_slice(headers);
+        self.http.execute(self.signed(request)).await
+    }
+
+    /// Execute an idempotent raw object DELETE with validated conditions.
+    pub async fn execute_delete_raw(
+        &self,
+        obj: &ObjectId,
+        conditions: &[(String, String)],
+    ) -> std::result::Result<HttpResponse, String> {
+        let mut request = self.build_delete(obj);
+        request.headers.extend_from_slice(conditions);
+        self.http.execute(self.signed(request)).await
+    }
+
     fn build_streamed_put(
         &self,
         obj: &ObjectId,
@@ -622,6 +678,7 @@ mod tests {
     struct MockHttp {
         last: Mutex<Option<HttpRequest>>,
         last_file: Mutex<Option<(HttpRequest, PathBuf, u64)>>,
+        last_body: Mutex<Option<(HttpRequest, Vec<u8>, u64)>>,
         response: HttpResponse,
     }
 
@@ -630,6 +687,7 @@ mod tests {
             Arc::new(Self {
                 last: Mutex::new(None),
                 last_file: Mutex::new(None),
+                last_body: Mutex::new(None),
                 response,
             })
         }
@@ -649,6 +707,21 @@ mod tests {
             len: u64,
         ) -> std::result::Result<HttpResponse, String> {
             *self.last_file.lock().unwrap() = Some((req, path.to_path_buf(), len));
+            Ok(self.response.clone())
+        }
+
+        async fn execute_body(
+            &self,
+            req: HttpRequest,
+            mut body: HttpRequestBody,
+            len: u64,
+        ) -> std::result::Result<HttpResponse, String> {
+            use futures::StreamExt as _;
+            let mut bytes = Vec::new();
+            while let Some(chunk) = body.next().await {
+                bytes.extend_from_slice(&chunk?);
+            }
+            *self.last_body.lock().unwrap() = Some((req, bytes, len));
             Ok(self.response.clone())
         }
     }
@@ -1125,5 +1198,60 @@ mod tests {
             .unwrap();
         let req = http.last.lock().unwrap().clone().unwrap();
         assert!(req.url.contains("max-keys=1000"), "url: {}", req.url);
+    }
+
+    #[tokio::test]
+    async fn raw_streamed_put_is_resigned_and_preserves_metadata() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: vec![("etag".into(), "\"v2\"".into())],
+            body: bytes::Bytes::new(),
+        });
+        let backend = S3Backend::new(S3Config::aws("us-east-1"), creds(), http.clone());
+        let body = futures::stream::iter([Ok(bytes::Bytes::from_static(b"abc"))]);
+        backend
+            .execute_put_body_raw(
+                &obj(),
+                &[("x-amz-meta-owner".into(), "team-a".into())],
+                Box::pin(body),
+                3,
+                "UNSIGNED-PAYLOAD",
+            )
+            .await
+            .unwrap();
+
+        let (request, body, len) = http.last_body.lock().unwrap().clone().unwrap();
+        assert_eq!(body, b"abc");
+        assert_eq!(len, 3);
+        assert_eq!(
+            request.header("x-amz-content-sha256"),
+            Some("UNSIGNED-PAYLOAD")
+        );
+        assert_eq!(request.header("x-amz-meta-owner"), Some("team-a"));
+        let authorization = request.header("authorization").unwrap();
+        assert!(authorization.contains("x-amz-meta-owner"));
+    }
+
+    #[tokio::test]
+    async fn copy_source_is_signed_with_origin_credentials() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: bytes::Bytes::new(),
+        });
+        let backend = S3Backend::new(S3Config::aws("us-east-1"), creds(), http.clone());
+        backend
+            .execute_copy_raw(
+                &obj(),
+                &[("x-amz-copy-source".into(), "/source/key".into())],
+            )
+            .await
+            .unwrap();
+        let request = http.last.lock().unwrap().clone().unwrap();
+        assert_eq!(request.header("x-amz-copy-source"), Some("/source/key"));
+        assert!(request
+            .header("authorization")
+            .unwrap()
+            .contains("x-amz-copy-source"));
     }
 }

--- a/crates/talon-backend/src/sigv4.rs
+++ b/crates/talon-backend/src/sigv4.rs
@@ -47,6 +47,10 @@ fn to_hex(bytes: &[u8]) -> String {
     s
 }
 
+fn normalize_header_value(value: &str) -> String {
+    value.split_ascii_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 /// RFC 3986 encode a path, preserving `/`. Unreserved chars pass through; all
 /// others are percent-encoded. S3 canonical URIs are single-encoded.
 fn uri_encode_path(path: &str) -> String {
@@ -243,11 +247,23 @@ pub fn sign_request_with_payload_hash(
     }
 
     // Canonical headers: the signed set, lowercased, sorted, trimmed values.
-    let mut signed: Vec<(String, String)> = vec![
+    let mut signed: Vec<(String, String)> = req
+        .headers
+        .iter()
+        .filter(|(name, _)| {
+            name.to_ascii_lowercase().starts_with("x-amz-")
+                && !matches!(
+                    name.to_ascii_lowercase().as_str(),
+                    "x-amz-date" | "x-amz-content-sha256" | "x-amz-security-token"
+                )
+        })
+        .map(|(name, value)| (name.to_ascii_lowercase(), normalize_header_value(value)))
+        .collect();
+    signed.extend([
         ("host".into(), host),
         ("x-amz-content-sha256".into(), payload_hash.to_string()),
         ("x-amz-date".into(), date.datetime.clone()),
-    ];
+    ]);
     if let Some(tok) = &creds.session_token {
         signed.push(("x-amz-security-token".into(), tok.clone()));
     }
@@ -259,7 +275,7 @@ pub fn sign_request_with_payload_hash(
         .join(";");
     let canonical_headers = signed
         .iter()
-        .map(|(k, v)| format!("{k}:{}\n", v.trim()))
+        .map(|(k, v)| format!("{k}:{}\n", normalize_header_value(v)))
         .collect::<String>();
 
     let canonical_request = format!(

--- a/crates/talon-cache-client/src/block_reader.rs
+++ b/crates/talon-cache-client/src/block_reader.rs
@@ -142,6 +142,11 @@ impl BlockReader {
         self.coordinator.addr()
     }
 
+    /// Drop all local placement entries for an object after an origin mutation.
+    pub fn invalidate_object(&self, object: &ObjectId) -> usize {
+        self.cache.invalidate_object(object)
+    }
+
     /// The read-path counters this reader updates.
     pub fn stats(&self) -> &ReadStats {
         &self.stats

--- a/crates/talon-cache-client/src/placement_cache.rs
+++ b/crates/talon-cache-client/src/placement_cache.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 
 use crate::lock::RwLockExt;
-use talon_core::BlockId;
+use talon_core::{BlockId, ObjectId};
 
 /// Why a cached placement entry was (or should be) invalidated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -113,6 +113,14 @@ impl PlacementCache {
         self.entries.write_recover().remove(block).is_some()
     }
 
+    /// Invalidate every cached placement for an object after a committed mutation.
+    pub fn invalidate_object(&self, object: &ObjectId) -> usize {
+        let mut entries = self.entries.write_recover();
+        let before = entries.len();
+        entries.retain(|block, _| &block.object != object);
+        before - entries.len()
+    }
+
     /// Reconcile against an observed placement version: if the cached entry's
     /// version differs from `observed_epoch`, drop it so the next access
     /// re-ranks against membership.
@@ -199,6 +207,23 @@ mod tests {
             // Second invalidate is a no-op.
             assert!(!c.invalidate(&block(2), reason));
         }
+    }
+
+    #[test]
+    fn object_invalidation_removes_every_version_and_only_that_object() {
+        let c = PlacementCache::new(1000);
+        let first = block(1);
+        let mut second_version = first.clone();
+        second_version.version = Version::new("v2");
+        let other = block(2);
+        c.insert(first.clone(), cached(1, &["a"]), 0);
+        c.insert(second_version.clone(), cached(1, &["b"]), 0);
+        c.insert(other.clone(), cached(1, &["c"]), 0);
+
+        assert_eq!(c.invalidate_object(&first.object), 2);
+        assert!(c.get(&first, 0).is_none());
+        assert!(c.get(&second_version, 0).is_none());
+        assert!(c.get(&other, 0).is_some());
     }
 
     #[test]

--- a/crates/talon-gateway/Cargo.toml
+++ b/crates/talon-gateway/Cargo.toml
@@ -23,6 +23,7 @@ percent-encoding.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+tempfile.workspace = true
 rustls.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
@@ -36,4 +37,3 @@ x509-cert.workspace = true
 
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
-tempfile.workspace = true

--- a/crates/talon-gateway/src/audit.rs
+++ b/crates/talon-gateway/src/audit.rs
@@ -73,32 +73,64 @@ fn principal_hash(principal: &AuthenticatedPrincipal) -> String {
 }
 
 fn resource_hash(access: &GatewayAccess) -> String {
-    match &access.target {
-        GatewayTarget::Object(object) => hash_parts(&[
-            access.provider_account.as_deref().unwrap_or(""),
-            object.backend.prefix(),
-            &object.bucket,
-            &object.object_path,
-        ]),
+    let mut hash = Sha256::new();
+    hash_requirement(
+        &mut hash,
+        access.operation,
+        access.provider_account.as_deref(),
+        &access.target,
+    );
+    for requirement in &access.additional {
+        hash_requirement(
+            &mut hash,
+            requirement.operation,
+            requirement.provider_account.as_deref(),
+            &requirement.target,
+        );
+    }
+    truncate_hash(hash)
+}
+
+fn hash_requirement(
+    hash: &mut Sha256,
+    operation: crate::GatewayOperation,
+    provider_account: Option<&str>,
+    target: &GatewayTarget,
+) {
+    update_hash(hash, operation.label());
+    update_hash(hash, provider_account.unwrap_or(""));
+    match target {
+        GatewayTarget::Object(object) => {
+            update_hash(hash, object.backend.prefix());
+            update_hash(hash, &object.bucket);
+            update_hash(hash, &object.object_path);
+        }
         GatewayTarget::Namespace {
             backend,
             namespace,
             prefix,
-        } => hash_parts(&[
-            access.provider_account.as_deref().unwrap_or(""),
-            backend.prefix(),
-            namespace,
-            prefix.as_deref().unwrap_or(""),
-        ]),
+        } => {
+            update_hash(hash, backend.prefix());
+            update_hash(hash, namespace);
+            update_hash(hash, prefix.as_deref().unwrap_or(""));
+        }
     }
 }
 
 fn hash_parts(parts: &[&str]) -> String {
     let mut hash = Sha256::new();
     for part in parts {
-        hash.update((part.len() as u64).to_be_bytes());
-        hash.update(part.as_bytes());
+        update_hash(&mut hash, part);
     }
+    truncate_hash(hash)
+}
+
+fn update_hash(hash: &mut Sha256, part: &str) {
+    hash.update((part.len() as u64).to_be_bytes());
+    hash.update(part.as_bytes());
+}
+
+fn truncate_hash(hash: Sha256) -> String {
     let digest = hash.finalize();
     let mut output = String::with_capacity(32);
     for byte in &digest[..16] {
@@ -126,6 +158,7 @@ mod tests {
                 "private-bucket",
                 "customer/path.txt",
             )),
+            additional: Vec::new(),
         };
         let event = SecurityAuditEvent::new(
             "request-id",
@@ -146,5 +179,26 @@ mod tests {
         ] {
             assert!(!rendered.contains(secret));
         }
+    }
+
+    #[test]
+    fn copy_source_changes_resource_hash_without_being_exposed() {
+        let mut first = GatewayAccess {
+            operation: GatewayOperation::Write,
+            provider_account: Some("account-secret".into()),
+            target: GatewayTarget::Object(ObjectId::new(Backend::S3, "dst", "object")),
+            additional: vec![crate::GatewayAccessRequirement {
+                operation: GatewayOperation::Read,
+                provider_account: Some("account-secret".into()),
+                target: GatewayTarget::Object(ObjectId::new(Backend::S3, "src", "first")),
+            }],
+        };
+        let first_hash = resource_hash(&first);
+        first.additional[0].target =
+            GatewayTarget::Object(ObjectId::new(Backend::S3, "src", "second-secret"));
+        let second_hash = resource_hash(&first);
+        assert_ne!(first_hash, second_hash);
+        assert_eq!(first_hash.len(), 32);
+        assert_eq!(second_hash.len(), 32);
     }
 }

--- a/crates/talon-gateway/src/authorization.rs
+++ b/crates/talon-gateway/src/authorization.rs
@@ -94,27 +94,48 @@ impl AuthorizationPolicy {
         protocol: ProviderProtocol,
         access: &GatewayAccess,
     ) -> bool {
-        if access
-            .provider_account
-            .as_deref()
-            .is_some_and(|account| account != principal.provider_account)
-        {
-            return false;
-        }
-        let (backend, namespace, requested_prefix) = target_parts(&access.target);
-        if backend != protocol_backend(protocol) {
-            return false;
-        }
         let current = self.current.read().unwrap().clone();
-        current.grants.iter().any(|grant| {
+        allows_requirement(
+            &current,
+            principal,
+            protocol,
+            access.operation,
+            access.provider_account.as_deref(),
+            &access.target,
+        ) && access.additional.iter().all(|requirement| {
+            allows_requirement(
+                &current,
+                principal,
+                protocol,
+                requirement.operation,
+                requirement.provider_account.as_deref(),
+                &requirement.target,
+            )
+        })
+    }
+}
+
+fn allows_requirement(
+    policy: &CompiledPolicy,
+    principal: &AuthenticatedPrincipal,
+    protocol: ProviderProtocol,
+    operation: GatewayOperation,
+    provider_account: Option<&str>,
+    target: &GatewayTarget,
+) -> bool {
+    if provider_account.is_some_and(|account| account != principal.provider_account) {
+        return false;
+    }
+    let (backend, namespace, requested_prefix) = target_parts(target);
+    backend == protocol_backend(protocol)
+        && policy.grants.iter().any(|grant| {
             grant.principal == principal.id
                 && grant.protocol == protocol
                 && grant.provider_account == principal.provider_account
                 && grant.namespace == namespace
-                && grant.operations.contains(&access.operation)
+                && grant.operations.contains(&operation)
                 && prefix_contains(grant.prefix.as_deref(), requested_prefix)
         })
-    }
 }
 
 fn target_parts(target: &GatewayTarget) -> (Backend, &str, Option<&str>) {
@@ -226,6 +247,7 @@ mod tests {
             operation,
             provider_account: None,
             target: GatewayTarget::Object(ObjectId::new(Backend::S3, namespace, key)),
+            additional: Vec::new(),
         }
     }
 
@@ -238,6 +260,7 @@ mod tests {
                 namespace: "bucket-a".into(),
                 prefix: prefix.map(str::to_string),
             },
+            additional: Vec::new(),
         }
     }
 
@@ -332,5 +355,38 @@ mod tests {
             AuthorizationPolicy::new(vec![first, duplicate_id]),
             Err(AuthorizationPolicyError::AmbiguousGrant(_))
         ));
+    }
+
+    #[test]
+    fn every_copy_resource_must_be_authorized() {
+        let mut destination = grant(None);
+        destination.operations = vec![GatewayOperation::Write];
+        let mut source = grant(None);
+        source.id = "source".into();
+        source.namespace = "bucket-b".into();
+        source.operations = vec![GatewayOperation::Read];
+        let principal = AuthenticatedPrincipal::new("principal-a", "account-a");
+        let mut copy = access("bucket-a", "copy", GatewayOperation::Write);
+        copy.additional.push(crate::GatewayAccessRequirement {
+            operation: GatewayOperation::Read,
+            provider_account: None,
+            target: GatewayTarget::Object(ObjectId::new(Backend::S3, "bucket-b", "source")),
+        });
+
+        assert!(!AuthorizationPolicy::new(vec![destination.clone()])
+            .unwrap()
+            .allows(&principal, ProviderProtocol::S3, &copy));
+        assert!(AuthorizationPolicy::new(vec![destination, source])
+            .unwrap()
+            .allows(&principal, ProviderProtocol::S3, &copy));
+
+        copy.additional[0].provider_account = Some("account-b".into());
+        assert!(
+            !AuthorizationPolicy::new(vec![grant(None)]).unwrap().allows(
+                &principal,
+                ProviderProtocol::S3,
+                &copy
+            )
+        );
     }
 }

--- a/crates/talon-gateway/src/azure.rs
+++ b/crates/talon-gateway/src/azure.rs
@@ -1427,6 +1427,7 @@ impl AzureBlobAdapter {
                     namespace: target.container,
                     prefix: query.prefix,
                 },
+                additional: Vec::new(),
             });
         }
         let blob = target.blob.ok_or_else(|| {
@@ -1443,6 +1444,7 @@ impl AzureBlobAdapter {
             operation,
             provider_account: Some(self.config.account.clone()),
             target: GatewayTarget::Object(ObjectId::new(Backend::Azure, target.container, blob)),
+            additional: Vec::new(),
         })
     }
 

--- a/crates/talon-gateway/src/lib.rs
+++ b/crates/talon-gateway/src/lib.rs
@@ -25,8 +25,9 @@ pub use cache_mark::{
 pub use config::{GatewayConfig, GatewayConfigError, GatewayMode, GatewaySecurity};
 pub use metrics::GatewayMetrics;
 pub use model::{
-    FailureReason, GatewayAccess, GatewayAdapter, GatewayOperation, GatewayOutcome,
-    GatewayRequestContext, GatewayResponse, GatewayRoute, GatewayTarget, ProviderProtocol,
+    FailureReason, GatewayAccess, GatewayAccessRequirement, GatewayAdapter, GatewayOperation,
+    GatewayOutcome, GatewayRequestContext, GatewayResponse, GatewayRoute, GatewayTarget,
+    ProviderProtocol,
 };
 pub use runtime::{
     gateway_router, serve, serve_tls, GatewayReadiness, GatewayRuntime, GatewayTlsServeError,

--- a/crates/talon-gateway/src/model.rs
+++ b/crates/talon-gateway/src/model.rs
@@ -189,6 +189,19 @@ pub struct GatewayAccess {
     pub provider_account: Option<String>,
     /// Canonical namespace and optional object or listing prefix.
     pub target: GatewayTarget,
+    /// Additional resources that the same request must be authorized to access.
+    pub additional: Vec<GatewayAccessRequirement>,
+}
+
+/// One secondary authorization requirement for a multi-resource operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayAccessRequirement {
+    /// Required operation on the secondary target.
+    pub operation: GatewayOperation,
+    /// Provider tenant or storage account, when protocol parsing establishes it.
+    pub provider_account: Option<String>,
+    /// Canonical secondary target.
+    pub target: GatewayTarget,
 }
 
 /// Adapter response plus provider-neutral accounting metadata.

--- a/crates/talon-gateway/src/runtime.rs
+++ b/crates/talon-gateway/src/runtime.rs
@@ -880,6 +880,7 @@ mod tests {
                     "bucket-a",
                     request.uri().path().trim_start_matches('/'),
                 )),
+                additional: Vec::new(),
             })
         }
 

--- a/crates/talon-gateway/src/s3.rs
+++ b/crates/talon-gateway/src/s3.rs
@@ -10,13 +10,16 @@ use axum::http::{header, HeaderMap, HeaderName, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
-use talon_backend::{HttpResponse, HttpStreamResponse, S3Backend};
+use sha2::{Digest, Sha256};
+use talon_backend::{HttpRequestBody, HttpResponse, HttpStreamResponse, S3Backend};
 use talon_cache_client::{BlockReader, CacheReadError, FileView, DEFAULT_TRANSFER_CHUNK_BYTES};
 use talon_core::{Backend, ObjectId, Version};
+use tokio::io::AsyncWriteExt;
 
 use crate::{
-    FailureReason, GatewayAccess, GatewayAdapter, GatewayOperation, GatewayOutcome,
-    GatewayRequestContext, GatewayResponse, GatewayRoute, GatewayTarget, ProviderProtocol,
+    FailureReason, GatewayAccess, GatewayAccessRequirement, GatewayAdapter, GatewayOperation,
+    GatewayOutcome, GatewayRequestContext, GatewayResponse, GatewayRoute, GatewayTarget,
+    ProviderProtocol,
 };
 
 const MAX_ERROR_BODY_BYTES: usize = 64 * 1024;
@@ -94,6 +97,11 @@ impl S3AdapterConfig {
 pub trait S3Cache: Send + Sync + 'static {
     /// Stream one exact object range from Talon.
     fn stream(&self, request: S3CacheRequest<'_>) -> Result<CacheStream, CacheReadError>;
+
+    /// Drop local placement knowledge after an origin mutation commits.
+    fn invalidate_object(&self, _object: &ObjectId) -> usize {
+        0
+    }
 }
 
 impl S3Cache for BlockReader {
@@ -112,6 +120,10 @@ impl S3Cache for BlockReader {
             request.now_ms,
         )
         .map(|stream| Box::pin(stream) as CacheStream)
+    }
+
+    fn invalidate_object(&self, object: &ObjectId) -> usize {
+        BlockReader::invalidate_object(self, object)
     }
 }
 
@@ -140,6 +152,44 @@ pub trait S3Origin: Send + Sync + 'static {
         max_keys: u32,
         encoding_type: Option<&str>,
     ) -> Result<HttpResponse, String>;
+
+    async fn put_body(
+        &self,
+        _object: &ObjectId,
+        _headers: &[(String, String)],
+        _body: HttpRequestBody,
+        _len: u64,
+        _payload_hash: &str,
+    ) -> Result<HttpResponse, String> {
+        Err("S3 origin does not implement PUT".into())
+    }
+
+    async fn put_file(
+        &self,
+        _object: &ObjectId,
+        _headers: &[(String, String)],
+        _path: &std::path::Path,
+        _len: u64,
+        _payload_hash: &str,
+    ) -> Result<HttpResponse, String> {
+        Err("S3 origin does not implement file PUT".into())
+    }
+
+    async fn copy(
+        &self,
+        _object: &ObjectId,
+        _headers: &[(String, String)],
+    ) -> Result<HttpResponse, String> {
+        Err("S3 origin does not implement CopyObject".into())
+    }
+
+    async fn delete(
+        &self,
+        _object: &ObjectId,
+        _conditions: &[(String, String)],
+    ) -> Result<HttpResponse, String> {
+        Err("S3 origin does not implement DELETE".into())
+    }
 }
 
 #[async_trait]
@@ -179,6 +229,46 @@ impl S3Origin for S3Backend {
             encoding_type,
         )
         .await
+    }
+
+    async fn put_body(
+        &self,
+        object: &ObjectId,
+        headers: &[(String, String)],
+        body: HttpRequestBody,
+        len: u64,
+        payload_hash: &str,
+    ) -> Result<HttpResponse, String> {
+        self.execute_put_body_raw(object, headers, body, len, payload_hash)
+            .await
+    }
+
+    async fn put_file(
+        &self,
+        object: &ObjectId,
+        headers: &[(String, String)],
+        path: &std::path::Path,
+        len: u64,
+        payload_hash: &str,
+    ) -> Result<HttpResponse, String> {
+        self.execute_put_file_raw(object, headers, path, len, payload_hash)
+            .await
+    }
+
+    async fn copy(
+        &self,
+        object: &ObjectId,
+        headers: &[(String, String)],
+    ) -> Result<HttpResponse, String> {
+        self.execute_copy_raw(object, headers).await
+    }
+
+    async fn delete(
+        &self,
+        object: &ObjectId,
+        conditions: &[(String, String)],
+    ) -> Result<HttpResponse, String> {
+        self.execute_delete_raw(object, conditions).await
     }
 }
 
@@ -287,6 +377,7 @@ struct S3Query {
     continuation_token: Option<String>,
     max_keys: Option<String>,
     encoding_type: Option<String>,
+    multipart: bool,
 }
 
 impl S3Query {
@@ -301,6 +392,7 @@ impl S3Query {
                 "continuation-token" => parsed.continuation_token = Some(value.into_owned()),
                 "max-keys" => parsed.max_keys = Some(value.into_owned()),
                 "encoding-type" => parsed.encoding_type = Some(value.into_owned()),
+                "uploads" | "uploadId" | "partNumber" => parsed.multipart = true,
                 _ => {}
             }
         }
@@ -334,6 +426,114 @@ impl S3Query {
                 }),
         }
     }
+}
+
+fn single_content_length(headers: &HeaderMap) -> Result<u64, S3RequestError> {
+    let values = headers.get_all(header::CONTENT_LENGTH);
+    let mut values = values.iter();
+    let value = values.next().ok_or_else(|| {
+        S3RequestError::invalid("MissingContentLength", "Content-Length is required")
+    })?;
+    if values.next().is_some() {
+        return Err(S3RequestError::invalid(
+            "InvalidArgument",
+            "Content-Length must occur exactly once",
+        ));
+    }
+    value
+        .to_str()
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .ok_or_else(|| S3RequestError::invalid("InvalidArgument", "Content-Length is invalid"))
+}
+
+fn payload_declaration(request: &Request) -> Result<String, S3RequestError> {
+    if let Some(value) = request.headers().get("x-amz-content-sha256") {
+        return value
+            .to_str()
+            .map(str::to_string)
+            .map_err(|_| S3RequestError::invalid("InvalidArgument", "payload hash is invalid"));
+    }
+    for (name, value) in
+        url::form_urlencoded::parse(request.uri().query().unwrap_or_default().as_bytes())
+    {
+        if name.eq_ignore_ascii_case("X-Amz-Content-Sha256") {
+            return Ok(value.into_owned());
+        }
+    }
+    Ok("UNSIGNED-PAYLOAD".into())
+}
+
+fn mutation_headers(
+    headers: &HeaderMap,
+    copy: bool,
+) -> Result<Vec<(String, String)>, S3RequestError> {
+    const EXACT: [&str; 18] = [
+        "cache-control",
+        "content-disposition",
+        "content-encoding",
+        "content-language",
+        "content-md5",
+        "content-type",
+        "expires",
+        "if-match",
+        "if-none-match",
+        "x-amz-acl",
+        "x-amz-checksum-algorithm",
+        "x-amz-copy-source",
+        "x-amz-metadata-directive",
+        "x-amz-storage-class",
+        "x-amz-tagging",
+        "x-amz-tagging-directive",
+        "x-amz-server-side-encryption",
+        "x-amz-server-side-encryption-aws-kms-key-id",
+    ];
+    let mut output = Vec::new();
+    for (name, value) in headers {
+        let name = name.as_str().to_ascii_lowercase();
+        let allowed = EXACT.contains(&name.as_str())
+            || name.starts_with("x-amz-meta-")
+            || name.starts_with("x-amz-checksum-")
+            || (copy && name.starts_with("x-amz-copy-source-if-"));
+        if !allowed || (!copy && name.starts_with("x-amz-copy-")) {
+            continue;
+        }
+        if output
+            .iter()
+            .any(|(existing, _): &(String, String)| existing == &name)
+        {
+            return Err(S3RequestError::invalid(
+                "InvalidArgument",
+                format!("{name} must occur exactly once"),
+            ));
+        }
+        let value = value.to_str().map_err(|_| {
+            S3RequestError::invalid("InvalidArgument", format!("{name} is invalid"))
+        })?;
+        output.push((name, value.to_string()));
+    }
+    Ok(output)
+}
+
+fn copy_source(headers: &HeaderMap) -> Result<Option<ObjectId>, S3RequestError> {
+    let Some(value) = headers.get("x-amz-copy-source") else {
+        return Ok(None);
+    };
+    let value = value
+        .to_str()
+        .map_err(|_| S3RequestError::invalid("InvalidArgument", "copy source is invalid"))?;
+    if value.contains('?') {
+        return Err(S3RequestError::invalid(
+            "NotImplemented",
+            "versioned CopyObject is not supported",
+        ));
+    }
+    let decoded = decode_path(value.trim_start_matches('/'))?;
+    let (bucket, key) = decoded
+        .split_once('/')
+        .filter(|(bucket, key)| !bucket.is_empty() && !key.is_empty())
+        .ok_or_else(|| S3RequestError::invalid("InvalidArgument", "copy source is invalid"))?;
+    Ok(Some(ObjectId::new(Backend::S3, bucket, key)))
 }
 
 fn conditional_headers(headers: &HeaderMap) -> Result<Vec<(String, String)>, S3RequestError> {
@@ -539,6 +739,16 @@ fn raw_response(
     }
 }
 
+fn copy_response_failed(response: &HttpResponse) -> bool {
+    if !response.is_success() {
+        return true;
+    }
+    std::str::from_utf8(&response.body)
+        .ok()
+        .and_then(|xml| talon_backend::xml::element(xml, "Error"))
+        .is_some()
+}
+
 async fn raw_streaming_response(
     mut origin: HttpStreamResponse,
     operation: GatewayOperation,
@@ -659,6 +869,7 @@ struct S3RequestError {
     message: String,
     failure: FailureReason,
     content_range: Option<String>,
+    indeterminate_commit: bool,
 }
 
 impl S3RequestError {
@@ -669,6 +880,7 @@ impl S3RequestError {
             message: message.into(),
             failure: FailureReason::InvalidRequest,
             content_range: None,
+            indeterminate_commit: false,
         }
     }
 
@@ -679,6 +891,7 @@ impl S3RequestError {
             message: "The requested range is not satisfiable".into(),
             failure: FailureReason::InvalidRequest,
             content_range: Some(format!("bytes */{size}")),
+            indeterminate_commit: false,
         }
     }
 
@@ -689,6 +902,7 @@ impl S3RequestError {
             message: "The specified key does not exist".into(),
             failure: FailureReason::NotFound,
             content_range: None,
+            indeterminate_commit: false,
         }
     }
 
@@ -699,6 +913,7 @@ impl S3RequestError {
             message: "At least one precondition failed".into(),
             failure: FailureReason::Precondition,
             content_range: None,
+            indeterminate_commit: false,
         }
     }
 
@@ -710,6 +925,19 @@ impl S3RequestError {
             message: "Please reduce your request rate".into(),
             failure: FailureReason::Origin,
             content_range: None,
+            indeterminate_commit: false,
+        }
+    }
+
+    fn indeterminate_commit() -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "InternalError",
+            message: "The mutation result is indeterminate; inspect the object before retrying"
+                .into(),
+            failure: FailureReason::Origin,
+            content_range: None,
+            indeterminate_commit: true,
         }
     }
 
@@ -720,6 +948,7 @@ impl S3RequestError {
             message: message.into(),
             failure: FailureReason::Internal,
             content_range: None,
+            indeterminate_commit: false,
         }
     }
 }
@@ -733,6 +962,7 @@ fn cache_error(error: CacheReadError) -> S3RequestError {
             message,
             failure: FailureReason::NotFound,
             content_range: None,
+            indeterminate_commit: false,
         },
         CacheReadError::VersionMismatch(message) => S3RequestError {
             status: StatusCode::PRECONDITION_FAILED,
@@ -740,6 +970,7 @@ fn cache_error(error: CacheReadError) -> S3RequestError {
             message,
             failure: FailureReason::Precondition,
             content_range: None,
+            indeterminate_commit: false,
         },
         CacheReadError::Timeout(message) => S3RequestError {
             status: StatusCode::GATEWAY_TIMEOUT,
@@ -747,6 +978,7 @@ fn cache_error(error: CacheReadError) -> S3RequestError {
             message,
             failure: FailureReason::Timeout,
             content_range: None,
+            indeterminate_commit: false,
         },
         CacheReadError::Unavailable(message) => S3RequestError {
             status: StatusCode::SERVICE_UNAVAILABLE,
@@ -754,6 +986,7 @@ fn cache_error(error: CacheReadError) -> S3RequestError {
             message,
             failure: FailureReason::CacheUnavailable,
             content_range: None,
+            indeterminate_commit: false,
         },
         CacheReadError::Origin(message) => S3RequestError::origin_unavailable(message),
         CacheReadError::Protocol(message)
@@ -779,6 +1012,12 @@ fn error_response(error: S3RequestError, request_id: &str) -> GatewayResponse {
         if let Ok(value) = HeaderValue::from_str(&content_range) {
             response.headers_mut().insert(header::CONTENT_RANGE, value);
         }
+    }
+    if error.indeterminate_commit {
+        response.headers_mut().insert(
+            "x-talon-commit-state",
+            HeaderValue::from_static("indeterminate"),
+        );
     }
     stamp_gateway_headers(response.headers_mut(), request_id);
     GatewayResponse {
@@ -810,6 +1049,51 @@ fn unix_millis() -> u64 {
         .as_millis()
         .try_into()
         .unwrap_or(u64::MAX)
+}
+
+async fn spool_and_hash<S>(
+    mut body: S,
+    expected_len: u64,
+) -> Result<(tempfile::NamedTempFile, String), S3RequestError>
+where
+    S: Stream<Item = Result<Bytes, axum::Error>> + Unpin,
+{
+    let spool = tempfile::NamedTempFile::new()
+        .map_err(|_| S3RequestError::internal("could not create upload spool"))?;
+    let file = spool
+        .reopen()
+        .map_err(|_| S3RequestError::internal("could not open upload spool"))?;
+    let mut file = tokio::fs::File::from_std(file);
+    let mut hasher = Sha256::new();
+    let mut received = 0u64;
+    while let Some(chunk) = body.next().await {
+        let chunk = chunk.map_err(|_| {
+            S3RequestError::invalid("IncompleteBody", "The request body could not be read")
+        })?;
+        received = received.checked_add(chunk.len() as u64).ok_or_else(|| {
+            S3RequestError::invalid("InvalidArgument", "request body is too large")
+        })?;
+        if received > expected_len {
+            return Err(S3RequestError::invalid(
+                "InvalidArgument",
+                "request body exceeds Content-Length",
+            ));
+        }
+        hasher.update(&chunk);
+        file.write_all(&chunk)
+            .await
+            .map_err(|_| S3RequestError::internal("could not spool upload body"))?;
+    }
+    if received != expected_len {
+        return Err(S3RequestError::invalid(
+            "IncompleteBody",
+            "request body is shorter than Content-Length",
+        ));
+    }
+    file.flush()
+        .await
+        .map_err(|_| S3RequestError::internal("could not flush upload spool"))?;
+    Ok((spool, format!("{:x}", hasher.finalize())))
 }
 
 #[async_trait]
@@ -849,6 +1133,7 @@ impl S3Adapter {
                     namespace: target.bucket,
                     prefix: query.prefix,
                 },
+                additional: Vec::new(),
             });
         }
         let key = target
@@ -861,11 +1146,22 @@ impl S3Adapter {
             axum::http::Method::DELETE => GatewayOperation::Delete,
             _ => GatewayOperation::Unsupported,
         };
-        Ok(GatewayAccess {
+        let mut access = GatewayAccess {
             operation,
             provider_account: None,
             target: GatewayTarget::Object(ObjectId::new(Backend::S3, target.bucket, key)),
-        })
+            additional: Vec::new(),
+        };
+        if request.method() == axum::http::Method::PUT {
+            if let Some(source) = copy_source(request.headers())? {
+                access.additional.push(GatewayAccessRequirement {
+                    operation: GatewayOperation::Read,
+                    provider_account: None,
+                    target: GatewayTarget::Object(source),
+                });
+            }
+        }
+        Ok(access)
     }
 
     async fn handle_request(
@@ -883,17 +1179,126 @@ impl S3Adapter {
             .key
             .ok_or_else(|| S3RequestError::invalid("InvalidURI", "request has no object key"))?;
         let object = ObjectId::new(Backend::S3, target.bucket, key);
+        if query.multipart {
+            return Err(S3RequestError {
+                status: StatusCode::NOT_IMPLEMENTED,
+                code: "NotImplemented",
+                message: "Multipart upload operations are not supported by this endpoint".into(),
+                failure: FailureReason::Unsupported,
+                content_range: None,
+                indeterminate_commit: false,
+            });
+        }
         match *request.method() {
             axum::http::Method::HEAD => self.head(object, request.headers(), context).await,
             axum::http::Method::GET => self.get(object, request.headers(), context).await,
+            axum::http::Method::PUT => self.put(object, request, context).await,
+            axum::http::Method::DELETE => self.delete(object, request.headers(), context).await,
             _ => Err(S3RequestError {
                 status: StatusCode::METHOD_NOT_ALLOWED,
                 code: "MethodNotAllowed",
                 message: "The specified method is not allowed".into(),
                 failure: FailureReason::Unsupported,
                 content_range: None,
+                indeterminate_commit: false,
             }),
         }
+    }
+
+    async fn put(
+        &self,
+        object: ObjectId,
+        request: Request,
+        context: &GatewayRequestContext,
+    ) -> Result<GatewayResponse, S3RequestError> {
+        if copy_source(request.headers())?.is_some() {
+            return self.copy(object, request.headers(), context).await;
+        }
+        let len = single_content_length(request.headers())?;
+        let payload_hash = payload_declaration(&request)?;
+        let headers = mutation_headers(request.headers(), false)?;
+        let body = request.into_body().into_data_stream();
+        let response = if payload_hash == "UNSIGNED-PAYLOAD" {
+            let body = body.map(|chunk| chunk.map_err(|error| error.to_string()));
+            self.origin
+                .put_body(&object, &headers, Box::pin(body), len, &payload_hash)
+                .await
+        } else {
+            let (spool, actual_hash) = spool_and_hash(body, len).await?;
+            if actual_hash != payload_hash {
+                return Err(S3RequestError::invalid(
+                    "XAmzContentSHA256Mismatch",
+                    "The provided payload hash does not match the request body",
+                ));
+            }
+            self.origin
+                .put_file(&object, &headers, spool.path(), len, &actual_hash)
+                .await
+        }
+        .map_err(|_| S3RequestError::indeterminate_commit())?;
+        if response.is_success() {
+            let _ = self.cache.invalidate_object(&object);
+        }
+        let mut response = raw_response(
+            response,
+            GatewayOperation::Write,
+            Some(GatewayTarget::Object(object)),
+            context,
+        );
+        response.requested_bytes = len;
+        Ok(response)
+    }
+
+    async fn copy(
+        &self,
+        object: ObjectId,
+        headers: &HeaderMap,
+        context: &GatewayRequestContext,
+    ) -> Result<GatewayResponse, S3RequestError> {
+        let headers = mutation_headers(headers, true)?;
+        let response = self
+            .origin
+            .copy(&object, &headers)
+            .await
+            .map_err(|_| S3RequestError::indeterminate_commit())?;
+        let failed = copy_response_failed(&response);
+        if !failed {
+            let _ = self.cache.invalidate_object(&object);
+        }
+        let mut response = raw_response(
+            response,
+            GatewayOperation::Write,
+            Some(GatewayTarget::Object(object)),
+            context,
+        );
+        if failed && response.response.status().is_success() {
+            response.outcome = GatewayOutcome::Failed;
+            response.failure = Some(FailureReason::Origin);
+        }
+        Ok(response)
+    }
+
+    async fn delete(
+        &self,
+        object: ObjectId,
+        headers: &HeaderMap,
+        context: &GatewayRequestContext,
+    ) -> Result<GatewayResponse, S3RequestError> {
+        let conditions = conditional_headers(headers)?;
+        let response = self
+            .origin
+            .delete(&object, &conditions)
+            .await
+            .map_err(|_| S3RequestError::indeterminate_commit())?;
+        if response.is_success() || response.status == 404 {
+            let _ = self.cache.invalidate_object(&object);
+        }
+        Ok(raw_response(
+            response,
+            GatewayOperation::Delete,
+            Some(GatewayTarget::Object(object)),
+            context,
+        ))
     }
 
     async fn head(
@@ -1212,6 +1617,175 @@ mod tests {
 
     struct MockOrigin {
         lists: Mutex<Vec<ListRequest>>,
+    }
+
+    struct MutationCache {
+        invalidations: AtomicUsize,
+    }
+
+    impl S3Cache for MutationCache {
+        fn stream(&self, _request: S3CacheRequest<'_>) -> Result<CacheStream, CacheReadError> {
+            unreachable!("mutation tests do not read")
+        }
+
+        fn invalidate_object(&self, _object: &ObjectId) -> usize {
+            self.invalidations.fetch_add(1, Ordering::SeqCst);
+            1
+        }
+    }
+
+    struct MutationOrigin {
+        response: Mutex<Result<HttpResponse, String>>,
+        calls: AtomicUsize,
+        body: Mutex<Vec<u8>>,
+        headers: Mutex<Vec<(String, String)>>,
+    }
+
+    struct StallingMutationOrigin;
+
+    #[async_trait]
+    impl S3Origin for StallingMutationOrigin {
+        async fn head(
+            &self,
+            _object: &ObjectId,
+            _conditions: &[(String, String)],
+        ) -> Result<HttpResponse, String> {
+            unreachable!("mutation test does not stat")
+        }
+
+        async fn get(
+            &self,
+            _object: &ObjectId,
+            _range: Option<(u64, u64)>,
+            _conditions: &[(String, String)],
+        ) -> Result<HttpStreamResponse, String> {
+            unreachable!("mutation test does not read")
+        }
+
+        async fn list(
+            &self,
+            _bucket: &str,
+            _prefix: &str,
+            _delimiter: Option<&str>,
+            _continuation_token: Option<&str>,
+            _max_keys: u32,
+            _encoding_type: Option<&str>,
+        ) -> Result<HttpResponse, String> {
+            unreachable!("mutation test does not list")
+        }
+
+        async fn put_body(
+            &self,
+            _object: &ObjectId,
+            _headers: &[(String, String)],
+            mut body: HttpRequestBody,
+            _len: u64,
+            _payload_hash: &str,
+        ) -> Result<HttpResponse, String> {
+            let _ = body.next().await;
+            futures::future::pending().await
+        }
+    }
+
+    impl MutationOrigin {
+        fn new(response: Result<HttpResponse, String>) -> Arc<Self> {
+            Arc::new(Self {
+                response: Mutex::new(response),
+                calls: AtomicUsize::new(0),
+                body: Mutex::new(Vec::new()),
+                headers: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn response(&self) -> Result<HttpResponse, String> {
+            self.response.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl S3Origin for MutationOrigin {
+        async fn head(
+            &self,
+            _object: &ObjectId,
+            _conditions: &[(String, String)],
+        ) -> Result<HttpResponse, String> {
+            unreachable!("mutation tests do not stat")
+        }
+
+        async fn get(
+            &self,
+            _object: &ObjectId,
+            _range: Option<(u64, u64)>,
+            _conditions: &[(String, String)],
+        ) -> Result<HttpStreamResponse, String> {
+            unreachable!("mutation tests do not read")
+        }
+
+        async fn list(
+            &self,
+            _bucket: &str,
+            _prefix: &str,
+            _delimiter: Option<&str>,
+            _continuation_token: Option<&str>,
+            _max_keys: u32,
+            _encoding_type: Option<&str>,
+        ) -> Result<HttpResponse, String> {
+            unreachable!("mutation tests do not list")
+        }
+
+        async fn put_body(
+            &self,
+            _object: &ObjectId,
+            headers: &[(String, String)],
+            mut body: HttpRequestBody,
+            _len: u64,
+            _payload_hash: &str,
+        ) -> Result<HttpResponse, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            *self.headers.lock().unwrap() = headers.to_vec();
+            while let Some(chunk) = body.next().await {
+                self.body.lock().unwrap().extend_from_slice(&chunk?);
+            }
+            self.response()
+        }
+
+        async fn put_file(
+            &self,
+            _object: &ObjectId,
+            headers: &[(String, String)],
+            path: &std::path::Path,
+            _len: u64,
+            _payload_hash: &str,
+        ) -> Result<HttpResponse, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            *self.headers.lock().unwrap() = headers.to_vec();
+            *self.body.lock().unwrap() = tokio::fs::read(path).await.map_err(|e| e.to_string())?;
+            self.response()
+        }
+
+        async fn copy(
+            &self,
+            _object: &ObjectId,
+            headers: &[(String, String)],
+        ) -> Result<HttpResponse, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            *self.headers.lock().unwrap() = headers.to_vec();
+            self.response()
+        }
+
+        async fn delete(
+            &self,
+            _object: &ObjectId,
+            conditions: &[(String, String)],
+        ) -> Result<HttpResponse, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            *self.headers.lock().unwrap() = conditions.to_vec();
+            self.response()
+        }
+    }
+
+    fn mutation_adapter(cache: Arc<MutationCache>, origin: Arc<MutationOrigin>) -> S3Adapter {
+        S3Adapter::new(S3AdapterConfig::path_style("localhost"), cache, origin).unwrap()
     }
 
     impl MockOrigin {
@@ -1551,5 +2125,206 @@ mod tests {
         assert!(body
             .windows(b"<Code>InvalidRange</Code>".len())
             .any(|window| window == b"<Code>InvalidRange</Code>"));
+    }
+
+    #[test]
+    fn copy_access_requires_source_read_and_destination_write() {
+        let mut copy = request(axum::http::Method::PUT, "/destination/copied");
+        copy.headers_mut().insert(
+            "x-amz-copy-source",
+            HeaderValue::from_static("/source/original"),
+        );
+        let access = adapter(
+            MockCache {
+                response: Ok(Vec::new()),
+            },
+            MockOrigin::new(),
+        )
+        .classify_access(&copy)
+        .unwrap();
+        assert_eq!(access.operation, GatewayOperation::Write);
+        assert_eq!(access.additional.len(), 1);
+        assert_eq!(access.additional[0].operation, GatewayOperation::Read);
+        assert_eq!(
+            access.additional[0].target,
+            GatewayTarget::Object(ObjectId::new(Backend::S3, "source", "original"))
+        );
+    }
+
+    #[tokio::test]
+    async fn verified_put_rejects_tampering_before_origin_dispatch() {
+        let cache = Arc::new(MutationCache {
+            invalidations: AtomicUsize::new(0),
+        });
+        let origin = MutationOrigin::new(Ok(HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: Bytes::new(),
+        }));
+        let request = Request::builder()
+            .method("PUT")
+            .uri("/bucket/key")
+            .header(header::HOST, "localhost")
+            .header(header::CONTENT_LENGTH, "3")
+            .header(
+                "x-amz-content-sha256",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            )
+            .body(Body::from("abc"))
+            .unwrap();
+        let response = mutation_adapter(Arc::clone(&cache), Arc::clone(&origin))
+            .handle(request, context())
+            .await;
+        assert_eq!(response.response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(origin.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(cache.invalidations.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn unsigned_put_streams_sanitized_headers_and_invalidates_after_commit() {
+        let cache = Arc::new(MutationCache {
+            invalidations: AtomicUsize::new(0),
+        });
+        let origin = MutationOrigin::new(Ok(HttpResponse {
+            status: 200,
+            headers: vec![("etag".into(), "\"v2\"".into())],
+            body: Bytes::new(),
+        }));
+        let request = Request::builder()
+            .method("PUT")
+            .uri("/bucket/key")
+            .header(header::HOST, "localhost")
+            .header(header::CONTENT_LENGTH, "3")
+            .header("authorization", "incoming-secret")
+            .header("x-amz-date", "incoming-date")
+            .header("x-amz-security-token", "incoming-token")
+            .header("x-amz-content-sha256", "UNSIGNED-PAYLOAD")
+            .header("x-amz-meta-owner", "team-a")
+            .body(Body::from("abc"))
+            .unwrap();
+        let response = mutation_adapter(Arc::clone(&cache), Arc::clone(&origin))
+            .handle(request, context())
+            .await;
+        assert_eq!(response.response.status(), StatusCode::OK);
+        assert_eq!(origin.body.lock().unwrap().as_slice(), b"abc");
+        assert_eq!(
+            origin.headers.lock().unwrap().as_slice(),
+            &[("x-amz-meta-owner".into(), "team-a".into())]
+        );
+        assert_eq!(cache.invalidations.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn failed_or_indeterminate_put_never_invalidates_cache() {
+        let cache = Arc::new(MutationCache {
+            invalidations: AtomicUsize::new(0),
+        });
+        let rejected = MutationOrigin::new(Ok(HttpResponse {
+            status: 412,
+            headers: Vec::new(),
+            body: Bytes::new(),
+        }));
+        let put = || {
+            Request::builder()
+                .method("PUT")
+                .uri("/bucket/key")
+                .header(header::HOST, "localhost")
+                .header(header::CONTENT_LENGTH, "3")
+                .header("x-amz-content-sha256", "UNSIGNED-PAYLOAD")
+                .body(Body::from("abc"))
+                .unwrap()
+        };
+        let response = mutation_adapter(Arc::clone(&cache), rejected)
+            .handle(put(), context())
+            .await;
+        assert_eq!(response.response.status(), StatusCode::PRECONDITION_FAILED);
+        assert_eq!(cache.invalidations.load(Ordering::SeqCst), 0);
+
+        let unavailable = MutationOrigin::new(Err("response lost".into()));
+        let response = mutation_adapter(Arc::clone(&cache), unavailable)
+            .handle(put(), context())
+            .await;
+        assert_eq!(
+            response.response.status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+        assert_eq!(
+            response.response.headers()["x-talon-commit-state"],
+            "indeterminate"
+        );
+        assert_eq!(cache.invalidations.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn embedded_copy_error_does_not_invalidate_destination() {
+        let cache = Arc::new(MutationCache {
+            invalidations: AtomicUsize::new(0),
+        });
+        let origin = MutationOrigin::new(Ok(HttpResponse {
+            status: 200,
+            headers: vec![("content-type".into(), "application/xml".into())],
+            body: Bytes::from_static(
+                b"<Error><Code>InternalError</Code><Message>copy failed</Message></Error>",
+            ),
+        }));
+        let request = Request::builder()
+            .method("PUT")
+            .uri("/destination/copied")
+            .header(header::HOST, "localhost")
+            .header("x-amz-copy-source", "/source/original")
+            .body(Body::empty())
+            .unwrap();
+        let response = mutation_adapter(Arc::clone(&cache), origin)
+            .handle(request, context())
+            .await;
+        assert_eq!(response.response.status(), StatusCode::OK);
+        assert_eq!(response.outcome, GatewayOutcome::Failed);
+        assert_eq!(response.failure, Some(FailureReason::Origin));
+        assert_eq!(cache.invalidations.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn streaming_put_is_demand_driven_and_cancellation_drops_the_body() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let dropped = Arc::new(AtomicBool::new(false));
+        let chunks = VecDeque::from([Bytes::from_static(b"abc"), Bytes::from_static(b"def")]);
+        let stream_polls = Arc::clone(&polls);
+        let guard = DropSignal(Arc::clone(&dropped));
+        let stream = futures::stream::unfold((chunks, guard), move |(mut chunks, guard)| {
+            let polls = Arc::clone(&stream_polls);
+            async move {
+                polls.fetch_add(1, Ordering::SeqCst);
+                chunks
+                    .pop_front()
+                    .map(|chunk| (Ok::<_, std::io::Error>(chunk), (chunks, guard)))
+            }
+        });
+        let request = Request::builder()
+            .method("PUT")
+            .uri("/bucket/key")
+            .header(header::HOST, "localhost")
+            .header(header::CONTENT_LENGTH, "6")
+            .header("x-amz-content-sha256", "UNSIGNED-PAYLOAD")
+            .body(Body::from_stream(stream))
+            .unwrap();
+        let adapter = S3Adapter::new(
+            S3AdapterConfig::path_style("localhost"),
+            Arc::new(MutationCache {
+                invalidations: AtomicUsize::new(0),
+            }),
+            Arc::new(StallingMutationOrigin),
+        )
+        .unwrap();
+        let task = tokio::spawn(async move { adapter.handle(request, context()).await });
+        for _ in 0..20 {
+            if polls.load(Ordering::SeqCst) > 0 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(polls.load(Ordering::SeqCst), 1);
+        task.abort();
+        let _ = task.await;
+        assert!(dropped.load(Ordering::SeqCst));
     }
 }

--- a/crates/talon-gateway/src/s3_auth.rs
+++ b/crates/talon-gateway/src/s3_auth.rs
@@ -341,9 +341,15 @@ fn validate_payload_hash(request: &Request, signed: &SignedRequest) -> Result<()
         if !accepted {
             return Err(AuthFailure);
         }
-    } else {
-        // Write support must install a streaming body verifier before payloads
-        // can be authenticated without buffering the whole object.
+    } else if signed.payload_hash != "UNSIGNED-PAYLOAD"
+        && (signed.payload_hash.len() != 64
+            || !signed
+                .payload_hash
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)))
+    {
+        // Streaming SigV4 chunk modes need per-chunk verification and are not
+        // accepted as ordinary object PUTs.
         return Err(AuthFailure);
     }
     Ok(())
@@ -723,6 +729,34 @@ mod tests {
         builder.body(Body::empty()).unwrap()
     }
 
+    fn signed_put(payload_hash: &str) -> Request {
+        let mut outgoing = HttpRequest::new(
+            Method::Put,
+            "https://example.com/bucket/object".into(),
+            vec![("content-length".into(), "3".into())],
+        );
+        sign_request_with_payload_hash(
+            &mut outgoing,
+            &S3Credentials {
+                access_key_id: ACCESS_KEY.into(),
+                secret_access_key: SECRET_KEY.into(),
+                session_token: None,
+            },
+            "us-east-1",
+            "s3",
+            &AmzDate {
+                datetime: DATETIME.into(),
+                date: "20130524".into(),
+            },
+            payload_hash,
+        );
+        let mut builder = Request::builder().method("PUT").uri("/bucket/object");
+        for (name, value) in outgoing.headers {
+            builder = builder.header(name, value);
+        }
+        builder.body(Body::from("abc")).unwrap()
+    }
+
     fn presigned_request(expires: u64, session_token: Option<&str>) -> Request {
         let credential = uri_encode(
             format!("{ACCESS_KEY}/20130524/us-east-1/s3/aws4_request").as_bytes(),
@@ -827,6 +861,24 @@ mod tests {
     }
 
     #[test]
+    fn accepts_supported_put_payload_declarations_only() {
+        let verifier = authenticator(None);
+        let digest = sha256_hex(b"abc");
+        assert!(verifier
+            .authenticate_at(&signed_put(&digest), now())
+            .is_ok());
+        assert!(verifier
+            .authenticate_at(&signed_put("UNSIGNED-PAYLOAD"), now())
+            .is_ok());
+        assert!(verifier
+            .authenticate_at(&signed_put("STREAMING-AWS4-HMAC-SHA256-PAYLOAD"), now())
+            .is_err());
+        assert!(verifier
+            .authenticate_at(&signed_put(&digest.to_ascii_uppercase()), now())
+            .is_err());
+    }
+
+    #[test]
     fn rejects_tampering_scope_replay_and_payload_hash() {
         let verifier = authenticator(None);
         let mut tampered = signed_header_request("/bucket/object", "s3", None);
@@ -896,7 +948,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_invalid_identity_sets_and_unsigned_payloads() {
+    fn rejects_invalid_identity_sets_and_streaming_payload_modes() {
         assert!(parse_datetime("0000000\u{e9}000000Z").is_err());
         assert!(matches!(
             S3SigV4Authenticator::new("us-east-1", Vec::new(), Duration::from_secs(1)),
@@ -921,7 +973,7 @@ mod tests {
                 datetime: DATETIME.into(),
                 date: "20130524".into(),
             },
-            "UNSIGNED-PAYLOAD",
+            "STREAMING-AWS4-HMAC-SHA256-PAYLOAD",
         );
         let mut builder = Request::builder().method("PUT").uri("/bucket/object");
         for (name, value) in outgoing.headers {

--- a/crates/talon-gateway/src/tls.rs
+++ b/crates/talon-gateway/src/tls.rs
@@ -597,6 +597,7 @@ mod tests {
                     "bucket-a",
                     "tenant/object",
                 )),
+                additional: Vec::new(),
             })
         }
 

--- a/crates/talon-gateway/tests/s3_sdk_e2e.rs
+++ b/crates/talon-gateway/tests/s3_sdk_e2e.rs
@@ -103,6 +103,13 @@ impl S3Cache for ReadThroughCache {
             Ok(body)
         })))
     }
+
+    fn invalidate_object(&self, object: &ObjectId) -> usize {
+        let mut entries = self.entries.lock().unwrap();
+        let before = entries.len();
+        entries.retain(|(cached, _, _, _), _| cached != object);
+        before - entries.len()
+    }
 }
 
 fn env(name: &str) -> Option<String> {
@@ -196,6 +203,8 @@ async fn s3_sdks_and_localstack_gateway_conformance() {
                 GatewayOperation::Stat,
                 GatewayOperation::Read,
                 GatewayOperation::List,
+                GatewayOperation::Write,
+                GatewayOperation::Delete,
             ],
         }])
         .unwrap(),

--- a/docs/operations/object-store-gateway.md
+++ b/docs/operations/object-store-gateway.md
@@ -1,10 +1,10 @@
 # Object-store gateway deployment
 
-`talon-gateway` exposes the read-only compatibility surface documented in the
+`talon-gateway` exposes the compatibility surface documented in the
 [compatibility matrix](../reference/object-store-gateway-compatibility.md). One
 process serves either S3 or Azure Blob, connects to a Talon coordinator and
 worker fleet for cached bytes, and uses a separately scoped origin identity for
-metadata and fallback reads.
+metadata, fallback reads, and origin-authoritative mutations.
 
 ## Security state
 
@@ -37,9 +37,9 @@ with the process's origin identity.
 | Gateway to Azure | Exactly one of `TALON_GATEWAY_AZURE_SHARED_KEY` or `TALON_GATEWAY_AZURE_SAS` | Environment/secret injection only. |
 | Gateway to Talon | Coordinator and worker data-plane connection | Existing Talon cache-client boundary; mTLS integration is part of #446. |
 
-Use an origin identity limited to read metadata, object ranges, and bounded
-listing on the namespaces assigned to that gateway. Do not grant write or
-account administration permissions.
+Use an origin identity limited to the advertised read and mutation operations
+on namespaces assigned to that gateway. Do not grant bucket or account
+administration permissions.
 
 ## Configuration
 
@@ -146,7 +146,7 @@ intended:
       "provider_account": "tenant-a",
       "namespace": "datasets",
       "prefix": "published/",
-      "operations": ["stat", "read", "list"]
+      "operations": ["stat", "read", "list", "write", "delete"]
     }
   ]
 }
@@ -156,6 +156,15 @@ SigV4 verification enforces the configured region, `s3` service, host,
 canonical URI/query/headers, timestamp or presigned expiry, payload declaration,
 and STS token. A present `x-talon-cache-mark` must be signed and syntactically
 valid. Invalid requests fail before cache or origin dispatch.
+
+Ordinary S3 `PutObject`, `CopyObject`, and `DeleteObject` requests are sent to
+the origin exactly once. `PutObject` requires one valid `Content-Length` and is
+limited by the gateway's 16 MiB default body limit and 30 second default total
+deadline. `UNSIGNED-PAYLOAD` streams directly; a lowercase SHA-256 declaration
+is verified in a secure temporary file before the origin is mutated. AWS
+streaming chunk-signature modes and multipart uploads are not yet supported.
+Increase deployment limits only with corresponding disk, concurrency, and
+deadline capacity.
 
 Azure variables:
 
@@ -234,6 +243,7 @@ probe loopback with `exec` because kubelet HTTP probes target the Pod IP.
 | `503` with `ServerBusy` or `ServiceUnavailable` | Origin unavailable, or cache fallback also unavailable. | Check origin reachability and scoped credentials; correlate `x-talon-request-id`. |
 | `504` / timeout error | Worker or request deadline elapsed. | Check worker saturation, placement freshness, and network latency. |
 | `412` | Origin ETag changed or a client condition failed. | Re-resolve metadata; do not retry stale cached bytes. |
+| `500` with `x-talon-commit-state: indeterminate` | Mutation dispatch began but the origin response was lost. | Inspect the authoritative object before deciding whether to retry. |
 | `404` | Origin-authoritative object absence. | Verify namespace and key; cache does not override this result. |
 | `416` | Unsatisfiable or multi-range request. | Send one valid byte range. |
 | Cache errors increase while reads succeed | Infrastructure fallback is active. | Repair coordinator/workers before origin load becomes sustained. |

--- a/docs/reference/object-store-gateway-compatibility.md
+++ b/docs/reference/object-store-gateway-compatibility.md
@@ -52,13 +52,25 @@ and deployment are tracked separately.
 | Conditional reads | Supported | ETag and date conditions remain origin-authoritative; `If-Range` controls range use. |
 | Virtual-host addressing | Supported | The bucket is parsed from the configured endpoint suffix. |
 | Path addressing | Supported | `/bucket/key` endpoint-override clients are accepted. |
-| Put, delete, copy, and multipart APIs | Not yet supported | Rejected explicitly until a write-through milestone preserves S3 commit semantics. |
+| PutObject | Supported | Fixed-length bodies are passed through once. `UNSIGNED-PAYLOAD` streams with backpressure; a declared SHA-256 is verified in a bounded-memory spool before origin dispatch. |
+| CopyObject | Supported | Source read and destination write grants are both required. Copy conditions and metadata remain origin-authoritative. |
+| DeleteObject | Supported | Passed through once; the origin status remains authoritative and confirmed absence invalidates local placement state. |
+| Multipart upload | Not yet supported | Multipart query shapes return `NotImplemented`; tracked by issue #497. |
 
 Incoming client authorization material is never forwarded to a rewritten
 origin request. The gateway uses its scoped origin identity and signs the
 validated method, target, conditions, range, and listing parameters again.
-Full incoming SigV4 authentication and bucket authorization remain blocked on
-issue #446, so production exposure stays fail-closed.
+Incoming SigV4 authentication, bucket/prefix authorization, TLS, and optional
+client mTLS are enforced before dispatch in production mode. Copy authorization
+checks the source and destination independently.
+
+Mutation responses remain origin-authoritative. A confirmed success invalidates
+all local placement entries for the object; a failed origin response does not.
+If transport fails after dispatch, the gateway returns
+`x-talon-commit-state: indeterminate`; clients must inspect object state before
+retrying. Request bodies are bounded by the configured gateway body and request
+deadlines (16 MiB and 30 seconds by default). Multipart upload is the path for
+objects that exceed the configured ordinary-request bound.
 
 The S3 adapter emits S3 XML errors and gateway request IDs. Cache fallback and
 streaming behavior match the Azure adapter rules above. The `s3 backend and
@@ -70,9 +82,10 @@ the same test.
 
 ## Cache routing mark
 
-The version 1 cache-routing contract is defined but is not accepted by the
-read-only gateway until incoming authentication is implemented. S3 uses the
-SigV4-signed `x-talon-cache-mark` header. Azure Shared Key uses the canonical
+The version 1 cache-routing contract is parsed and signature-bound, while the
+adapter continues to use its deployment-selected route until worker
+lookup-only/populate operations land. S3 uses the SigV4-signed
+`x-talon-cache-mark` header. Azure Shared Key uses the canonical
 `x-ms-talon-cache-mark` header; Azure SAS requests cannot carry a non-default
 mark because SAS does not sign custom headers. An absent mark means lookup on,
 population on, and bounded origin fallback.

--- a/scripts/s3_gateway_sdk_conformance.py
+++ b/scripts/s3_gateway_sdk_conformance.py
@@ -1,5 +1,8 @@
 """Drive the Talon S3 gateway with boto3 and the MinIO Python SDK."""
 
+import base64
+import hashlib
+import io
 import os
 import urllib.request
 from urllib.parse import urlparse
@@ -8,6 +11,7 @@ import boto3
 from botocore.client import Config
 from botocore.exceptions import ClientError
 from minio import Minio
+from minio.commonconfig import CopySource
 
 
 def expected_object() -> bytes:
@@ -35,6 +39,7 @@ def main() -> None:
         signature_version="s3v4",
         retries={"max_attempts": 0},
         s3={"addressing_style": "path"},
+        request_checksum_calculation="when_required",
     )
 
     origin = boto3.client(
@@ -85,6 +90,57 @@ def main() -> None:
         s3.get_object(Bucket=bucket, Key="gateway/list/a space.txt")["Body"].read()
         == b"a"
     )
+    mutation_key = "gateway/mutations/object.bin"
+    copy_key = "gateway/mutations/copied.bin"
+    first_body = b"created-through-gateway"
+    second_body = b"overwritten-through-gateway"
+    checksum = base64.b64encode(hashlib.sha256(first_body).digest()).decode("ascii")
+    created = s3.put_object(
+        Bucket=bucket,
+        Key=mutation_key,
+        Body=first_body,
+        Metadata={"owner": "sdk-conformance"},
+        ChecksumSHA256=checksum,
+        IfNoneMatch="*",
+    )
+    assert created["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert s3.get_object(Bucket=bucket, Key=mutation_key)["Body"].read() == first_body
+    metadata = s3.head_object(Bucket=bucket, Key=mutation_key)
+    assert metadata["Metadata"]["owner"] == "sdk-conformance"
+
+    try:
+        s3.put_object(
+            Bucket=bucket,
+            Key=mutation_key,
+            Body=b"must-not-land",
+            IfNoneMatch="*",
+        )
+        raise AssertionError("conditional overwrite unexpectedly succeeded")
+    except ClientError as error:
+        assert error.response["ResponseMetadata"]["HTTPStatusCode"] == 412
+
+    s3.put_object(Bucket=bucket, Key=mutation_key, Body=second_body)
+    assert s3.get_object(Bucket=bucket, Key=mutation_key)["Body"].read() == second_body
+    copied = s3.copy_object(
+        Bucket=bucket,
+        Key=copy_key,
+        CopySource={"Bucket": bucket, "Key": mutation_key},
+        Metadata={"copied": "true"},
+        MetadataDirective="REPLACE",
+    )
+    assert copied["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert s3.get_object(Bucket=bucket, Key=copy_key)["Body"].read() == second_body
+    assert s3.head_object(Bucket=bucket, Key=copy_key)["Metadata"]["copied"] == "true"
+
+    s3.delete_object(Bucket=bucket, Key=mutation_key)
+    s3.delete_object(Bucket=bucket, Key=mutation_key)
+    s3.delete_object(Bucket=bucket, Key=copy_key)
+    for deleted_key in (mutation_key, copy_key):
+        try:
+            s3.head_object(Bucket=bucket, Key=deleted_key)
+            raise AssertionError("deleted object unexpectedly exists")
+        except ClientError as error:
+            assert error.response["ResponseMetadata"]["HTTPStatusCode"] == 404
     first = s3.list_objects_v2(Bucket=bucket, Prefix="gateway/list/", MaxKeys=1)
     assert first["IsTruncated"]
     second = s3.list_objects_v2(
@@ -126,6 +182,22 @@ def main() -> None:
     }
     assert "gateway/list/a space.txt" in minio_names
     assert "gateway/list/child/b.txt" in minio_names
+
+    minio_key = "gateway/mutations/minio.bin"
+    minio_copy_key = "gateway/mutations/minio-copy.bin"
+    minio_body = b"written-with-minio"
+    minio.put_object(
+        bucket,
+        minio_key,
+        io.BytesIO(minio_body),
+        len(minio_body),
+        metadata={"owner": "minio"},
+    )
+    assert read_minio(minio.get_object(bucket, minio_key)) == minio_body
+    minio.copy_object(bucket, minio_copy_key, CopySource(bucket, minio_key))
+    assert read_minio(minio.get_object(bucket, minio_copy_key)) == minio_body
+    minio.remove_object(bucket, minio_key)
+    minio.remove_object(bucket, minio_copy_key)
 
     print("S3 SDK gateway conformance passed")
 


### PR DESCRIPTION
## Summary

- stream fixed-length S3 `PutObject` requests once with backpressure, origin re-signing, and no implicit retry
- verify declared SHA-256 payloads in a secure bounded-memory spool before origin mutation; stream `UNSIGNED-PAYLOAD` directly
- pass through `CopyObject` and `DeleteObject`, requiring source read plus destination write grants for copies
- invalidate object placement entries only after confirmed origin success and mark response-loss failures as indeterminate
- extend boto3 and MinIO LocalStack conformance for create, overwrite, conditions, metadata/checksum, copy, and delete

## Safety

- incoming authorization, date, and session credentials are never forwarded
- multipart and SigV4 streaming chunk modes remain explicitly unsupported under #497
- consumed request bodies are single-use and bypass retry decorators
- HTTP 200 CopyObject responses containing `<Error>` do not invalidate cache state

## Verification

- `just ci`
- `cargo deny check advisories bans sources`
- `mdbook build docs/book`
- `just spell`
- `just linkcheck`
- `python3 -m py_compile scripts/s3_gateway_sdk_conformance.py`
- `git diff --check`

Closes #496
