### PR TITLE
fix(gateway): serve the h2 it advertises in ALPN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,6 +2106,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",

--- a/crates/talon-gateway/Cargo.toml
+++ b/crates/talon-gateway/Cargo.toml
@@ -7,6 +7,14 @@ repository.workspace = true
 rust-version.workspace = true
 description = "Shared bounded HTTP runtime for Talon object-store gateways"
 
+# `http2` gates BOTH the h2 serving stack and the `h2` entry the TLS listener
+# advertises in ALPN (see `tls.rs::alpn_protocols`). They are one switch on
+# purpose: advertising a protocol this server cannot serve makes every
+# ALPN-capable client negotiate it and then have its connection reset.
+[features]
+default = ["http2"]
+http2 = ["axum/http2"]
+
 [dependencies]
 talon-core.workspace = true
 talon-backend = { path = "../talon-backend" }
@@ -36,4 +44,11 @@ url.workspace = true
 x509-cert.workspace = true
 
 [dev-dependencies]
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
+# `http2` here is what makes the ALPN test meaningful: with it off, reqwest
+# only ever offers http/1.1, so a server advertising h2 it cannot serve still
+# looks healthy to every test in this crate.
+reqwest = { version = "0.12", default-features = false, features = [
+    "rustls-tls",
+    "stream",
+    "http2",
+] }

--- a/crates/talon-gateway/src/tls.rs
+++ b/crates/talon-gateway/src/tls.rs
@@ -525,11 +525,29 @@ fn load_server_config(config: &GatewayTlsConfig) -> Result<LoadedServerConfig, G
     let mut server = builder
         .with_single_cert(certificates, key)
         .map_err(|_| GatewayTlsError::IncompatibleKey)?;
-    server.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    server.alpn_protocols = alpn_protocols();
     Ok(LoadedServerConfig {
         server,
         client_auth: config.client_auth.clone(),
     })
+}
+
+/// ALPN offer, derived from what this build can actually serve.
+///
+/// `axum::serve` dispatches through hyper-util's automatic connection builder,
+/// whose h2 side only exists when axum's `http2` feature is on. Deriving the
+/// offer from the same feature keeps the advertisement and the serving stack
+/// from drifting apart: a hardcoded `h2` entry in a build without the feature
+/// makes every ALPN-capable client negotiate h2 and then get its connection
+/// reset — Kubernetes HTTPS probes attempt h2 by default, so a TLS gateway can
+/// never pass a readiness probe.
+fn alpn_protocols() -> Vec<Vec<u8>> {
+    let mut protocols = Vec::new();
+    if cfg!(feature = "http2") {
+        protocols.push(b"h2".to_vec());
+    }
+    protocols.push(b"http/1.1".to_vec());
+    protocols
 }
 
 #[cfg(test)]
@@ -782,6 +800,92 @@ mod tests {
             .await
             .is_err());
         server.await.unwrap();
