### PR TITLE
feat(gateway): add request-scoped origin credentials

### DIFF
--- a/crates/talon-backend/src/azure.rs
+++ b/crates/talon-backend/src/azure.rs
@@ -8,9 +8,10 @@
 //!
 //! The `ObjectId::bucket` field carries the **container** name for Azure (the
 //! account is part of the endpoint host). Like the other backends this is
-//! generic over an [`HttpClient`] and unit-testable offline. Authentication is
-//! either a SAS token (in the URL query) or Shared Key (see
-//! [`crate::azure_sharedkey`]), signed just before each request executes.
+//! generic over an [`HttpClient`] and unit-testable offline. Service
+//! authentication is either a static SAS token or Shared Key (see
+//! [`crate::azure_sharedkey`]); explicit request-scoped entry points use an
+//! origin-issued client SAS without consulting either service credential.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -23,6 +24,7 @@ use talon_core::{
 use crate::http::{
     HttpClient, HttpRequest, HttpRequestBody, HttpResponse, HttpStreamResponse, Method,
 };
+use crate::AzureSas;
 
 /// Percent-encode a query value. `/` is escaped: a listing prefix contains
 /// slashes and an unescaped one would change the request path.
@@ -395,6 +397,102 @@ impl AzureBackend {
         headers.extend_from_slice(conditions);
         let request = HttpRequest::new(Method::Get, self.blob_url(obj), headers);
         self.http.execute_stream(self.authorized(request)).await
+    }
+
+    fn sas_object_request(
+        &self,
+        method: Method,
+        obj: &ObjectId,
+        credential: &AzureSas,
+        headers: &[(String, String)],
+    ) -> HttpRequest {
+        let mut url = self.blob_url(obj);
+        if let Some(query) = url.find('?') {
+            url.truncate(query);
+        }
+        url.push('?');
+        url.push_str(credential.expose_secret());
+        let mut outgoing = self.common_headers();
+        outgoing.extend_from_slice(headers);
+        HttpRequest::new(method, url, outgoing)
+    }
+
+    /// Execute a bodyless object request using only the supplied SAS. The
+    /// backend's configured Shared Key or static SAS is not used.
+    pub async fn execute_sas_raw(
+        &self,
+        method: Method,
+        obj: &ObjectId,
+        credential: &AzureSas,
+        headers: &[(String, String)],
+    ) -> std::result::Result<HttpResponse, String> {
+        self.http
+            .execute(self.sas_object_request(method, obj, credential, headers))
+            .await
+    }
+
+    /// Execute a streaming object request using only the supplied SAS.
+    pub async fn execute_sas_stream_raw(
+        &self,
+        method: Method,
+        obj: &ObjectId,
+        credential: &AzureSas,
+        headers: &[(String, String)],
+    ) -> std::result::Result<HttpStreamResponse, String> {
+        self.http
+            .execute_stream(self.sas_object_request(method, obj, credential, headers))
+            .await
+    }
+
+    /// Execute a single-use request body using only the supplied SAS.
+    pub async fn execute_sas_body_raw(
+        &self,
+        method: Method,
+        obj: &ObjectId,
+        credential: &AzureSas,
+        headers: &[(String, String)],
+        body: HttpRequestBody,
+        len: u64,
+    ) -> std::result::Result<HttpResponse, String> {
+        self.http
+            .execute_body(
+                self.sas_object_request(method, obj, credential, headers),
+                body,
+                len,
+            )
+            .await
+    }
+
+    /// Execute a container-scoped request, such as List Blobs, preserving the
+    /// client's complete SAS-bearing query byte-for-byte.
+    pub async fn execute_sas_container_raw(
+        &self,
+        method: Method,
+        container: &str,
+        credential: &AzureSas,
+        headers: &[(String, String)],
+    ) -> std::result::Result<HttpResponse, String> {
+        let scheme = if self.config.tls { "https" } else { "http" };
+        let host =
+            self.config.endpoint_host.clone().unwrap_or_else(|| {
+                format!("{}.{}", self.config.account, self.config.endpoint_suffix)
+            });
+        let base = if self.config.path_style {
+            format!("{scheme}://{host}/{}/{container}", self.config.account)
+        } else {
+            format!("{scheme}://{host}/{container}")
+        };
+        self.http
+            .execute(HttpRequest::new(
+                method,
+                format!("{base}?{}", credential.expose_secret()),
+                {
+                    let mut outgoing = self.common_headers();
+                    outgoing.extend_from_slice(headers);
+                    outgoing
+                },
+            ))
+            .await
     }
 
     /// Execute one raw Azure List Blobs page.
