### PR TITLE
feat(gateway): pass through S3 multipart uploads

### DIFF
--- a/crates/talon-backend/src/azure_sharedkey.rs
+++ b/crates/talon-backend/src/azure_sharedkey.rs
@@ -61,6 +61,7 @@ fn method_str(m: Method) -> &'static str {
         Method::Get => "GET",
         Method::Head => "HEAD",
         Method::Put => "PUT",
+        Method::Post => "POST",
         Method::Delete => "DELETE",
     }
 }

--- a/crates/talon-backend/src/http.rs
+++ b/crates/talon-backend/src/http.rs
@@ -22,6 +22,8 @@ pub enum Method {
     Head,
     /// PUT, used to upload a whole object (write-through, #226).
     Put,
+    /// POST, used for multipart create and completion requests.
+    Post,
     /// DELETE, used to remove an object.
     Delete,
 }

--- a/crates/talon-backend/src/lib.rs
+++ b/crates/talon-backend/src/lib.rs
@@ -25,5 +25,5 @@ pub use http::{
 };
 pub use reqwest_client::ReqwestClient;
 pub use retry::{RetryConfig, RetryObserver, RetryingHttpClient};
-pub use s3::{S3Backend, S3Config, S3Credentials};
+pub use s3::{S3Backend, S3Config, S3Credentials, S3MultipartRequest};
 pub use sigv4::{sign_request, AmzDate};

--- a/crates/talon-backend/src/reqwest_client.rs
+++ b/crates/talon-backend/src/reqwest_client.rs
@@ -79,6 +79,7 @@ impl HttpClient for ReqwestClient {
             Method::Get => reqwest::Method::GET,
             Method::Head => reqwest::Method::HEAD,
             Method::Put => reqwest::Method::PUT,
+            Method::Post => reqwest::Method::POST,
             Method::Delete => reqwest::Method::DELETE,
         };
         let mut builder = self.inner.request(method, &req.url);
@@ -109,6 +110,7 @@ impl HttpClient for ReqwestClient {
             Method::Get => reqwest::Method::GET,
             Method::Head => reqwest::Method::HEAD,
             Method::Put => reqwest::Method::PUT,
+            Method::Post => reqwest::Method::POST,
             Method::Delete => reqwest::Method::DELETE,
         };
         let mut builder = self.inner.request(method, &req.url);
@@ -150,6 +152,7 @@ impl HttpClient for ReqwestClient {
             Method::Get => reqwest::Method::GET,
             Method::Head => reqwest::Method::HEAD,
             Method::Put => reqwest::Method::PUT,
+            Method::Post => reqwest::Method::POST,
             Method::Delete => reqwest::Method::DELETE,
         };
         let mut builder = self.inner.request(method, &req.url);
@@ -196,6 +199,7 @@ impl HttpClient for ReqwestClient {
             Method::Get => reqwest::Method::GET,
             Method::Head => reqwest::Method::HEAD,
             Method::Put => reqwest::Method::PUT,
+            Method::Post => reqwest::Method::POST,
             Method::Delete => reqwest::Method::DELETE,
         };
         let mut builder = self.inner.request(method, &req.url);

--- a/crates/talon-backend/src/s3.rs
+++ b/crates/talon-backend/src/s3.rs
@@ -26,6 +26,19 @@ use crate::http::{
     HttpClient, HttpRequest, HttpRequestBody, HttpResponse, HttpStreamResponse, Method,
 };
 
+/// Validated S3 multipart request metadata supplied by a protocol adapter.
+#[derive(Clone, Copy)]
+pub struct S3MultipartRequest<'a> {
+    /// Origin method for the multipart operation.
+    pub method: Method,
+    /// Canonical destination object.
+    pub object: &'a ObjectId,
+    /// Percent-encoded multipart query without the leading question mark.
+    pub query: &'a str,
+    /// Sanitized provider headers to sign and forward.
+    pub headers: &'a [(String, String)],
+}
+
 /// Percent-encode a query value.
 ///
 /// The URL is signed after this, and SigV4 canonicalizes the query itself, so
@@ -405,6 +418,62 @@ impl S3Backend {
         let mut request = self.build_delete(obj);
         request.headers.extend_from_slice(conditions);
         self.http.execute(self.signed(request)).await
+    }
+
+    /// Execute a bodyless multipart request with an adapter-validated query.
+    pub async fn execute_multipart_raw(
+        &self,
+        request: S3MultipartRequest<'_>,
+    ) -> std::result::Result<HttpResponse, String> {
+        let mut outgoing = HttpRequest::new(
+            request.method,
+            format!("{}?{}", self.object_url(request.object), request.query),
+            self.session_headers(),
+        );
+        outgoing.headers.extend_from_slice(request.headers);
+        self.http.execute(self.signed(outgoing)).await
+    }
+
+    /// Execute a single-use multipart request body without implicit replay.
+    pub async fn execute_multipart_body_raw(
+        &self,
+        request: S3MultipartRequest<'_>,
+        body: HttpRequestBody,
+        len: u64,
+        payload_hash: &str,
+    ) -> std::result::Result<HttpResponse, String> {
+        let mut outgoing = HttpRequest::new(
+            request.method,
+            format!("{}?{}", self.object_url(request.object), request.query),
+            self.session_headers(),
+        );
+        outgoing
+            .headers
+            .push(("content-length".into(), len.to_string()));
+        outgoing.headers.extend_from_slice(request.headers);
+        let outgoing = self.signed_with_payload_hash(outgoing, payload_hash);
+        self.http.execute_body(outgoing, body, len).await
+    }
+
+    /// Execute a multipart request from a verified spool file.
+    pub async fn execute_multipart_file_raw(
+        &self,
+        request: S3MultipartRequest<'_>,
+        path: &Path,
+        len: u64,
+        payload_hash: &str,
+    ) -> std::result::Result<HttpResponse, String> {
+        let mut outgoing = HttpRequest::new(
+            request.method,
+            format!("{}?{}", self.object_url(request.object), request.query),
+            self.session_headers(),
+        );
+        outgoing
+            .headers
+            .push(("content-length".into(), len.to_string()));
+        outgoing.headers.extend_from_slice(request.headers);
+        let outgoing = self.signed_with_payload_hash(outgoing, payload_hash);
+        self.http.execute_file(outgoing, path, len).await
     }
 
     fn build_streamed_put(
@@ -1253,5 +1322,44 @@ mod tests {
             .header("authorization")
             .unwrap()
             .contains("x-amz-copy-source"));
+    }
+
+    #[tokio::test]
+    async fn multipart_post_query_and_body_are_resigned() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: bytes::Bytes::new(),
+        });
+        let backend = S3Backend::new(S3Config::aws("us-east-1"), creds(), http.clone());
+        let body = futures::stream::iter([Ok(bytes::Bytes::from_static(b"<Complete/>"))]);
+        backend
+            .execute_multipart_body_raw(
+                S3MultipartRequest {
+                    method: Method::Post,
+                    object: &obj(),
+                    query: "uploadId=opaque%2Fid",
+                    headers: &[("x-amz-meta-operation".into(), "complete".into())],
+                },
+                Box::pin(body),
+                11,
+                "UNSIGNED-PAYLOAD",
+            )
+            .await
+            .unwrap();
+
+        let (request, body, len) = http.last_body.lock().unwrap().clone().unwrap();
+        assert_eq!(request.method, Method::Post);
+        assert!(request.url.ends_with("?uploadId=opaque%2Fid"));
+        assert_eq!(body, b"<Complete/>");
+        assert_eq!(len, 11);
+        assert_eq!(
+            request.header("x-amz-content-sha256"),
+            Some("UNSIGNED-PAYLOAD")
+        );
+        assert!(request
+            .header("authorization")
+            .unwrap()
+            .contains("x-amz-meta-operation"));
     }
 }

--- a/crates/talon-backend/src/sigv4.rs
+++ b/crates/talon-backend/src/sigv4.rs
@@ -195,6 +195,7 @@ fn method_str(m: Method) -> &'static str {
         Method::Get => "GET",
         Method::Head => "HEAD",
         Method::Put => "PUT",
+        Method::Post => "POST",
         Method::Delete => "DELETE",
     }
 }

