### PR TITLE
feat(cache): add cache-only worker range probes

### DIFF
--- a/crates/talon-cache-client/src/worker_client.rs
+++ b/crates/talon-cache-client/src/worker_client.rs
@@ -20,8 +20,9 @@ use std::time::Duration;
 use talon_core::{ObjectId, RequestId, Version};
 use talon_transport::frame::{FrameHeader, MsgType, HEADER_LEN};
 use talon_transport::{
-    decode_error_payload, encode_delete, encode_put_header, encode_request, DataPlaneError,
-    DeleteRequest, Flags, PutRequest, RangeRequest, MAX_CONTROL_PAYLOAD_LEN,
+    decode_error_payload, encode_cached_request, encode_delete, encode_put_header, encode_request,
+    CachedRangeRequest, DataPlaneError, DeleteRequest, Flags, PutRequest, RangeRequest,
+    MAX_CONTROL_PAYLOAD_LEN,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -155,6 +156,44 @@ impl WorkerClient {
                 );
                 Err(err)
             }
+        }
+    }
+
+    /// Fetch a versioned range only if it is already resident on the worker.
+    ///
+    /// The distinct wire operation is fail-closed during rolling upgrades: an
+    /// older worker rejects it instead of performing an origin-backed read.
+    pub async fn fetch_cached_range(
+        &self,
+        object: &ObjectId,
+        version: &Version,
+        offset: u64,
+        len: u64,
+    ) -> Result<Vec<u8>, WorkerError> {
+        let request = CachedRangeRequest {
+            object: object.clone(),
+            version: version.clone(),
+            offset,
+            len,
+        };
+        let request_id = RequestId::next();
+        let output = encode_cached_request(request_id.0, &request)?;
+        match self.exchange(&output, len).await {
+            Ok(bytes) => Ok(bytes),
+            Err((true, _)) => {
+                let mut stream = self.pool.fresh(&self.addr).await?;
+                let bytes = self
+                    .pool
+                    .with_request_deadline("worker fetch_cached_range retry", async {
+                        stream.write_all(&output).await?;
+                        stream.flush().await?;
+                        read_range_reply(&mut stream, len).await
+                    })
+                    .await?;
+                self.pool.release(&self.addr, stream);
+                Ok(bytes)
+            }
+            Err((false, error)) => Err(error),
         }
     }
 
@@ -535,7 +574,9 @@ mod tests {
     use super::*;
     use std::time::Duration;
     use talon_core::Backend;
-    use talon_transport::{decode_request, encode_error, response_header_ok};
+    use talon_transport::{
+        decode_cached_request, decode_request, encode_error, response_header_ok,
+    };
     use tokio::net::TcpListener;
 
     fn object() -> ObjectId {
@@ -651,6 +692,37 @@ mod tests {
         assert_eq!(bytes[0], 0);
         assert_eq!(bytes[250], 250);
         assert_eq!(bytes[251], 0);
+    }
+
+    #[tokio::test]
+    async fn cached_fetch_sends_the_versioned_fail_closed_operation() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut header = [0_u8; HEADER_LEN];
+            socket.read_exact(&mut header).await.unwrap();
+            let frame = FrameHeader::decode(&header).unwrap();
+            assert_eq!(frame.msg_type, MsgType::GetCachedRange);
+            let mut body = vec![0_u8; frame.length as usize];
+            socket.read_exact(&mut body).await.unwrap();
+            let mut request = header.to_vec();
+            request.extend_from_slice(&body);
+            let (_, request) = decode_cached_request(&request).unwrap();
+            assert_eq!(request.version, Version::new("etag-v2"));
+            assert_eq!((request.offset, request.len), (3, 4));
+            socket
+                .write_all(&response_header_ok(frame.request_id, 4))
+                .await
+                .unwrap();
+            socket.write_all(b"data").await.unwrap();
+        });
+
+        let bytes = WorkerClient::new(address)
+            .fetch_cached_range(&object(), &Version::new("etag-v2"), 3, 4)
+            .await
+            .unwrap();
+        assert_eq!(bytes, b"data");
     }
 
     #[tokio::test]

