### PR TITLE
feat: add asynchronous C client bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2562,6 +2562,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "talon-c"
+version = "0.1.0"
+dependencies = [
+ "cc",
+ "talon-cache-client",
+ "talon-core",
+ "talon-transport",
+ "tokio",
+]
+
+[[package]]
 name = "talon-cache-client"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/talon-transport",
     "crates/talon-backend",
     "crates/talon-client",
+    "clients/c",
     "clients/python",
     "crates/talon-observability",
     "crates/talon-metadata",

--- a/Justfile
+++ b/Justfile
@@ -28,6 +28,11 @@ ci: fmt-check clippy test
 
 # --- documentation ---
 
+# Build the C client and stage its header and libraries in target/talon-c-sdk.
+# Pass a destination with: just package-c path/to/output
+package-c OUTPUT="target/talon-c-sdk":
+    ./clients/c/package.sh "{{OUTPUT}}"
+
 # Regenerate the configuration reference from the ConfigVar schemas.
 gen-config-docs:
     cargo run -q -p talon-coordinator --features etcd,kubernetes \

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ talon-fuse --mountpoint /mnt/talon \
 ls /mnt/talon                 # your bucket, as a directory tree
 ```
 
-or skip the mount and use the [Python](docs/clients/python.md) /
-[Java](docs/clients/java.md) SDKs:
+or skip the mount and use the [Python](docs/clients/python.md),
+[Java](docs/clients/java.md), or [C](docs/clients/c.md) SDKs:
 
 ```python
 import talon
@@ -142,8 +142,9 @@ Start with the section that matches what you're doing:
   training, checkpointing, notebooks and data sharing, cross-cloud reads, and
   analytics — including where it does *not* help.
 - **Reading from Talon in code** — [Client SDKs](docs/clients/overview.md):
-  a [Python](docs/clients/python.md) wheel and a native-free
-  [Java](docs/clients/java.md) jar, for when a FUSE mount is not the right fit.
+  a [Python](docs/clients/python.md) wheel, a native-free
+  [Java](docs/clients/java.md) jar, and async [C](docs/clients/c.md) bindings
+  for when a FUSE mount is not the right fit.
 - **Using Talon** — the [Getting started tutorial](docs/tutorials/getting-started.md)
   builds the workspace, runs a cluster, and opens the management console;
   [DESIGN.md](DESIGN.md) explains what each component does, and

--- a/clients/c/Cargo.toml
+++ b/clients/c/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "talon-c"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "C bindings for the Talon distributed object-store cache client"
+publish = false
+
+[lib]
+name = "talon_c"
+crate-type = ["cdylib", "staticlib", "rlib"]
+
+[dependencies]
+talon-core.workspace = true
+talon-cache-client.workspace = true
+talon-transport.workspace = true
+tokio.workspace = true
+
+[build-dependencies]
+cc = "1"

--- a/clients/c/build.rs
+++ b/clients/c/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    println!("cargo:rerun-if-changed=include/talon.h");
+    println!("cargo:rerun-if-changed=tests/c_api_smoke.c");
+
+    cc::Build::new()
+        .file("tests/c_api_smoke.c")
+        .include("include")
+        .flag_if_supported("-std=c11")
+        .compile("talon_c_api_smoke");
+}

--- a/clients/c/examples/async_read.c
+++ b/clients/c/examples/async_read.c
@@ -1,0 +1,79 @@
+#include "talon.h"
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef struct read_context {
+    uint8_t *buffer;
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    int done;
+    int status;
+} read_context;
+
+static void on_read(talon_result *result, void *user_data) {
+    read_context *ctx = (read_context *)user_data;
+    int status = 0;
+    if (talon_result_status(result) == TALON_STATUS_OK) {
+        printf("read %zu bytes\n", talon_result_bytes_written(result));
+    } else {
+        fprintf(stderr, "read failed: %s\n", talon_result_error(result));
+        status = 1;
+    }
+    talon_result_free(result);
+
+    pthread_mutex_lock(&ctx->mutex);
+    ctx->status = status;
+    ctx->done = 1;
+    pthread_cond_signal(&ctx->cond);
+    pthread_mutex_unlock(&ctx->mutex);
+}
+
+int main(void) {
+    talon_client_options options;
+    talon_client_options_init(&options);
+
+    talon_client *client = NULL;
+    if (talon_client_new("127.0.0.1:7000", &options, &client) != TALON_STATUS_OK) {
+        fprintf(stderr, "client init failed: %s\n", talon_last_error());
+        return 1;
+    }
+
+    read_context *ctx = (read_context *)calloc(1, sizeof(read_context));
+    ctx->buffer = (uint8_t *)malloc(4096);
+    pthread_mutex_init(&ctx->mutex, NULL);
+    pthread_cond_init(&ctx->cond, NULL);
+
+    uint64_t request_id = 0;
+    int status = talon_read_async(
+        client,
+        "s3://bucket/path/object.bin",
+        0,
+        ctx->buffer,
+        4096,
+        on_read,
+        ctx,
+        &request_id);
+    if (status != TALON_STATUS_OK) {
+        fprintf(stderr, "submit failed: %s\n", talon_last_error());
+        pthread_mutex_lock(&ctx->mutex);
+        ctx->status = 1;
+        pthread_mutex_unlock(&ctx->mutex);
+    } else {
+        pthread_mutex_lock(&ctx->mutex);
+        while (!ctx->done) {
+            pthread_cond_wait(&ctx->cond, &ctx->mutex);
+        }
+        pthread_mutex_unlock(&ctx->mutex);
+    }
+
+    talon_client_free(client);
+    status = ctx->status;
+    pthread_cond_destroy(&ctx->cond);
+    pthread_mutex_destroy(&ctx->mutex);
+    free(ctx->buffer);
+    free(ctx);
+    return status;
+}

--- a/clients/c/examples/custom_executor.c
+++ b/clients/c/examples/custom_executor.c
@@ -1,0 +1,102 @@
+#include "talon.h"
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef struct scheduled_task {
+    talon_task_fn run;
+    void *task_ctx;
+} scheduled_task;
+
+typedef struct stat_context {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    int done;
+    int status;
+} stat_context;
+
+static void *task_main(void *arg) {
+    scheduled_task *task = (scheduled_task *)arg;
+    task->run(task->task_ctx);
+    free(task);
+    return NULL;
+}
+
+static void submit_to_application_executor(
+    void *executor_ctx,
+    talon_task_fn run,
+    void *task_ctx) {
+    (void)executor_ctx;
+    scheduled_task *task = (scheduled_task *)malloc(sizeof(scheduled_task));
+    task->run = run;
+    task->task_ctx = task_ctx;
+
+    pthread_t thread;
+    pthread_create(&thread, NULL, task_main, task);
+    pthread_detach(thread);
+}
+
+static void on_stat(talon_result *result, void *user_data) {
+    stat_context *ctx = (stat_context *)user_data;
+    int status = 0;
+    if (talon_result_status(result) == TALON_STATUS_OK) {
+        printf("size=%llu version=%s\n",
+               (unsigned long long)talon_result_object_size(result),
+               talon_result_version(result));
+    } else {
+        status = 1;
+    }
+    talon_result_free(result);
+
+    pthread_mutex_lock(&ctx->mutex);
+    ctx->status = status;
+    ctx->done = 1;
+    pthread_cond_signal(&ctx->cond);
+    pthread_mutex_unlock(&ctx->mutex);
+}
+
+int main(void) {
+    talon_callback_executor executor = {
+        .executor_ctx = NULL,
+        .submit = submit_to_application_executor,
+    };
+
+    talon_client_options options;
+    talon_client_options_init(&options);
+    options.callback_executor = &executor;
+
+    talon_client *client = NULL;
+    if (talon_client_new("127.0.0.1:7000", &options, &client) != TALON_STATUS_OK) {
+        fprintf(stderr, "client init failed: %s\n", talon_last_error());
+        return 1;
+    }
+
+    uint64_t request_id = 0;
+    stat_context ctx = {0};
+    pthread_mutex_init(&ctx.mutex, NULL);
+    pthread_cond_init(&ctx.cond, NULL);
+    int status = talon_stat_async(
+        client,
+        "s3://bucket/path/object.bin",
+        on_stat,
+        &ctx,
+        &request_id);
+    if (status != TALON_STATUS_OK) {
+        fprintf(stderr, "submit failed: %s\n", talon_last_error());
+        ctx.status = 1;
+    } else {
+        pthread_mutex_lock(&ctx.mutex);
+        while (!ctx.done) {
+            pthread_cond_wait(&ctx.cond, &ctx.mutex);
+        }
+        pthread_mutex_unlock(&ctx.mutex);
+    }
+
+    talon_client_free(client);
+    status = ctx.status;
+    pthread_cond_destroy(&ctx.cond);
+    pthread_mutex_destroy(&ctx.mutex);
+    return status;
+}

