### PR TITLE
feat(cache): admit gateway-fetched blocks locally

### DIFF
--- a/crates/talon-cache-client/src/worker_client.rs
+++ b/crates/talon-cache-client/src/worker_client.rs
@@ -17,12 +17,12 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
-use talon_core::{ObjectId, RequestId, Version};
+use talon_core::{BlockId, ObjectId, RequestId, Version};
 use talon_transport::frame::{FrameHeader, MsgType, HEADER_LEN};
 use talon_transport::{
-    decode_error_payload, encode_cached_request, encode_delete, encode_put_header, encode_request,
-    CachedRangeRequest, DataPlaneError, DeleteRequest, Flags, PutRequest, RangeRequest,
-    MAX_CONTROL_PAYLOAD_LEN,
+    decode_error_payload, encode_cached_block_put_header, encode_cached_request, encode_delete,
+    encode_put_header, encode_request, CachedBlockPutRequest, CachedRangeRequest, DataPlaneError,
+    DeleteRequest, Flags, PutRequest, RangeRequest, MAX_CONTROL_PAYLOAD_LEN,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -194,6 +194,74 @@ impl WorkerClient {
                 Ok(bytes)
             }
             Err((false, error)) => Err(error),
+        }
+    }
+
+    /// Admit one complete, versioned block without asking the worker to access
+    /// its configured backend.
+    pub async fn admit_cached_block(
+        &self,
+        block: &BlockId,
+        object_len: u64,
+        body: &[u8],
+    ) -> Result<(), WorkerError> {
+        let request_id = RequestId::next();
+        let header = encode_cached_block_put_header(
+            request_id.0,
+            &CachedBlockPutRequest {
+                block: block.clone(),
+                object_len,
+                body_len: body.len() as u64,
+            },
+        )?;
+        match self.admit_exchange(&header, body).await {
+            Ok(()) => Ok(()),
+            Err((true, _)) => {
+                let mut stream = self.pool.fresh(&self.addr).await?;
+                self.pool
+                    .with_deadline(
+                        "worker admit_cached_block retry",
+                        streamed_put_timeout(body.len() as u64),
+                        async {
+                            stream.write_all(&header).await?;
+                            stream.write_all(body).await?;
+                            stream.flush().await?;
+                            read_range_reply(&mut stream, 0).await.map(|_| ())
+                        },
+                    )
+                    .await?;
+                self.pool.release(&self.addr, stream);
+                Ok(())
+            }
+            Err((false, error)) => Err(error),
+        }
+    }
+
+    async fn admit_exchange(&self, header: &[u8], body: &[u8]) -> Result<(), (bool, WorkerError)> {
+        let (mut stream, reused) = self
+            .pool
+            .checkout(&self.addr)
+            .await
+            .map_err(|error| (false, WorkerError::from(error)))?;
+        let result = self
+            .pool
+            .with_deadline(
+                "worker admit_cached_block",
+                streamed_put_timeout(body.len() as u64),
+                async {
+                    stream.write_all(header).await?;
+                    stream.write_all(body).await?;
+                    stream.flush().await?;
+                    read_range_reply(&mut stream, 0).await.map(|_| ())
+                },
+            )
+            .await;
+        match result {
+            Ok(()) => {
+                self.pool.release(&self.addr, stream);
+                Ok(())
+            }
+            Err(error) => Err((reused, error)),
         }
     }
 
