### PR TITLE
doc(gateway): design trusted credential passthrough

### DIFF
--- a/docs/adr/0005-object-store-compatible-gateways.md
+++ b/docs/adr/0005-object-store-compatible-gateways.md
@@ -191,6 +191,46 @@ binding to a loopback address. It is not a production configuration and must
 emit a startup warning. Production readiness fails closed without TLS,
 authentication, and an authorization policy.
 
+### 6a. Allow capability passthrough only for a trusted local sidecar
+
+Issue #510 adds a separate, opt-in origin-authentication mode for colocated
+jobs that already hold an origin-issued capability. This mode is not an
+exception to the production security model above: it is accepted only in
+`development` mode on a loopback listener and must fail configuration
+validation in `production` mode or on a routable listener.
+
+The first capability forms are S3 presigned-query credentials and Azure Blob
+service or account SAS. On an origin access, the gateway restores the
+configured origin authority and preserves the signed method, canonical path,
+query, headers, and body needed by the provider. It does not replace the
+capability with gateway credentials. Header-signed requests are outside the
+first milestone unless interception preserves their signed authority and
+target exactly; an STS session token by itself is not S3 authorization.
+
+The security boundary is deliberately narrower: possession of the loopback
+listener grants access to resident cache bytes. A cache hit is not
+re-authorized, tokens are excluded from cache keys, and a revoked capability
+does not revoke bytes already available to that local process. Mutations,
+listings, metadata misses, and data misses still require an origin request and
+therefore provider authorization. Raw capabilities must remain request-scoped
+and must never enter logs, metrics, cache metadata, worker storage, or control
+messages.
+
+This behavior cannot be implemented by forwarding one header through the
+existing read path. Workers currently read through with their process origin
+identity. The trusted passthrough path instead requires a cache-only worker
+probe, a gateway origin fetch, and bounded admission of the validated response
+into the cache. A probe miss must never invoke a worker `BackendStore`.
+
+Version metadata is held in a bounded, process-local gateway index populated
+from successful origin responses. An S3 GET presigned URL cannot authorize a
+separate HEAD, so a cold or restart-lost metadata entry goes directly to the
+origin GET before it can address versioned cache blocks. Consequently the
+first request after gateway restart may access the origin even when matching
+bytes remain on workers. Metadata expiry and mutable-object freshness are
+deployment policy; this mode targets immutable training inputs and must not
+claim the production close-to-open contract.
+
 ### 7. Use the provider's HTTP stack, not a hand-written parser
 
 The gateway uses the repository's Tokio runtime and a maintained HTTP server
