### PR TITLE
feat(gateway): pass through S3 ListObjects V1

### DIFF
--- a/crates/talon-backend/src/s3.rs
+++ b/crates/talon-backend/src/s3.rs
@@ -483,6 +483,43 @@ impl S3Backend {
         self.http.execute(self.signed(request)).await
     }
 
+    /// Execute one raw ListObjects (V1) page. The V1 response body
+    /// (`ListBucketResult` with `Marker`/`NextMarker` pagination) passes back
+    /// unchanged; the origin already speaks V1 so nothing is translated.
+    pub async fn execute_list_v1_raw(
+        &self,
+        bucket: &str,
+        prefix: &str,
+        delimiter: Option<&str>,
+        marker: Option<&str>,
+        max_keys: u32,
+        encoding_type: Option<&str>,
+    ) -> std::result::Result<HttpResponse, String> {
+        let mut query = format!("max-keys={}", max_keys.min(1000));
+        if !prefix.is_empty() {
+            query.push_str("&prefix=");
+            query.push_str(&encode_query_value(prefix));
+        }
+        if let Some(delimiter) = delimiter {
+            query.push_str("&delimiter=");
+            query.push_str(&encode_query_value(delimiter));
+        }
+        if let Some(marker) = marker {
+            query.push_str("&marker=");
+            query.push_str(&encode_query_value(marker));
+        }
+        if let Some(encoding_type) = encoding_type {
+            query.push_str("&encoding-type=");
+            query.push_str(&encode_query_value(encoding_type));
+        }
+        let request = HttpRequest::new(
+            Method::Get,
+            format!("{}?{query}", self.bucket_url(bucket)),
+            self.session_headers(),
+        );
+        self.http.execute(self.signed(request)).await
+    }
+
     /// Execute a single-use streaming PUT. The payload declaration is signed
     /// by the scoped origin credential and the body is never retried here.
     pub async fn execute_put_body_raw(
@@ -1022,6 +1059,46 @@ mod tests {
             .header("authorization")
             .is_some_and(|value| value.starts_with("AWS4-HMAC-SHA256")));
         assert_eq!(request.header("x-amz-security-token"), Some("SERVICETOKEN"));
+    }
+
+    #[tokio::test]
+    async fn list_v1_targets_the_bucket_url_without_a_list_type() {
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: bytes::Bytes::new(),
+        });
+        let backend = S3Backend::new(
+            S3Config {
+                region: "us-east-1".into(),
+                endpoint: "minio:9000".into(),
+                path_style: true,
+                tls: false,
+            },
+            creds(),
+            http.clone(),
+        );
+        backend
+            .execute_list_v1_raw(
+                "my-bucket",
+                "gateway/a b",
+                None,
+                Some("start/key"),
+                2000,
+                None,
+            )
+            .await
+            .unwrap();
+        let request = http.last.lock().unwrap().take().unwrap();
+        assert_eq!(request.method, Method::Get);
+        assert_eq!(
+            request.url,
+            "http://minio:9000/my-bucket?max-keys=1000&prefix=gateway%2Fa%20b&marker=start%2Fkey",
+            "V1 pages carry no list-type and clamp max-keys"
+        );
+        assert!(request
+            .header("authorization")
+            .is_some_and(|value| value.starts_with("AWS4-HMAC-SHA256")));
     }
 
     #[test]

--- a/crates/talon-gateway/src/s3.rs
+++ b/crates/talon-gateway/src/s3.rs
@@ -181,6 +181,18 @@ pub trait S3Origin: Send + Sync + 'static {
         Err("S3 origin does not implement HeadBucket".into())
     }
 