@@ -575,12 +643,48 @@ mod tests {
     use std::time::Duration;
     use talon_core::Backend;
     use talon_transport::{
-        decode_cached_request, decode_request, encode_error, response_header_ok,
+        decode_cached_block_put_header, decode_cached_request, decode_request, encode_error,
+        response_header_ok,
     };
     use tokio::net::TcpListener;
 
     fn object() -> ObjectId {
         ObjectId::new(Backend::Azure, "container", "path/to/blob.bin")
+    }
+
+    #[tokio::test]
+    async fn cache_admission_sends_exact_versioned_block_and_body() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let block = BlockId::new(object(), 8, 8, Version::new("etag-v2"));
+        let expected = block.clone();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut header_bytes = [0_u8; HEADER_LEN];
+            socket.read_exact(&mut header_bytes).await.unwrap();
+            let header = FrameHeader::decode(&header_bytes).unwrap();
+            assert_eq!(header.msg_type, MsgType::AdmitCachedBlock);
+            let mut payload = vec![0_u8; header.length as usize];
+            socket.read_exact(&mut payload).await.unwrap();
+            let mut frame = header_bytes.to_vec();
+            frame.extend_from_slice(&payload);
+            let (_, request) = decode_cached_block_put_header(&frame).unwrap();
+            assert_eq!(request.block, expected);
+            assert_eq!(request.object_len, 13);
+            assert_eq!(request.body_len, 5);
+            let mut body = vec![0_u8; 5];
+            socket.read_exact(&mut body).await.unwrap();
+            assert_eq!(body, b"tail!");
+            socket
+                .write_all(&response_header_ok(header.request_id, 0))
+                .await
+                .unwrap();
+        });
+
+        WorkerClient::new(addr)
+            .admit_cached_block(&block, 13, b"tail!")
+            .await
+            .unwrap();
     }
 
     /// What a mock write-worker records: the object and body it received.

--- a/crates/talon-transport/src/data.rs
+++ b/crates/talon-transport/src/data.rs
@@ -12,7 +12,7 @@
 //! module only handles the request encode/decode and the response header shape.
 
 use serde::{Deserialize, Serialize};
-use talon_core::{ObjectId, Version};
+use talon_core::{BlockId, ObjectId, Version};
 
 use crate::frame::{Flags, FrameError, FrameHeader, MsgType, HEADER_LEN};
 
@@ -102,6 +102,21 @@ pub struct PutRequest {
     pub body_len: u64,
 }
 
+/// A request to admit one complete origin-fetched block into the local cache.
+///
+/// The raw block bytes (`body_len` of them) follow this framed header. The
+/// worker validates the block geometry against `object_len` and never accesses
+/// its backend while handling this operation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CachedBlockPutRequest {
+    /// Exact versioned cache identity of the block.
+    pub block: BlockId,
+    /// Authoritative total object length observed by the gateway.
+    pub object_len: u64,
+    /// Number of raw block bytes following this header.
+    pub body_len: u64,
+}
+
 /// A client→worker request to delete an object (#226). No body follows.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DeleteRequest {
@@ -121,6 +136,9 @@ pub enum DataError {
     /// A non-`Put` frame was handed to the put codec.
     #[error("expected a Put frame, got {0:?}")]
     NotPut(MsgType),
+    /// A non-`AdmitCachedBlock` frame was handed to the admission codec.
+    #[error("expected an AdmitCachedBlock frame, got {0:?}")]
+    NotCachedBlockPut(MsgType),
     /// A non-`Delete` frame was handed to the delete codec.
     #[error("expected a Delete frame, got {0:?}")]
     NotDelete(MsgType),
@@ -232,6 +250,39 @@ pub fn decode_put_header(buf: &[u8]) -> Result<(FrameHeader, PutRequest), DataEr
     }
     let req: PutRequest = bincode::deserialize(body)?;
     Ok((header, req))
+}
+
+/// Encode a cache-admission header. The caller writes exactly `body_len` raw
+/// bytes after the returned frame.
+pub fn encode_cached_block_put_header(
+    request_id: u32,
+    req: &CachedBlockPutRequest,
+) -> Result<Vec<u8>, DataError> {
+    let body = bincode::serialize(req)?;
+    let header = FrameHeader::new(MsgType::AdmitCachedBlock, request_id, body.len() as u32);
+    let mut buf = Vec::with_capacity(HEADER_LEN + body.len());
+    buf.extend_from_slice(&header.encode());
+    buf.extend_from_slice(&body);
+    Ok(buf)
+}
+
+/// Decode a cache-admission header (without its trailing raw body).
+pub fn decode_cached_block_put_header(
+    buf: &[u8],
+) -> Result<(FrameHeader, CachedBlockPutRequest), DataError> {
+    let header = FrameHeader::decode(buf)?;
+    if header.msg_type != MsgType::AdmitCachedBlock {
+        return Err(DataError::NotCachedBlockPut(header.msg_type));
+    }
+    let declared = header.length as usize;
+    let body = &buf[HEADER_LEN..];
+    if body.len() != declared {
+        return Err(DataError::LengthMismatch {
+            declared,
+            actual: body.len(),
+        });
+    }
+    Ok((header, bincode::deserialize(body)?))
 }
 
 /// Encode a [`DeleteRequest`] into `header || bincode(req)` (no body follows).