@@ -848,6 +946,60 @@ mod tests {
     fn obj() -> ObjectId {
         // bucket == Azure container.
         ObjectId::new(Backend::Azure, "my-container", "data/checkpoint.bin")
+    }
+
+    #[tokio::test]
+    async fn request_sas_replaces_service_auth_and_preserves_the_client_query() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: bytes::Bytes::new(),
+        });
+        let backend =
+            AzureBackend::with_shared_key(AzureConfig::new("myacct"), "SERVICEKEY", http.clone());
+        let credential = AzureSas::new(
+            "sv=2024-11-04&sp=r&sig=CLIENTSECRET&comp=metadata&snapshot=opaque%2Bvalue",
+        )
+        .unwrap();
+        backend
+            .execute_sas_raw(
+                Method::Head,
+                &obj(),
+                &credential,
+                &[("if-match".into(), "\"etag\"".into())],
+            )
+            .await
+            .unwrap();
+        let request = http.last.lock().unwrap().take().unwrap();
+        assert_eq!(
+            request.url,
+            format!(
+                "https://myacct.blob.core.windows.net/my-container/data/checkpoint.bin?{}",
+                credential.expose_secret()
+            )
+        );
+        assert_eq!(
+            request.header("x-ms-version"),
+            Some(AzureBackend::API_VERSION)
+        );
+        assert_eq!(request.header("if-match"), Some("\"etag\""));
+        assert!(request.header("authorization").is_none());
+        assert!(request.header("x-ms-date").is_none());
+        assert!(!format!("{request:?}").contains("CLIENTSECRET"));
+
+        backend
+            .execute_sas_container_raw(Method::Get, "my-container", &credential, &[])
+            .await
+            .unwrap();
+        let request = http.last.lock().unwrap().take().unwrap();
+        assert_eq!(
+            request.url,
+            format!(
+                "https://myacct.blob.core.windows.net/my-container?{}",
+                credential.expose_secret()
+            )
+        );
+        assert!(request.header("authorization").is_none());
     }
 
     #[test]

--- a/crates/talon-backend/src/http.rs
+++ b/crates/talon-backend/src/http.rs
@@ -29,7 +29,7 @@ pub enum Method {
 }
 
 /// An outgoing HTTP request built by a backend.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct HttpRequest {
     /// Request method.
     pub method: Method,