--- a/clients/c/include/talon.h
+++ b/clients/c/include/talon.h
@@ -1,0 +1,103 @@
+#ifndef TALON_H
+#define TALON_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct talon_client talon_client;
+typedef struct talon_result talon_result;
+
+typedef enum talon_status {
+    TALON_STATUS_OK = 0,
+    TALON_STATUS_INVALID_ARGUMENT = 1,
+    TALON_STATUS_RUNTIME_ERROR = 2,
+    TALON_STATUS_SUBMIT_ERROR = 3,
+    TALON_STATUS_OPERATION_ERROR = 4
+} talon_status;
+
+typedef enum talon_operation {
+    TALON_OPERATION_READ = 1,
+    TALON_OPERATION_STAT = 2
+} talon_operation;
+
+typedef void (*talon_callback)(talon_result *result, void *user_data);
+
+typedef void (*talon_task_fn)(void *task_ctx);
+typedef void (*talon_executor_submit_fn)(
+    void *executor_ctx,
+    talon_task_fn run,
+    void *task_ctx);
+
+typedef struct talon_callback_executor {
+    void *executor_ctx;
+    /*
+     * May be called concurrently from internal SDK threads. It must be
+     * thread-safe and must eventually call run(task_ctx) exactly once.
+     */
+    talon_executor_submit_fn submit;
+} talon_callback_executor;
+
+typedef struct talon_client_options {
+    uint32_t block_size;
+    const talon_callback_executor *callback_executor;
+} talon_client_options;
+
+void talon_client_options_init(talon_client_options *options);
+
+int talon_client_new(
+    const char *coordinator_addr,
+    const talon_client_options *options,
+    talon_client **out);
+
+void talon_client_free(talon_client *client);
+
+/*
+ * The client must remain alive until callbacks for all submitted operations have
+ * run. Freeing the client earlier cancels in-flight work.
+ *
+ * Without a callback executor, callbacks run inline on the SDK's Tokio runtime
+ * thread that completed the operation. Callbacks must not block that thread;
+ * provide a callback executor to schedule blocking or expensive work elsewhere.
+ *
+ * If dst_len is greater than zero, dst must be non-NULL. The byte range
+ * [dst, dst + dst_len) is exclusively owned by the SDK until the callback runs:
+ * callers must not read, write, free, or reuse overlapping storage for another
+ * operation during that interval. A zero-length read may pass NULL for dst.
+ */
+int talon_read_async(
+    talon_client *client,
+    const char *uri,
+    uint64_t offset,
+    uint8_t *dst,
+    size_t dst_len,
+    talon_callback callback,
+    void *user_data,
+    uint64_t *request_id_out);
+
+int talon_stat_async(
+    talon_client *client,
+    const char *uri,
+    talon_callback callback,
+    void *user_data,
+    uint64_t *request_id_out);
+
+int talon_result_status(const talon_result *result);
+int talon_result_operation(const talon_result *result);
+uint64_t talon_result_request_id(const talon_result *result);
+size_t talon_result_bytes_written(const talon_result *result);
+uint64_t talon_result_object_size(const talon_result *result);
+const char *talon_result_version(const talon_result *result);
+const char *talon_result_error(const talon_result *result);
+void talon_result_free(talon_result *result);
+
+const char *talon_last_error(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/clients/c/package.sh
+++ b/clients/c/package.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+# Build and stage the distributable C client files.
+set -eu
+
+if [ "$#" -gt 1 ]; then
+    echo "usage: $0 [output-directory]" >&2
+    exit 64
+fi
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+OUTPUT_DIR=${1:-"$REPO_DIR/target/talon-c-sdk"}
+
+case "$OUTPUT_DIR" in
+    /*) ;;
+    *) OUTPUT_DIR="$(pwd)/$OUTPUT_DIR" ;;
+esac
+
+cargo build --manifest-path "$SCRIPT_DIR/Cargo.toml" --release --locked
+
+mkdir -p "$OUTPUT_DIR/include" "$OUTPUT_DIR/lib"
+install -m 644 "$SCRIPT_DIR/include/talon.h" "$OUTPUT_DIR/include/talon.h"
+install -m 644 "$REPO_DIR/target/release/libtalon_c.so" "$OUTPUT_DIR/lib/libtalon_c.so"
+install -m 644 "$REPO_DIR/target/release/libtalon_c.a" "$OUTPUT_DIR/lib/libtalon_c.a"
+install -m 644 "$REPO_DIR/LICENSE" "$OUTPUT_DIR/LICENSE"
+
+echo "C client SDK staged in $OUTPUT_DIR"

--- a/clients/c/src/lib.rs
+++ b/clients/c/src/lib.rs
@@ -1,0 +1,1048 @@
+//! C ABI bindings for the Talon client.
+//!
+//! The exported API is intentionally opaque: C callers receive handles and
+//! result objects, while Rust owns the async runtime, placement cache, and
+//! callback dispatch machinery.
+
+#![allow(clippy::missing_safety_doc)]
+
+use std::cell::RefCell;
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_int, c_void};
+use std::ptr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use talon_cache_client::block_reader::FileView;
+use talon_cache_client::{BlockReader, CoordinatorClient, PlacementCache};
+use talon_core::{ObjectId, Version};
+
+const DEFAULT_BLOCK_SIZE: u32 = 256 << 20;
+const PLACEMENT_TTL_MS: u64 = 30_000;
+const REPLICAS_K: u8 = 1;
+
+const STATUS_OK: c_int = 0;
+const STATUS_INVALID_ARGUMENT: c_int = 1;
+const STATUS_RUNTIME_ERROR: c_int = 2;
+const STATUS_OPERATION_ERROR: c_int = 4;
+
+const OPERATION_READ: c_int = 1;
+const OPERATION_STAT: c_int = 2;
+
+type TalonCallback = unsafe extern "C" fn(*mut TalonResult, *mut c_void);
+type TalonTaskFn = unsafe extern "C" fn(*mut c_void);
+type TalonExecutorSubmitFn = unsafe extern "C" fn(*mut c_void, TalonTaskFn, *mut c_void);
+
+thread_local! {
+    static LAST_ERROR: RefCell<Option<CString>> = const { RefCell::new(None) };
+}
+
+/// Optional callback executor supplied by the caller.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct TalonCallbackExecutor {
+    /// Opaque context passed to `submit`.
+    pub executor_ctx: *mut c_void,
+    /// Function that schedules a callback task.
+    pub submit: Option<TalonExecutorSubmitFn>,
+}
+
+unsafe impl Send for TalonCallbackExecutor {}
+unsafe impl Sync for TalonCallbackExecutor {}
+
+/// Client construction options.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct TalonClientOptions {
+    /// Logical block size. Zero means the SDK default.
+    pub block_size: u32,
+    /// Optional caller-owned callback executor. Without one, callbacks run on
+    /// the Tokio runtime thread that completed the operation.
+    pub callback_executor: *const TalonCallbackExecutor,
+}
+
+/// Opaque client handle.
+pub struct TalonClient {
+    inner: Arc<ClientInner>,
+}
+
+struct ClientInner {
+    runtime: Arc<tokio::runtime::Runtime>,
+    coordinator: CoordinatorClient,
+    reader: BlockReader,
+    block_size: u32,
+    dispatcher: Arc<CallbackDispatcher>,
+    next_request_id: AtomicU64,
+}
+
+/// Opaque operation result.
+pub struct TalonResult {
+    operation: c_int,
+    status: c_int,
+    request_id: u64,
+    bytes_written: usize,
+    object_size: u64,
+    version: Option<CString>,
+    error: Option<CString>,
+}
+
+struct ReadBuffer {
+    ptr: *mut u8,
+    len: usize,
+}
+
+unsafe impl Send for ReadBuffer {}
+
+impl ReadBuffer {
+    unsafe fn into_mut_slice(self) -> &'static mut [u8] {
+        std::slice::from_raw_parts_mut(self.ptr, self.len)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct UserData(*mut c_void);
+
+unsafe impl Send for UserData {}
+unsafe impl Sync for UserData {}
+
+struct CallbackTask {
+    callback: TalonCallback,
+    result: *mut TalonResult,
+    user_data: UserData,
+}
+
+unsafe impl Send for CallbackTask {}
+
+impl CallbackTask {
+    fn run(self) {
+        unsafe {
+            (self.callback)(self.result, self.user_data.0);
+        }
+    }
+}
+
+enum CallbackDispatcher {
+    Inline,
+    Custom(TalonCallbackExecutor),
+}
+
+unsafe impl Send for CallbackDispatcher {}
+unsafe impl Sync for CallbackDispatcher {}
+
+impl CallbackDispatcher {
+    fn new_custom(executor: TalonCallbackExecutor) -> Self {
+        Self::Custom(executor)
+    }
+
+    fn dispatch(&self, task: CallbackTask) -> Result<(), CallbackTask> {
+        match self {
+            CallbackDispatcher::Inline => {
+                task.run();
+                Ok(())
+            }
+            CallbackDispatcher::Custom(executor) => {
+                let Some(submit) = executor.submit else {
+                    return Err(task);
+                };
+                let task_ctx = Box::into_raw(Box::new(task)).cast::<c_void>();
+                unsafe {
+                    submit(executor.executor_ctx, run_callback_task, task_ctx);
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+unsafe extern "C" fn run_callback_task(task_ctx: *mut c_void) {
+    if task_ctx.is_null() {
+        return;
+    }
+    let task = unsafe { Box::from_raw(task_ctx.cast::<CallbackTask>()) };
+    task.run();
+}
+
+/// Initialize client options with SDK defaults.
+#[no_mangle]
+pub unsafe extern "C" fn talon_client_options_init(options: *mut TalonClientOptions) {
+    if options.is_null() {
+        return;
+    }
+    unsafe {
+        ptr::write(
+            options,
+            TalonClientOptions {
+                block_size: DEFAULT_BLOCK_SIZE,
+                callback_executor: ptr::null(),
+            },
+        );
+    }
+}
+
+/// Create a Talon client.
+#[no_mangle]
+pub unsafe extern "C" fn talon_client_new(
+    coordinator_addr: *const c_char,
+    options: *const TalonClientOptions,
+    out: *mut *mut TalonClient,
+) -> c_int {
+    ffi_status(|| {
+        if coordinator_addr.is_null() {
+            return Err((STATUS_INVALID_ARGUMENT, "coordinator_addr is null".into()));
+        }
+        if out.is_null() {
+            return Err((STATUS_INVALID_ARGUMENT, "out is null".into()));
+        }
+
+        let coordinator_addr = c_string(coordinator_addr, "coordinator_addr")?;
+        let options = if options.is_null() {
+            TalonClientOptions {
+                block_size: DEFAULT_BLOCK_SIZE,
+                callback_executor: ptr::null(),
+            }
+        } else {
+            unsafe { *options }
+        };
+        let block_size = if options.block_size == 0 {
+            DEFAULT_BLOCK_SIZE
+        } else {
+            options.block_size
+        };
+        let dispatcher = if options.callback_executor.is_null() {
+            CallbackDispatcher::Inline
+        } else {
+            let executor = unsafe { *options.callback_executor };
+            if executor.submit.is_none() {
+                return Err((
+                    STATUS_INVALID_ARGUMENT,
+                    "callback executor submit is null".into(),
+                ));
+            }
+            CallbackDispatcher::new_custom(executor)
+        };
+
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| (STATUS_RUNTIME_ERROR, error.to_string()))?;
+        let coordinator = CoordinatorClient::new(coordinator_addr);
+        let cache = Arc::new(PlacementCache::new(PLACEMENT_TTL_MS));
+        let reader = BlockReader::new(coordinator.clone(), cache, REPLICAS_K);
+        let client = Box::new(TalonClient {
+            inner: Arc::new(ClientInner {
+                runtime: Arc::new(runtime),
+                coordinator,
+                reader,
+                block_size,
+                dispatcher: Arc::new(dispatcher),
+                next_request_id: AtomicU64::new(1),
+            }),
+        });
+        unsafe {
+            *out = Box::into_raw(client);
+        }
+        Ok(())
+    })
+}
+
+/// Free a Talon client handle.
+#[no_mangle]
+pub unsafe extern "C" fn talon_client_free(client: *mut TalonClient) {
+    if client.is_null() {
+        return;
+    }
+    let client = unsafe { Box::from_raw(client) };
+    if tokio::runtime::Handle::try_current().is_ok() {
+        let _ = std::thread::spawn(move || drop(client)).join();
+    } else {
+        drop(client);
+    }
+}
+
+/// Submit an async read.
+#[no_mangle]
+pub unsafe extern "C" fn talon_read_async(
+    client: *mut TalonClient,
+    uri: *const c_char,
+    offset: u64,
+    dst: *mut u8,
+    dst_len: usize,
+    callback: Option<TalonCallback>,
+    user_data: *mut c_void,
+    request_id_out: *mut u64,
+) -> c_int {
+    ffi_status(|| {
+        let inner = client_inner(client)?;
+        if uri.is_null() {
+            return Err((STATUS_INVALID_ARGUMENT, "uri is null".into()));
+        }
+        if dst_len > 0 && dst.is_null() {
+            return Err((STATUS_INVALID_ARGUMENT, "dst is null".into()));
+        }
+        if dst_len > isize::MAX as usize {
+            return Err((STATUS_INVALID_ARGUMENT, "dst_len exceeds isize::MAX".into()));
+        }
+        let Some(callback) = callback else {
+            return Err((STATUS_INVALID_ARGUMENT, "callback is null".into()));
+        };
+        if request_id_out.is_null() {
+            return Err((STATUS_INVALID_ARGUMENT, "request_id_out is null".into()));
+        }
+
+        let uri = c_string(uri, "uri")?;
+        let object = parse_uri(&uri)?;
+        let request_id = inner.next_request_id.fetch_add(1, Ordering::Relaxed);
+        unsafe {
+            *request_id_out = request_id;
+        }
+
+        let read_buffer = ReadBuffer {
+            ptr: dst,
+            len: dst_len,
+        };
+        let user_data = UserData(user_data);
+        let runtime = Arc::clone(&inner.runtime);
+        let coordinator = inner.coordinator.clone();
+        let reader = inner.reader.clone();
+        let dispatcher = Arc::clone(&inner.dispatcher);
+        let block_size = inner.block_size;
+        runtime.spawn(async move {
+            let result = async {
+                if read_buffer.len == 0 {
+                    return Ok(0);
+                }
+                let stat = coordinator
+                    .stat_object(&object)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                let version = Version::new(stat.version.as_str());
+                let file = FileView {
+                    object: &object,
+                    block_size,
+                    version: &version,
+                    size: stat.size,
+                };
+                let dst = unsafe { read_buffer.into_mut_slice() };
+                reader
+                    .read_into(&file, offset, dst, now_ms())
+                    .await
+                    .map_err(|error| error.to_string())
+            }
+            .await;
+            dispatch_result(
+                dispatcher,
+                callback,
+                user_data,
+                TalonResult::read(request_id, result),
+            );
+        });
+        Ok(())
+    })
+}
+
+/// Submit an async stat.
+#[no_mangle]
+pub unsafe extern "C" fn talon_stat_async(
+    client: *mut TalonClient,
+    uri: *const c_char,
+    callback: Option<TalonCallback>,
+    user_data: *mut c_void,
+    request_id_out: *mut u64,
+) -> c_int {
+    ffi_status(|| {
+        let inner = client_inner(client)?;
+        if uri.is_null() {
+            return Err((STATUS_INVALID_ARGUMENT, "uri is null".into()));
+        }
+        let Some(callback) = callback else {
+            return Err((STATUS_INVALID_ARGUMENT, "callback is null".into()));
+        };
+        if request_id_out.is_null() {
+            return Err((STATUS_INVALID_ARGUMENT, "request_id_out is null".into()));
+        }
+
+        let uri = c_string(uri, "uri")?;
+        let object = parse_uri(&uri)?;
+        let request_id = inner.next_request_id.fetch_add(1, Ordering::Relaxed);
+        unsafe {
+            *request_id_out = request_id;
+        }
+
+        let user_data = UserData(user_data);
+        let runtime = Arc::clone(&inner.runtime);
+        let coordinator = inner.coordinator.clone();
+        let dispatcher = Arc::clone(&inner.dispatcher);
+        runtime.spawn(async move {
+            let result = coordinator
+                .stat_object(&object)
+                .await
+                .map_err(|error| error.to_string());
+            dispatch_result(
+                dispatcher,
+                callback,
+                user_data,
+                TalonResult::stat(request_id, result),
+            );
+        });
+        Ok(())
+    })
+}
+
+/// Return the operation status.
+#[no_mangle]
+pub unsafe extern "C" fn talon_result_status(result: *const TalonResult) -> c_int {
+    unsafe {
+        result
+            .as_ref()
+            .map(|r| r.status)
+            .unwrap_or(STATUS_INVALID_ARGUMENT)
+    }
+}
+
+/// Return the operation kind.
+#[no_mangle]
+pub unsafe extern "C" fn talon_result_operation(result: *const TalonResult) -> c_int {
+    unsafe { result.as_ref().map(|r| r.operation).unwrap_or(0) }
+}
+
+/// Return the SDK request id.
+#[no_mangle]
+pub unsafe extern "C" fn talon_result_request_id(result: *const TalonResult) -> u64 {
+    unsafe { result.as_ref().map(|r| r.request_id).unwrap_or(0) }
+}
+
+/// Return bytes written for a read result.
+#[no_mangle]
+pub unsafe extern "C" fn talon_result_bytes_written(result: *const TalonResult) -> usize {
+    unsafe { result.as_ref().map(|r| r.bytes_written).unwrap_or(0) }
+}
+
+/// Return object size for a stat result.
+#[no_mangle]
+pub unsafe extern "C" fn talon_result_object_size(result: *const TalonResult) -> u64 {
+    unsafe { result.as_ref().map(|r| r.object_size).unwrap_or(0) }
+}
+
+/// Return object version for a stat result, or null.
+#[no_mangle]
+pub unsafe extern "C" fn talon_result_version(result: *const TalonResult) -> *const c_char {
+    unsafe {
+        result
+            .as_ref()
+            .and_then(|r| r.version.as_ref())
+            .map(|s| s.as_ptr())
+            .unwrap_or(ptr::null())
+    }
+}
+
+/// Return operation error text, or null.
+#[no_mangle]
+pub unsafe extern "C" fn talon_result_error(result: *const TalonResult) -> *const c_char {
+    unsafe {
+        result
+            .as_ref()
+            .and_then(|r| r.error.as_ref())
+            .map(|s| s.as_ptr())
+            .unwrap_or(ptr::null())
+    }
+}
+
+/// Free an operation result.
+#[no_mangle]
+pub unsafe extern "C" fn talon_result_free(result: *mut TalonResult) {
+    if result.is_null() {
+        return;
+    }
+    unsafe {
+        drop(Box::from_raw(result));
+    }
+}
+
+/// Return the last synchronous FFI error for the current thread.
+#[no_mangle]
+pub unsafe extern "C" fn talon_last_error() -> *const c_char {
+    LAST_ERROR.with(|slot| {
+        slot.borrow()
+            .as_ref()
+            .map(|error| error.as_ptr())
+            .unwrap_or(ptr::null())
+    })
+}
+
+impl TalonResult {
+    fn read(request_id: u64, result: Result<usize, String>) -> Self {
+        match result {
+            Ok(bytes_written) => Self {
+                operation: OPERATION_READ,
+                status: STATUS_OK,
+                request_id,
+                bytes_written,
+                object_size: 0,
+                version: None,
+                error: None,
+            },
+            Err(error) => Self::operation_error(OPERATION_READ, request_id, error),
+        }
+    }
+
+    fn stat(
+        request_id: u64,
+        result: Result<talon_cache_client::coordinator_client::ObjectStat, String>,
+    ) -> Self {
+        match result {
+            Ok(stat) => Self {
+                operation: OPERATION_STAT,
+                status: STATUS_OK,
+                request_id,
+                bytes_written: 0,
+                object_size: stat.size,
+                version: Some(cstring_lossy(stat.version)),
+                error: None,
+            },
+            Err(error) => Self::operation_error(OPERATION_STAT, request_id, error),
+        }
+    }
+
+    fn operation_error(operation: c_int, request_id: u64, error: String) -> Self {
+        Self {
+            operation,
+            status: STATUS_OPERATION_ERROR,
+            request_id,
+            bytes_written: 0,
+            object_size: 0,
+            version: None,
+            error: Some(cstring_lossy(error)),
+        }
+    }
+}
+
+fn dispatch_result(
+    dispatcher: Arc<CallbackDispatcher>,
+    callback: TalonCallback,
+    user_data: UserData,
+    result: TalonResult,
+) {
+    let result = Box::into_raw(Box::new(result));
+    let task = CallbackTask {
+        callback,
+        result,
+        user_data,
+    };
+    if let Err(task) = dispatcher.dispatch(task) {
+        unsafe {
+            drop(Box::from_raw(task.result));
+        }
+    }
+}
+
+fn client_inner(client: *mut TalonClient) -> Result<Arc<ClientInner>, (c_int, String)> {
+    if client.is_null() {
+        return Err((STATUS_INVALID_ARGUMENT, "client is null".into()));
+    }
+    let client = unsafe { &*client };
+    Ok(Arc::clone(&client.inner))
+}
+
+fn c_string(ptr: *const c_char, name: &str) -> Result<String, (c_int, String)> {
+    let s = unsafe { CStr::from_ptr(ptr) }.to_str().map_err(|error| {
+        (
+            STATUS_INVALID_ARGUMENT,
+            format!("{name} is not UTF-8: {error}"),
+        )
+    })?;
+    Ok(s.to_string())
+}
+
+fn parse_uri(uri: &str) -> Result<ObjectId, (c_int, String)> {
+    let (scheme, rest) = uri.split_once("://").ok_or_else(|| {
+        (
+            STATUS_INVALID_ARGUMENT,
+            format!("expected a scheme://bucket/key URI, got {uri:?} (schemes: s3, gcs, az)"),
+        )
+    })?;
+    let backend = scheme.parse().map_err(|_| {
+        (
+            STATUS_INVALID_ARGUMENT,
+            format!("unknown backend scheme {scheme:?}"),
+        )
+    })?;
+    let (bucket, key) = rest.split_once('/').ok_or_else(|| {
+        (
+            STATUS_INVALID_ARGUMENT,
+            format!("URI is missing an object key: {uri:?}"),
+        )
+    })?;
+    if bucket.is_empty() {
+        return Err((
+            STATUS_INVALID_ARGUMENT,
+            format!("URI has an empty bucket: {uri:?}"),
+        ));
+    }
+    if key.is_empty() {
+        return Err((
+            STATUS_INVALID_ARGUMENT,
+            format!("URI has an empty object key: {uri:?}"),
+        ));
+    }
+    Ok(ObjectId::new(backend, bucket, key))
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn ffi_status<F>(f: F) -> c_int
+where
+    F: FnOnce() -> Result<(), (c_int, String)>,
+{
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(Ok(())) => {
+            clear_last_error();
+            STATUS_OK
+        }
+        Ok(Err((status, error))) => {
+            set_last_error(error);
+            status
+        }
+        Err(_) => {
+            set_last_error("panic across FFI boundary".into());
+            STATUS_RUNTIME_ERROR
+        }
+    }
+}
+
+fn set_last_error(error: String) {
+    LAST_ERROR.with(|slot| {
+        *slot.borrow_mut() = Some(cstring_lossy(error));
+    });
+}
+
+fn clear_last_error() {
+    LAST_ERROR.with(|slot| {
+        *slot.borrow_mut() = None;
+    });
+}
+
+fn cstring_lossy(value: String) -> CString {
+    let bytes: Vec<u8> = value.into_bytes().into_iter().filter(|b| *b != 0).collect();
+    CString::new(bytes).unwrap_or_else(|_| CString::new("invalid string").unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CStr;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Condvar, Mutex};
+    use std::time::Duration;
+
+    use talon_core::{NodeId, NodeInfo, NodeRole};
+    use talon_transport::frame::{FrameHeader, HEADER_LEN};
+    use talon_transport::{decode_request, response_header_ok, ControlMessage, RangeRequest};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    unsafe extern "C" {
+        fn talon_c_api_smoke_test() -> c_int;
+    }
+
+    struct CallbackState {
+        done: Mutex<Option<CallbackSnapshot>>,
+        ready: Condvar,
+    }
+
+    #[derive(Debug)]
+    struct CallbackSnapshot {
+        operation: c_int,
+        status: c_int,
+        request_id: u64,
+        bytes_written: usize,
+        object_size: u64,
+        version: Option<String>,
+        error: Option<String>,
+    }
+
+    impl CallbackState {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                done: Mutex::new(None),
+                ready: Condvar::new(),
+            })
+        }
+
+        fn user_data(self: &Arc<Self>) -> *mut c_void {
+            Arc::into_raw(Arc::clone(self)).cast_mut().cast::<c_void>()
+        }
+
+        fn wait(&self) -> CallbackSnapshot {
+            let mut guard = self.done.lock().unwrap();
+            loop {
+                if let Some(snapshot) = guard.take() {
+                    return snapshot;
+                }
+                let (next, timeout) = self
+                    .ready
+                    .wait_timeout(guard, Duration::from_secs(5))
+                    .unwrap();
+                assert!(!timeout.timed_out(), "callback did not fire");
+                guard = next;
+            }
+        }
+    }
+
+    unsafe extern "C" fn capture_callback(result: *mut TalonResult, user_data: *mut c_void) {
+        let state = unsafe { Arc::from_raw(user_data.cast::<CallbackState>()) };
+        let version = unsafe { talon_result_version(result) };
+        let version = if version.is_null() {
+            None
+        } else {
+            Some(
+                unsafe { CStr::from_ptr(version) }
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+        };
+        let error = unsafe { talon_result_error(result) };
+        let error = if error.is_null() {
+            None
+        } else {
+            Some(
+                unsafe { CStr::from_ptr(error) }
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+        };
+        let snapshot = CallbackSnapshot {
+            operation: unsafe { talon_result_operation(result) },
+            status: unsafe { talon_result_status(result) },
+            request_id: unsafe { talon_result_request_id(result) },
+            bytes_written: unsafe { talon_result_bytes_written(result) },
+            object_size: unsafe { talon_result_object_size(result) },
+            version,
+            error,
+        };
+        unsafe {
+            talon_result_free(result);
+        }
+        let mut guard = state.done.lock().unwrap();
+        *guard = Some(snapshot);
+        state.ready.notify_one();
+    }
+
+    unsafe extern "C" fn capture_callback_thread(result: *mut TalonResult, user_data: *mut c_void) {
+        let callback_thread =
+            unsafe { Arc::from_raw(user_data.cast::<Mutex<Option<std::thread::ThreadId>>>()) };
+        *callback_thread.lock().unwrap() = Some(std::thread::current().id());
+        unsafe {
+            talon_result_free(result);
+        }
+    }
+
+    async fn mock_worker() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            loop {
+                let (mut sock, _) = match listener.accept().await {
+                    Ok(v) => v,
+                    Err(_) => return,
+                };
+                tokio::spawn(async move {
+                    let mut hdr = [0u8; HEADER_LEN];
+                    if sock.read_exact(&mut hdr).await.is_err() {
+                        return;
+                    }
+                    let header = FrameHeader::decode(&hdr).unwrap();
+                    let mut body = vec![0u8; header.length as usize];
+                    sock.read_exact(&mut body).await.unwrap();
+                    let mut full = hdr.to_vec();
+                    full.extend_from_slice(&body);
+                    let (_header, req): (_, RangeRequest) = decode_request(&full).unwrap();
+                    let payload: Vec<u8> = (0..req.len)
+                        .map(|i| ((req.offset + i) % 251) as u8)
+                        .collect();
+                    let mut out = response_header_ok(0, payload.len() as u32).to_vec();
+                    out.extend_from_slice(&payload);
+                    sock.write_all(&out).await.unwrap();
+                    sock.flush().await.unwrap();
+                });
+            }
+        });
+        addr
+    }
+
+    async fn mock_coordinator(worker_addr: String) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            loop {
+                let (mut sock, _) = match listener.accept().await {
+                    Ok(v) => v,
+                    Err(_) => return,
+                };
+                let worker_addr = worker_addr.clone();
+                tokio::spawn(async move {
+                    let mut hdr = [0u8; HEADER_LEN];
+                    if sock.read_exact(&mut hdr).await.is_err() {
+                        return;
+                    }
+                    let header = FrameHeader::decode(&hdr).unwrap();
+                    let mut body = vec![0u8; header.length as usize];
+                    sock.read_exact(&mut body).await.unwrap();
+                    let mut full = hdr.to_vec();
+                    full.extend_from_slice(&body);
+                    let (_header, msg) = talon_transport::decode(&full).unwrap();
+                    let reply = match msg {
+                        ControlMessage::StatObject { .. } => ControlMessage::ObjectStat {
+                            size: 8192,
+                            version: "test-version".into(),
+                        },
+                        ControlMessage::MembershipQuery {} => ControlMessage::MembershipList {
+                            nodes: vec![NodeInfo {
+                                id: NodeId::new("worker-a"),
+                                address: worker_addr,
+                                role: NodeRole::Worker,
+                            }],
+                        },
+                        _ => ControlMessage::Ack {
+                            ok: false,
+                            detail: None,
+                        },
+                    };
+                    sock.write_all(&talon_transport::encode(0, &reply).unwrap())
+                        .await
+                        .unwrap();
+                    sock.flush().await.unwrap();
+                });
+            }
+        });
+        addr
+    }
+
+    fn cstring(value: &str) -> CString {
+        CString::new(value).unwrap()
+    }
+
+    async fn new_client() -> (*mut TalonClient, String) {
+        let worker = mock_worker().await;
+        let coordinator = mock_coordinator(worker).await;
+        let coordinator_c = cstring(&coordinator);
+        let mut options = TalonClientOptions {
+            block_size: 0,
+            callback_executor: ptr::null(),
+        };
+        unsafe {
+            talon_client_options_init(&mut options);
+        }
+        let mut client = ptr::null_mut();
+        let status = unsafe { talon_client_new(coordinator_c.as_ptr(), &options, &mut client) };
+        assert_eq!(status, STATUS_OK);
+        assert!(!client.is_null());
+        (client, coordinator)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn client_create_and_free_with_default_options() {
+        let (client, _coordinator) = new_client().await;
+        unsafe {
+            talon_client_free(client);
+        }
+    }
+
+    #[test]
+    fn inline_dispatch_result_runs_callback_synchronously_on_submitting_thread() {
+        let callback_thread = Arc::new(Mutex::new(None));
+        let expected_thread = std::thread::current().id();
+        dispatch_result(
+            Arc::new(CallbackDispatcher::Inline),
+            capture_callback_thread,
+            UserData(
+                Arc::into_raw(Arc::clone(&callback_thread))
+                    .cast_mut()
+                    .cast::<c_void>(),
+            ),
+            TalonResult::read(1, Ok(0)),
+        );
+
+        assert_eq!(*callback_thread.lock().unwrap(), Some(expected_thread));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn async_read_invokes_inline_callback_and_fills_buffer() {
+        let (client, _coordinator) = new_client().await;
+        let state = CallbackState::new();
+        let uri = cstring("s3://bucket/object.bin");
+        let mut dst = vec![0u8; 4096];
+        let mut request_id = 0u64;
+
+        let status = unsafe {
+            talon_read_async(
+                client,
+                uri.as_ptr(),
+                100,
+                dst.as_mut_ptr(),
+                dst.len(),
+                Some(capture_callback),
+                state.user_data(),
+                &mut request_id,
+            )
+        };
+        assert_eq!(status, STATUS_OK);
+        let snapshot = state.wait();
+        assert_eq!(snapshot.operation, OPERATION_READ);
+        assert_eq!(snapshot.status, STATUS_OK);
+        assert_eq!(snapshot.request_id, request_id);
+        assert_eq!(snapshot.bytes_written, dst.len());
+        assert_eq!(dst[0], 100);
+        assert_eq!(dst[1], 101);
+        assert!(snapshot.error.is_none());
+
+        unsafe {
+            talon_client_free(client);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn zero_length_read_accepts_null_buffer() {
+        let (client, _coordinator) = new_client().await;
+        let state = CallbackState::new();
+        let uri = cstring("s3://bucket/object.bin");
+        let mut request_id = 0u64;
+
+        let status = unsafe {
+            talon_read_async(
+                client,
+                uri.as_ptr(),
+                100,
+                ptr::null_mut(),
+                0,
+                Some(capture_callback),
+                state.user_data(),
+                &mut request_id,
+            )
+        };
+        assert_eq!(status, STATUS_OK);
+        let snapshot = state.wait();
+        assert_eq!(snapshot.operation, OPERATION_READ);
+        assert_eq!(snapshot.status, STATUS_OK);
+        assert_eq!(snapshot.request_id, request_id);
+        assert_eq!(snapshot.bytes_written, 0);
+        assert!(snapshot.error.is_none());
+
+        unsafe {
+            talon_client_free(client);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn async_stat_invokes_inline_callback() {
+        let (client, _coordinator) = new_client().await;
+        let state = CallbackState::new();
+        let uri = cstring("s3://bucket/object.bin");
+        let mut request_id = 0u64;
+
+        let status = unsafe {
+            talon_stat_async(
+                client,
+                uri.as_ptr(),
+                Some(capture_callback),
+                state.user_data(),
+                &mut request_id,
+            )
+        };
+        assert_eq!(status, STATUS_OK);
+        let snapshot = state.wait();
+        assert_eq!(snapshot.operation, OPERATION_STAT);
+        assert_eq!(snapshot.status, STATUS_OK);
+        assert_eq!(snapshot.request_id, request_id);
+        assert_eq!(snapshot.object_size, 8192);
+        assert_eq!(snapshot.version.as_deref(), Some("test-version"));
+
+        unsafe {
+            talon_client_free(client);
+        }
+    }
+
+    unsafe extern "C" fn custom_submit(
+        executor_ctx: *mut c_void,
+        run: TalonTaskFn,
+        task_ctx: *mut c_void,
+    ) {
+        let calls = unsafe { &*(executor_ctx.cast::<AtomicUsize>()) };
+        calls.fetch_add(1, Ordering::SeqCst);
+        let task_ctx = task_ctx as usize;
+        std::thread::spawn(move || unsafe {
+            run(task_ctx as *mut c_void);
+        });
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn custom_scheduler_hook_receives_callback_job() {
+        let worker = mock_worker().await;
+        let coordinator = mock_coordinator(worker).await;
+        let coordinator_c = cstring(&coordinator);
+        let calls = AtomicUsize::new(0);
+        let executor = TalonCallbackExecutor {
+            executor_ctx: (&calls as *const AtomicUsize).cast_mut().cast::<c_void>(),
+            submit: Some(custom_submit),
+        };
+        let options = TalonClientOptions {
+            block_size: DEFAULT_BLOCK_SIZE,
+            callback_executor: &executor,
+        };
+        let mut client = ptr::null_mut();
+        let status = unsafe { talon_client_new(coordinator_c.as_ptr(), &options, &mut client) };
+        assert_eq!(status, STATUS_OK);
+
+        let state = CallbackState::new();
+        let uri = cstring("s3://bucket/object.bin");
+        let mut request_id = 0u64;
+        let status = unsafe {
+            talon_stat_async(
+                client,
+                uri.as_ptr(),
+                Some(capture_callback),
+                state.user_data(),
+                &mut request_id,
+            )
+        };
+        assert_eq!(status, STATUS_OK);
+        let snapshot = state.wait();
+        assert_eq!(snapshot.status, STATUS_OK);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        unsafe {
+            talon_client_free(client);
+        }
+    }
+
+    #[test]
+    fn invalid_arguments_fail_synchronously() {
+        let mut request_id = 0u64;
+        let uri = cstring("s3://bucket/object.bin");
+        let status = unsafe {
+            talon_read_async(
+                ptr::null_mut(),
+                uri.as_ptr(),
+                0,
+                ptr::null_mut(),
+                0,
+                Some(capture_callback),
+                ptr::null_mut(),
+                &mut request_id,
+            )
+        };
+        assert_eq!(status, STATUS_INVALID_ARGUMENT);
+        let msg = unsafe { CStr::from_ptr(talon_last_error()) }.to_string_lossy();
+        assert!(msg.contains("client is null"));
+    }
+
+    #[test]
+    fn c_header_and_abi_smoke_test() {
+        let status = unsafe { talon_c_api_smoke_test() };
+        assert_eq!(status, 0, "C API smoke test failed at check {status}");
+    }
+}

--- a/clients/c/tests/c_api_smoke.c
+++ b/clients/c/tests/c_api_smoke.c
@@ -1,0 +1,95 @@
+#include "talon.h"
+
+#include <stdatomic.h>
+#include <string.h>
+
+static atomic_int callback_done;
+static atomic_int callback_ok;
+
+static void capture_zero_length_read(talon_result *result, void *user_data) {
+    int ok = user_data == NULL &&
+             talon_result_status(result) == TALON_STATUS_OK &&
+             talon_result_operation(result) == TALON_OPERATION_READ &&
+             talon_result_request_id(result) == 1 &&
+             talon_result_bytes_written(result) == 0 &&
+             talon_result_object_size(result) == 0 &&
+             talon_result_version(result) == NULL &&
+             talon_result_error(result) == NULL;
+
+    talon_result_free(result);
+    atomic_store_explicit(&callback_ok, ok, memory_order_release);
+    atomic_store_explicit(&callback_done, 1, memory_order_release);
+}
+
+/*
+ * Called from a Rust unit test. Keeping this test in C verifies that the
+ * published header, exported ABI, callback signature, and opaque handles work
+ * together for a real C caller.
+ */
+int talon_c_api_smoke_test(void) {
+    talon_client_options options;
+    talon_client *client = NULL;
+    uint64_t request_id = 0;
+    const char *last_error;
+
+    talon_client_options_init(&options);
+    if (options.block_size != (256u << 20) || options.callback_executor != NULL) {
+        return 1;
+    }
+
+    if (talon_client_new(NULL, &options, &client) != TALON_STATUS_INVALID_ARGUMENT) {
+        return 2;
+    }
+    last_error = talon_last_error();
+    if (last_error == NULL || strstr(last_error, "coordinator_addr is null") == NULL) {
+        return 3;
+    }
+
+    if (talon_client_new("127.0.0.1:1", &options, &client) != TALON_STATUS_OK ||
+        client == NULL) {
+        return 4;
+    }
+
+    if (talon_read_async(client, "s3://bucket/object", 0, NULL, 1,
+                         capture_zero_length_read, NULL, &request_id) !=
+        TALON_STATUS_INVALID_ARGUMENT) {
+        talon_client_free(client);
+        return 5;
+    }
+    if (talon_stat_async(client, NULL, capture_zero_length_read, NULL, &request_id) !=
+        TALON_STATUS_INVALID_ARGUMENT) {
+        talon_client_free(client);
+        return 6;
+    }
+
+    atomic_store_explicit(&callback_done, 0, memory_order_relaxed);
+    atomic_store_explicit(&callback_ok, 0, memory_order_relaxed);
+    if (talon_read_async(client, "s3://bucket/object", 0, NULL, 0,
+                         capture_zero_length_read, NULL, &request_id) != TALON_STATUS_OK ||
+        request_id != 1) {
+        talon_client_free(client);
+        return 7;
+    }
+
+    for (unsigned int i = 0; i < 100000000u; ++i) {
+        if (atomic_load_explicit(&callback_done, memory_order_acquire)) {
+            break;
+        }
+    }
+    if (!atomic_load_explicit(&callback_done, memory_order_acquire) ||
+        !atomic_load_explicit(&callback_ok, memory_order_acquire)) {
+        talon_client_free(client);
+        return 8;
+    }
+
+    if (talon_result_status(NULL) != TALON_STATUS_INVALID_ARGUMENT ||
+        talon_result_operation(NULL) != 0 || talon_result_request_id(NULL) != 0 ||
+        talon_result_bytes_written(NULL) != 0 || talon_result_object_size(NULL) != 0 ||
+        talon_result_version(NULL) != NULL || talon_result_error(NULL) != NULL) {
+        talon_client_free(client);
+        return 9;
+    }
+    talon_result_free(NULL);
+    talon_client_free(client);
+    return 0;
+}

--- a/crates/talon-cache-client/src/block_reader.rs
+++ b/crates/talon-cache-client/src/block_reader.rs
@@ -260,6 +260,57 @@ impl BlockReader {
         }
     }
 