@@ -454,6 +505,21 @@ mod tests {
         assert_eq!(header.request_id, 42);
         assert_eq!(back, req);
         // The frame length covers only the small header, NOT the body.
+        assert!((header.length as usize) < 1024);
+    }
+
+    #[test]
+    fn cached_block_put_header_round_trips() {
+        let request = CachedBlockPutRequest {
+            block: BlockId::new(obj(), 8, 8, Version::new("etag-v3")),
+            object_len: 13,
+            body_len: 5,
+        };
+        let encoded = encode_cached_block_put_header(43, &request).unwrap();
+        let (header, decoded) = decode_cached_block_put_header(&encoded).unwrap();
+        assert_eq!(header.msg_type, MsgType::AdmitCachedBlock);
+        assert_eq!(header.request_id, 43);
+        assert_eq!(decoded, request);
         assert!((header.length as usize) < 1024);
     }
 

--- a/crates/talon-transport/src/frame.rs
+++ b/crates/talon-transport/src/frame.rs
@@ -61,6 +61,9 @@ pub enum MsgType {
     /// Read a versioned range only when every requested byte is resident.
     /// This operation must never access the worker backend.
     GetCachedRange = 6,
+    /// Admit one complete, versioned block into the worker cache without
+    /// accessing the configured backend.
+    AdmitCachedBlock = 7,
 }
 
 impl MsgType {
@@ -74,6 +77,7 @@ impl MsgType {
             4 => MsgType::Ping,
             5 => MsgType::Delete,
             6 => MsgType::GetCachedRange,
+            7 => MsgType::AdmitCachedBlock,
             other => return Err(FrameError::UnknownMsgType(other)),
         })
     }
@@ -215,6 +219,7 @@ mod tests {
             MsgType::Ping,
             MsgType::Delete,
             MsgType::GetCachedRange,
+            MsgType::AdmitCachedBlock,
         ]
         .into_iter()
         .enumerate()

--- a/crates/talon-transport/src/lib.rs
+++ b/crates/talon-transport/src/lib.rs
@@ -23,9 +23,10 @@ pub use codec::{
     CONTROL_SCHEMA_VERSION, MIN_CONTROL_SCHEMA_VERSION,
 };
 pub use data::{
-    decode_cached_request, decode_delete, decode_error_payload, decode_put_header, decode_request,
-    encode_cached_request, encode_delete, encode_error, encode_put_header, encode_request,
-    encode_typed_error, response_header_ok, CachedRangeRequest, DataError, DataErrorCode,
+    decode_cached_block_put_header, decode_cached_request, decode_delete, decode_error_payload,
+    decode_put_header, decode_request, encode_cached_block_put_header, encode_cached_request,
+    encode_delete, encode_error, encode_put_header, encode_request, encode_typed_error,
+    response_header_ok, CachedBlockPutRequest, CachedRangeRequest, DataError, DataErrorCode,
     DataPlaneError, DeleteRequest, PutRequest, RangeRequest,
 };
 pub use frame::{Flags, FrameError, FrameHeader, MsgType, HEADER_LEN, MAGIC, PROTOCOL_VERSION};