--- a/crates/talon-transport/src/data.rs
+++ b/crates/talon-transport/src/data.rs
@@ -12,7 +12,7 @@
 //! module only handles the request encode/decode and the response header shape.
 
 use serde::{Deserialize, Serialize};
-use talon_core::ObjectId;
+use talon_core::{ObjectId, Version};
 
 use crate::frame::{Flags, FrameError, FrameHeader, MsgType, HEADER_LEN};
 
@@ -69,6 +69,19 @@ struct ErrorEnvelope {
 pub struct RangeRequest {
     /// The source object whose bytes are requested.
     pub object: ObjectId,
+    /// Byte offset within the object to start reading at.
+    pub offset: u64,
+    /// Number of bytes to read.
+    pub len: u64,
+}
+
+/// A cache-only range probe carrying the exact versioned cache identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CachedRangeRequest {
+    /// The source object whose resident bytes are requested.
+    pub object: ObjectId,
+    /// Exact origin version used in the cache block key.
+    pub version: Version,
     /// Byte offset within the object to start reading at.
     pub offset: u64,
     /// Number of bytes to read.
@@ -149,6 +162,38 @@ pub fn decode_request(buf: &[u8]) -> Result<(FrameHeader, RangeRequest), DataErr
         });
     }
     let req: RangeRequest = bincode::deserialize(body)?;
+    Ok((header, req))
+}
+
+/// Encode a cache-only range probe. Older workers reject its distinct message
+/// type instead of accidentally treating it as an origin-backed read.
+pub fn encode_cached_request(
+    request_id: u32,
+    req: &CachedRangeRequest,
+) -> Result<Vec<u8>, DataError> {
+    let body = bincode::serialize(req)?;
+    let header = FrameHeader::new(MsgType::GetCachedRange, request_id, body.len() as u32);
+    let mut buf = Vec::with_capacity(HEADER_LEN + body.len());
+    buf.extend_from_slice(&header.encode());
+    buf.extend_from_slice(&body);
+    Ok(buf)
+}
+
+/// Decode a framed cache-only range probe.
+pub fn decode_cached_request(buf: &[u8]) -> Result<(FrameHeader, CachedRangeRequest), DataError> {
+    let header = FrameHeader::decode(buf)?;
+    if header.msg_type != MsgType::GetCachedRange {
+        return Err(DataError::NotGetRange(header.msg_type));
+    }
+    let declared = header.length as usize;
+    let body = &buf[HEADER_LEN..];
+    if body.len() != declared {
+        return Err(DataError::LengthMismatch {
+            declared,
+            actual: body.len(),
+        });
+    }
+    let req = bincode::deserialize(body)?;
     Ok((header, req))
 }
 
@@ -305,6 +350,21 @@ mod tests {
         assert_eq!(header.msg_type, MsgType::GetRange);
         assert_eq!(header.request_id, 11);
         assert_eq!(back, req());
+    }
+
+    #[test]
+    fn cached_request_round_trips_with_version() {
+        let request = CachedRangeRequest {
+            object: req().object,
+            version: Version::new("etag-v2"),
+            offset: 17,
+            len: 23,
+        };
+        let encoded = encode_cached_request(12, &request).unwrap();
+        let (header, decoded) = decode_cached_request(&encoded).unwrap();
+        assert_eq!(header.msg_type, MsgType::GetCachedRange);
+        assert_eq!(header.request_id, 12);
+        assert_eq!(decoded, request);
     }
 
     #[test]

--- a/crates/talon-transport/src/frame.rs
+++ b/crates/talon-transport/src/frame.rs
@@ -58,6 +58,9 @@ pub enum MsgType {
     /// Data-plane delete (#226): a bincode
     /// [`DeleteRequest`](crate::data::DeleteRequest) header, no body.
     Delete = 5,
+    /// Read a versioned range only when every requested byte is resident.
+    /// This operation must never access the worker backend.
+    GetCachedRange = 6,
 }
 
 impl MsgType {
@@ -70,6 +73,7 @@ impl MsgType {
             3 => MsgType::Put,
             4 => MsgType::Ping,
             5 => MsgType::Delete,
+            6 => MsgType::GetCachedRange,
             other => return Err(FrameError::UnknownMsgType(other)),
         })
     }