+    /// Read `dst.len()` bytes at `offset_in_block` within `block` into `dst`.
+    ///
+    /// This follows the same placement-cache, replica fallback, and refresh
+    /// behavior as [`read_block`](Self::read_block), without allocating an
+    /// intermediate result buffer.
+    pub async fn read_block_into(
+        &self,
+        block: &BlockId,
+        offset_in_block: u32,
+        dst: &mut [u8],
+        now_ms: u64,
+    ) -> Result<usize, BlockReadError> {
+        let cached = match self.cache.get(block, now_ms) {
+            Some(cached) => {
+                self.stats.record_cache_hit();
+                cached
+            }
+            None => {
+                self.stats.record_cache_miss();
+                self.resolve_and_cache(block, now_ms).await?
+            }
+        };
+        let abs_offset = block.offset + u64::from(offset_in_block);
+
+        match self
+            .try_replicas_into(block, &cached.replicas, abs_offset, dst)
+            .await
+        {
+            Ok(n) => {
+                self.stats.add_bytes_served(n as u64);
+                return Ok(n);
+            }
+            Err(failure) => {
+                if !failure.retryable {
+                    return Err(BlockReadError::AllReplicasFailed);
+                }
+                tracing::debug!(%block, reason = ?failure.reason, "all cached replicas failed; refreshing placement");
+                self.cache.invalidate(block, failure.reason);
+                self.stats.record_coordinator_refresh();
+            }
+        }
+
+        let fresh = self.resolve_and_cache_forced(block, now_ms).await?;
+        let n = self
+            .try_replicas_into(block, &fresh.replicas, abs_offset, dst)
+            .await
+            .map_err(|_| BlockReadError::AllReplicasFailed)?;
+        self.stats.add_bytes_served(n as u64);
+        Ok(n)
+    }
+
     /// Read one block slice while preserving the last worker failure.
     ///
     /// The public FUSE-compatible API intentionally retains its historical