--- a/crates/talon-transport/src/limits.rs
+++ b/crates/talon-transport/src/limits.rs
@@ -48,7 +48,9 @@ pub fn max_payload_for(msg_type: MsgType) -> u32 {
     match msg_type {
         MsgType::Control => MAX_CONTROL_PAYLOAD_LEN,
         MsgType::Ping => MAX_PING_PAYLOAD_LEN,
-        MsgType::Put | MsgType::Delete | MsgType::GetCachedRange => MAX_CONTROL_PAYLOAD_LEN,
+        MsgType::Put | MsgType::Delete | MsgType::GetCachedRange | MsgType::AdmitCachedBlock => {
+            MAX_CONTROL_PAYLOAD_LEN
+        }
         MsgType::Get | MsgType::GetRange => MAX_PAYLOAD_LEN,
     }
 }

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -1367,6 +1367,97 @@ mod tests {
 
         drop(client);
         server.await.unwrap();
+
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn tokio_conn_admits_a_complete_block_without_origin_access() {
+        use talon_core::BlockId;
+        use talon_transport::data::{
+            encode_cached_block_put_header, CachedBlockPutRequest, CachedRangeRequest,
+        };
+
+        let (worker, observability, _, root) = test_worker();
+        observability.readiness().set_backend_ready(true);
+        observability.readiness().set_store_ready(true);
+        observability.readiness().set_control_registered(true);
+        let object = ObjectId::new(talon_core::Backend::Azure, "c", "admitted");
+        let block = BlockId::new(object.clone(), 0, 8, Version::new("origin-v2"));
+        let request = CachedBlockPutRequest {
+            block,
+            object_len: 8,
+            body_len: 8,
+        };
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_worker = Arc::clone(&worker);
+        let server_observability = Arc::clone(&observability);
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            handle_conn(stream, server_worker, server_observability)
+                .await
+                .unwrap();
+        });
+
+        let mut client = TcpStream::connect(address).await.unwrap();
+        client
+            .write_all(&encode_cached_block_put_header(7, &request).unwrap())
+            .await
+            .unwrap();
+        client.write_all(b"gateway!").await.unwrap();
+        let mut reply = [0_u8; HEADER_LEN];
+        client.read_exact(&mut reply).await.unwrap();
+        let reply = FrameHeader::decode(&reply).unwrap();
+        assert_eq!(reply.length, 0);
+        assert!(!reply.flags.contains(talon_transport::Flags::ERROR));
+        assert_eq!(
+            worker
+                .serve_cached(&CachedRangeRequest {
+                    object: object.clone(),
+                    version: Version::new("origin-v2"),
+                    offset: 0,
+                    len: 8,
+                })
+                .await
+                .unwrap(),
+            Bytes::from_static(b"gateway!")
+        );
+        drop(client);
+        server.await.unwrap();
+
+        let truncated = CachedBlockPutRequest {
+            block: BlockId::new(object.clone(), 0, 8, Version::new("truncated")),
+            object_len: 8,
+            body_len: 8,
+        };
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_worker = Arc::clone(&worker);
+        let server_observability = Arc::clone(&observability);
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            handle_conn(stream, server_worker, server_observability)
+                .await
+                .is_err()
+        });
+        let mut client = TcpStream::connect(address).await.unwrap();
+        client
+            .write_all(&encode_cached_block_put_header(8, &truncated).unwrap())
+            .await
+            .unwrap();
+        client.write_all(b"short").await.unwrap();
+        client.shutdown().await.unwrap();
+        assert!(server.await.unwrap());
+        assert!(worker
+            .serve_cached(&CachedRangeRequest {
+                object,
+                version: Version::new("truncated"),
+                offset: 0,
+                len: 1,
+            })
+            .await
+            .is_err());
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -9,7 +9,7 @@ use talon_core::{
     Backend, BackendStore, BlockForm, BlockHandle, BlockId, BlockMeta, Error, ObjectId,
     ObjectStore, PageIndex, Version,
 };