@@ -239,6 +279,8 @@ one begins.
    conformance before claiming transparent write support.
 10. Publish deployment configuration, compatibility matrices, and gateway
     overhead benchmarks (#478).
+11. Add the trusted local capability-passthrough path as cache probe, bounded
+    admission, provider forwarding, and conformance PRs (#510).
 
 ## Consequences
 
@@ -278,9 +320,12 @@ payloads through it adds a throughput bottleneck and violates #440.
 
 ### Forward client authorization directly to the origin
 
-Rejected. S3 signatures include the authority and signed headers, and endpoint
-override commonly changes both. Re-signing after explicit authorization gives
-the gateway a coherent trust boundary.
+Rejected for production and shared gateways. S3 signatures include the
+authority and signed headers, and endpoint override commonly changes both.
+Re-signing after explicit authorization gives the gateway a coherent trust
+boundary. The loopback-only capability mode in section 6a is a deliberately
+weaker, opt-in boundary for a colocated process and preserves the signed
+request when it accesses the origin.
 
 ### Build two independent proxies
 

--- a/docs/operations/object-store-gateway.md
+++ b/docs/operations/object-store-gateway.md
@@ -41,6 +41,36 @@ Use an origin identity limited to the advertised read and mutation operations
 on namespaces assigned to that gateway. Do not grant bucket or account
 administration permissions.
 
+### Planned trusted passthrough mode
+
+Issue #510 tracks `TALON_GATEWAY_ORIGIN_AUTH=trusted-passthrough`. It is a
+planned sidecar mode, not a currently accepted configuration value. It will be
+restricted to a loopback `development` listener and initially accept S3
+presigned-query credentials and Azure service/account SAS.
+
+In that mode a resident cache read is intentionally not authorized again. Any
+process that can reach the listener can read matching resident data, so the
+listener must share the training job's network namespace and must not be
+published by a container port, Service, ingress, or host-network wildcard.
+Cache keys exclude credentials. Listings, mutations, cold metadata, and data
+misses go to the provider with the request-scoped capability; Talon service
+credentials are not substituted.
+
+The mode requires a cache-only worker probe and gateway-driven cache fill.
+Until those protocol changes land, setting no origin credentials does not
+produce passthrough: workers still read through using their configured backend
+identity. For S3, a cold GET uses the original GET at the origin because its
+presigned query cannot authorize a synthetic HEAD. Successful origin responses
+seed a bounded in-memory metadata index; restart loses that index and forces a
+new origin request. Capability revocation and mutable-object freshness are not
+enforced for already resident bytes.
+
+Clients must create the capability for the configured origin authority and
+canonical target. Replacing the network destination is valid only when the
+gateway can restore that authority without changing the signed method, path,
+query, signed headers, or body. `x-amz-security-token` without a matching
+SigV4 signature is not a bearer credential.
+
 ## Configuration
 
 Common variables:
@@ -50,6 +80,7 @@ Common variables:
 | `TALON_GATEWAY_PROTOCOL` | `s3` | `s3` or `azure`. |
 | `TALON_GATEWAY_BIND` | `127.0.0.1:8080` | Listener; development mode rejects non-loopback addresses. |
 | `TALON_GATEWAY_MODE` | `development` | `development` or fail-closed `production`. |
+| `TALON_GATEWAY_ORIGIN_AUTH` | `service` | Planned: `service` or loopback-only `trusted-passthrough` (#510). |
 | `TALON_COORDINATOR_ADDR` | required | Talon coordinator control address. |
 | `TALON_GATEWAY_ROUTE` | `cache` | `cache`, `cache-only`, or direct `origin`. |
 | `TALON_GATEWAY_PATH_STYLE` | `false` | Accept `/bucket/key` or `/account/container/blob`. |

--- a/docs/reference/object-store-gateway-compatibility.md
+++ b/docs/reference/object-store-gateway-compatibility.md
@@ -58,6 +58,12 @@ authenticated principal and cache decision for 24 hours by default. A gateway
 restart intentionally loses that binding and fails closed rather than adopting
 orphaned blocks. Only a successful Put Block List invalidates cached data.
 
+Azure SAS passthrough for a trusted loopback sidecar is designed but not yet
+implemented (#510). The target behavior preserves all SAS query fields on an
+origin access and shares cache entries across capabilities. A resident hit is
+not re-authorized; a miss, listing, or mutation remains origin-authoritative.
+Shared Key passthrough is not part of the first milestone.
+
 Production exposure remains blocked until provider authentication and
 authorization are installed as tracked by issue #446. The protocol adapter is
 currently intended for conformance and integration work; executable packaging
@@ -111,6 +117,13 @@ encoding, conditions, presigned URLs, listing pagination and delimiters,
 ordinary mutations, boto3 and MinIO multipart operations, part copy, abort,
 ordering failures, and standard errors. Arrow-compatible signed HEAD and ranged
 GET fixtures run in the same test.
+
+S3 presigned-query passthrough for a trusted loopback sidecar is designed but
+not yet implemented (#510). The capability must have been signed for the
+configured origin method, authority, canonical path, query, headers, and body;
+the gateway restores that origin request after a cache miss. A resident hit is
+not re-authorized. Header SigV4 and a standalone STS session token are not part
+of the first milestone.
 
 ## Cache routing mark
 


### PR DESCRIPTION
## Summary

- define a loopback-only trusted capability passthrough mode for colocated jobs
- document why worker cache-only probes and gateway-driven admission are required
- scope the first milestone to S3 presigned query credentials and Azure SAS
- record metadata restart, revocation, and mutable-object limitations

Closes the design task in #510; implementation remains split into the tracked follow-up PRs.

## Verification

- `git diff --check`
- `mdbook build docs/book`
- `typos` on changed documentation