@@ -39,6 +39,27 @@ pub struct HttpRequest {
     pub headers: Vec<(String, String)>,
     /// Request body. Empty for GET/HEAD/DELETE; carries the object bytes for PUT.
     pub body: bytes::Bytes,
+}
+
+impl std::fmt::Debug for HttpRequest {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let url = self.url.split_once('?').map_or_else(
+            || self.url.clone(),
+            |(base, _)| format!("{base}?[REDACTED]"),
+        );
+        let header_names = self
+            .headers
+            .iter()
+            .map(|(name, _)| name.as_str())
+            .collect::<Vec<_>>();
+        formatter
+            .debug_struct("HttpRequest")
+            .field("method", &self.method)
+            .field("url", &url)
+            .field("header_names", &header_names)
+            .field("body_len", &self.body.len())
+            .finish()
+    }
 }
 
 impl HttpRequest {

--- a/crates/talon-backend/src/lib.rs
+++ b/crates/talon-backend/src/lib.rs
@@ -11,6 +11,7 @@ pub mod azure_sharedkey;
 pub mod delay;
 pub mod gcs;
 pub mod http;
+mod query_auth;
 pub mod reqwest_client;
 pub mod retry;
 pub mod s3;
@@ -23,6 +24,7 @@ pub use gcs::{GcsBackend, GcsConfig};
 pub use http::{
     HttpClient, HttpRequest, HttpRequestBody, HttpResponse, HttpStreamResponse, Method,
 };
+pub use query_auth::{AzureSas, S3PresignedQuery};
 pub use reqwest_client::ReqwestClient;
 pub use retry::{RetryConfig, RetryObserver, RetryingHttpClient};
 pub use s3::{S3Backend, S3Config, S3Credentials, S3MultipartRequest};

--- a/crates/talon-backend/src/query_auth.rs
+++ b/crates/talon-backend/src/query_auth.rs
@@ -1,0 +1,112 @@
+//! Request-scoped query credentials for trusted local gateway forwarding.
+
+fn normalized(raw: impl Into<String>, kind: &str) -> Result<String, String> {
+    let raw = raw.into();
+    let query = raw.strip_prefix('?').unwrap_or(&raw);
+    if query.is_empty() || query.contains('#') || query.bytes().any(|byte| byte.is_ascii_control())
+    {
+        return Err(format!("{kind} query credential is malformed"));
+    }
+    Ok(query.to_owned())
+}
+
+fn contains_key(query: &str, expected: &str) -> bool {
+    url::form_urlencoded::parse(query.as_bytes()).any(|(key, _)| key == expected)
+}
+
+/// An origin-issued S3 presigned query, preserved byte-for-byte after an
+/// optional leading `?`.
+#[derive(Clone, PartialEq, Eq)]
+pub struct S3PresignedQuery(String);
+
+impl S3PresignedQuery {
+    /// Validate the credential shape without verifying its signature.
+    pub fn new(raw: impl Into<String>) -> Result<Self, String> {
+        let query = normalized(raw, "S3 presigned")?;
+        for required in [
+            "X-Amz-Algorithm",
+            "X-Amz-Credential",
+            "X-Amz-Date",
+            "X-Amz-Expires",
+            "X-Amz-SignedHeaders",
+            "X-Amz-Signature",
+        ] {
+            if !contains_key(&query, required) {
+                return Err("S3 presigned query credential is incomplete".into());
+            }
+        }
+        Ok(Self(query))
+    }
+
+    /// Access the exact raw query for origin request construction.
+    pub fn expose_secret(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for S3PresignedQuery {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("S3PresignedQuery([REDACTED])")
+    }
+}
+
+/// An origin-issued Azure SAS query, preserved byte-for-byte after an optional
+/// leading `?`.
+#[derive(Clone, PartialEq, Eq)]
+pub struct AzureSas(String);
+
+impl AzureSas {
+    /// Validate the credential shape without verifying its signature.
+    pub fn new(raw: impl Into<String>) -> Result<Self, String> {
+        let query = normalized(raw, "Azure SAS")?;
+        if !contains_key(&query, "sig") || !contains_key(&query, "sv") {
+            return Err("Azure SAS query credential is incomplete".into());
+        }
+        Ok(Self(query))
+    }
+
+    /// Access the exact raw query for origin request construction.
+    pub fn expose_secret(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for AzureSas {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("AzureSas([REDACTED])")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn credentials_are_redacted_and_preserve_the_raw_query() {
+        let s3 = S3PresignedQuery::new(
+            "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a%2Fb&X-Amz-Date=d&X-Amz-Expires=60&X-Amz-SignedHeaders=host&X-Amz-Signature=secret",
+        )
+        .unwrap();
+        assert!(s3.expose_secret().contains("a%2Fb"));
+        assert_eq!(format!("{s3:?}"), "S3PresignedQuery([REDACTED])");
+        assert!(!format!("{s3:?}").contains("secret"));
+
+        let azure = AzureSas::new("?sv=2024-11-04&sp=r&sig=secret%2Bvalue").unwrap();
+        assert_eq!(
+            azure.expose_secret(),
+            "sv=2024-11-04&sp=r&sig=secret%2Bvalue"
+        );
+        assert_eq!(format!("{azure:?}"), "AzureSas([REDACTED])");
+    }
+
+    #[test]
+    fn malformed_or_incomplete_credentials_fail_without_echoing_secrets() {
+        for result in [
+            S3PresignedQuery::new("X-Amz-Signature=secret").map(|_| ()),
+            AzureSas::new("sv=2024-11-04&sig=secret#fragment").map(|_| ()),
+        ] {
+            let error = result.unwrap_err();
+            assert!(!error.contains("secret"));
+        }
+    }
+}

--- a/crates/talon-backend/src/s3.rs
+++ b/crates/talon-backend/src/s3.rs
@@ -7,10 +7,10 @@
 //! response parsing are all unit-testable without network access; a real client
 //! is injected in production.
 //!
-//! Authentication is AWS Signature v4 (see [`crate::sigv4`]): every request is
-//! signed just before execution with the configured [`S3Credentials`], region,
-//! and the `s3` service. Endpoints are configurable so MinIO/Ceph and other
-//! S3-compatible stores work.
+//! Service-authenticated requests use AWS Signature v4 (see [`crate::sigv4`]).
+//! Explicit request-scoped entry points instead preserve an origin-issued
+//! presigned query and never consult [`S3Credentials`]. Endpoints are
+//! configurable so MinIO/Ceph and other S3-compatible stores work.
 
 use std::io::{Read, Take};
 use std::path::{Path, PathBuf};
@@ -25,6 +25,7 @@ use talon_core::{
 use crate::http::{
     HttpClient, HttpRequest, HttpRequestBody, HttpResponse, HttpStreamResponse, Method,
 };
+use crate::S3PresignedQuery;
 
 /// Validated S3 multipart request metadata supplied by a protocol adapter.
 #[derive(Clone, Copy)]
@@ -329,6 +330,105 @@ impl S3Backend {
         headers.extend_from_slice(conditions);
         let request = HttpRequest::new(Method::Get, self.object_url(obj), headers);
         self.http.execute_stream(self.signed(request)).await
+    }
+
+    fn presigned_object_request(
+        &self,
+        method: Method,
+        obj: &ObjectId,
+        credential: &S3PresignedQuery,
+        headers: &[(String, String)],
+    ) -> HttpRequest {
+        HttpRequest::new(
+            method,
+            format!("{}?{}", self.object_url(obj), credential.expose_secret()),
+            headers.to_vec(),
+        )
+    }
+
+    /// Execute a bodyless object request using only the supplied presigned
+    /// query. Configured service credentials are not added or used.
+    pub async fn execute_presigned_raw(
+        &self,
+        method: Method,
+        obj: &ObjectId,
+        credential: &S3PresignedQuery,
+        headers: &[(String, String)],
+    ) -> std::result::Result<HttpResponse, String> {
+        self.http
+            .execute(self.presigned_object_request(method, obj, credential, headers))
+            .await
+    }
+
+    /// Execute a streaming object request using only the supplied presigned
+    /// query.
+    pub async fn execute_presigned_stream_raw(
+        &self,
+        method: Method,
+        obj: &ObjectId,
+        credential: &S3PresignedQuery,
+        headers: &[(String, String)],
+    ) -> std::result::Result<HttpStreamResponse, String> {
+        self.http
+            .execute_stream(self.presigned_object_request(method, obj, credential, headers))
+            .await
+    }
+
+    /// Execute a single-use request body using only the supplied presigned
+    /// query.
+    pub async fn execute_presigned_body_raw(
+        &self,
+        method: Method,
+        obj: &ObjectId,
+        credential: &S3PresignedQuery,
+        headers: &[(String, String)],
+        body: HttpRequestBody,
+        len: u64,
+    ) -> std::result::Result<HttpResponse, String> {
+        self.http
+            .execute_body(
+                self.presigned_object_request(method, obj, credential, headers),
+                body,
+                len,
+            )
+            .await
+    }
+
+    /// Execute a staged request body using only the supplied presigned query.
+    pub async fn execute_presigned_file_raw(
+        &self,
+        method: Method,
+        obj: &ObjectId,
+        credential: &S3PresignedQuery,
+        headers: &[(String, String)],
+        path: &Path,
+        len: u64,
+    ) -> std::result::Result<HttpResponse, String> {
+        self.http
+            .execute_file(
+                self.presigned_object_request(method, obj, credential, headers),
+                path,
+                len,
+            )
+            .await
+    }
+
+    /// Execute a bucket-scoped request, such as ListObjectsV2, preserving the
+    /// client's complete presigned query byte-for-byte.
+    pub async fn execute_presigned_bucket_raw(
+        &self,
+        method: Method,
+        bucket: &str,
+        credential: &S3PresignedQuery,
+        headers: &[(String, String)],
+    ) -> std::result::Result<HttpResponse, String> {
+        self.http
+            .execute(HttpRequest::new(
+                method,
+                format!("{}?{}", self.bucket_url(bucket), credential.expose_secret()),
+                headers.to_vec(),
+            ))
+            .await
     }
 
     /// Execute one raw ListObjectsV2 page.
@@ -805,6 +905,74 @@ mod tests {
 
     fn obj() -> ObjectId {
         ObjectId::new(Backend::S3, "my-bucket", "data/checkpoint.bin")
+    }
+
+    fn presigned() -> S3PresignedQuery {
+        S3PresignedQuery::new(
+            "X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=client%2Fscope&X-Amz-Date=20260810T000000Z&X-Amz-Expires=60&X-Amz-SignedHeaders=host&X-Amz-Signature=CLIENTSECRET",
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn presigned_execution_preserves_query_and_never_uses_service_credentials() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: bytes::Bytes::new(),
+        });
+        let backend = S3Backend::new(
+            S3Config {
+                region: "us-east-1".into(),
+                endpoint: "localhost:9000".into(),
+                path_style: true,
+                tls: false,
+            },
+            S3Credentials {
+                access_key_id: "SERVICE".into(),
+                secret_access_key: "SERVICESECRET".into(),
+                session_token: Some("SERVICETOKEN".into()),
+            },
+            http.clone(),
+        );
+        let credential = presigned();
+        backend
+            .execute_presigned_raw(
+                Method::Head,
+                &obj(),
+                &credential,
+                &[("if-match".into(), "\"etag\"".into())],
+            )
+            .await
+            .unwrap();
+        let request = http.last.lock().unwrap().take().unwrap();
+        assert_eq!(
+            request.url,
+            format!(
+                "http://localhost:9000/my-bucket/data/checkpoint.bin?{}",
+                credential.expose_secret()
+            )
+        );
+        assert_eq!(request.header("if-match"), Some("\"etag\""));
+        assert!(request.header("authorization").is_none());
+        assert!(request.header("x-amz-security-token").is_none());
+        let debug = format!("{request:?}");
+        assert!(!debug.contains("SERVICESECRET"));
+        assert!(!debug.contains("CLIENTSECRET"));
+        assert!(!debug.contains("etag"));
+
+        backend
+            .execute_presigned_bucket_raw(Method::Get, "my-bucket", &credential, &[])
+            .await
+            .unwrap();
+        let request = http.last.lock().unwrap().take().unwrap();
+        assert_eq!(
+            request.url,
+            format!(
+                "http://localhost:9000/my-bucket?{}",
+                credential.expose_secret()
+            )
+        );
     }
 
     #[test]

--- a/crates/talon-gateway/src/azure.rs
+++ b/crates/talon-gateway/src/azure.rs
@@ -12,7 +12,9 @@ use axum::http::{header, HeaderMap, HeaderName, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
-use talon_backend::{AzureBackend, HttpRequestBody, HttpResponse, HttpStreamResponse};
+use talon_backend::{
+    AzureBackend, AzureSas, HttpRequestBody, HttpResponse, HttpStreamResponse, Method,
+};
 use talon_cache_client::{BlockReader, CacheReadError, FileView, DEFAULT_TRANSFER_CHUNK_BYTES};
 use talon_core::{Backend, ObjectId, Version};
 
@@ -141,7 +143,8 @@ impl AzureCache for BlockReader {
     }
 }
 
-/// Origin seam. The production implementation keeps GET bodies streaming.
+/// Origin seam. Service-auth methods and explicit request-scoped SAS methods
+/// are separate; the production implementation keeps GET bodies streaming.
 #[async_trait]
 pub trait AzureOrigin: Send + Sync + 'static {
     /// Execute a conditional blob metadata request.
@@ -240,6 +243,48 @@ pub trait AzureOrigin: Send + Sync + 'static {
         _headers: &[(String, String)],
     ) -> Result<HttpResponse, String> {
         Err("Azure origin does not implement Get Block List".into())
+    }
+
+    async fn sas_object(
+        &self,
+        _method: Method,
+        _object: &ObjectId,
+        _credential: &AzureSas,
+        _headers: &[(String, String)],
+    ) -> Result<HttpResponse, String> {
+        Err("Azure origin does not implement SAS requests".into())
+    }
+
+    async fn sas_object_stream(
+        &self,
+        _method: Method,
+        _object: &ObjectId,
+        _credential: &AzureSas,
+        _headers: &[(String, String)],
+    ) -> Result<HttpStreamResponse, String> {
+        Err("Azure origin does not implement streaming SAS requests".into())
+    }
+
+    async fn sas_object_body(
+        &self,
+        _method: Method,
+        _object: &ObjectId,
+        _credential: &AzureSas,
+        _headers: &[(String, String)],
+        _body: HttpRequestBody,
+        _len: u64,
+    ) -> Result<HttpResponse, String> {
+        Err("Azure origin does not implement SAS request bodies".into())
+    }
+
+    async fn sas_container(
+        &self,
+        _method: Method,
+        _container: &str,
+        _credential: &AzureSas,
+        _headers: &[(String, String)],
+    ) -> Result<HttpResponse, String> {
+        Err("Azure origin does not implement container SAS requests".into())
     }
 }
 
@@ -340,6 +385,52 @@ impl AzureOrigin for AzureBackend {
         headers: &[(String, String)],
     ) -> Result<HttpResponse, String> {
         self.execute_get_query_raw(object, query, headers).await
+    }
+
+    async fn sas_object(
+        &self,
+        method: Method,
+        object: &ObjectId,
+        credential: &AzureSas,
+        headers: &[(String, String)],
+    ) -> Result<HttpResponse, String> {
+        self.execute_sas_raw(method, object, credential, headers)
+            .await
+    }
+
+    async fn sas_object_stream(
+        &self,
+        method: Method,
+        object: &ObjectId,
+        credential: &AzureSas,
+        headers: &[(String, String)],
+    ) -> Result<HttpStreamResponse, String> {
+        self.execute_sas_stream_raw(method, object, credential, headers)
+            .await
+    }
+
+    async fn sas_object_body(
+        &self,
+        method: Method,
+        object: &ObjectId,
+        credential: &AzureSas,
+        headers: &[(String, String)],
+        body: HttpRequestBody,
+        len: u64,
+    ) -> Result<HttpResponse, String> {
+        self.execute_sas_body_raw(method, object, credential, headers, body, len)
+            .await
+    }
+
+    async fn sas_container(
+        &self,
+        method: Method,
+        container: &str,
+        credential: &AzureSas,
+        headers: &[(String, String)],
+    ) -> Result<HttpResponse, String> {
+        self.execute_sas_container_raw(method, container, credential, headers)
+            .await
     }
 }
 

--- a/crates/talon-gateway/src/s3.rs
+++ b/crates/talon-gateway/src/s3.rs
@@ -15,6 +15,7 @@ use futures::{Stream, StreamExt};
 use sha2::{Digest, Sha256};
 use talon_backend::{
     HttpRequestBody, HttpResponse, HttpStreamResponse, Method, S3Backend, S3MultipartRequest,
+    S3PresignedQuery,
 };
 use talon_cache_client::{BlockReader, CacheReadError, FileView, DEFAULT_TRANSFER_CHUNK_BYTES};
 use talon_core::{Backend, ObjectId, Version};
@@ -142,7 +143,9 @@ impl S3Cache for BlockReader {
     }
 }
 
-/// Scoped origin identity. Incoming client signatures are never forwarded.
+/// Origin execution seam. Service-auth methods and explicit request-scoped
+/// presigned methods are separate so one can never silently substitute for the
+/// other.
 #[async_trait]
 pub trait S3Origin: Send + Sync + 'static {
     async fn head(
@@ -228,6 +231,60 @@ pub trait S3Origin: Send + Sync + 'static {
         _payload_hash: &str,
     ) -> Result<HttpResponse, String> {
         Err("S3 origin does not implement multipart file bodies".into())
+    }
+
+    async fn presigned_object(
+        &self,
+        _method: Method,
+        _object: &ObjectId,
+        _credential: &S3PresignedQuery,
+        _headers: &[(String, String)],
+    ) -> Result<HttpResponse, String> {
+        Err("S3 origin does not implement presigned requests".into())
+    }
+
+    async fn presigned_object_stream(
+        &self,
+        _method: Method,
+        _object: &ObjectId,
+        _credential: &S3PresignedQuery,
+        _headers: &[(String, String)],
+    ) -> Result<HttpStreamResponse, String> {
+        Err("S3 origin does not implement streaming presigned requests".into())
+    }
+
+    async fn presigned_object_body(
+        &self,
+        _method: Method,
+        _object: &ObjectId,
+        _credential: &S3PresignedQuery,
+        _headers: &[(String, String)],
+        _body: HttpRequestBody,
+        _len: u64,
+    ) -> Result<HttpResponse, String> {
+        Err("S3 origin does not implement presigned request bodies".into())
+    }
+
+    async fn presigned_object_file(
+        &self,
+        _method: Method,
+        _object: &ObjectId,
+        _credential: &S3PresignedQuery,
+        _headers: &[(String, String)],
+        _path: &std::path::Path,
+        _len: u64,
+    ) -> Result<HttpResponse, String> {
+        Err("S3 origin does not implement presigned request files".into())
+    }
+
+    async fn presigned_bucket(
+        &self,
+        _method: Method,
+        _bucket: &str,
+        _credential: &S3PresignedQuery,
+        _headers: &[(String, String)],
+    ) -> Result<HttpResponse, String> {
+        Err("S3 origin does not implement bucket presigned requests".into())
     }
 }
 