-use talon_transport::data::{CachedRangeRequest, RangeRequest};
+use talon_transport::data::{CachedBlockPutRequest, CachedRangeRequest, RangeRequest};
 use talon_transport::frame::{HEADER_LEN, MAX_PAYLOAD_LEN};
 use talon_transport::{codec, ControlMessage, ObjectEntry, MAX_CONTROL_PAYLOAD_LEN};
 
@@ -1225,9 +1225,18 @@ impl WorkerRuntime {
             }
         };
 
+        self.commit_cached_block(block, bytes.clone()).await?;
+        Ok(bytes)
+    }
+
+    async fn commit_cached_block(
+        &self,
+        block: &BlockId,
+        bytes: bytes::Bytes,
+    ) -> anyhow::Result<()> {
         let len = bytes.len() as u64;
         self.store
-            .put(block, bytes.clone())
+            .put(block, bytes)
             .await
             .map_err(|error| anyhow::anyhow!("commit block failed: {error}"))?;
         self.index.commit(BlockMeta {
@@ -1251,7 +1260,62 @@ impl WorkerRuntime {
             self.refresh_l1_metrics();
         }
         tracing::info!(block = %block, bytes = len, "committed block");
-        Ok(bytes)
+        Ok(())
+    }
+
+    /// Validate a gateway cache admission before its raw body is read.
+    pub fn validate_cached_block_admission(
+        &self,
+        request: &CachedBlockPutRequest,
+    ) -> anyhow::Result<()> {
+        self.ensure_configured_backend(request.block.object.backend)?;
+        let block_size = u64::from(self.block_size);
+        if request.block.block_size != self.block_size {
+            anyhow::bail!(
+                "admission block size {} does not match worker block size {}",
+                request.block.block_size,
+                self.block_size
+            );
+        }
+        if request.block.offset % block_size != 0 {
+            anyhow::bail!(
+                "admission block offset {} is not aligned",
+                request.block.offset
+            );
+        }
+        if request.block.offset >= request.object_len {
+            anyhow::bail!(
+                "admission block offset {} is outside object length {}",
+                request.block.offset,
+                request.object_len
+            );
+        }
+        let expected = block_size.min(request.object_len - request.block.offset);
+        if request.body_len != expected {
+            anyhow::bail!(
+                "admission body length {} does not match complete block length {}",
+                request.body_len,
+                expected
+            );
+        }
+        Ok(())
+    }
+
+    /// Admit one complete versioned block without consulting the backend.
+    pub async fn admit_cached_block(
+        &self,
+        request: &CachedBlockPutRequest,
+        body: bytes::Bytes,
+    ) -> anyhow::Result<()> {
+        self.validate_cached_block_admission(request)?;
+        if body.len() as u64 != request.body_len {
+            anyhow::bail!(
+                "admission body length changed: expected {}, received {}",
+                request.body_len,
+                body.len()
+            );
+        }
+        self.commit_cached_block(&request.block, body).await
     }
 
     /// Write a whole object through to the backend, then cache it (#226/#229).
@@ -2446,6 +2510,109 @@ mod tests {
         let miss = runtime.serve_cached(&wrong_version).await.unwrap_err();
         assert!(miss.downcast_ref::<CacheMiss>().is_some());
         assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn cache_admission_is_versioned_local_only_and_rejects_partial_blocks() {
+        let root = tmp_root();
+        let backend = Arc::new(MockBackend {
+            calls: AtomicUsize::new(0),
+        });
+        let runtime = runtime(Arc::clone(&backend), WorkerMetrics::new(1024), &root);
+        let object = request("admitted").object;
+        let block = BlockId::new(object.clone(), 0, 8, Version::new("origin-v2"));
+        let admission = CachedBlockPutRequest {
+            block: block.clone(),
+            object_len: 8,
+            body_len: 8,
+        };
+
+        runtime
+            .admit_cached_block(&admission, Bytes::from_static(b"gateway!"))
+            .await
+            .unwrap();
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            runtime
+                .serve_cached(&CachedRangeRequest {
+                    object: object.clone(),
+                    version: Version::new("origin-v2"),
+                    offset: 1,
+                    len: 4,
+                })
+                .await
+                .unwrap(),
+            Bytes::from_static(b"atew")
+        );
+        let wrong_version = runtime
+            .serve_cached(&CachedRangeRequest {
+                object: object.clone(),
+                version: Version::new("other"),
+                offset: 0,
+                len: 1,
+            })
+            .await
+            .unwrap_err();
+        assert!(wrong_version.downcast_ref::<CacheMiss>().is_some());
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 0);
+
+        let tail = CachedBlockPutRequest {
+            block: BlockId::new(object.clone(), 8, 8, Version::new("origin-v2")),
+            object_len: 11,
+            body_len: 3,
+        };
+        runtime
+            .admit_cached_block(&tail, Bytes::from_static(b"end"))
+            .await
+            .unwrap();
+        assert_eq!(
+            runtime
+                .serve_cached(&CachedRangeRequest {
+                    object: object.clone(),
+                    version: Version::new("origin-v2"),
+                    offset: 8,
+                    len: 3,
+                })
+                .await
+                .unwrap(),
+            Bytes::from_static(b"end")
+        );
+
+        let invalid = [
+            CachedBlockPutRequest {
+                block: BlockId::new(object.clone(), 1, 8, Version::new("misaligned")),
+                object_len: 9,
+                body_len: 8,
+            },
+            CachedBlockPutRequest {
+                block: BlockId::new(object.clone(), 8, 8, Version::new("partial")),
+                object_len: 16,
+                body_len: 7,
+            },
+            CachedBlockPutRequest {
+                block: BlockId::new(object.clone(), 0, 4, Version::new("wrong-size")),
+                object_len: 4,
+                body_len: 4,
+            },
+        ];
+        for request in invalid {
+            assert!(runtime
+                .admit_cached_block(&request, Bytes::from(vec![0; request.body_len as usize]))
+                .await
+                .is_err());
+            assert!(runtime
+                .serve_cached(&CachedRangeRequest {
+                    object: object.clone(),
+                    version: request.block.version,
+                    offset: request.block.offset,
+                    len: 1,
+                })
+                .await
+                .is_err());
+        }
+        assert_eq!(runtime.block_count(), 2);
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 0);
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/crates/talon-worker/src/tokio_conn.rs
+++ b/crates/talon-worker/src/tokio_conn.rs
@@ -72,6 +72,21 @@ pub async fn handle_conn(
             .await?;
             continue;
         }
+        if header.msg_type == MsgType::AdmitCachedBlock {
+            if !handle_cached_block_admission(
+                &mut stream,
+                &header,
+                &payload,
+                &worker,
+                &observability,
+                request_started,
+            )
+            .await?
+            {
+                return Ok(());
+            }
+            continue;
+        }
         if header.msg_type == MsgType::Delete {
             handle_delete(
                 &mut stream,
@@ -233,6 +248,87 @@ pub async fn handle_conn(
             }
         }
     }
+}
+
+async fn handle_cached_block_admission(
+    stream: &mut TcpStream,
+    header: &FrameHeader,
+    payload: &[u8],
+    worker: &Arc<WorkerRuntime>,
+    observability: &Arc<WorkerObservability>,
+    request_started: Instant,
+) -> anyhow::Result<bool> {
+    let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
+    full.extend_from_slice(&header.encode());
+    full.extend_from_slice(payload);
+    let (h, req) = match data::decode_cached_block_put_header(&full) {
+        Ok(value) => value,
+        Err(error) => {
+            let reply = data::encode_typed_error(
+                header.request_id,
+                DataErrorCode::InvalidRequest,
+                format!("bad cache admission: {error}"),
+            );
+            stream.write_all(&reply).await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+            return Ok(false);
+        }
+    };
+    if !observability.is_ready() {
+        let reply = data::encode_typed_error(
+            h.request_id,
+            DataErrorCode::Unavailable,
+            "worker is not ready",
+        );
+        stream.write_all(&reply).await?;
+        stream.flush().await?;
+        return Ok(false);
+    }
+    if let Err(error) = worker.validate_cached_block_admission(&req) {
+        let reply = data::encode_typed_error(
+            h.request_id,
+            DataErrorCode::InvalidRequest,
+            error.to_string(),
+        );
+        stream.write_all(&reply).await?;
+        stream.flush().await?;
+        observability
+            .metrics()
+            .record_request_error(request_started.elapsed());
+        return Ok(false);
+    }
+
+    let body_len = usize::try_from(req.body_len)
+        .map_err(|_| anyhow::anyhow!("cache admission body length is not representable"))?;
+    let mut body = vec![0_u8; body_len];
+    stream.read_exact(&mut body).await?;
+    match worker
+        .admit_cached_block(&req, bytes::Bytes::from(body))
+        .await
+    {
+        Ok(()) => {
+            stream
+                .write_all(&data::response_header_ok(h.request_id, 0))
+                .await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_request_success(req.body_len, request_started.elapsed());
+        }
+        Err(error) => {
+            stream
+                .write_all(&encode_runtime_error(h.request_id, &error))
+                .await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+        }
+    }
+    Ok(true)
 }
 
 async fn handle_cached_range(

--- a/crates/talon-worker/src/uring_conn.rs
+++ b/crates/talon-worker/src/uring_conn.rs
@@ -20,8 +20,8 @@
 //!
 //! - per-message-type payload caps enforced *before* allocation, and read
 //!   timeouts (#111) — via [`talon_transport::uring::read_frame`];
-//! - `GetRange`/`GetCachedRange`/`Put`/`Delete` dispatch, with any other type rejected before
-//!   per-request work is done;
+//! - `GetRange`/`GetCachedRange`/`AdmitCachedBlock`/`Put`/`Delete` dispatch,
+//!   with any other type rejected before per-request work is done;
 //! - readiness gating, so an unready worker returns an error frame rather than
 //!   serving;
 //! - the desync rule: once a response header promising `len` bytes is on the
@@ -106,6 +106,22 @@ pub async fn handle_conn(
                     request_started,
                 )
                 .await?;
+                continue;
+            }
+            MsgType::AdmitCachedBlock => {
+                if !handle_cached_block_admission(
+                    &mut stream,
+                    &mut reader,
+                    &header,
+                    &payload,
+                    &worker,
+                    &observability,
+                    request_started,
+                )
+                .await?
+                {
+                    return Ok(());
+                }
                 continue;
             }
             MsgType::Delete => {
@@ -251,6 +267,77 @@ pub async fn handle_conn(
             }
         }
     }