@@ -209,6 +213,8 @@ mod tests {
             MsgType::GetRange,
             MsgType::Put,
             MsgType::Ping,
+            MsgType::Delete,
+            MsgType::GetCachedRange,
         ]
         .into_iter()
         .enumerate()

--- a/crates/talon-transport/src/lib.rs
+++ b/crates/talon-transport/src/lib.rs
@@ -23,9 +23,10 @@ pub use codec::{
     CONTROL_SCHEMA_VERSION, MIN_CONTROL_SCHEMA_VERSION,
 };
 pub use data::{
-    decode_delete, decode_error_payload, decode_put_header, decode_request, encode_delete,
-    encode_error, encode_put_header, encode_request, encode_typed_error, response_header_ok,
-    DataError, DataErrorCode, DataPlaneError, DeleteRequest, PutRequest, RangeRequest,
+    decode_cached_request, decode_delete, decode_error_payload, decode_put_header, decode_request,
+    encode_cached_request, encode_delete, encode_error, encode_put_header, encode_request,
+    encode_typed_error, response_header_ok, CachedRangeRequest, DataError, DataErrorCode,
+    DataPlaneError, DeleteRequest, PutRequest, RangeRequest,
 };
 pub use frame::{Flags, FrameError, FrameHeader, MsgType, HEADER_LEN, MAGIC, PROTOCOL_VERSION};
 pub use limits::{

--- a/crates/talon-transport/src/limits.rs
+++ b/crates/talon-transport/src/limits.rs
@@ -48,7 +48,7 @@ pub fn max_payload_for(msg_type: MsgType) -> u32 {
     match msg_type {
         MsgType::Control => MAX_CONTROL_PAYLOAD_LEN,
         MsgType::Ping => MAX_PING_PAYLOAD_LEN,
-        MsgType::Put | MsgType::Delete => MAX_CONTROL_PAYLOAD_LEN,
+        MsgType::Put | MsgType::Delete | MsgType::GetCachedRange => MAX_CONTROL_PAYLOAD_LEN,
         MsgType::Get | MsgType::GetRange => MAX_PAYLOAD_LEN,
     }
 }

--- a/crates/talon-worker/src/data_error.rs
+++ b/crates/talon-worker/src/data_error.rs
@@ -3,12 +3,27 @@
 use talon_core::Error;
 use talon_transport::{encode_typed_error, DataErrorCode};
 
+/// Marker returned when a cache-only request is not fully resident.
+#[derive(Debug)]
+pub(crate) struct CacheMiss;
+
+impl std::fmt::Display for CacheMiss {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("requested range is not fully resident")
+    }
+}
+
+impl std::error::Error for CacheMiss {}
+
 /// Encode an error returned by [`crate::WorkerRuntime`] for a range request.
 pub(crate) fn encode_runtime_error(request_id: u32, error: &anyhow::Error) -> Vec<u8> {
     encode_typed_error(request_id, classify(error), error.to_string())
 }
 
 fn classify(error: &anyhow::Error) -> DataErrorCode {
+    if error.downcast_ref::<CacheMiss>().is_some() {
+        return DataErrorCode::CacheMiss;
+    }
     if let Some(error) = error.downcast_ref::<Error>() {
         return match error {
             Error::NotFound(_) => DataErrorCode::NotFound,
@@ -47,6 +62,7 @@ mod tests {
 
     #[test]
     fn core_failures_have_stable_codes() {
+        assert_eq!(encoded_code(CacheMiss.into()), DataErrorCode::CacheMiss);
         assert_eq!(
             encoded_code(Error::NotFound("x".into()).into()),
             DataErrorCode::NotFound

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -9,10 +9,11 @@ use talon_core::{
     Backend, BackendStore, BlockForm, BlockHandle, BlockId, BlockMeta, Error, ObjectId,
     ObjectStore, PageIndex, Version,
 };
-use talon_transport::data::RangeRequest;
-use talon_transport::frame::HEADER_LEN;
+use talon_transport::data::{CachedRangeRequest, RangeRequest};
+use talon_transport::frame::{HEADER_LEN, MAX_PAYLOAD_LEN};
 use talon_transport::{codec, ControlMessage, ObjectEntry, MAX_CONTROL_PAYLOAD_LEN};
 
+use crate::data_error::CacheMiss;
 use crate::{
     miss::touched_pages, BlockIndex, CacheUnit, InFlightLoads, LoadKey, Lru, MemoryInsert,
     MemoryStore, PagedBlockStore, Presence, WholeBlockStore, WorkerMetrics,
@@ -255,7 +256,6 @@ impl WorkerRuntime {
         if request.len == 0 {
             return Ok(bytes::Bytes::new());
         }
-
         // Resolve using the cache first; on a precondition failure (the object
         // was overwritten within the version-cache window) drop the stale entry
         // and retry once against a force-resolved version.
@@ -299,6 +299,73 @@ impl WorkerRuntime {
             }
             Err(error) => Err(error),
         }
+    }
+
+    /// Serve a versioned range only from resident cache state.
+    ///
+    /// Unlike [`serve`](Self::serve), this path neither resolves metadata nor
+    /// invokes `BackendStore`. A partially resident multi-block/page request is
+    /// a complete miss; no prefix is returned.
+    pub async fn serve_cached(&self, request: &CachedRangeRequest) -> anyhow::Result<bytes::Bytes> {
+        self.ensure_configured_backend(request.object.backend)?;
+        if request.len == 0 {
+            return Ok(bytes::Bytes::new());
+        }
+        if request.len > u64::from(MAX_PAYLOAD_LEN) {
+            anyhow::bail!(
+                "cache-only range length {} exceeds response frame limit {}",
+                request.len,
+                MAX_PAYLOAD_LEN
+            );
+        }
+        let end = request
+            .offset
+            .checked_add(request.len)
+            .ok_or_else(|| anyhow::anyhow!("range offset+len overflows u64"))?;
+        let block_size = u64::from(self.block_size);
+        let mut output = bytes::BytesMut::with_capacity(request.len as usize);
+        let mut cursor = request.offset;
+        while cursor < end {
+            let block = self.block_for(&request.object, cursor, &request.version);
+            let offset = cursor - block.offset;
+            let take = (block.offset + block_size).min(end) - cursor;
+            let Some(meta) = self.index.get(&block) else {
+                return Err(CacheMiss.into());
+            };
+            let piece = match meta.form {
+                BlockForm::Whole => self
+                    .cached_block_range(&block, offset, take)
+                    .await?
+                    .ok_or(CacheMiss)?,
+                BlockForm::Paged { page_size, .. } => {
+                    let available = available_range_len(meta.len, offset, take)?;
+                    if available != take {
+                        return Err(CacheMiss.into());
+                    }
+                    let mut piece = bytes::BytesMut::with_capacity(take as usize);
+                    for page in touched_pages(offset, take, page_size) {
+                        let page_start = u64::from(page.0) * u64::from(page_size);
+                        let page_len = talon_core::page_len(meta.len, page_size, page);
+                        let from = offset.max(page_start);
+                        let to = (offset + take).min(page_start + page_len);
+                        if to <= from {
+                            continue;
+                        }
+                        let bytes = self.cached_page(&block, page).await?.ok_or(CacheMiss)?;
+                        piece.extend_from_slice(&slice(&bytes, from - page_start, to - from)?);
+                    }
+                    self.metrics.record_cache_hit();
+                    piece.freeze()
+                }
+            };
+            if piece.len() != take as usize {
+                return Err(CacheMiss.into());
+            }
+            output.extend_from_slice(&piece);
+            cursor += take;
+        }
+        debug_assert_eq!(request.len as usize, output.len());
+        Ok(output.freeze())
     }
 
     /// The single-resolved-version body of [`serve`](Self::serve).
@@ -2339,6 +2406,45 @@ mod tests {
         let outcome = runtime.serve(&request("ok")).await.unwrap();
         assert_eq!(read_handle(outcome), b"abcd");
         // No second backend fetch.
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn cache_only_probe_never_fetches_the_backend() {
+        let root = tmp_root();
+        let backend = Arc::new(MockBackend {
+            calls: AtomicUsize::new(0),
+        });
+        let runtime = runtime(Arc::clone(&backend), WorkerMetrics::new(1024), &root);
+        let probe = CachedRangeRequest {
+            object: request("ok").object,
+            version: Version::new("v1"),
+            offset: 0,
+            len: 4,
+        };
+
+        let miss = runtime.serve_cached(&probe).await.unwrap_err();
+        assert!(miss.downcast_ref::<CacheMiss>().is_some());
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 0);
+
+        assert_eq!(
+            runtime.serve_range(&request("ok")).await.unwrap(),
+            Bytes::from_static(b"abcd")
+        );
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            runtime.serve_cached(&probe).await.unwrap(),
+            Bytes::from_static(b"abcd")
+        );
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+
+        let wrong_version = CachedRangeRequest {
+            version: Version::new("different"),
+            ..probe
+        };
+        let miss = runtime.serve_cached(&wrong_version).await.unwrap_err();
+        assert!(miss.downcast_ref::<CacheMiss>().is_some());
         assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
         std::fs::remove_dir_all(root).ok();
     }

--- a/crates/talon-worker/src/tokio_conn.rs
+++ b/crates/talon-worker/src/tokio_conn.rs
@@ -33,7 +33,7 @@ use tokio::net::TcpStream;
 use crate::data_error::encode_runtime_error;
 use crate::{send_file_range, ServeOutcome, WorkerObservability, WorkerRuntime, DEFAULT_CHUNK};
 
-/// Serve data-plane range requests on one connection until EOF.
+/// Serve data-plane range and cache-only probe requests until EOF.
 pub async fn handle_conn(
     mut stream: TcpStream,
     worker: Arc<WorkerRuntime>,
@@ -91,6 +91,18 @@ pub async fn handle_conn(
         // giving the coordinator backend access.
         if header.msg_type == MsgType::Control {
             handle_control_frame(
+                &mut stream,
+                &header,
+                &payload,
+                &worker,
+                &observability,
+                request_started,
+            )
+            .await?;
+            continue;
+        }
+        if header.msg_type == MsgType::GetCachedRange {
+            handle_cached_range(
                 &mut stream,
                 &header,
                 &payload,
@@ -221,6 +233,81 @@ pub async fn handle_conn(
             }
         }
     }
+}
+
+async fn handle_cached_range(
+    stream: &mut TcpStream,
+    header: &FrameHeader,
+    payload: &[u8],
+    worker: &WorkerRuntime,
+    observability: &WorkerObservability,
+    request_started: Instant,
+) -> std::io::Result<()> {
+    let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
+    full.extend_from_slice(&header.encode());
+    full.extend_from_slice(payload);
+    let (decoded, request) = match data::decode_cached_request(&full) {
+        Ok(value) => value,
+        Err(error) => {
+            let reply = data::encode_typed_error(
+                header.request_id,
+                DataErrorCode::InvalidRequest,
+                format!("bad cache-only request: {error}"),
+            );
+            stream.write_all(&reply).await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+            return Ok(());
+        }
+    };
+    if !observability.is_ready() {
+        let reply = data::encode_typed_error(
+            decoded.request_id,
+            DataErrorCode::Unavailable,
+            "worker is not ready",
+        );
+        stream.write_all(&reply).await?;
+        stream.flush().await?;
+        observability
+            .metrics()
+            .record_request_error(request_started.elapsed());
+        return Ok(());
+    }
+    if request.offset.checked_add(request.len).is_none() {
+        let reply = data::encode_typed_error(
+            decoded.request_id,
+            DataErrorCode::InvalidRequest,
+            "range offset+len overflows u64",
+        );
+        stream.write_all(&reply).await?;
+        stream.flush().await?;
+        observability
+            .metrics()
+            .record_request_error(request_started.elapsed());
+        return Ok(());
+    }
+    match worker.serve_cached(&request).await {
+        Ok(bytes) => {
+            let reply = data::response_header_ok(decoded.request_id, bytes.len() as u32);
+            stream.write_all(&reply).await?;
+            stream.write_all(&bytes).await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_request_success(bytes.len() as u64, request_started.elapsed());
+        }
+        Err(error) => {
+            let reply = encode_runtime_error(decoded.request_id, &error);
+            stream.write_all(&reply).await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+        }
+    }
+    Ok(())
 }
 
 /// Handle a `Control` frame on the data plane.

--- a/crates/talon-worker/src/uring_conn.rs
+++ b/crates/talon-worker/src/uring_conn.rs
@@ -20,7 +20,7 @@
 //!
 //! - per-message-type payload caps enforced *before* allocation, and read
 //!   timeouts (#111) — via [`talon_transport::uring::read_frame`];
-//! - `GetRange`/`Put`/`Delete` dispatch, with any other type rejected before
+//! - `GetRange`/`GetCachedRange`/`Put`/`Delete` dispatch, with any other type rejected before
 //!   per-request work is done;
 //! - readiness gating, so an unready worker returns an error frame rather than
 //!   serving;
@@ -135,6 +135,18 @@ pub async fn handle_conn(
                 .await?;
                 continue;
             }
+            MsgType::GetCachedRange => {
+                handle_cached_range(
+                    &mut stream,
+                    &header,
+                    &payload,
+                    &worker,
+                    &observability,
+                    request_started,
+                )
+                .await?;
+                continue;
+            }
             MsgType::GetRange => {}
             // A data listener serves only GetRange/Put/Delete; anything else is
             // rejected before any per-request work.
@@ -239,6 +251,73 @@ pub async fn handle_conn(
             }
         }
     }
+}
+
+async fn handle_cached_range(
+    stream: &mut TcpStream,
+    header: &FrameHeader,
+    payload: &[u8],
+    worker: &WorkerRuntime,
+    observability: &WorkerObservability,
+    request_started: Instant,
+) -> std::io::Result<()> {
+    let (decoded, request) = match data::decode_cached_request(&rejoin(header, payload)) {
+        Ok(value) => value,
+        Err(error) => {
+            let reply = data::encode_typed_error(
+                header.request_id,
+                DataErrorCode::InvalidRequest,
+                format!("bad cache-only request: {error}"),
+            );
+            write_all(stream, reply).await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+            return Ok(());
+        }
+    };
+    if !observability.is_ready() {
+        let reply = data::encode_typed_error(
+            decoded.request_id,
+            DataErrorCode::Unavailable,
+            "worker is not ready",
+        );
+        write_all(stream, reply).await?;
+        observability
+            .metrics()
+            .record_request_error(request_started.elapsed());
+        return Ok(());
+    }
+    if request.offset.checked_add(request.len).is_none() {
+        let reply = data::encode_typed_error(
+            decoded.request_id,
+            DataErrorCode::InvalidRequest,
+            "range offset+len overflows u64",
+        );
+        write_all(stream, reply).await?;
+        observability
+            .metrics()
+            .record_request_error(request_started.elapsed());
+        return Ok(());
+    }
+    match worker.serve_cached(&request).await {
+        Ok(bytes) => {
+            let header = data::response_header_ok(decoded.request_id, bytes.len() as u32);
+            write_all(stream, header.to_vec()).await?;
+            let len = bytes.len() as u64;
+            write_all(stream, bytes.to_vec()).await?;
+            observability
+                .metrics()
+                .record_request_success(len, request_started.elapsed());
+        }
+        Err(error) => {
+            write_all(stream, encode_runtime_error(decoded.request_id, &error)).await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+        }
+    }
+    Ok(())
 }
 
 /// Rebuild the contiguous `header || payload` buffer the `data` decoders expect.


### PR DESCRIPTION
## Summary

- add a distinct `GetCachedRange` wire operation carrying the exact object version
- serve whole-block, paged, and cross-block ranges only when all requested bytes are resident
- return typed `CacheMiss` without metadata resolution or backend access
- expose `WorkerClient::fetch_cached_range` and dispatch it in both Tokio and io_uring workers
- keep rolling upgrades fail-closed because old workers reject the new message type

Part of #510.

## Verification

- `cargo test -p talon-transport -p talon-cache-client -p talon-worker` (369 passed)
- `cargo clippy -p talon-transport -p talon-cache-client -p talon-worker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`