@@ -333,6 +390,65 @@ impl S3Origin for S3Backend {
         payload_hash: &str,
     ) -> Result<HttpResponse, String> {
         self.execute_multipart_file_raw(request, path, len, payload_hash)
+            .await
+    }
+
+    async fn presigned_object(
+        &self,
+        method: Method,
+        object: &ObjectId,
+        credential: &S3PresignedQuery,
+        headers: &[(String, String)],
+    ) -> Result<HttpResponse, String> {
+        self.execute_presigned_raw(method, object, credential, headers)
+            .await
+    }
+
+    async fn presigned_object_stream(
+        &self,
+        method: Method,
+        object: &ObjectId,
+        credential: &S3PresignedQuery,
+        headers: &[(String, String)],
+    ) -> Result<HttpStreamResponse, String> {
+        self.execute_presigned_stream_raw(method, object, credential, headers)
+            .await
+    }
+
+    async fn presigned_object_body(
+        &self,
+        method: Method,
+        object: &ObjectId,
+        credential: &S3PresignedQuery,
+        headers: &[(String, String)],
+        body: HttpRequestBody,
+        len: u64,
+    ) -> Result<HttpResponse, String> {
+        self.execute_presigned_body_raw(method, object, credential, headers, body, len)
+            .await
+    }
+
+    async fn presigned_object_file(
+        &self,
+        method: Method,
+        object: &ObjectId,
+        credential: &S3PresignedQuery,
+        headers: &[(String, String)],
+        path: &std::path::Path,
+        len: u64,
+    ) -> Result<HttpResponse, String> {
+        self.execute_presigned_file_raw(method, object, credential, headers, path, len)
+            .await
+    }
+
+    async fn presigned_bucket(
+        &self,
+        method: Method,
+        bucket: &str,
+        credential: &S3PresignedQuery,
+        headers: &[(String, String)],
+    ) -> Result<HttpResponse, String> {
+        self.execute_presigned_bucket_raw(method, bucket, credential, headers)
             .await
     }
 }


### PR DESCRIPTION
Advances #510.

## What changed
- add redacted `S3PresignedQuery` and `AzureSas` capability types that preserve the original query bytes after validating required shape
- add explicit S3 object/bucket buffered, streaming, body, and file execution paths that never invoke SigV4 or add service session credentials
- add explicit Azure object/container buffered, streaming, and body paths that never invoke Shared Key or retain the configured static SAS
- expose the capabilities through separate `S3Origin` / `AzureOrigin` methods; existing service-auth methods are unchanged
- redact query strings and all header values from `HttpRequest` debug output

The new methods only accept canonical object/container identities and rebuild the configured origin authority, so a caller cannot inject an arbitrary destination URL. Gateway mode selection and cache-miss orchestration remain in the next PR.

## Verification
- `cargo test -p talon-backend -p talon-gateway` (249 passed)
- `cargo clippy -p talon-backend -p talon-gateway --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`