+}
+
+async fn handle_cached_block_admission(
+    stream: &mut TcpStream,
+    reader: &mut BufferedFrameReader,
+    header: &FrameHeader,
+    payload: &[u8],
+    worker: &Arc<WorkerRuntime>,
+    observability: &Arc<WorkerObservability>,
+    request_started: Instant,
+) -> anyhow::Result<bool> {
+    let (h, req) = match data::decode_cached_block_put_header(&rejoin(header, payload)) {
+        Ok(value) => value,
+        Err(error) => {
+            let reply = data::encode_typed_error(
+                header.request_id,
+                DataErrorCode::InvalidRequest,
+                format!("bad cache admission: {error}"),
+            );
+            write_all(stream, reply).await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+            return Ok(false);
+        }
+    };
+    if !observability.is_ready() {
+        let reply = data::encode_typed_error(
+            h.request_id,
+            DataErrorCode::Unavailable,
+            "worker is not ready",
+        );
+        write_all(stream, reply).await?;
+        return Ok(false);
+    }
+    if let Err(error) = worker.validate_cached_block_admission(&req) {
+        let reply = data::encode_typed_error(
+            h.request_id,
+            DataErrorCode::InvalidRequest,
+            error.to_string(),
+        );
+        write_all(stream, reply).await?;
+        observability
+            .metrics()
+            .record_request_error(request_started.elapsed());
+        return Ok(false);
+    }
+
+    let body_len = usize::try_from(req.body_len)
+        .map_err(|_| anyhow::anyhow!("cache admission body length is not representable"))?;
+    let body = reader
+        .read_exact_bytes(stream, body_len, talon_transport::DEFAULT_READ_TIMEOUT)
+        .await?;
+    match worker
+        .admit_cached_block(&req, bytes::Bytes::from(body))
+        .await
+    {
+        Ok(()) => {
+            write_all(stream, data::response_header_ok(h.request_id, 0).to_vec()).await?;
+            observability
+                .metrics()
+                .record_request_success(req.body_len, request_started.elapsed());
+        }
+        Err(error) => {
+            write_all(stream, encode_runtime_error(h.request_id, &error)).await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+        }
+    }
+    Ok(true)
 }
 
 async fn handle_cached_range(
@@ -662,10 +749,11 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Mutex;
     use talon_core::{
-        BackendStore, NodeId, NodeInfo, NodeRole, ObjectId, ObjectStat, Result, Version,
+        BackendStore, BlockId, NodeId, NodeInfo, NodeRole, ObjectId, ObjectStat, Result, Version,
     };
     use talon_transport::data::{
-        encode_delete, encode_put_header, encode_request, DeleteRequest, PutRequest, RangeRequest,
+        encode_cached_block_put_header, encode_delete, encode_put_header, encode_request,
+        CachedBlockPutRequest, CachedRangeRequest, DeleteRequest, PutRequest, RangeRequest,
     };
     use talon_transport::Flags;
 
@@ -847,6 +935,48 @@ mod tests {
                 );
                 assert_eq!(body, expected, "pass {pass}: range bytes must match");
             }