@@ -381,6 +432,66 @@ impl BlockReader {
         Err(last.expect("non-empty replica list records a failure"))
     }
 
+    /// Buffer-oriented variant of [`try_replicas`](Self::try_replicas).
+    async fn try_replicas_into(
+        &self,
+        block: &BlockId,
+        replicas: &[String],
+        abs_offset: u64,
+        dst: &mut [u8],
+    ) -> Result<usize, ReplicaFailure> {
+        if replicas.is_empty() {
+            return Err(ReplicaFailure {
+                reason: RefreshReason::WrongOwner,
+                error: WorkerError::Remote(talon_transport::DataPlaneError {
+                    code: talon_transport::DataErrorCode::Internal,
+                    message: "placement contained no worker addresses".into(),
+                }),
+                retryable: true,
+            });
+        }
+        let mut last = None;
+        for addr in replicas {
+            let worker = WorkerClient::with_pool(addr.clone(), Arc::clone(&self.worker_pool));
+            self.stats.record_worker_fetch();
+            match worker
+                .fetch_range_into(&block.object, abs_offset, dst)
+                .await
+            {
+                Ok(n) if n == dst.len() => return Ok(n),
+                Ok(n) => {
+                    self.stats.record_worker_failure();
+                    last = Some(ReplicaFailure {
+                        reason: RefreshReason::WrongOwner,
+                        error: WorkerError::RangeLengthMismatch {
+                            expected: dst.len() as u64,
+                            actual: n as u64,
+                        },
+                        retryable: true,
+                    });
+                }
+                Err(error) => {
+                    self.stats.record_worker_failure();
+                    let reason = match &error {
+                        WorkerError::Io(_) => RefreshReason::ConnectFailure,
+                        _ => RefreshReason::WrongOwner,
+                    };
+                    let retryable = replica_retryable(&error);
+                    let failure = ReplicaFailure {
+                        reason,
+                        error,
+                        retryable,
+                    };
+                    if !retryable {
+                        return Err(failure);
+                    }
+                    last = Some(failure);
+                }
+            }
+        }
+        Err(last.expect("non-empty replica list records a failure"))
+    }
+
     /// Reconcile the cache against an observed placement version.
     ///
     /// When a response (placement or otherwise) carries a version token that
