### PR TITLE
feat(gateway): make body and deadline limits configurable

### DIFF
--- a/crates/talon-gateway/src/main.rs
+++ b/crates/talon-gateway/src/main.rs
@@ -34,6 +34,8 @@ struct Settings {
     transfer_chunk_bytes: u32,
     placement_ttl_ms: u64,
     replicas: u8,
+    max_body_bytes: usize,
+    request_deadline_ms: u64,
     route: GatewayRoute,
     incoming_path_style: bool,
     endpoint_suffix: Option<String>,
@@ -128,6 +130,16 @@ impl Settings {
             value(&mut get, "TALON_GATEWAY_REPLICAS"),
             "1",
             "TALON_GATEWAY_REPLICAS",
+        )?;
+        let max_body_bytes = parse_or(
+            value(&mut get, "TALON_GATEWAY_MAX_BODY_BYTES"),
+            "16777216",
+            "TALON_GATEWAY_MAX_BODY_BYTES",
+        )?;
+        let request_deadline_ms = parse_or(
+            value(&mut get, "TALON_GATEWAY_REQUEST_DEADLINE_MS"),
+            "30000",
+            "TALON_GATEWAY_REQUEST_DEADLINE_MS",
         )?;
         let route = match value(&mut get, "TALON_GATEWAY_ROUTE").as_deref() {
             None | Some("cache") => GatewayRoute::Cache,
@@ -224,6 +236,8 @@ impl Settings {
             transfer_chunk_bytes,
             placement_ttl_ms,
             replicas,
+            max_body_bytes,
+            request_deadline_ms,
             route,
             incoming_path_style,
             endpoint_suffix: value(&mut get, "TALON_GATEWAY_ENDPOINT_SUFFIX"),
@@ -684,6 +698,8 @@ async fn main() -> MainResult<()> {
             bind: settings.bind,
             mode: settings.mode,
             origin_auth: settings.origin_auth,
+            max_body_bytes: settings.max_body_bytes,
+            request_deadline: std::time::Duration::from_millis(settings.request_deadline_ms),
             ..GatewayConfig::default()
         },
         adapter,
@@ -770,6 +786,25 @@ mod tests {
         assert_eq!(settings.azure_max_clock_skew_ms, 900_000);
         assert_eq!(settings.azure_max_block_bindings, 1024);
         assert_eq!(settings.azure_block_binding_ttl_ms, 86_400_000);
+        assert_eq!(settings.max_body_bytes, 16 * 1024 * 1024);
+        assert_eq!(settings.request_deadline_ms, 30_000);
+    }
+
+    #[test]
+    fn body_and_deadline_limits_are_configurable() {
+        let configured = settings(&[
+            ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
+            ("TALON_GATEWAY_MAX_BODY_BYTES", "536870912"),
+            ("TALON_GATEWAY_REQUEST_DEADLINE_MS", "300000"),
+        ])
+        .unwrap();
+        assert_eq!(configured.max_body_bytes, 512 * 1024 * 1024);
+        assert_eq!(configured.request_deadline_ms, 300_000);
+        assert!(settings(&[
+            ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
+            ("TALON_GATEWAY_MAX_BODY_BYTES", "not-a-number"),
+        ])
+        .is_err());
     }
 
     #[test]

--- a/docs/operations/object-store-gateway.md
+++ b/docs/operations/object-store-gateway.md
@@ -86,6 +86,8 @@ Common variables:
 | `TALON_GATEWAY_PATH_STYLE` | `false` | Accept `/bucket/key` or `/account/container/blob`. |
 | `TALON_GATEWAY_ENDPOINT_SUFFIX` | provider default | Virtual-host suffix accepted from clients. |
 | `TALON_GATEWAY_BLOCK_SIZE` | `268435456` | Must match worker cache granularity. |
+| `TALON_GATEWAY_MAX_BODY_BYTES` | `16777216` | Request body limit, enforced before spooling. Raise only with matching disk and concurrency capacity. |
+| `TALON_GATEWAY_REQUEST_DEADLINE_MS` | `30000` | Total request deadline, covering the streamed response body. Raise for large objects on slow links. |
 | `TALON_GATEWAY_TRANSFER_CHUNK_BYTES` | `1048576` | Maximum cache body frame. |
 | `TALON_GATEWAY_PLACEMENT_TTL_MS` | `5000` | Client-side placement freshness. |
 | `TALON_GATEWAY_REPLICAS` | `1` | Ordered worker replicas attempted by the cache client. |


### PR DESCRIPTION
Closes #525.

The gateway's request-body limit and total request deadline were fixed at `GatewayConfig::default()` (16 MiB, 30 seconds): `main.rs` built the runtime with `..GatewayConfig::default()` and exposed no override, while the runbook already told operators to raise deployment limits "only with corresponding disk, concurrency, and deadline capacity" — with no knob to raise.

## What this does

- `TALON_GATEWAY_MAX_BODY_BYTES` (default `16777216`) and `TALON_GATEWAY_REQUEST_DEADLINE_MS` (default `30000`) feed the existing `GatewayConfig` fields through the same `parse_or` pattern as every other gateway variable.
- Defaults are unchanged; zero values stay rejected by the existing `GatewayConfig::validate()`; enforcement paths (Content-Length pre-check, `Limited` body wrapper, response-stream deadline) are untouched.
- Runbook variable rows repeat the capacity warning.

Independent of #524: this touches only the binary's environment assembly (`main.rs`), not the protocol adapters — no shared diff region.

## Testing

Settings tests cover the defaults, both overrides, and a malformed value; `cargo fmt --check`, scoped `clippy -D warnings`, and the gateway suite pass locally, with the full `--all-features` gate on Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