--- a/crates/talon-gateway/src/main.rs
+++ b/crates/talon-gateway/src/main.rs
@@ -49,6 +49,8 @@ struct Settings {
     s3_session_token: Option<String>,
     s3_client_identities_path: Option<PathBuf>,
     s3_max_clock_skew_ms: u64,
+    s3_max_multipart_uploads: usize,
+    s3_multipart_ttl_ms: u64,
     authorization_path: Option<PathBuf>,
     tls: Option<GatewayTlsConfig>,
 }
@@ -226,6 +228,16 @@ impl Settings {
                 "900000",
                 "TALON_GATEWAY_S3_MAX_CLOCK_SKEW_MS",
             )?,
+            s3_max_multipart_uploads: parse_or(
+                value(&mut get, "TALON_GATEWAY_S3_MAX_MULTIPART_UPLOADS"),
+                "1024",
+                "TALON_GATEWAY_S3_MAX_MULTIPART_UPLOADS",
+            )?,
+            s3_multipart_ttl_ms: parse_or(
+                value(&mut get, "TALON_GATEWAY_S3_MULTIPART_TTL_MS"),
+                "86400000",
+                "TALON_GATEWAY_S3_MULTIPART_TTL_MS",
+            )?,
             authorization_path: value(&mut get, "TALON_GATEWAY_AUTHORIZATION_PATH")
                 .map(PathBuf::from),
             tls,