@@ -433,6 +544,50 @@ impl BlockReader {
             out.extend_from_slice(&bytes);
         }
         Ok(out)
+    }
+
+    /// Read from `file` at `offset` into `dst`, spanning block boundaries.
+    ///
+    /// The returned value is the number of bytes written. Reads at or past EOF
+    /// return `0`, and reads overlapping EOF return a short count, matching
+    /// [`read`](Self::read).
+    pub async fn read_into(
+        &self,
+        file: &FileView<'_>,
+        offset: u64,
+        dst: &mut [u8],
+        now_ms: u64,
+    ) -> Result<usize, BlockReadError> {
+        let plan = plan_read(
+            file.object,
+            offset,
+            dst.len() as u64,
+            file.block_size,
+            file.version,
+            file.size,
+        );
+        let mut written = 0usize;
+        for seg in plan {
+            let len = seg.len as usize;
+            let end = written + len;
+            let n = self
+                .read_block_into(
+                    &seg.block,
+                    seg.offset_in_block,
+                    &mut dst[written..end],
+                    now_ms,
+                )
+                .await?;
+            if n != len {
+                return Err(WorkerError::RangeLengthMismatch {
+                    expected: len as u64,
+                    actual: n as u64,
+                }
+                .into());
+            }
+            written = end;
+        }
+        Ok(written)
     }
 
     /// Resolve the worker address that owns `object` (for a write/delete).