+    }
+
+    #[test]
+    fn alpn_offer_matches_what_this_build_can_serve() {
+        let offer = alpn_protocols();
+        assert!(
+            offer.contains(&b"http/1.1".to_vec()),
+            "http/1.1 is always served"
+        );
+        assert_eq!(
+            offer.contains(&b"h2".to_vec()),
+            cfg!(feature = "http2"),
+            "h2 may be advertised only by a build whose axum has the http2 feature"
+        );
+        assert_eq!(
+            offer.first().map(Vec::as_slice),
+            Some(if cfg!(feature = "http2") {
+                b"h2".as_slice()
+            } else {
+                b"http/1.1".as_slice()
+            }),
+            "the preferred protocol is the most capable one this build serves"
+        );
+    }
+
+    /// Regression: the listener used to advertise `h2` unconditionally while
+    /// axum's `http2` feature was off, so every client that negotiated h2 had
+    /// its connection reset. This drives a real request over the negotiated
+    /// protocol rather than inspecting the ALPN result, because a reset only
+    /// shows up once bytes are exchanged.
+    #[tokio::test]
+    async fn negotiated_protocol_serves_a_real_request() {
+        let temp = TempDir::new().unwrap();
+        let tls = write_material(temp.path());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let runtime = Arc::new(
+            GatewayRuntime::new(
+                GatewayConfig {
+                    bind: address,
+                    mode: GatewayMode::Production,
+                    ..GatewayConfig::default()
+                },
+                Arc::new(Adapter),
+                GatewaySecurity::default(),
+            )
+            .unwrap(),
+        );
+        runtime.install_authentication(Arc::new(Authenticator));
+        runtime.install_authorization(AuthorizationPolicy::new(Vec::new()).unwrap());
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let server_runtime = Arc::clone(&runtime);
+        let server = tokio::spawn(async move {
+            serve_tls(listener, server_runtime, tls, async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+        });
+
+        // Offers h2 and http/1.1, exactly like the ALPN-capable clients that
+        // hit this listener in production (Kubernetes probes, proxies, curl).
+        let client = reqwest::Client::builder()
+            .danger_accept_invalid_certs(true)
+            .build()
+            .unwrap();
+        let response = client
+            .get(format!("https://{address}/readyz"))
+            .send()
+            .await
+            .expect("a protocol this server advertises must survive a request");
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert_eq!(
+            response.version(),
+            if cfg!(feature = "http2") {
+                reqwest::Version::HTTP_2
+            } else {
+                reqwest::Version::HTTP_11
+            },
+            "the client must have negotiated the protocol the offer promised"
+        );
+        // The body has to arrive too: an h2 connection that resets mid-stream
+        // still yields response headers first.
+        assert!(response.text().await.unwrap().contains("\"ready\""));
+
+        shutdown_tx.send(()).unwrap();
+        server.await.unwrap().unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## The bug

The gateway's TLS listener has advertised `h2` ahead of `http/1.1` since #501, but nothing ever enabled the serving side. `axum::serve` dispatches through hyper-util's automatic connection builder, whose h2 half sits behind axum's `http2` feature — not a default, and not enabled here. On `main`:

```
$ cargo tree -p talon-gateway -e no-dev,features -i axum | grep 'axum feature "http'
├── axum feature "http1"          # ← no http2

$ cargo tree -p talon-gateway -e no-dev,features -i hyper-util | grep -oE 'hyper-util feature "http[12]"'
hyper-util feature "http1"        # ← no http2
```

So the ALPN offer was a promise the server could not keep. Any ALPN-capable client selects `h2`, sends an h2 preface, and has its connection reset.

## Why it matters

**Kubernetes HTTPS probes attempt HTTP/2 by default**, so a production-mode gateway can never pass a startup or readiness probe. Observed on a real deployment:

```
Warning  Unhealthy  kubelet  Startup probe failed: Get "https://10.15.73.86:7002/healthz":
                             read tcp ...->10.15.73.86:7002: read: connection reset by peer
Warning  Unhealthy  kubelet  Startup probe failed: ... unexpected EOF
Normal   Killing    kubelet  Container talon-gateway failed startup probe, will be restarted
```

The same endpoint, same pod, forced to HTTP/1.1:

```
$ curl -sSk --http1.1 https://10.15.73.86:7002/readyz
{"ready":true,"reasons":[]}
$ curl -sSk --http2   https://10.15.73.86:7002/readyz
curl: (55) OpenSSL SSL_read: ... unexpected eof while reading
```

The gateway was fully healthy — TLS, authentication and authorization all installed — and still could not be rolled out. Anything else that prefers h2 upstream (service meshes, proxies, browsers) hits the same wall.

## The fix

Enable the feature rather than withdraw the offer: h2 was clearly intended by #501, and it is worth having on a data-plane proxy that sits behind load balancers.

- `crates/talon-gateway/Cargo.toml` gains `http2 = ["axum/http2"]`, on by default.
- The ALPN list is derived from `cfg!(feature = "http2")` instead of being hardcoded, so the advertisement and the serving stack cannot drift apart again. This is the part that keeps the class of bug from returning, not just this instance.

After:

```
axum feature "http1"     hyper-util feature "http1"
axum feature "http2"     hyper-util feature "http2"
```

`Cargo.lock` moves by one line — the `h2` edge already existed under `hyper`, which is why the lockfile never hinted at any of this. Features are what changed, and the lockfile does not record features.

## Why no test caught it

Two independent reasons, both worth closing:

1. **Development mode is plaintext and loopback-only, so it never performs ALPN.** The TLS listener #501 added is production-only, and no test drove a negotiated h2 request through it.
2. **The crate's own test client could not speak h2.** The dev-dependency carried `default-features = false` without `http2`, so reqwest only ever offered `http/1.1` — it agreed with any server offer, including an impossible one. This PR enables `http2` on the dev-dependency, which is what gives the new test teeth.

## Tests

- `alpn_offer_matches_what_this_build_can_serve` — the offer must contain `h2` exactly when the feature is on, and prefer the most capable protocol the build serves.
- `negotiated_protocol_serves_a_real_request` — drives a full request over the negotiated protocol and asserts both the status and `response.version()`. It checks the negotiated protocol *works*, not merely what ALPN returned, because a reset only appears once bytes are exchanged.

Verified the test actually fails on the regression by restoring the unconditional `h2` under `--no-default-features`:

```
assertion `left == right` failed: the client must have negotiated the protocol the offer promised
  left: HTTP/2.0
 right: HTTP/1.1
```

`cargo test -p talon-gateway` and `cargo test -p talon-gateway --no-default-features` both pass 99 tests; `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)