@@ -392,6 +404,8 @@ fn s3_adapter(settings: &Settings) -> MainResult<Arc<dyn GatewayAdapter>> {
     config.block_size = settings.block_size;
     config.transfer_chunk_bytes = settings.transfer_chunk_bytes;
     config.default_route = settings.route;
+    config.max_multipart_uploads = settings.s3_max_multipart_uploads;
+    config.multipart_state_ttl = std::time::Duration::from_millis(settings.s3_multipart_ttl_ms);
     let cache = cache_reader(settings);
     Ok(Arc::new(S3Adapter::new(
         config,
@@ -680,6 +694,8 @@ mod tests {
         assert!(settings.tls.is_none());
         assert!(settings.s3_client_identities_path.is_none());
         assert_eq!(settings.s3_max_clock_skew_ms, 900_000);
+        assert_eq!(settings.s3_max_multipart_uploads, 1024);
+        assert_eq!(settings.s3_multipart_ttl_ms, 86_400_000);
         assert!(settings.authorization_path.is_none());
         assert!(settings.azure_client_identities_path.is_none());
         assert_eq!(settings.azure_max_clock_skew_ms, 900_000);

--- a/crates/talon-gateway/src/runtime.rs
+++ b/crates/talon-gateway/src/runtime.rs
@@ -319,7 +319,10 @@ pub enum GatewayTlsServeError {
     Io(#[from] std::io::Error),
 }
 
-async fn adapter_handler(State(runtime): State<Arc<GatewayRuntime>>, request: Request) -> Response {
+async fn adapter_handler(
+    State(runtime): State<Arc<GatewayRuntime>>,
+    mut request: Request,
+) -> Response {
     let context = request
         .extensions()
         .get::<GatewayRequestContext>()
@@ -434,6 +437,9 @@ async fn adapter_handler(State(runtime): State<Arc<GatewayRuntime>>, request: Re
             "allow",
             "policy_allowed",
         ));
+    }
+    if let Some(principal) = authenticated {
+        request.extensions_mut().insert(principal);
     }
     let result =
         match tokio::time::timeout(remaining, runtime.adapter.handle(request, context.clone()))

--- a/crates/talon-gateway/src/s3.rs
+++ b/crates/talon-gateway/src/s3.rs
@@ -1,7 +1,9 @@
 //! Amazon S3-compatible read adapter.
 
+use std::collections::HashMap;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use axum::body::Body;
@@ -11,15 +13,18 @@ use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use sha2::{Digest, Sha256};
-use talon_backend::{HttpRequestBody, HttpResponse, HttpStreamResponse, S3Backend};
+use talon_backend::{
+    HttpRequestBody, HttpResponse, HttpStreamResponse, Method, S3Backend, S3MultipartRequest,
+};
 use talon_cache_client::{BlockReader, CacheReadError, FileView, DEFAULT_TRANSFER_CHUNK_BYTES};
 use talon_core::{Backend, ObjectId, Version};
 use tokio::io::AsyncWriteExt;
 
 use crate::{
-    FailureReason, GatewayAccess, GatewayAccessRequirement, GatewayAdapter, GatewayOperation,
-    GatewayOutcome, GatewayRequestContext, GatewayResponse, GatewayRoute, GatewayTarget,
-    ProviderProtocol,
+    AuthenticatedPrincipal, EffectiveDecision, FailureReason, GatewayAccess,
+    GatewayAccessRequirement, GatewayAdapter, GatewayOperation, GatewayOutcome,
+    GatewayRequestContext, GatewayResponse, GatewayRoute, GatewayTarget, ProviderProtocol,
+    S3_CACHE_MARK_HEADER,
 };
 
 const MAX_ERROR_BODY_BYTES: usize = 64 * 1024;
@@ -58,6 +63,10 @@ pub struct S3AdapterConfig {
     pub transfer_chunk_bytes: u32,
     /// Route used until signed cache marks are implemented by #441.
     pub default_route: GatewayRoute,
+    /// Maximum active multipart uploads tracked by one gateway process.
+    pub max_multipart_uploads: usize,
+    /// Lifetime of an inactive multipart binding.
+    pub multipart_state_ttl: Duration,
 }
 
 impl S3AdapterConfig {
@@ -69,6 +78,8 @@ impl S3AdapterConfig {
             block_size: 256 * 1024 * 1024,
             transfer_chunk_bytes: DEFAULT_TRANSFER_CHUNK_BYTES,
             default_route: GatewayRoute::Cache,
+            max_multipart_uploads: 1024,
+            multipart_state_ttl: Duration::from_secs(24 * 60 * 60),
         }
     }
 
@@ -82,7 +93,11 @@ impl S3AdapterConfig {
     }
 
     fn validate(&self) -> Result<(), S3RequestError> {
-        if self.endpoint_suffix.is_empty() || self.block_size == 0 || self.transfer_chunk_bytes == 0
+        if self.endpoint_suffix.is_empty()
+            || self.block_size == 0
+            || self.transfer_chunk_bytes == 0
+            || self.max_multipart_uploads == 0
+            || self.multipart_state_ttl.is_zero()
         {
             return Err(S3RequestError::invalid(
                 "InvalidArgument",
@@ -190,6 +205,30 @@ pub trait S3Origin: Send + Sync + 'static {
     ) -> Result<HttpResponse, String> {
         Err("S3 origin does not implement DELETE".into())
     }
+
+    async fn multipart(&self, _request: S3MultipartRequest<'_>) -> Result<HttpResponse, String> {
+        Err("S3 origin does not implement multipart requests".into())
+    }
+
+    async fn multipart_body(
+        &self,
+        _request: S3MultipartRequest<'_>,
+        _body: HttpRequestBody,
+        _len: u64,
+        _payload_hash: &str,
+    ) -> Result<HttpResponse, String> {
+        Err("S3 origin does not implement multipart request bodies".into())
+    }
+
+    async fn multipart_file(
+        &self,
+        _request: S3MultipartRequest<'_>,
+        _path: &std::path::Path,
+        _len: u64,
+        _payload_hash: &str,
+    ) -> Result<HttpResponse, String> {
+        Err("S3 origin does not implement multipart file bodies".into())
+    }
 }
 
 #[async_trait]
@@ -270,6 +309,32 @@ impl S3Origin for S3Backend {
     ) -> Result<HttpResponse, String> {
         self.execute_delete_raw(object, conditions).await
     }
+
+    async fn multipart(&self, request: S3MultipartRequest<'_>) -> Result<HttpResponse, String> {
+        self.execute_multipart_raw(request).await
+    }
+
+    async fn multipart_body(
+        &self,
+        request: S3MultipartRequest<'_>,
+        body: HttpRequestBody,
+        len: u64,
+        payload_hash: &str,
+    ) -> Result<HttpResponse, String> {
+        self.execute_multipart_body_raw(request, body, len, payload_hash)
+            .await
+    }
+
+    async fn multipart_file(
+        &self,
+        request: S3MultipartRequest<'_>,
+        path: &std::path::Path,
+        len: u64,
+        payload_hash: &str,
+    ) -> Result<HttpResponse, String> {
+        self.execute_multipart_file_raw(request, path, len, payload_hash)
+            .await
+    }
 }
 
 /// S3 protocol adapter over Talon and a scoped origin identity.
@@ -277,6 +342,7 @@ pub struct S3Adapter {
     config: S3AdapterConfig,
     cache: Arc<dyn S3Cache>,
     origin: Arc<dyn S3Origin>,
+    uploads: MultipartRegistry,
 }
 
 impl S3Adapter {
@@ -288,10 +354,102 @@ impl S3Adapter {
     ) -> Result<Self, String> {
         config.validate().map_err(|error| error.message)?;
         Ok(Self {
+            uploads: MultipartRegistry::new(
+                config.max_multipart_uploads,
+                config.multipart_state_ttl,
+            ),
             config,
             cache,
             origin,
         })
+    }
+}
+
+#[derive(Clone)]
+struct MultipartBinding {
+    object: ObjectId,
+    principal: AuthenticatedPrincipal,
+    decision: EffectiveDecision,
+    touched: Instant,
+}
+
+#[derive(Default)]
+struct MultipartRegistryState {
+    uploads: HashMap<String, MultipartBinding>,
+    reservations: usize,
+}
+
+struct MultipartRegistry {
+    state: Mutex<MultipartRegistryState>,
+    max_uploads: usize,
+    ttl: Duration,
+}
+
+impl MultipartRegistry {
+    fn new(max_uploads: usize, ttl: Duration) -> Self {
+        Self {
+            state: Mutex::new(MultipartRegistryState::default()),
+            max_uploads,
+            ttl,
+        }
+    }
+
+    fn reserve(&self, now: Instant) -> bool {
+        let mut state = self.state.lock().unwrap();
+        self.prune_locked(&mut state, now);
+        if state.uploads.len().saturating_add(state.reservations) >= self.max_uploads {
+            return false;
+        }
+        state.reservations += 1;
+        true
+    }
+
+    fn cancel_reservation(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.reservations = state.reservations.saturating_sub(1);
+    }
+
+    fn publish(&self, upload_id: String, binding: MultipartBinding) -> bool {
+        let mut state = self.state.lock().unwrap();
+        state.reservations = state.reservations.saturating_sub(1);
+        if state.uploads.contains_key(&upload_id) {
+            return false;
+        }
+        state.uploads.insert(upload_id, binding);
+        true
+    }
+
+    fn authorize(
+        &self,
+        upload_id: &str,
+        object: &ObjectId,
+        principal: &AuthenticatedPrincipal,
+        decision: EffectiveDecision,
+        now: Instant,
+    ) -> bool {
+        let mut state = self.state.lock().unwrap();
+        self.prune_locked(&mut state, now);
+        let Some(binding) = state.uploads.get_mut(upload_id) else {
+            return false;
+        };
+        if binding.object != *object
+            || binding.principal != *principal
+            || binding.decision != decision
+        {
+            return false;
+        }
+        binding.touched = now;
+        true
+    }
+
+    fn remove(&self, upload_id: &str) {
+        self.state.lock().unwrap().uploads.remove(upload_id);
+    }
+
+    fn prune_locked(&self, state: &mut MultipartRegistryState, now: Instant) {
+        state
+            .uploads
+            .retain(|_, binding| now.saturating_duration_since(binding.touched) <= self.ttl);
     }
 }
 
@@ -377,7 +535,11 @@ struct S3Query {
     continuation_token: Option<String>,
     max_keys: Option<String>,
     encoding_type: Option<String>,
-    multipart: bool,
+    uploads: Option<String>,
+    upload_id: Option<String>,
+    part_number: Option<String>,
+    part_number_marker: Option<String>,
+    max_parts: Option<String>,
 }
 
 impl S3Query {
@@ -392,7 +554,21 @@ impl S3Query {
                 "continuation-token" => parsed.continuation_token = Some(value.into_owned()),
                 "max-keys" => parsed.max_keys = Some(value.into_owned()),
                 "encoding-type" => parsed.encoding_type = Some(value.into_owned()),
-                "uploads" | "uploadId" | "partNumber" => parsed.multipart = true,
+                "uploads" => set_query_value(&mut parsed.uploads, value.into_owned(), "uploads")?,
+                "uploadId" => {
+                    set_query_value(&mut parsed.upload_id, value.into_owned(), "uploadId")?
+                }
+                "partNumber" => {
+                    set_query_value(&mut parsed.part_number, value.into_owned(), "partNumber")?
+                }
+                "part-number-marker" => set_query_value(
+                    &mut parsed.part_number_marker,
+                    value.into_owned(),
+                    "part-number-marker",
+                )?,
+                "max-parts" => {
+                    set_query_value(&mut parsed.max_parts, value.into_owned(), "max-parts")?
+                }
                 _ => {}
             }
         }
@@ -405,6 +581,94 @@ impl S3Query {
             }
         }
         Ok(parsed)
+    }
+
+    fn multipart_operation(
+        &self,
+        method: &axum::http::Method,
+        copy: bool,
+    ) -> Result<Option<MultipartOperation>, S3RequestError> {
+        let multipart = self.uploads.is_some()
+            || self.upload_id.is_some()
+            || self.part_number.is_some()
+            || self.part_number_marker.is_some()
+            || self.max_parts.is_some();
+        if !multipart {
+            return Ok(None);
+        }
+        if let Some(value) = self.uploads.as_deref() {
+            if method == axum::http::Method::POST
+                && value.is_empty()
+                && self.upload_id.is_none()
+                && self.part_number.is_none()
+                && self.part_number_marker.is_none()
+                && self.max_parts.is_none()
+            {
+                return Ok(Some(MultipartOperation::Create));
+            }
+            return Err(S3RequestError::invalid(
+                "InvalidRequest",
+                "invalid CreateMultipartUpload request",
+            ));
+        }
+        let upload_id = self
+            .upload_id
+            .as_deref()
+            .filter(|value| !value.is_empty() && value.len() <= 2048)
+            .ok_or_else(|| S3RequestError::invalid("InvalidArgument", "uploadId is invalid"))?
+            .to_string();
+        match *method {
+            axum::http::Method::PUT => {
+                if self.part_number_marker.is_some() || self.max_parts.is_some() {
+                    return Err(S3RequestError::invalid(
+                        "InvalidArgument",
+                        "invalid UploadPart request",
+                    ));
+                }
+                let part_number = parse_part_number(self.part_number.as_deref())?;
+                Ok(Some(MultipartOperation::UploadPart {
+                    upload_id,
+                    part_number,
+                    copy,
+                }))
+            }
+            axum::http::Method::GET if self.part_number.is_none() => {
+                let part_number_marker = self
+                    .part_number_marker
+                    .as_deref()
+                    .map(parse_part_marker)
+                    .transpose()?;
+                let max_parts = self
+                    .max_parts
+                    .as_deref()
+                    .map(parse_max_parts)
+                    .transpose()?
+                    .unwrap_or(1000);
+                Ok(Some(MultipartOperation::ListParts {
+                    upload_id,
+                    part_number_marker,
+                    max_parts,
+                }))
+            }
+            axum::http::Method::POST
+                if self.part_number.is_none()
+                    && self.part_number_marker.is_none()
+                    && self.max_parts.is_none() =>
+            {
+                Ok(Some(MultipartOperation::Complete { upload_id }))
+            }
+            axum::http::Method::DELETE
+                if self.part_number.is_none()
+                    && self.part_number_marker.is_none()
+                    && self.max_parts.is_none() =>
+            {
+                Ok(Some(MultipartOperation::Abort { upload_id }))
+            }
+            _ => Err(S3RequestError::invalid(
+                "InvalidRequest",
+                "unsupported multipart request shape",
+            )),
+        }
     }
 
     fn is_list_v2(&self) -> bool {
@@ -426,6 +690,147 @@ impl S3Query {
                 }),
         }
     }
+}
+
+fn set_query_value(
+    slot: &mut Option<String>,
+    value: String,
+    name: &str,
+) -> Result<(), S3RequestError> {
+    if slot.replace(value).is_some() {
+        return Err(S3RequestError::invalid(
+            "InvalidArgument",
+            format!("{name} must occur exactly once"),
+        ));
+    }
+    Ok(())
+}
+
+fn parse_part_number(value: Option<&str>) -> Result<u16, S3RequestError> {
+    value
+        .and_then(|value| value.parse::<u16>().ok())
+        .filter(|value| (1..=10_000).contains(value))
+        .ok_or_else(|| {
+            S3RequestError::invalid("InvalidArgument", "partNumber must be between 1 and 10000")
+        })
+}
+
+fn parse_part_marker(value: &str) -> Result<u16, S3RequestError> {
+    value
+        .parse::<u16>()
+        .ok()
+        .filter(|value| *value <= 10_000)
+        .ok_or_else(|| S3RequestError::invalid("InvalidArgument", "part-number-marker is invalid"))
+}
+
+fn parse_max_parts(value: &str) -> Result<u16, S3RequestError> {
+    value
+        .parse::<u16>()
+        .ok()
+        .filter(|value| *value <= 1000)
+        .ok_or_else(|| S3RequestError::invalid("InvalidArgument", "max-parts is invalid"))
+}
+
+#[derive(Debug)]
+enum MultipartOperation {
+    Create,
+    UploadPart {
+        upload_id: String,
+        part_number: u16,
+        copy: bool,
+    },
+    ListParts {
+        upload_id: String,
+        part_number_marker: Option<u16>,
+        max_parts: u16,
+    },
+    Complete {
+        upload_id: String,
+    },
+    Abort {
+        upload_id: String,
+    },
+}
+
+impl MultipartOperation {
+    fn upload_id(&self) -> Option<&str> {
+        match self {
+            Self::Create => None,
+            Self::UploadPart { upload_id, .. }
+            | Self::ListParts { upload_id, .. }
+            | Self::Complete { upload_id }
+            | Self::Abort { upload_id } => Some(upload_id),
+        }
+    }
+
+    fn query(&self) -> String {
+        match self {
+            Self::Create => "uploads=".into(),
+            Self::UploadPart {
+                upload_id,
+                part_number,
+                ..
+            } => format!(
+                "partNumber={part_number}&uploadId={}",
+                encode_query_value(upload_id)
+            ),
+            Self::ListParts {
+                upload_id,
+                part_number_marker,
+                max_parts,
+            } => {
+                let mut query = format!("uploadId={}", encode_query_value(upload_id));
+                if let Some(marker) = part_number_marker {
+                    query.push_str(&format!("&part-number-marker={marker}"));
+                }
+                query.push_str(&format!("&max-parts={max_parts}"));
+                query
+            }
+            Self::Complete { upload_id } | Self::Abort { upload_id } => {
+                format!("uploadId={}", encode_query_value(upload_id))
+            }
+        }
+    }
+}
+
+fn encode_query_value(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    encoded
+}
+
+fn multipart_principal(request: &Request) -> Result<AuthenticatedPrincipal, S3RequestError> {
+    request
+        .extensions()
+        .get::<AuthenticatedPrincipal>()
+        .cloned()
+        .ok_or_else(S3RequestError::access_denied)
+}
+
+fn cache_decision(headers: &HeaderMap) -> Result<EffectiveDecision, S3RequestError> {
+    let mut values = headers.get_all(S3_CACHE_MARK_HEADER).iter();
+    let Some(value) = values.next() else {
+        return Ok(EffectiveDecision::default());
+    };
+    if values.next().is_some() {
+        return Err(S3RequestError::invalid(
+            "InvalidRequest",
+            "cache decision must occur exactly once",
+        ));
+    }
+    EffectiveDecision::parse(
+        value
+            .to_str()
+            .map_err(|_| S3RequestError::invalid("InvalidRequest", "cache decision is invalid"))?,
+    )
+    .map_err(|_| S3RequestError::invalid("InvalidRequest", "cache decision is invalid"))
 }
 
 fn single_content_length(headers: &HeaderMap) -> Result<u64, S3RequestError> {
@@ -468,7 +873,7 @@ fn mutation_headers(
     headers: &HeaderMap,
     copy: bool,
 ) -> Result<Vec<(String, String)>, S3RequestError> {
-    const EXACT: [&str; 18] = [
+    const EXACT: [&str; 19] = [
         "cache-control",
         "content-disposition",
         "content-encoding",
@@ -481,6 +886,7 @@ fn mutation_headers(
         "x-amz-acl",
         "x-amz-checksum-algorithm",
         "x-amz-copy-source",
+        "x-amz-copy-source-range",
         "x-amz-metadata-directive",
         "x-amz-storage-class",
         "x-amz-tagging",
@@ -906,6 +1312,39 @@ impl S3RequestError {
         }
     }
 
+    fn no_such_upload() -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            code: "NoSuchUpload",
+            message: "The specified multipart upload does not exist".into(),
+            failure: FailureReason::NotFound,
+            content_range: None,
+            indeterminate_commit: false,
+        }
+    }
+
+    fn access_denied() -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            code: "AccessDenied",
+            message: "Access Denied".into(),
+            failure: FailureReason::Authorization,
+            content_range: None,
+            indeterminate_commit: false,
+        }
+    }
+
+    fn multipart_capacity() -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            code: "ServiceUnavailable",
+            message: "Multipart upload capacity is temporarily exhausted".into(),
+            failure: FailureReason::Internal,
+            content_range: None,
+            indeterminate_commit: false,
+        }
+    }
+
     fn precondition_failed() -> Self {
         Self {
             status: StatusCode::PRECONDITION_FAILED,
@@ -1139,12 +1578,21 @@ impl S3Adapter {
         let key = target
             .key
             .ok_or_else(|| S3RequestError::invalid("InvalidURI", "request has no object key"))?;
-        let operation = match *request.method() {
-            axum::http::Method::HEAD => GatewayOperation::Stat,
-            axum::http::Method::GET => GatewayOperation::Read,
-            axum::http::Method::PUT | axum::http::Method::POST => GatewayOperation::Write,
-            axum::http::Method::DELETE => GatewayOperation::Delete,
-            _ => GatewayOperation::Unsupported,
+        let multipart = query.multipart_operation(
+            request.method(),
+            request.headers().contains_key("x-amz-copy-source"),
+        )?;
+        let operation = match multipart.as_ref() {
+            Some(MultipartOperation::ListParts { .. }) => GatewayOperation::List,
+            Some(MultipartOperation::Abort { .. }) => GatewayOperation::Delete,
+            Some(_) => GatewayOperation::Write,
+            None => match *request.method() {
+                axum::http::Method::HEAD => GatewayOperation::Stat,
+                axum::http::Method::GET => GatewayOperation::Read,
+                axum::http::Method::PUT | axum::http::Method::POST => GatewayOperation::Write,
+                axum::http::Method::DELETE => GatewayOperation::Delete,
+                _ => GatewayOperation::Unsupported,
+            },
         };
         let mut access = GatewayAccess {
             operation,
@@ -1179,15 +1627,11 @@ impl S3Adapter {
             .key
             .ok_or_else(|| S3RequestError::invalid("InvalidURI", "request has no object key"))?;
         let object = ObjectId::new(Backend::S3, target.bucket, key);
-        if query.multipart {
-            return Err(S3RequestError {
-                status: StatusCode::NOT_IMPLEMENTED,
-                code: "NotImplemented",
-                message: "Multipart upload operations are not supported by this endpoint".into(),
-                failure: FailureReason::Unsupported,
-                content_range: None,
-                indeterminate_commit: false,
-            });
+        if let Some(operation) = query.multipart_operation(
+            request.method(),
+            request.headers().contains_key("x-amz-copy-source"),
+        )? {
+            return self.multipart(object, operation, request, context).await;
         }
         match *request.method() {
             axum::http::Method::HEAD => self.head(object, request.headers(), context).await,
@@ -1203,6 +1647,358 @@ impl S3Adapter {
                 indeterminate_commit: false,
             }),
         }
+    }
+
+    async fn multipart(
+        &self,
+        object: ObjectId,
+        operation: MultipartOperation,
+        request: Request,
+        context: &GatewayRequestContext,
+    ) -> Result<GatewayResponse, S3RequestError> {
+        let principal = multipart_principal(&request)?;
+        let decision = cache_decision(request.headers())?;
+        if matches!(operation, MultipartOperation::Create) {
+            return self
+                .create_multipart(object, request.headers(), principal, decision, context)
+                .await;
+        }
+        let upload_id = operation
+            .upload_id()
+            .expect("non-create multipart operation has an upload ID");
+        if !self
+            .uploads
+            .authorize(upload_id, &object, &principal, decision, Instant::now())
+        {
+            return Err(S3RequestError::no_such_upload());
+        }
+        match operation {
+            MultipartOperation::Create => unreachable!(),
+            MultipartOperation::UploadPart {
+                part_number,
+                copy,
+                upload_id,
+            } => {
+                self.upload_part(object, upload_id, part_number, copy, request, context)
+                    .await
+            }
+            MultipartOperation::ListParts {
+                upload_id,
+                part_number_marker,
+                max_parts,
+            } => {
+                self.list_parts(object, upload_id, part_number_marker, max_parts, context)
+                    .await
+            }
+            MultipartOperation::Complete { upload_id } => {
+                self.complete_multipart(object, upload_id, request, context)
+                    .await
+            }
+            MultipartOperation::Abort { upload_id } => {
+                self.abort_multipart(object, upload_id, context).await
+            }
+        }
+    }
+
+    async fn create_multipart(
+        &self,
+        object: ObjectId,
+        headers: &HeaderMap,
+        principal: AuthenticatedPrincipal,
+        decision: EffectiveDecision,
+        context: &GatewayRequestContext,
+    ) -> Result<GatewayResponse, S3RequestError> {
+        if !self.uploads.reserve(Instant::now()) {
+            return Err(S3RequestError::multipart_capacity());
+        }
+        let headers = match mutation_headers(headers, false) {
+            Ok(headers) => headers,
+            Err(error) => {
+                self.uploads.cancel_reservation();
+                return Err(error);
+            }
+        };
+        let response = match self
+            .origin
+            .multipart(S3MultipartRequest {
+                method: Method::Post,
+                object: &object,
+                query: "uploads=",
+                headers: &headers,
+            })
+            .await
+        {
+            Ok(response) => response,
+            Err(_) => {
+                self.uploads.cancel_reservation();
+                return Err(S3RequestError::indeterminate_commit());
+            }
+        };
+        if !response.is_success() {
+            self.uploads.cancel_reservation();
+            return Ok(raw_response(
+                response,
+                GatewayOperation::Write,
+                Some(GatewayTarget::Object(object)),
+                context,
+            ));
+        }
+        let upload_id = std::str::from_utf8(&response.body)
+            .ok()
+            .and_then(|xml| talon_backend::xml::element(xml, "UploadId"))
+            .map(talon_backend::xml::unescape)
+            .filter(|upload_id| !upload_id.is_empty() && upload_id.len() <= 2048);
+        let Some(upload_id) = upload_id else {
+            self.uploads.cancel_reservation();
+            return Err(S3RequestError::indeterminate_commit());
+        };
+        let published = self.uploads.publish(
+            upload_id,
+            MultipartBinding {
+                object: object.clone(),
+                principal,
+                decision,
+                touched: Instant::now(),
+            },
+        );
+        if !published {
+            return Err(S3RequestError::indeterminate_commit());
+        }
+        Ok(raw_response(
+            response,
+            GatewayOperation::Write,
+            Some(GatewayTarget::Object(object)),
+            context,
+        ))
+    }
+
+    async fn upload_part(
+        &self,
+        object: ObjectId,
+        upload_id: String,
+        part_number: u16,
+        copy: bool,
+        request: Request,
+        context: &GatewayRequestContext,
+    ) -> Result<GatewayResponse, S3RequestError> {
+        let query = MultipartOperation::UploadPart {
+            upload_id,
+            part_number,
+            copy,
+        }
+        .query();
+        if copy {
+            let headers = mutation_headers(request.headers(), true)?;
+            let response = self
+                .origin
+                .multipart(S3MultipartRequest {
+                    method: Method::Put,
+                    object: &object,
+                    query: &query,
+                    headers: &headers,
+                })
+                .await
+                .map_err(|_| S3RequestError::indeterminate_commit())?;
+            let failed = copy_response_failed(&response);
+            let mut response = raw_response(
+                response,
+                GatewayOperation::Write,
+                Some(GatewayTarget::Object(object)),
+                context,
+            );
+            if failed && response.response.status().is_success() {
+                response.outcome = GatewayOutcome::Failed;
+                response.failure = Some(FailureReason::Origin);
+            }
+            return Ok(response);
+        }
+        let len = single_content_length(request.headers())?;
+        let payload_hash = payload_declaration(&request)?;
+        let headers = mutation_headers(request.headers(), false)?;
+        let body = request.into_body().into_data_stream();
+        let response = if payload_hash == "UNSIGNED-PAYLOAD" {
+            let body = body.map(|chunk| chunk.map_err(|error| error.to_string()));
+            self.origin
+                .multipart_body(
+                    S3MultipartRequest {
+                        method: Method::Put,
+                        object: &object,
+                        query: &query,
+                        headers: &headers,
+                    },
+                    Box::pin(body),
+                    len,
+                    &payload_hash,
+                )
+                .await
+        } else {
+            let (spool, actual_hash) = spool_and_hash(body, len).await?;
+            if actual_hash != payload_hash {
+                return Err(S3RequestError::invalid(
+                    "XAmzContentSHA256Mismatch",
+                    "The provided payload hash does not match the request body",
+                ));
+            }
+            self.origin
+                .multipart_file(
+                    S3MultipartRequest {
+                        method: Method::Put,
+                        object: &object,
+                        query: &query,
+                        headers: &headers,
+                    },
+                    spool.path(),
+                    len,
+                    &actual_hash,
+                )
+                .await
+        }
+        .map_err(|_| S3RequestError::indeterminate_commit())?;
+        let mut response = raw_response(
+            response,
+            GatewayOperation::Write,
+            Some(GatewayTarget::Object(object)),
+            context,
+        );
+        response.requested_bytes = len;
+        Ok(response)
+    }
+
+    async fn list_parts(
+        &self,
+        object: ObjectId,
+        upload_id: String,
+        part_number_marker: Option<u16>,
+        max_parts: u16,
+        context: &GatewayRequestContext,
+    ) -> Result<GatewayResponse, S3RequestError> {
+        let query = MultipartOperation::ListParts {
+            upload_id,
+            part_number_marker,
+            max_parts,
+        }
+        .query();
+        let response = self
+            .origin
+            .multipart(S3MultipartRequest {
+                method: Method::Get,
+                object: &object,
+                query: &query,
+                headers: &[],
+            })
+            .await
+            .map_err(S3RequestError::origin_unavailable)?;
+        Ok(raw_response(
+            response,
+            GatewayOperation::List,
+            Some(GatewayTarget::Object(object)),
+            context,
+        ))
+    }
+
+    async fn complete_multipart(
+        &self,
+        object: ObjectId,
+        upload_id: String,
+        request: Request,
+        context: &GatewayRequestContext,
+    ) -> Result<GatewayResponse, S3RequestError> {
+        let query = MultipartOperation::Complete {
+            upload_id: upload_id.clone(),
+        }
+        .query();
+        let len = single_content_length(request.headers())?;
+        let payload_hash = payload_declaration(&request)?;
+        let headers = mutation_headers(request.headers(), false)?;
+        let body = request.into_body().into_data_stream();
+        let response = if payload_hash == "UNSIGNED-PAYLOAD" {
+            let body = body.map(|chunk| chunk.map_err(|error| error.to_string()));
+            self.origin
+                .multipart_body(
+                    S3MultipartRequest {
+                        method: Method::Post,
+                        object: &object,
+                        query: &query,
+                        headers: &headers,
+                    },
+                    Box::pin(body),
+                    len,
+                    &payload_hash,
+                )
+                .await
+        } else {
+            let (spool, actual_hash) = spool_and_hash(body, len).await?;
+            if actual_hash != payload_hash {
+                return Err(S3RequestError::invalid(
+                    "XAmzContentSHA256Mismatch",
+                    "The provided payload hash does not match the request body",
+                ));
+            }
+            self.origin
+                .multipart_file(
+                    S3MultipartRequest {
+                        method: Method::Post,
+                        object: &object,
+                        query: &query,
+                        headers: &headers,
+                    },
+                    spool.path(),
+                    len,
+                    &actual_hash,
+                )
+                .await
+        }
+        .map_err(|_| S3RequestError::indeterminate_commit())?;
+        let embedded_error = copy_response_failed(&response);
+        if (response.is_success() && !embedded_error) || response.status == 404 {
+            self.uploads.remove(&upload_id);
+        }
+        if response.is_success() && !embedded_error {
+            let _ = self.cache.invalidate_object(&object);
+        }
+        let mut response = raw_response(
+            response,
+            GatewayOperation::Write,
+            Some(GatewayTarget::Object(object)),
+            context,
+        );
+        response.requested_bytes = len;
+        if embedded_error && response.response.status().is_success() {
+            response.outcome = GatewayOutcome::Failed;
+            response.failure = Some(FailureReason::Origin);
+        }
+        Ok(response)
+    }
+
+    async fn abort_multipart(
+        &self,
+        object: ObjectId,
+        upload_id: String,
+        context: &GatewayRequestContext,
+    ) -> Result<GatewayResponse, S3RequestError> {
+        let query = MultipartOperation::Abort {
+            upload_id: upload_id.clone(),
+        }
+        .query();
+        let response = self
+            .origin
+            .multipart(S3MultipartRequest {
+                method: Method::Delete,
+                object: &object,
+                query: &query,
+                headers: &[],
+            })
+            .await
+            .map_err(|_| S3RequestError::indeterminate_commit())?;
+        if response.is_success() || response.status == 404 {
+            self.uploads.remove(&upload_id);
+        }
+        Ok(raw_response(
+            response,
+            GatewayOperation::Delete,
+            Some(GatewayTarget::Object(object)),
+            context,
+        ))
     }
 
     async fn put(
@@ -1641,6 +2437,30 @@ mod tests {
         headers: Mutex<Vec<(String, String)>>,
     }
 
+    type MultipartCall = (Method, String, Vec<(String, String)>, Vec<u8>);
+
+    struct MultipartOrigin {
+        responses: Mutex<VecDeque<Result<HttpResponse, String>>>,
+        calls: Mutex<Vec<MultipartCall>>,
+    }
+
+    impl MultipartOrigin {
+        fn new(responses: impl IntoIterator<Item = Result<HttpResponse, String>>) -> Arc<Self> {
+            Arc::new(Self {
+                responses: Mutex::new(responses.into_iter().collect()),
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn response(&self) -> Result<HttpResponse, String> {
+            self.responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("multipart test provided one response per origin call")
+        }
+    }
+
     struct StallingMutationOrigin;
 
     #[async_trait]
@@ -1784,6 +2604,87 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl S3Origin for MultipartOrigin {
+        async fn head(
+            &self,
+            _object: &ObjectId,
+            _conditions: &[(String, String)],
+        ) -> Result<HttpResponse, String> {
+            unreachable!("multipart tests do not stat")
+        }
+
+        async fn get(
+            &self,
+            _object: &ObjectId,
+            _range: Option<(u64, u64)>,
+            _conditions: &[(String, String)],
+        ) -> Result<HttpStreamResponse, String> {
+            unreachable!("multipart tests do not read objects")
+        }
+
+        async fn list(
+            &self,
+            _bucket: &str,
+            _prefix: &str,
+            _delimiter: Option<&str>,
+            _continuation_token: Option<&str>,
+            _max_keys: u32,
+            _encoding_type: Option<&str>,
+        ) -> Result<HttpResponse, String> {
+            unreachable!("multipart tests do not list objects")
+        }
+
+        async fn multipart(&self, request: S3MultipartRequest<'_>) -> Result<HttpResponse, String> {
+            self.calls.lock().unwrap().push((
+                request.method,
+                request.query.into(),
+                request.headers.to_vec(),
+                Vec::new(),
+            ));
+            self.response()
+        }
+
+        async fn multipart_body(
+            &self,
+            request: S3MultipartRequest<'_>,
+            mut body: HttpRequestBody,
+            _len: u64,
+            _payload_hash: &str,
+        ) -> Result<HttpResponse, String> {
+            let mut bytes = Vec::new();
+            while let Some(chunk) = body.next().await {
+                bytes.extend_from_slice(&chunk?);
+            }
+            self.calls.lock().unwrap().push((
+                request.method,
+                request.query.into(),
+                request.headers.to_vec(),
+                bytes,
+            ));
+            self.response()
+        }
+
+        async fn multipart_file(
+            &self,
+            request: S3MultipartRequest<'_>,
+            path: &std::path::Path,
+            _len: u64,
+            _payload_hash: &str,
+        ) -> Result<HttpResponse, String> {
+            let bytes = tokio::fs::read(path)
+                .await
+                .map_err(|error| error.to_string())?;
+            self.calls.lock().unwrap().push((
+                request.method,
+                request.query.into(),
+                request.headers.to_vec(),
+                bytes,
+            ));
+            self.response()
+        }
+    }
+
     fn mutation_adapter(cache: Arc<MutationCache>, origin: Arc<MutationOrigin>) -> S3Adapter {
         S3Adapter::new(S3AdapterConfig::path_style("localhost"), cache, origin).unwrap()
     }
@@ -1912,6 +2813,19 @@ mod tests {
             .unwrap()
     }
 
+    fn authenticated_request(method: &str, uri: &str, body: Body) -> Request {
+        let mut request = Request::builder()
+            .method(method)
+            .uri(uri)
+            .header(header::HOST, "localhost")
+            .body(body)
+            .unwrap();
+        request
+            .extensions_mut()
+            .insert(AuthenticatedPrincipal::new("multipart-user", "account-a"));
+        request
+    }
+
     fn context() -> GatewayRequestContext {
         GatewayRequestContext {
             request_id: "00000000-0000-4000-8000-000000000001".into(),
@@ -1941,6 +2855,77 @@ mod tests {
                 .unwrap(),
             0
         );
+    }
+
+    #[test]
+    fn parses_only_supported_multipart_shapes() {
+        let upload = S3Query::parse(Some("partNumber=7&uploadId=id%2Ftoken"))
+            .unwrap()
+            .multipart_operation(&axum::http::Method::PUT, false)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            upload.query(),
+            "partNumber=7&uploadId=id%2Ftoken",
+            "opaque upload IDs are decoded once and safely re-encoded"
+        );
+        assert!(S3Query::parse(Some("uploadId=a&uploadId=b")).is_err());
+        assert!(S3Query::parse(Some("partNumber=0&uploadId=id"))
+            .unwrap()
+            .multipart_operation(&axum::http::Method::PUT, false)
+            .is_err());
+        assert!(S3Query::parse(Some("uploads=&uploadId=id"))
+            .unwrap()
+            .multipart_operation(&axum::http::Method::POST, false)
+            .is_err());
+    }
+
+    #[test]
+    fn multipart_registry_is_bounded_expires_and_fails_closed() {
+        let registry = MultipartRegistry::new(1, Duration::from_secs(5));
+        let now = Instant::now();
+        let object = ObjectId::new(Backend::S3, "bucket", "key");
+        let principal = AuthenticatedPrincipal::new("user", "account");
+        assert!(registry.reserve(now));
+        assert!(!registry.reserve(now));
+        assert!(registry.publish(
+            "upload".into(),
+            MultipartBinding {
+                object: object.clone(),
+                principal: principal.clone(),
+                decision: EffectiveDecision::DEFAULT,
+                touched: now,
+            }
+        ));
+        assert!(!registry.authorize(
+            "upload",
+            &ObjectId::new(Backend::S3, "bucket", "other"),
+            &principal,
+            EffectiveDecision::DEFAULT,
+            now,
+        ));
+        assert!(!registry.authorize(
+            "upload",
+            &object,
+            &AuthenticatedPrincipal::new("other", "account"),
+            EffectiveDecision::DEFAULT,
+            now,
+        ));
+        assert!(!registry.authorize(
+            "upload",
+            &object,
+            &principal,
+            EffectiveDecision::ORIGIN_ONLY,
+            now,
+        ));
+        assert!(!registry.authorize(
+            "upload",
+            &object,
+            &principal,
+            EffectiveDecision::DEFAULT,
+            now + Duration::from_secs(6),
+        ));
+        assert!(registry.reserve(now + Duration::from_secs(6)));
     }
 
     #[tokio::test]
@@ -2149,6 +3134,26 @@ mod tests {
             access.additional[0].target,
             GatewayTarget::Object(ObjectId::new(Backend::S3, "source", "original"))
         );
+
+        let mut part_copy = request(
+            axum::http::Method::PUT,
+            "/destination/copied?partNumber=1&uploadId=opaque",
+        );
+        part_copy.headers_mut().insert(
+            "x-amz-copy-source",
+            HeaderValue::from_static("/source/original"),
+        );
+        let access = adapter(
+            MockCache {
+                response: Ok(Vec::new()),
+            },
+            MockOrigin::new(),
+        )
+        .classify_access(&part_copy)
+        .unwrap();
+        assert_eq!(access.operation, GatewayOperation::Write);
+        assert_eq!(access.additional.len(), 1);
+        assert_eq!(access.additional[0].operation, GatewayOperation::Read);
     }
 
     #[tokio::test]
@@ -2281,6 +3286,96 @@ mod tests {
         assert_eq!(response.outcome, GatewayOutcome::Failed);
         assert_eq!(response.failure, Some(FailureReason::Origin));
         assert_eq!(cache.invalidations.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn multipart_binding_and_completion_are_fail_closed() {
+        let cache = Arc::new(MutationCache {
+            invalidations: AtomicUsize::new(0),
+        });
+        let origin = MultipartOrigin::new([
+            Ok(HttpResponse {
+                status: 200,
+                headers: vec![("content-type".into(), "application/xml".into())],
+                body: Bytes::from_static(
+                    b"<InitiateMultipartUploadResult><UploadId>opaque/id</UploadId></InitiateMultipartUploadResult>",
+                ),
+            }),
+            Ok(HttpResponse {
+                status: 200,
+                headers: vec![("content-type".into(), "application/xml".into())],
+                body: Bytes::from_static(
+                    b"<Error><Code>InternalError</Code><Message>complete failed</Message></Error>",
+                ),
+            }),
+            Ok(HttpResponse {
+                status: 200,
+                headers: vec![("content-type".into(), "application/xml".into())],
+                body: Bytes::from_static(b"<CompleteMultipartUploadResult/>")
+            }),
+        ]);
+        let adapter = S3Adapter::new(
+            S3AdapterConfig::path_style("localhost"),
+            Arc::clone(&cache) as Arc<dyn S3Cache>,
+            Arc::clone(&origin) as Arc<dyn S3Origin>,
+        )
+        .unwrap();
+
+        let create = adapter
+            .handle(
+                authenticated_request("POST", "/bucket/key?uploads", Body::empty()),
+                context(),
+            )
+            .await;
+        assert_eq!(create.response.status(), StatusCode::OK);
+        assert_eq!(origin.calls.lock().unwrap()[0].1, "uploads=");
+
+        let mut wrong_principal =
+            authenticated_request("GET", "/bucket/key?uploadId=opaque%2Fid", Body::empty());
+        wrong_principal
+            .extensions_mut()
+            .insert(AuthenticatedPrincipal::new("different-user", "account-a"));
+        let rejected = adapter.handle(wrong_principal, context()).await;
+        assert_eq!(rejected.response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(origin.calls.lock().unwrap().len(), 1);
+
+        let complete_body = "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>etag</ETag></Part></CompleteMultipartUpload>";
+        let complete = || {
+            let mut request = authenticated_request(
+                "POST",
+                "/bucket/key?uploadId=opaque%2Fid",
+                Body::from(complete_body),
+            );
+            request.headers_mut().insert(
+                header::CONTENT_LENGTH,
+                HeaderValue::from_str(&complete_body.len().to_string()).unwrap(),
+            );
+            request.headers_mut().insert(
+                "x-amz-content-sha256",
+                HeaderValue::from_static("UNSIGNED-PAYLOAD"),
+            );
+            request
+        };
+        let embedded_error = adapter.handle(complete(), context()).await;
+        assert_eq!(embedded_error.response.status(), StatusCode::OK);
+        assert_eq!(embedded_error.outcome, GatewayOutcome::Failed);
+        assert_eq!(cache.invalidations.load(Ordering::SeqCst), 0);
+
+        let success = adapter.handle(complete(), context()).await;
+        assert_eq!(success.response.status(), StatusCode::OK);
+        assert_eq!(success.outcome, GatewayOutcome::Complete);
+        assert_eq!(cache.invalidations.load(Ordering::SeqCst), 1);
+        assert_eq!(origin.calls.lock().unwrap()[2].0, Method::Post);
+        assert_eq!(origin.calls.lock().unwrap()[2].3, complete_body.as_bytes());
+
+        let removed = adapter
+            .handle(
+                authenticated_request("GET", "/bucket/key?uploadId=opaque%2Fid", Body::empty()),
+                context(),
+            )
+            .await;
+        assert_eq!(removed.response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(origin.calls.lock().unwrap().len(), 3);
     }
 
     #[tokio::test]

--- a/crates/talon-worker/tests/latency_lab_e2e.rs
+++ b/crates/talon-worker/tests/latency_lab_e2e.rs
@@ -90,7 +90,7 @@ impl HttpClient for CountingHttpClient {
                 })
             }
             // The read path only issues HEAD + ranged GET.
-            Method::Put | Method::Delete => {
+            Method::Put | Method::Post | Method::Delete => {
                 Err(format!("unexpected {:?} in the read-path test", req.method))
             }
         }

--- a/docs/operations/object-store-gateway.md
+++ b/docs/operations/object-store-gateway.md
@@ -114,6 +114,8 @@ S3 variables:
 | `AWS_SESSION_TOKEN` | unset | Optional STS token. |
 | `TALON_GATEWAY_S3_CLIENT_IDENTITIES_PATH` | unset | JSON incoming identity file. Required for S3 production readiness. |
 | `TALON_GATEWAY_S3_MAX_CLOCK_SKEW_MS` | `900000` | Maximum header-signature clock skew and presigned grace. |
+| `TALON_GATEWAY_S3_MAX_MULTIPART_UPLOADS` | `1024` | Maximum active multipart bindings held by one gateway process. |
+| `TALON_GATEWAY_S3_MULTIPART_TTL_MS` | `86400000` | Inactivity lifetime for one process-local multipart binding. |
 
 The identity file is separate from the origin environment variables. Do not use
 the gateway's origin access key as a client identity in production:
@@ -162,9 +164,15 @@ the origin exactly once. `PutObject` requires one valid `Content-Length` and is
 limited by the gateway's 16 MiB default body limit and 30 second default total
 deadline. `UNSIGNED-PAYLOAD` streams directly; a lowercase SHA-256 declaration
 is verified in a secure temporary file before the origin is mutated. AWS
-streaming chunk-signature modes and multipart uploads are not yet supported.
-Increase deployment limits only with corresponding disk, concurrency, and
-deadline capacity.
+streaming chunk-signature modes are not supported. S3 multipart create,
+upload-part, upload-part-copy, list-parts, complete, and abort are supported.
+Active uploads are process-local, bounded to 1024 entries, and expire after 24
+hours by default. A gateway restart or a binding mismatch fails closed with
+`NoSuchUpload`; operators must abort the orphan directly at the origin before
+starting a replacement upload. Completion alone invalidates local object
+placement, and HTTP 200 completion responses carrying `<Error>` do not commit
+gateway state. Increase deployment limits only with corresponding disk,
+concurrency, and deadline capacity.
 
 Azure variables:
 

--- a/docs/reference/object-store-gateway-compatibility.md
+++ b/docs/reference/object-store-gateway-compatibility.md
@@ -55,7 +55,7 @@ and deployment are tracked separately.
 | PutObject | Supported | Fixed-length bodies are passed through once. `UNSIGNED-PAYLOAD` streams with backpressure; a declared SHA-256 is verified in a bounded-memory spool before origin dispatch. |
 | CopyObject | Supported | Source read and destination write grants are both required. Copy conditions and metadata remain origin-authoritative. |
 | DeleteObject | Supported | Passed through once; the origin status remains authoritative and confirmed absence invalidates local placement state. |
-| Multipart upload | Not yet supported | Multipart query shapes return `NotImplemented`; tracked by issue #497. |
+| Multipart upload | Supported | Create, upload-part, upload-part-copy, list-parts, complete, and abort are passed through. Upload IDs remain origin-issued; source and destination authorization is enforced for part copy. |
 
 Incoming client authorization material is never forwarded to a rewritten
 origin request. The gateway uses its scoped origin identity and signs the
@@ -69,16 +69,25 @@ all local placement entries for the object; a failed origin response does not.
 If transport fails after dispatch, the gateway returns
 `x-talon-commit-state: indeterminate`; clients must inspect object state before
 retrying. Request bodies are bounded by the configured gateway body and request
-deadlines (16 MiB and 30 seconds by default). Multipart upload is the path for
-objects that exceed the configured ordinary-request bound.
+deadlines (16 MiB and 30 seconds by default). Each multipart part and completion
+document must fit that bound, while the completed object may be larger.
+
+Active multipart uploads are held in a bounded, 24-hour in-memory registry by
+default. The binding includes the destination object, authenticated principal,
+provider account, and immutable cache decision. A missing, expired, mismatched,
+or restart-lost binding returns `NoSuchUpload` before origin dispatch. Complete
+invalidates local placement only after a confirmed success; an HTTP 200 body
+containing `<Error>` remains a failure. Abort removes the binding after origin
+success or confirmed absence.
 
 The S3 adapter emits S3 XML errors and gateway request IDs. Cache fallback and
 streaming behavior match the Azure adapter rules above. The `s3 backend and
 gateway e2e (localstack)` CI job runs the backend plus the gateway through
 boto3 and the MinIO SDK. It covers cold and warm reads, exact ranges, URL
-encoding, conditions, presigned URLs, listing pagination and delimiters, and
-standard errors. Arrow-compatible signed HEAD and ranged GET fixtures run in
-the same test.
+encoding, conditions, presigned URLs, listing pagination and delimiters,
+ordinary mutations, boto3 and MinIO multipart operations, part copy, abort,
+ordering failures, and standard errors. Arrow-compatible signed HEAD and ranged
+GET fixtures run in the same test.
 
 ## Cache routing mark
 

--- a/scripts/s3_gateway_sdk_conformance.py
+++ b/scripts/s3_gateway_sdk_conformance.py
@@ -141,6 +141,88 @@ def main() -> None:
             raise AssertionError("deleted object unexpectedly exists")
         except ClientError as error:
             assert error.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
+    multipart_key = "gateway/multipart/boto3.bin"
+    multipart = s3.create_multipart_upload(
+        Bucket=bucket, Key=multipart_key, Metadata={"owner": "boto3-multipart"}
+    )
+    upload_id = multipart["UploadId"]
+    part_one = b"a" * (5 * 1024 * 1024)
+    part_two = b"tail"
+    uploaded_one = s3.upload_part(
+        Bucket=bucket, Key=multipart_key, UploadId=upload_id,
+        PartNumber=1, Body=part_one,
+    )
+    uploaded_two = s3.upload_part(
+        Bucket=bucket, Key=multipart_key, UploadId=upload_id,
+        PartNumber=2, Body=part_two,
+    )
+    listed_parts = s3.list_parts(Bucket=bucket, Key=multipart_key, UploadId=upload_id)
+    assert [part["PartNumber"] for part in listed_parts["Parts"]] == [1, 2]
+    completed = s3.complete_multipart_upload(
+        Bucket=bucket, Key=multipart_key, UploadId=upload_id,
+        MultipartUpload={"Parts": [
+            {"PartNumber": 1, "ETag": uploaded_one["ETag"]},
+            {"PartNumber": 2, "ETag": uploaded_two["ETag"]},
+        ]},
+    )
+    assert completed["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert s3.get_object(Bucket=bucket, Key=multipart_key)["Body"].read() == part_one + part_two
+
+    invalid_key = "gateway/multipart/invalid-order.bin"
+    invalid = s3.create_multipart_upload(Bucket=bucket, Key=invalid_key)
+    invalid_id = invalid["UploadId"]
+    invalid_one = s3.upload_part(
+        Bucket=bucket, Key=invalid_key, UploadId=invalid_id,
+        PartNumber=1, Body=part_one,
+    )
+    invalid_two = s3.upload_part(
+        Bucket=bucket, Key=invalid_key, UploadId=invalid_id,
+        PartNumber=2, Body=part_two,
+    )
+    try:
+        s3.complete_multipart_upload(
+            Bucket=bucket, Key=invalid_key, UploadId=invalid_id,
+            MultipartUpload={"Parts": [
+                {"PartNumber": 2, "ETag": invalid_two["ETag"]},
+                {"PartNumber": 1, "ETag": invalid_one["ETag"]},
+            ]},
+        )
+        raise AssertionError("out-of-order multipart completion unexpectedly succeeded")
+    except ClientError as error:
+        assert error.response["ResponseMetadata"]["HTTPStatusCode"] >= 400
+    s3.abort_multipart_upload(Bucket=bucket, Key=invalid_key, UploadId=invalid_id)
+
+    copy_multipart_key = "gateway/multipart/copied.bin"
+    copy_upload = s3.create_multipart_upload(Bucket=bucket, Key=copy_multipart_key)
+    copy_upload_id = copy_upload["UploadId"]
+    copied_part = s3.upload_part_copy(
+        Bucket=bucket, Key=copy_multipart_key, UploadId=copy_upload_id,
+        PartNumber=1, CopySource={"Bucket": bucket, "Key": multipart_key},
+        CopySourceRange=f"bytes=0-{len(part_one) - 1}",
+    )
+    s3.complete_multipart_upload(
+        Bucket=bucket, Key=copy_multipart_key, UploadId=copy_upload_id,
+        MultipartUpload={"Parts": [{
+            "PartNumber": 1,
+            "ETag": copied_part["CopyPartResult"]["ETag"],
+        }]},
+    )
+    assert s3.get_object(Bucket=bucket, Key=copy_multipart_key)["Body"].read() == part_one
+
+    aborted_key = "gateway/multipart/aborted.bin"
+    aborted = s3.create_multipart_upload(Bucket=bucket, Key=aborted_key)
+    aborted_id = aborted["UploadId"]
+    s3.upload_part(
+        Bucket=bucket, Key=aborted_key, UploadId=aborted_id,
+        PartNumber=1, Body=part_two,
+    )
+    s3.abort_multipart_upload(Bucket=bucket, Key=aborted_key, UploadId=aborted_id)
+    try:
+        s3.list_parts(Bucket=bucket, Key=aborted_key, UploadId=aborted_id)
+        raise AssertionError("aborted multipart upload unexpectedly remained visible")
+    except ClientError as error:
+        assert error.response["Error"]["Code"] == "NoSuchUpload"
     first = s3.list_objects_v2(Bucket=bucket, Prefix="gateway/list/", MaxKeys=1)
     assert first["IsTruncated"]
     second = s3.list_objects_v2(
@@ -198,6 +280,17 @@ def main() -> None:
     assert read_minio(minio.get_object(bucket, minio_copy_key)) == minio_body
     minio.remove_object(bucket, minio_key)
     minio.remove_object(bucket, minio_copy_key)
+
+    minio_multipart_key = "gateway/multipart/minio.bin"
+    minio_multipart_body = b"m" * (6 * 1024 * 1024)
+    minio.put_object(
+        bucket, minio_multipart_key, io.BytesIO(minio_multipart_body),
+        len(minio_multipart_body), part_size=5 * 1024 * 1024,
+    )
+    assert read_minio(minio.get_object(bucket, minio_multipart_key)) == minio_multipart_body
+    minio.remove_object(bucket, minio_multipart_key)
+    for key in (multipart_key, copy_multipart_key):
+        s3.delete_object(Bucket=bucket, Key=key)
 
     print("S3 SDK gateway conformance passed")
 


### PR DESCRIPTION
Closes #497

## Summary
- pass through create, upload-part, upload-part-copy, list-parts, complete, and abort with origin re-signing and bounded body handling
- bind opaque origin upload IDs to the authenticated principal, destination object, and immutable cache decision in a bounded expiring registry
- invalidate placement only after a confirmed completion and preserve state for embedded HTTP 200 errors or indeterminate outcomes
- cover boto3 and MinIO multipart flows, ordering failures, part copy, abort, registry boundaries, and signing behavior

## Verification
- `just ci`
- `cargo deny check advisories bans sources`
- `mdbook build docs/book`
- `just spell`
- `just linkcheck`
- `python3 -m py_compile scripts/s3_gateway_sdk_conformance.py`
- `git diff --check`

LocalStack is not available in the devbox; the repository S3 e2e job runs the real boto3/MinIO suite against LocalStack 3.8.