+        });
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn admits_a_complete_block_through_the_ring_handler() {
+        let root = tmp_root("admit");
+        run(async {
+            let (worker, obs) = build(&root, Arc::new(RampBackend), 8);
+            let retained = Arc::clone(&worker);
+            let listener = monoio::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let address = listener.local_addr().unwrap();
+            monoio::spawn(async move {
+                let (stream, _) = listener.accept().await.unwrap();
+                let _ = handle_conn(stream, worker, obs).await;
+            });
+            let object = ObjectId::new(talon_core::Backend::Azure, "c", "admitted");
+            let request = CachedBlockPutRequest {
+                block: BlockId::new(object.clone(), 0, 8, Version::new("origin-v2")),
+                object_len: 8,
+                body_len: 8,
+            };
+            let mut client = TcpStream::connect(address).await.unwrap();
+            let mut wire = encode_cached_block_put_header(7, &request).unwrap();
+            wire.extend_from_slice(b"gateway!");
+            let (result, _) = client.write_all(wire).await;
+            result.unwrap();
+            let (reply, body) = read_response(&mut client).await;
+            assert!(!reply.flags.contains(Flags::ERROR));
+            assert!(body.is_empty());
+            assert_eq!(
+                retained
+                    .serve_cached(&CachedRangeRequest {
+                        object,
+                        version: Version::new("origin-v2"),
+                        offset: 0,
+                        len: 8,
+                    })
+                    .await
+                    .unwrap(),
+                Bytes::from_static(b"gateway!")
+            );
         });
         std::fs::remove_dir_all(root).ok();
     }


### PR DESCRIPTION
Closes one task in #510.

## What changed
- add a distinct `AdmitCachedBlock` data-plane operation carrying an exact versioned block identity, object length, and raw body length
- validate alignment, worker block size, complete-block/tail length, and backend namespace before allocating or committing
- commit admitted bytes only to worker cache state; no metadata resolution or backend call is possible
- expose `WorkerClient::admit_cached_block` with bounded one-block transfer and pooled connection reuse
- dispatch identically on Tokio and io_uring; malformed requests close the connection, and truncated bodies never commit

Old workers reject message type 7, so rolling upgrades fail closed instead of falling back to write-through behavior.

## Verification
- `cargo test -p talon-transport -p talon-cache-client -p talon-worker` (387 passed)
- `cargo clippy -p talon-transport -p talon-cache-client -p talon-worker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`