@@ -1053,6 +1208,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn multi_block_read_into_stitches_in_caller_buffer() {
+        let hits = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let worker_addr = mock_worker(Arc::clone(&hits)).await;
+        let coord_addr = mock_coordinator(worker_addr).await;
+        let cache = Arc::new(PlacementCache::new(10_000));
+        let reader = BlockReader::new(CoordinatorClient::new(coord_addr), Arc::clone(&cache), 1);
+
+        let object = ObjectId::new(Backend::S3, "b", "o/1");
+        let version = Version::new("v1");
+        let offset = 900u64;
+        let mut dst = vec![0u8; 2300];
+        let file = FileView {
+            object: &object,
+            block_size: 1024,
+            version: &version,
+            size: 100_000,
+        };
+
+        let n = reader.read_into(&file, offset, &mut dst, 0).await.unwrap();
+        assert_eq!(n, dst.len());
+        for (index, byte) in dst.iter().enumerate() {
+            assert_eq!(*byte, ((offset + index as u64) % 256) as u8);
+        }
+        assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 4);
+        assert_eq!(cache.len(), 4);
+    }
+
+    #[tokio::test]
     async fn read_past_eof_is_empty_without_fetch() {
         let hits = Arc::new(std::sync::atomic::AtomicU32::new(0));
         let worker_addr = mock_worker(Arc::clone(&hits)).await;
@@ -1070,6 +1253,29 @@ mod tests {
         };
         let bytes = reader.read(&file, 5000, 10, 0).await.unwrap();
         assert!(bytes.is_empty());
+        assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn read_into_past_eof_is_empty_without_fetch() {
+        let hits = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let worker_addr = mock_worker(Arc::clone(&hits)).await;
+        let coord_addr = mock_coordinator(worker_addr).await;
+        let cache = Arc::new(PlacementCache::new(10_000));
+        let reader = BlockReader::new(CoordinatorClient::new(coord_addr), cache, 1);
+        let object = ObjectId::new(Backend::S3, "b", "o/1");
+        let version = Version::new("v1");
+        let file = FileView {
+            object: &object,
+            block_size: 1024,
+            version: &version,
+            size: 1500,
+        };
+        let mut dst = vec![7u8; 10];
+
+        let n = reader.read_into(&file, 5000, &mut dst, 0).await.unwrap();
+        assert_eq!(n, 0);
+        assert_eq!(dst, vec![7u8; 10]);
         assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 0);
     }
 