+    async fn list_v1(
+        &self,
+        _bucket: &str,
+        _prefix: &str,
+        _delimiter: Option<&str>,
+        _marker: Option<&str>,
+        _max_keys: u32,
+        _encoding_type: Option<&str>,
+    ) -> Result<HttpResponse, String> {
+        Err("S3 origin does not implement ListObjects V1".into())
+    }
+
     async fn put_body(
         &self,
         _object: &ObjectId,
@@ -339,6 +351,19 @@ impl S3Origin for S3Backend {
 
     async fn head_bucket(&self, bucket: &str) -> Result<HttpResponse, String> {
         self.execute_head_bucket_raw(bucket).await
+    }
+
+    async fn list_v1(
+        &self,
+        bucket: &str,
+        prefix: &str,
+        delimiter: Option<&str>,
+        marker: Option<&str>,
+        max_keys: u32,
+        encoding_type: Option<&str>,
+    ) -> Result<HttpResponse, String> {
+        self.execute_list_v1_raw(bucket, prefix, delimiter, marker, max_keys, encoding_type)
+            .await
     }
 
     async fn put_body(
@@ -598,6 +623,33 @@ enum BucketProbe {
     Location,
 }
 
+/// A bucket-level `GET` is a V1 listing only when its query carries nothing
+/// but listing parameters. Known sub-resources (`uploads`), multipart
+/// parameters, unrecognized query keys (`versions`, `acl`, ...), and
+/// unsupported `list-type` values name different S3 operations, so they are
+/// rejected rather than approximated by a listing.
+fn require_v1_list_shape(query: &S3Query) -> Result<(), S3RequestError> {
+    if query.list_type.is_some() {
+        return Err(S3RequestError::invalid(
+            "InvalidArgument",
+            "list-type must be 2",
+        ));
+    }
+    if query.uploads.is_some()
+        || query.upload_id.is_some()
+        || query.part_number.is_some()
+        || query.part_number_marker.is_some()
+        || query.max_parts.is_some()
+        || query.unknown.is_some()
+    {
+        return Err(S3RequestError::invalid(
+            "NotImplemented",
+            "bucket sub-resource requests are not supported",
+        ));
+    }
+    Ok(())
+}
+
 fn bucket_probe(
     method: &axum::http::Method,
     target: &ParsedTarget,
@@ -695,6 +747,11 @@ struct S3Query {
     part_number_marker: Option<String>,
     max_parts: Option<String>,
     location: Option<String>,
+    marker: Option<String>,
+    /// First query key outside the recognized set, kept so bucket-level
+    /// requests can reject unknown sub-resources instead of approximating
+    /// them with a listing.
+    unknown: Option<String>,
 }
 
 impl S3Query {
@@ -727,7 +784,12 @@ impl S3Query {
                 "location" => {
                     set_query_value(&mut parsed.location, value.into_owned(), "location")?
                 }
-                _ => {}
+                "marker" => set_query_value(&mut parsed.marker, value.into_owned(), "marker")?,
+                other => {
+                    if parsed.unknown.is_none() {
+                        parsed.unknown = Some(other.to_string());
+                    }
+                }
             }
         }
         if let Some(value) = parsed.encoding_type.as_deref() {
@@ -1745,6 +1807,19 @@ impl S3Adapter {
                 additional: Vec::new(),
             });
         }
+        if request.method() == axum::http::Method::GET && target.key.is_none() {
+            require_v1_list_shape(&query)?;
+            return Ok(GatewayAccess {
+                operation: GatewayOperation::List,
+                provider_account: None,
+                target: GatewayTarget::Namespace {
+                    backend: Backend::S3,
+                    namespace: target.bucket,
+                    prefix: query.prefix,
+                },
+                additional: Vec::new(),
+            });
+        }
         let key = target
             .key
             .ok_or_else(|| S3RequestError::invalid("InvalidURI", "request has no object key"))?;
@@ -1797,6 +1872,10 @@ impl S3Adapter {
             Some(BucketProbe::Head) => return self.head_bucket(target.bucket, context).await,
             Some(BucketProbe::Location) => return Ok(self.bucket_location(target.bucket, context)),
             None => {}
+        }
+        if request.method() == axum::http::Method::GET && target.key.is_none() {
+            require_v1_list_shape(&query)?;
+            return self.list_v1(target.bucket, query, context).await;
         }
         let key = target
             .key
@@ -2374,6 +2453,40 @@ impl S3Adapter {
                 query.prefix.as_deref().unwrap_or(""),
                 query.delimiter.as_deref(),
                 query.continuation_token.as_deref(),
+                max_keys,
+                query.encoding_type.as_deref(),
+            )
+            .await
+            .map_err(S3RequestError::origin_unavailable)?;
+        Ok(raw_response(
+            response,
+            GatewayOperation::List,
+            Some(GatewayTarget::Namespace {
+                backend: Backend::S3,
+                namespace: bucket,
+                prefix: query.prefix,
+            }),
+            context,
+        ))
+    }
+
+    /// ListObjects (V1): the listing dialect of the AWS C++ SDK's
+    /// `ListObjectsRequest`. The origin's V1 response body passes back
+    /// unchanged, including `Marker`/`NextMarker` pagination.
+    async fn list_v1(
+        &self,
+        bucket: String,
+        query: S3Query,
+        context: &GatewayRequestContext,
+    ) -> Result<GatewayResponse, S3RequestError> {
+        let max_keys = query.max_keys()?;
+        let response = self
+            .origin
+            .list_v1(
+                &bucket,
+                query.prefix.as_deref().unwrap_or(""),
+                query.delimiter.as_deref(),
+                query.marker.as_deref(),
                 max_keys,
                 query.encoding_type.as_deref(),
             )
@@ -3123,9 +3236,12 @@ mod tests {
             .is_err());
     }
 
+    type V1ListRequest = (String, String, Option<String>, Option<String>, u32);
+
     struct BucketOrigin {
         responses: Mutex<VecDeque<Result<HttpResponse, String>>>,
         buckets: Mutex<Vec<String>>,
+        v1_lists: Mutex<Vec<V1ListRequest>>,
     }
 
     impl BucketOrigin {
@@ -3133,7 +3249,16 @@ mod tests {
             Arc::new(Self {
                 responses: Mutex::new(responses.into_iter().collect()),
                 buckets: Mutex::new(Vec::new()),
+                v1_lists: Mutex::new(Vec::new()),
             })
+        }
+
+        fn next_response(&self) -> Result<HttpResponse, String> {
+            self.responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("bucket probe test provided one response per call")
         }
     }
 
@@ -3170,11 +3295,26 @@ mod tests {
 
         async fn head_bucket(&self, bucket: &str) -> Result<HttpResponse, String> {
             self.buckets.lock().unwrap().push(bucket.to_string());
-            self.responses
-                .lock()
-                .unwrap()
-                .pop_front()
-                .expect("bucket probe test provided one response per call")
+            self.next_response()
+        }
+
+        async fn list_v1(
+            &self,
+            bucket: &str,
+            prefix: &str,
+            delimiter: Option<&str>,
+            marker: Option<&str>,
+            max_keys: u32,
+            _encoding_type: Option<&str>,
+        ) -> Result<HttpResponse, String> {
+            self.v1_lists.lock().unwrap().push((
+                bucket.to_string(),
+                prefix.to_string(),
+                delimiter.map(str::to_string),
+                marker.map(str::to_string),
+                max_keys,
+            ));
+            self.next_response()
         }
     }
 
@@ -3213,10 +3353,96 @@ mod tests {
             .classify_access(&request(axum::http::Method::GET, "/bucket?list-type=2"))
             .unwrap();
         assert_eq!(list.operation, GatewayOperation::List);
-        assert!(adapter
+        let v1 = adapter
+            .classify_access(&request(axum::http::Method::GET, "/bucket?prefix=a/"))
+            .unwrap();
+        assert_eq!(v1.operation, GatewayOperation::List);
+        assert_eq!(
+            v1.target,
+            GatewayTarget::Namespace {
+                backend: Backend::S3,
+                namespace: "bucket".into(),
+                prefix: Some("a/".into()),
+            }
+        );
+        let bare = adapter
             .classify_access(&request(axum::http::Method::GET, "/bucket"))
-            .is_err());
+            .unwrap();
+        assert_eq!(bare.operation, GatewayOperation::List);
+        assert_eq!(
+            bare.target,
+            GatewayTarget::Namespace {
+                backend: Backend::S3,
+                namespace: "bucket".into(),
+                prefix: None,
+            },
+            "a bare bucket GET is a whole-bucket V1 listing"
+        );
+        assert!(
+            adapter
+                .classify_access(&request(axum::http::Method::PUT, "/bucket"))
+                .is_err(),
+            "bucket-level mutations stay rejected"
+        );
         assert!(S3Query::parse(Some("location=&location=")).is_err());
+    }
+
+    #[test]
+    fn bucket_sub_resources_are_rejected_not_approximated() {
+        let adapter = bucket_probe_adapter(BucketOrigin::new([]), "us-east-1");
+        for (uri, code) in [
+            ("/bucket?uploads=", "NotImplemented"),
+            ("/bucket?versions", "NotImplemented"),
+            ("/bucket?acl", "NotImplemented"),
+            ("/bucket?list-type=3", "InvalidArgument"),
+        ] {
+            let error = adapter
+                .classify_access(&request(axum::http::Method::GET, uri))
+                .unwrap_err();
+            assert_eq!(error.code, code, "{uri} must not become a V1 listing");
+        }
+    }
+
+    #[tokio::test]
+    async fn v1_listing_forwards_validated_parameters() {
+        let origin = BucketOrigin::new([Ok(HttpResponse {
+            status: 200,
+            headers: vec![("content-type".into(), "application/xml".into())],
+            body: Bytes::from_static(
+                b"<?xml version=\"1.0\"?><ListBucketResult><IsTruncated>true</IsTruncated>\
+                  <NextMarker>b.txt</NextMarker><Contents><Key>a.txt</Key></Contents>\
+                  </ListBucketResult>",
+            ),
+        })]);
+        let adapter = bucket_probe_adapter(Arc::clone(&origin), "us-east-1");
+        let response = adapter
+            .handle(
+                request(
+                    axum::http::Method::GET,
+                    "/bucket?prefix=gateway%2F&marker=start%2Fkey&max-keys=7",
+                ),
+                context(),
+            )
+            .await;
+        assert_eq!(response.response.status(), StatusCode::OK);
+        assert_eq!(response.operation, GatewayOperation::List);
+        assert_eq!(response.outcome, GatewayOutcome::Complete);
+        let body = to_bytes(response.response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(std::str::from_utf8(&body)
+            .unwrap()
+            .contains("<NextMarker>b.txt</NextMarker>"));
+        assert_eq!(
+            *origin.v1_lists.lock().unwrap(),
+            vec![(
+                "bucket".to_string(),
+                "gateway/".to_string(),
+                None,
+                Some("start/key".to_string()),
+                7,
+            )]
+        );
     }
 
     #[tokio::test]

--- a/docs/operations/object-store-gateway.md
+++ b/docs/operations/object-store-gateway.md
@@ -190,9 +190,12 @@ canonical URI/query/headers, timestamp or presigned expiry, payload declaration,
 and STS token. A present `x-talon-cache-mark` must be signed and syntactically
 valid. Invalid requests fail before cache or origin dispatch.
 
-`HeadBucket` existence probes pass through to the origin once and keep its
-status authoritative, so SDK startup checks (for example minio-go
-`BucketExists`) distinguish a missing bucket (404) from a denied one (403).
+Both listing dialects pass through: ListObjectsV2 and ListObjects V1, the
+latter being what the AWS C++ SDK's `ListObjectsRequest` and its startup
+connectivity checks emit. `HeadBucket` existence probes pass through to the
+origin once and keep its status authoritative, so SDK startup checks (for
+example minio-go `BucketExists`) distinguish a missing bucket (404) from a
+denied one (403).
 The response's `x-amz-bucket-region` is rewritten to the gateway region so
 clients never re-sign for the origin's real region. `GetBucketLocation` is
 answered locally with `TALON_GATEWAY_S3_REGION` because clients use it to pick

--- a/docs/reference/object-store-gateway-compatibility.md
+++ b/docs/reference/object-store-gateway-compatibility.md
@@ -81,6 +81,7 @@ and deployment are tracked separately.
 | One `Range` | Supported | Closed, open-ended, suffix, aligned, unaligned, and EOF-clamped ranges are supported. |
 | Multiple ranges | Rejected | Returns the S3 `InvalidRange` error; multipart responses are not approximated. |
 | ListObjectsV2 | Supported | `prefix`, `delimiter`, `continuation-token`, `max-keys`, and URL encoding are forwarded to one bounded origin page. |
+| ListObjects (V1) | Supported | A bucket-level `GET` whose query carries only listing parameters forwards `prefix`, `delimiter`, `marker`, `max-keys`, and URL encoding to one bounded origin page; the V1 response body passes back unchanged. Bucket sub-resource queries (`uploads`, `versions`, `acl`, and any unrecognized key) and `list-type` values other than `2` are rejected rather than approximated by a listing. |
 | Conditional reads | Supported | ETag and date conditions remain origin-authoritative; `If-Range` controls range use. |
 | Virtual-host addressing | Supported | The bucket is parsed from the configured endpoint suffix. |
 | Path addressing | Supported | `/bucket/key` endpoint-override clients are accepted. |

--- a/scripts/s3_gateway_sdk_conformance.py
+++ b/scripts/s3_gateway_sdk_conformance.py
@@ -59,6 +59,31 @@ def main() -> None:
         aws_secret_access_key=secret_key,
         config=config,
     )
+    v1_names = [
+        item["Key"]
+        for item in s3.list_objects(Bucket=bucket, Prefix="gateway/list/").get(
+            "Contents", []
+        )
+    ]
+    assert "gateway/list/a space.txt" in v1_names, v1_names
+    assert "gateway/list/child/b.txt" in v1_names, v1_names
+    first_page = s3.list_objects(Bucket=bucket, Prefix="gateway/list/", MaxKeys=1)
+    assert first_page["IsTruncated"] is True
+    # The marker deliberately needs no URL encoding: LocalStack compares raw
+    # markers against URL-encoded keys under the encoding-type=url parameter
+    # boto3 injects, so a marker containing a space never matches there. Real
+    # S3 applies encoding-type to the response only. The space-keyed object is
+    # still covered by the full-listing assertion above.
+    second_page = s3.list_objects(
+        Bucket=bucket,
+        Prefix="gateway/list/",
+        Marker="gateway/list/b",
+    )
+    second_names = [item["Key"] for item in second_page.get("Contents", [])]
+    assert second_names == ["gateway/list/child/b.txt"], (
+        f"V1 Marker pagination must resume after the marker key: {second_names}"
+    )
+
     s3.head_bucket(Bucket=bucket)
     location = s3.get_bucket_location(Bucket=bucket)
     expected_location = None if region == "us-east-1" else region


### PR DESCRIPTION
Closes #522.

The AWS C++ SDK's `ListObjectsRequest` speaks ListObjects V1, and clients built on it — including Milvus's C++ storage layer, which issues a V1 listing as its startup connectivity check — previously failed with `InvalidURI` because only `list-type=2` was recognized.

## What this does

- A bucket-level `GET` whose query carries only listing parameters (and is neither a V2 listing nor a bucket probe) forwards `prefix`, `delimiter`, `marker`, `max-keys`, and `encoding-type` to one bounded origin page. The V1 response body (`ListBucketResult` with `Marker`/`NextMarker` pagination) passes back unchanged — the origin already speaks V1, nothing is translated.
- Authorization is identical to V2: `list` on the namespace with the request's prefix, so prefix-scoped grants keep working, and a bare `GET /<bucket>` is a whole-bucket listing requiring a prefixless `list` grant.
- **Sub-resources are rejected, not approximated** — resolving the design question in #522 toward the repo's fail-closed convention: `?uploads` (ListMultipartUploads), `?versions`, `?acl`, any unrecognized query key, and `list-type` values other than `2` return an explicit error. Serving them a 200 with a wrong-shaped `ListBucketResult` would let sub-resource clients draw silently false conclusions (for example, "no multipart uploads left to abort").

## Testing

- Unit: bare-GET classification (`prefix: None`), validated parameter forwarding (prefix/marker/max-keys recorded at the origin seam), V1/V2/probe branch mutual exclusion, and rejection of `?uploads=`, `?versions`, `?acl`, `list-type=3`.
- Backend: `execute_list_v1_raw` URL shape (no `list-type`, encoded `prefix`/`marker`, clamped `max-keys`).
- Conformance (LocalStack CI): boto3 `list_objects` (V1) with prefix filtering and `Marker` pagination resuming after the marker key.
- `cargo fmt --check`, scoped `clippy -D warnings`, and the gateway/backend suites pass locally; the full `--all-features` gate runs on Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