--- a/crates/talon-cache-client/src/worker_client.rs
+++ b/crates/talon-cache-client/src/worker_client.rs
@@ -159,6 +159,53 @@ impl WorkerClient {
         }
     }
 
+    /// Fetch `[offset, offset + dst.len())` of `object` into `dst`.
+    ///
+    /// This avoids allocating an intermediate range buffer for callers that
+    /// retain ownership of their destination storage, such as C bindings.
+    pub async fn fetch_range_into(
+        &self,
+        object: &ObjectId,
+        offset: u64,
+        dst: &mut [u8],
+    ) -> Result<usize, WorkerError> {
+        let request = RangeRequest {
+            object: object.clone(),
+            offset,
+            len: dst.len() as u64,
+        };
+        let request_id = RequestId::next();
+        let output = encode_request(request_id.0, &request)?;
+        match self.exchange_into(&output, dst).await {
+            Ok(n) => Ok(n),
+            Err((true, _)) => {
+                let mut stream = self.pool.fresh(&self.addr).await?;
+                let n = self
+                    .pool
+                    .with_request_deadline("worker fetch_range retry", async {
+                        stream.write_all(&output).await?;
+                        stream.flush().await?;
+                        read_range_reply_into(&mut stream, dst).await
+                    })
+                    .await?;
+                self.pool.release(&self.addr, stream);
+                Ok(n)
+            }
+            Err((false, error)) => {
+                tracing::error!(
+                    req = %request_id,
+                    worker = %self.addr,
+                    object = %object.to_path(),
+                    offset,
+                    len = dst.len(),
+                    error = %error,
+                    "worker range fetch failed"
+                );
+                Err(error)
+            }
+        }
+    }
+
     /// Fetch a versioned range only if it is already resident on the worker.
     ///
     /// The distinct wire operation is fail-closed during rolling upgrades: an
@@ -296,6 +343,34 @@ impl WorkerClient {
                 Ok(bytes)
             }
             Err(err) => Err((reused, err)),
+        }
+    }
+
+    /// One request/response into a caller-owned buffer.
+    async fn exchange_into(
+        &self,
+        output: &[u8],
+        dst: &mut [u8],
+    ) -> Result<usize, (bool, WorkerError)> {
+        let (mut stream, reused) = self
+            .pool
+            .checkout(&self.addr)
+            .await
+            .map_err(|error| (false, WorkerError::from(error)))?;
+        let result: Result<usize, WorkerError> = self
+            .pool
+            .with_request_deadline("worker fetch_range", async {
+                stream.write_all(output).await?;
+                stream.flush().await?;
+                read_range_reply_into(&mut stream, dst).await
+            })
+            .await;
+        match result {
+            Ok(n) => {
+                self.pool.release(&self.addr, stream);
+                Ok(n)
+            }
+            Err(error) => Err((reused, error)),
         }
     }
 }
@@ -637,6 +712,39 @@ async fn read_range_reply(
     Ok(body)
 }
 
+/// Read a successful range reply directly into `dst`.
+async fn read_range_reply_into(
+    stream: &mut TcpStream,
+    dst: &mut [u8],
+) -> Result<usize, WorkerError> {
+    let mut header_buf = [0u8; HEADER_LEN];
+    stream.read_exact(&mut header_buf).await?;
+    let header = FrameHeader::decode(&header_buf)?;
+    if header.msg_type != MsgType::GetRange {
+        return Err(WorkerError::NotGetRange(header.msg_type));
+    }
+    if header.flags.contains(Flags::ERROR) {
+        if header.length > MAX_CONTROL_PAYLOAD_LEN {
+            return Err(WorkerError::PayloadTooLarge {
+                length: header.length,
+                cap: MAX_CONTROL_PAYLOAD_LEN,
+            });
+        }
+        let mut body = vec![0u8; header.length as usize];
+        stream.read_exact(&mut body).await?;
+        return Err(WorkerError::Remote(decode_error_payload(&body)));
+    }
+    let expected_len = dst.len() as u64;
+    if u64::from(header.length) != expected_len {
+        return Err(WorkerError::RangeLengthMismatch {
+            expected: expected_len,
+            actual: u64::from(header.length),
+        });
+    }
+    stream.read_exact(dst).await?;
+    Ok(dst.len())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -796,6 +904,27 @@ mod tests {
         assert_eq!(bytes[0], 0);
         assert_eq!(bytes[250], 250);
         assert_eq!(bytes[251], 0);
+    }
+
+    #[tokio::test]
+    async fn fetch_range_into_fills_caller_buffer() {
+        let addr = mock_worker(|req| {
+            let payload: Vec<u8> = (0..req.len).map(|i| (i % 251) as u8).collect();
+            let mut out = response_header_ok(0, payload.len() as u32).to_vec();
+            out.extend_from_slice(&payload);
+            out
+        })
+        .await;
+        let client = WorkerClient::new(addr);
+        let mut dst = vec![0u8; 4096];
+        let n = client
+            .fetch_range_into(&object(), 0, &mut dst)
+            .await
+            .unwrap();
+        assert_eq!(n, dst.len());
+        assert_eq!(dst[0], 0);
+        assert_eq!(dst[250], 250);
+        assert_eq!(dst[251], 0);
     }
 
     #[tokio::test]

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -35,6 +35,7 @@
 - [Overview](./clients/overview.md)
 - [Python client](./clients/python.md)
 - [Java client](./clients/java.md)
+- [C client](./clients/c.md)
 
 # Reference
 

--- a/docs/book/src/clients/c.md
+++ b/docs/book/src/clients/c.md
@@ -1,0 +1,1 @@
+{{#include ../../../clients/c.md}}

--- a/docs/clients/c.md
+++ b/docs/clients/c.md
@@ -1,0 +1,115 @@
+# C client
+
+A C ABI client for C and C++ applications that need asynchronous ranged reads
+without mounting FUSE.
+
+The client binds Talon's Rust read path. It talks to the coordinator for
+`stat`, membership, and placement refresh, then reads data directly from
+workers.
+
+## Build
+
+```sh
+cargo build --release -p talon-c
+```
+
+The public header is at `clients/c/include/talon.h`. The build produces shared
+and static libraries from the `talon_c` crate.
+
+To stage a standalone C SDK directory containing the header and libraries, run:
+
+```sh
+just package-c
+```
+
+This produces `target/talon-c-sdk/` with:
+
+```text
+include/talon.h
+lib/libtalon_c.so
+lib/libtalon_c.a
+LICENSE
+```
+
+Pass a destination directory with `just package-c path/to/talon-c-sdk`. When
+linking the shared library, add `lib/` to the platform's dynamic-library search
+path (for example, `LD_LIBRARY_PATH` on Linux), or configure an rpath in the
+application binary.
+
+## Async read
+
+```c
+#include "talon.h"
+
+static void on_read(talon_result *result, void *user_data) {
+    if (talon_result_status(result) == TALON_STATUS_OK) {
+        size_t n = talon_result_bytes_written(result);
+        (void)n;
+    } else {
+        const char *error = talon_result_error(result);
+        (void)error;
+    }
+    talon_result_free(result);
+}
+
+talon_client_options options;
+talon_client_options_init(&options);
+
+talon_client *client = NULL;
+talon_client_new("coordinator-host:7000", &options, &client);
+
+uint8_t *buffer = malloc(1 << 20);
+uint64_t request_id = 0;
+talon_read_async(
+    client,
+    "az://container/datasets/train.parquet",
+    0,
+    buffer,
+    1 << 20,
+    on_read,
+    NULL,
+    &request_id);
+```
+
+The buffer passed to `talon_read_async` is owned by the caller and must remain
+valid until the callback runs. While the operation is in flight, the SDK has
+exclusive access to that byte range: do not read, write, free, or reuse
+overlapping storage for another operation until the callback runs. A zero-length
+read may pass `NULL` for the buffer. The callback receives a `talon_result`;
+release it with `talon_result_free`.
+
+The client handle must also remain alive until callbacks for submitted
+operations have run. Freeing it earlier cancels in-flight work.
+
+## Callback dispatch
+
+By default, callbacks run inline on the SDK's Tokio runtime thread that
+completed the operation. Keep callbacks short and non-blocking so they do not
+delay other I/O work. To run callbacks on an application thread pool, set
+`options.callback_executor` to a `talon_callback_executor`.
+
+The executor's `submit` function receives a task function and task context. It
+may be called concurrently from internal SDK threads, so it must be thread-safe.
+It must schedule that task and eventually call `run(task_ctx)` exactly once.
+
+## Stat
+
+```c
+static void on_stat(talon_result *result, void *user_data) {
+    if (talon_result_status(result) == TALON_STATUS_OK) {
+        uint64_t size = talon_result_object_size(result);
+        const char *version = talon_result_version(result);
+        (void)size;
+        (void)version;
+    }
+    talon_result_free(result);
+}
+
+talon_stat_async(client, "az://container/datasets/train.parquet",
+                 on_stat, NULL, &request_id);
+```
+
+## Not yet available
+
+The C client exposes async `read` and async `stat` only. It does not yet expose
+`list`, writes, cancellation, batching, or request priorities.

--- a/docs/clients/overview.md
+++ b/docs/clients/overview.md
@@ -1,6 +1,6 @@
 # Client SDKs
 
-Talon can be reached three ways, and which one fits depends less on language
+Talon can be reached four ways, and which one fits depends less on language
 than on how much control the workload needs.
 
 | | best for | needs |
@@ -8,6 +8,7 @@ than on how much control the workload needs.
 | **FUSE mount** | unmodified applications, POSIX tooling | a privileged mount and `/dev/fuse` |
 | **Python client** | training loaders, notebooks, data pipelines | a wheel |
 | **Java client** | JVM query engines and data tooling | a jar |
+| **C client** | C/C++ engines that need async ranged reads | a header and shared/static library |
 
 ## Why a native client rather than the mount
 
@@ -25,7 +26,7 @@ keeps working. It also carries constraints a native client avoids:
 If the application already speaks in terms of objects and byte ranges, a client
 is a closer fit.
 
-## Two different architectures, deliberately
+## Different architectures, deliberately
 
 **Python binds the Rust core.** Block splitting, placement caching, replica
 fallback, and connection pooling already exist and are exercised by the FUSE
@@ -36,6 +37,11 @@ ecosystem already expects.
 **Java is a pure jar.** No JNI, no FFM, no native artifact — it drops into any
 JVM build with no per-platform matrix, no `System.loadLibrary` failure mode, and
 no JNI crash surface. The cost is that the wire protocol is implemented twice.
+
+**C binds the Rust read path behind a C ABI.** It exposes async `read` and
+`stat` with callback dispatch, while the Rust side keeps ownership of placement
+caching, replica fallback, and connection pooling. Callers own read buffers so
+the binding does not allocate an intermediate result buffer for range bytes.
 
 That duplication is why the [wire protocol reference](../reference/wire-protocol.md)
 exists as a specification with **conformance vectors** rather than as prose. The
@@ -51,7 +57,7 @@ have served, invisibly from both ends.
 
 ## Current scope
 
-Both clients are **read-only**: `read` and `stat`.
+All native clients are **read-only** in this release.
 
 `list` is implemented in both but not yet usable, because listing needs a
 capability the storage backends do not have yet
@@ -61,3 +67,4 @@ deserve a design pass rather than being rushed into a first release.
 
 - [Python client](./python.md)
 - [Java client](./java.md)
+- [C client](./c.md)


### PR DESCRIPTION
## Summary
- add asynchronous read and stat C ABI bindings with caller-owned buffers
- dispatch callbacks inline on Tokio I/O workers by default, with optional custom executors
- provide C ABI smoke coverage and a standalone C SDK packaging command

## Validation
- cargo test -p talon-c
- cargo test -p talon-fuse
- RUSTFLAGS="-D warnings" cargo clippy -p talon-c --all-targets --all-features
- cargo build -p talon-c --release --locked