### PR TITLE
feat(backend): keyless origin credentials via cloud workload identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ secrets.*
 *_secret*
 credentials
 credentials.*
+# The blanket credential-file patterns above must not swallow source code.
+!crates/talon-backend/src/credentials.rs
 
 # Python client build artifacts.
 clients/python/target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,6 +2574,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "tracing",
  "url",
 ]
 

--- a/crates/talon-backend/Cargo.toml
+++ b/crates/talon-backend/Cargo.toml
@@ -16,6 +16,7 @@ bytes.workspace = true
 futures.workspace = true
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
 tokio = { workspace = true, features = ["time"] }
+tracing.workspace = true
 tokio-util.workspace = true
 url.workspace = true
 sha2 = "0.10"

--- a/crates/talon-backend/examples/credentials_probe.rs
+++ b/crates/talon-backend/examples/credentials_probe.rs
@@ -1,0 +1,201 @@
+//! Live workload-identity verification probe.
+//!
+//! Resolves origin credentials through the production chain (static env,
+//! then the detected or explicitly selected cloud mechanism), then proves
+//! the material signs a real request by HEADing one key. A `NotFound`
+//! answer is the success signal: the exchange, the signature, and the
+//! bucket authorization all worked without reading any data.
+//!
+//! ```sh
+//! credentials_probe s3  --region us-west-2 --bucket b --key prefix/absent
+//! credentials_probe gcs --bucket b --key prefix/absent
+//! ```
+//!
+//! Select an env-markerless mechanism with
+//! `TALON_ORIGIN_CREDENTIALS_SOURCE` (`gcp-metadata`, `huawei-agency`).
+//! Output never contains key or token material.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use talon_backend::{
+    resolve_azure_bearer, resolve_gcs_bearer, resolve_s3_credentials, AzureBackend, AzureConfig,
+    CredentialsObserver, GcsBackend, GcsConfig, HttpClient, ReqwestClient, S3Backend, S3Config,
+};
+use talon_core::{Backend, BackendStore, Error, ObjectId};
+
+struct PrintObserver;
+
+impl CredentialsObserver for PrintObserver {
+    fn refresh_succeeded(&self, expires_at: Option<SystemTime>) {
+        match expires_at {
+            Some(at) => println!(
+                "credential expiry: unix {}",
+                at.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
+            ),
+            None => println!("credential expiry: unreported"),
+        }
+    }
+
+    fn refresh_failed(&self) {
+        println!("credential refresh failed");
+    }
+}
+
+fn arg(name: &str) -> Option<String> {
+    let mut args = std::env::args();
+    while let Some(current) = args.next() {
+        if current == name {
+            return args.next();
+        }
+    }
+    None
+}
+
+fn redacted(value: &str) -> String {
+    let head: String = value.chars().take(4).collect();
+    format!("{head}... ({} chars)", value.chars().count())
+}
+
+async fn probe(backend: &dyn BackendStore, kind: Backend, bucket: &str, key: &str) -> i32 {
+    match backend.head(&ObjectId::new(kind, bucket, key)).await {
+        Err(Error::NotFound(_)) => {
+            println!("probe HEAD: NotFound - exchange, signing, and authorization verified");
+            0
+        }
+        Ok(stat) => {
+            println!(
+                "probe HEAD: object exists ({} bytes) - exchange, signing, and authorization verified",
+                stat.len
+            );
+            0
+        }
+        Err(error) => {
+            println!("probe HEAD failed: {error}");
+            2
+        }
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let mode = std::env::args().nth(1).unwrap_or_default();
+    let selector = std::env::var("TALON_ORIGIN_CREDENTIALS_SOURCE")
+        .ok()
+        .filter(|value| !value.is_empty());
+    let http: Arc<dyn HttpClient> = Arc::new(ReqwestClient::new());
+    let observer = Arc::new(PrintObserver);
+    let key = arg("--key").unwrap_or_else(|| "talon-credentials-probe/absent".to_string());
+    let code = match mode.as_str() {
+        "s3" => {
+            let resolved = match resolve_s3_credentials(
+                None,
+                selector.as_deref(),
+                Arc::clone(&http),
+                observer,
+            )
+            .await
+            {
+                Ok(resolved) => resolved,
+                Err(error) => {
+                    println!("credential resolution failed: {error}");
+                    std::process::exit(1);
+                }
+            };
+            println!("credential source: {}", resolved.source);
+            let snapshot = resolved.provider.current();
+            println!("access key id: {}", redacted(&snapshot.access_key_id));
+            println!(
+                "session token: {}",
+                snapshot
+                    .session_token
+                    .as_deref()
+                    .map_or_else(|| "absent".to_string(), redacted)
+            );
+            match arg("--bucket") {
+                Some(bucket) => {
+                    let region = arg("--region")
+                        .or_else(|| std::env::var("AWS_REGION").ok())
+                        .unwrap_or_else(|| "us-east-1".to_string());
+                    // `--endpoint` targets an S3-compatible store (OSS, COS,
+                    // OBS, MinIO); `--path-style` selects path addressing.
+                    let config = match arg("--endpoint") {
+                        Some(endpoint) => S3Config {
+                            region,
+                            endpoint,
+                            path_style: std::env::args().any(|flag| flag == "--path-style"),
+                            tls: true,
+                        },
+                        None => S3Config::aws(&region),
+                    };
+                    let backend =
+                        S3Backend::with_credentials_provider(config, resolved.provider, http);
+                    probe(&backend, Backend::S3, &bucket, &key).await
+                }
+                None => 0,
+            }
+        }
+        "gcs" => {
+            let resolved =
+                match resolve_gcs_bearer(None, selector.as_deref(), Arc::clone(&http), observer)
+                    .await
+                {
+                    Ok(resolved) => resolved,
+                    Err(error) => {
+                        println!("credential resolution failed: {error}");
+                        std::process::exit(1);
+                    }
+                };
+            println!("credential source: {}", resolved.source);
+            match resolved.provider.current() {
+                Some(token) => println!("bearer token: {}", redacted(&token)),
+                None => println!("bearer token: absent (unauthenticated)"),
+            }
+            match arg("--bucket") {
+                Some(bucket) => {
+                    let backend = GcsBackend::with_bearer_provider(
+                        GcsConfig::default(),
+                        resolved.provider,
+                        http,
+                    );
+                    probe(&backend, Backend::Gcs, &bucket, &key).await
+                }
+                None => 0,
+            }
+        }
+        "azure" => {
+            let resolved = match resolve_azure_bearer(Arc::clone(&http), observer).await {
+                Ok(resolved) => resolved,
+                Err(error) => {
+                    println!("credential resolution failed: {error}");
+                    std::process::exit(1);
+                }
+            };
+            println!("credential source: {}", resolved.source);
+            match resolved.provider.current() {
+                Some(token) => println!("bearer token: {}", redacted(&token)),
+                None => println!("bearer token: absent"),
+            }
+            match (arg("--account"), arg("--container")) {
+                (Some(account), Some(container)) => {
+                    let backend = AzureBackend::with_bearer_provider(
+                        AzureConfig::new(&account),
+                        resolved.provider,
+                        http,
+                    );
+                    probe(&backend, Backend::Azure, &container, &key).await
+                }
+                _ => 0,
+            }
+        }
+        other => {
+            println!(
+                "usage: credentials_probe <s3|gcs|azure> [--region r] [--endpoint e] \
+                 [--path-style] [--bucket b] [--account a] [--container c] [--key k] \
+                 (got {other:?})"
+            );
+            1
+        }
+    };
+    std::process::exit(code);
+}

--- a/crates/talon-backend/src/azure.rs
+++ b/crates/talon-backend/src/azure.rs
@@ -100,6 +100,9 @@ pub struct AzureBackend {
     /// Optional base64 account key for Shared Key authorization (an alternative
     /// to SAS). When set, every request is signed just before execution.
     shared_key: Option<String>,
+    /// Optional Azure AD bearer-token source (workload identity), an
+    /// alternative to both SAS and Shared Key.
+    bearer: Option<Arc<dyn crate::credentials::ProvideBearerToken>>,
     http: Arc<dyn HttpClient>,
 }
 
@@ -110,6 +113,7 @@ impl AzureBackend {
             config,
             sas_token,
             shared_key: None,
+            bearer: None,
             http,
         }
     }
@@ -125,6 +129,24 @@ impl AzureBackend {
             config,
             sas_token: None,
             shared_key: Some(shared_key.into()),
+            bearer: None,
+            http,
+        }
+    }
+
+    /// Construct with an Azure AD bearer-token source (workload identity)
+    /// instead of a SAS token or Shared Key. Every request carries
+    /// `Authorization: Bearer` with the provider's current token.
+    pub fn with_bearer_provider(
+        config: AzureConfig,
+        bearer: Arc<dyn crate::credentials::ProvideBearerToken>,
+        http: Arc<dyn HttpClient>,
+    ) -> Self {
+        Self {
+            config,
+            sas_token: None,
+            shared_key: None,
+            bearer: Some(bearer),
             http,
         }
     }
@@ -316,6 +338,15 @@ impl AzureBackend {
     /// header. A SAS-only backend (no shared key) returns the request unchanged
     /// (the SAS travels in the URL query).
     fn authorized(&self, mut req: HttpRequest) -> HttpRequest {
+        if let Some(bearer) = &self.bearer {
+            // Azure AD auth: the always-stamped `x-ms-version` satisfies the
+            // minimum API version bearer tokens require.
+            if let Some(token) = bearer.current() {
+                req.headers
+                    .push(("Authorization".to_string(), format!("Bearer {token}")));
+            }
+            return req;
+        }
         let Some(key) = &self.shared_key else {
             return req;
         };
@@ -1107,6 +1138,34 @@ mod tests {
         );
         let auth = req.header("Authorization").expect("Authorization header");
         assert!(auth.starts_with("SharedKey acct:"), "got {auth}");
+    }
+
+    #[tokio::test]
+    async fn bearer_backend_sends_the_current_token_without_sas_or_key() {
+        let http = MockHttp::new(HttpResponse {
+            status: 206,
+            headers: vec![],
+            body: bytes::Bytes::from_static(b"az-bytes"),
+        });
+        let a = AzureBackend::with_bearer_provider(
+            AzureConfig::new("acct"),
+            Arc::new(crate::credentials::StaticBearerToken::new(Some(
+                "aad-token".into(),
+            ))),
+            http.clone(),
+        );
+        a.fetch_range(&obj(), 0, 8).await.unwrap();
+        let req = http.last.lock().unwrap().clone().unwrap();
+        assert_eq!(req.header("Authorization"), Some("Bearer aad-token"));
+        assert!(
+            req.header("x-ms-date").is_none(),
+            "bearer requests are not shared-key signed"
+        );
+        assert!(!req.url.contains('?'), "no SAS query is appended");
+        assert!(
+            req.header("x-ms-version").is_some(),
+            "bearer auth requires the API version header"
+        );
     }
 
     #[tokio::test]

--- a/crates/talon-backend/src/credentials.rs
+++ b/crates/talon-backend/src/credentials.rs
@@ -1,0 +1,430 @@
+//! Snapshot-based origin credential providers with background refresh.
+//!
+//! Backends sign every request with a point-in-time snapshot taken from a
+//! provider, so a refresh atomically replaces credentials without tearing an
+//! in-flight request. Static providers wrap fixed env/config material and
+//! never spawn anything; refreshing providers poll a [`CredentialsFetch`]
+//! implementation (STS, IMDS-style metadata, or an OAuth token endpoint) and
+//! retain the last good value when a refresh fails, matching the gateway's
+//! TLS and auth-file reload semantics.
+
+use std::sync::{Arc, RwLock, Weak};
+use std::time::{Duration, SystemTime};
+
+use async_trait::async_trait;
+
+use crate::s3::S3Credentials;
+
+/// Source of the S3-family credential triple used for SigV4 signing.
+pub trait ProvideS3Credentials: Send + Sync {
+    /// Cheap point-in-time snapshot used to build and sign exactly one request.
+    fn current(&self) -> Arc<S3Credentials>;
+}
+
+/// Source of an OAuth2-style bearer token (GCS, Azure AD).
+pub trait ProvideBearerToken: Send + Sync {
+    /// Current token, or `None` when the endpoint needs no authentication
+    /// (emulators).
+    fn current(&self) -> Option<Arc<String>>;
+}
+
+/// Fixed credentials from env/config; never refreshed.
+pub struct StaticS3Credentials(Arc<S3Credentials>);
+
+impl StaticS3Credentials {
+    /// Wrap fixed credentials.
+    pub fn new(creds: S3Credentials) -> Self {
+        Self(Arc::new(creds))
+    }
+}
+
+impl ProvideS3Credentials for StaticS3Credentials {
+    fn current(&self) -> Arc<S3Credentials> {
+        Arc::clone(&self.0)
+    }
+}
+
+/// Fixed bearer token from env/config; never refreshed.
+pub struct StaticBearerToken(Option<Arc<String>>);
+
+impl StaticBearerToken {
+    /// Wrap a fixed optional token.
+    pub fn new(token: Option<String>) -> Self {
+        Self(token.map(Arc::new))
+    }
+}
+
+impl ProvideBearerToken for StaticBearerToken {
+    fn current(&self) -> Option<Arc<String>> {
+        self.0.clone()
+    }
+}
+
+/// Observer for refresh outcomes so each binary counts them in its own
+/// metrics registry. Implementations must not block.
+pub trait CredentialsObserver: Send + Sync {
+    /// A refresh produced and installed new credentials.
+    fn refresh_succeeded(&self, expires_at: Option<SystemTime>) {
+        let _ = expires_at;
+    }
+
+    /// A refresh failed; the previous credentials remain in use.
+    fn refresh_failed(&self) {}
+}
+
+/// Observer that drops every event.
+pub struct NoopObserver;
+
+impl CredentialsObserver for NoopObserver {}
+
+/// One credential acquisition protocol (STS exchange, metadata endpoint, or
+/// OAuth token endpoint).
+#[async_trait]
+pub trait CredentialsFetch: Send + Sync + 'static {
+    /// The credential material produced by this fetcher.
+    type Value: Send + Sync + 'static;
+
+    /// Acquire fresh credentials and their hard expiry. Errors must not
+    /// contain token or key material.
+    async fn fetch(&self) -> Result<(Self::Value, Option<SystemTime>), String>;
+
+    /// Bounded label naming the acquisition mechanism, for logs.
+    fn source(&self) -> &'static str;
+}
+
+/// Refresh pacing. The margin scales with the credential lifetime and is
+/// clamped so short-lived tokens still refresh early and long-lived ones do
+/// not refresh needlessly often.
+#[derive(Debug, Clone)]
+pub struct RefreshPolicy {
+    /// Fraction of the remaining lifetime reserved as the refresh margin.
+    pub margin_fraction: f64,
+    /// Lower clamp for the margin.
+    pub min_margin: Duration,
+    /// Upper clamp for the margin.
+    pub max_margin: Duration,
+    /// Delay before retrying after a failed refresh.
+    pub retry_interval: Duration,
+    /// Refresh period when the mechanism reports no expiry.
+    pub unknown_expiry_interval: Duration,
+}
+
+impl Default for RefreshPolicy {
+    fn default() -> Self {
+        Self {
+            margin_fraction: 0.2,
+            min_margin: Duration::from_secs(60),
+            max_margin: Duration::from_secs(15 * 60),
+            retry_interval: Duration::from_secs(30),
+            unknown_expiry_interval: Duration::from_secs(10 * 60),
+        }
+    }
+}
+
+impl RefreshPolicy {
+    /// Time to sleep before the next refresh attempt for credentials fetched
+    /// `now` with `expires_at`.
+    fn next_delay(&self, now: SystemTime, expires_at: Option<SystemTime>) -> Duration {
+        let Some(expires_at) = expires_at else {
+            return self.unknown_expiry_interval;
+        };
+        let lifetime = expires_at.duration_since(now).unwrap_or(Duration::ZERO);
+        let margin = lifetime.mul_f64(self.margin_fraction.clamp(0.0, 1.0));
+        let margin = margin.clamp(self.min_margin, self.max_margin);
+        let delay = lifetime.saturating_sub(margin);
+        // An already-expired or nearly-expired credential still backs off by
+        // the retry interval so a broken issuer is not hammered.
+        delay.max(self.retry_interval)
+    }
+}
+
+/// Shared cell holding the latest credentials from a background refresh loop.
+pub struct RefreshingCredentials<F: CredentialsFetch> {
+    current: RwLock<Arc<F::Value>>,
+    expires_at: RwLock<Option<SystemTime>>,
+}
+
+impl<F: CredentialsFetch> RefreshingCredentials<F> {
+    /// Fetch initial credentials, then keep them fresh for as long as the
+    /// returned handle is alive. A failed initial fetch is a startup error so
+    /// a misconfigured process refuses to serve, exactly like missing static
+    /// credentials.
+    pub async fn bootstrap(
+        fetcher: F,
+        policy: RefreshPolicy,
+        observer: Arc<dyn CredentialsObserver>,
+    ) -> Result<Arc<Self>, String> {
+        let source = fetcher.source();
+        let (value, expires_at) = fetcher
+            .fetch()
+            .await
+            .map_err(|error| format!("initial {source} credential fetch failed: {error}"))?;
+        observer.refresh_succeeded(expires_at);
+        let cell = Arc::new(Self {
+            current: RwLock::new(Arc::new(value)),
+            expires_at: RwLock::new(expires_at),
+        });
+        spawn_refresh(Arc::downgrade(&cell), fetcher, policy, observer);
+        Ok(cell)
+    }
+
+    /// Expiry of the credentials currently installed, if the mechanism
+    /// reports one.
+    pub fn expires_at(&self) -> Option<SystemTime> {
+        *self.expires_at.read().unwrap()
+    }
+
+    fn snapshot(&self) -> Arc<F::Value> {
+        Arc::clone(&self.current.read().unwrap())
+    }
+
+    fn install(&self, value: F::Value, expires_at: Option<SystemTime>) {
+        *self.current.write().unwrap() = Arc::new(value);
+        *self.expires_at.write().unwrap() = expires_at;
+    }
+}
+
+impl<F> ProvideS3Credentials for RefreshingCredentials<F>
+where
+    F: CredentialsFetch<Value = S3Credentials>,
+{
+    fn current(&self) -> Arc<S3Credentials> {
+        self.snapshot()
+    }
+}
+
+impl<F> ProvideBearerToken for RefreshingCredentials<F>
+where
+    F: CredentialsFetch<Value = String>,
+{
+    fn current(&self) -> Option<Arc<String>> {
+        Some(self.snapshot())
+    }
+}
+
+fn spawn_refresh<F: CredentialsFetch>(
+    cell: Weak<RefreshingCredentials<F>>,
+    fetcher: F,
+    policy: RefreshPolicy,
+    observer: Arc<dyn CredentialsObserver>,
+) {
+    tokio::spawn(async move {
+        let source = fetcher.source();
+        let mut delay = {
+            let Some(cell) = cell.upgrade() else { return };
+            policy.next_delay(SystemTime::now(), cell.expires_at())
+        };
+        loop {
+            tokio::time::sleep(delay).await;
+            let Some(cell) = cell.upgrade() else { return };
+            match fetcher.fetch().await {
+                Ok((value, expires_at)) => {
+                    cell.install(value, expires_at);
+                    observer.refresh_succeeded(expires_at);
+                    tracing::info!(source, "origin credentials refreshed");
+                    delay = policy.next_delay(SystemTime::now(), expires_at);
+                }
+                Err(error) => {
+                    observer.refresh_failed();
+                    // Fetch errors never contain credential material, so the
+                    // reason is safe to log.
+                    tracing::warn!(
+                        source,
+                        %error,
+                        "origin credential refresh failed; retaining last credentials"
+                    );
+                    delay = policy.retry_interval;
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    struct ScriptedFetch {
+        calls: AtomicU32,
+        fail_from: u32,
+        lifetime: Duration,
+    }
+
+    #[async_trait]
+    impl CredentialsFetch for ScriptedFetch {
+        type Value = S3Credentials;
+
+        async fn fetch(&self) -> Result<(S3Credentials, Option<SystemTime>), String> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            if call >= self.fail_from {
+                return Err("issuer unavailable".into());
+            }
+            Ok((
+                S3Credentials {
+                    access_key_id: format!("AKID{call}"),
+                    secret_access_key: "secret".into(),
+                    session_token: Some(format!("token{call}")),
+                },
+                Some(SystemTime::now() + self.lifetime),
+            ))
+        }
+
+        fn source(&self) -> &'static str {
+            "scripted"
+        }
+    }
+
+    #[derive(Default)]
+    struct CountingObserver {
+        succeeded: AtomicU32,
+        failed: AtomicU32,
+    }
+
+    impl CredentialsObserver for CountingObserver {
+        fn refresh_succeeded(&self, _expires_at: Option<SystemTime>) {
+            self.succeeded.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn refresh_failed(&self) {
+            self.failed.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn fast_policy() -> RefreshPolicy {
+        RefreshPolicy {
+            margin_fraction: 0.5,
+            min_margin: Duration::from_millis(40),
+            max_margin: Duration::from_millis(40),
+            retry_interval: Duration::from_millis(10),
+            unknown_expiry_interval: Duration::from_millis(10),
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_replaces_snapshots_and_reports_expiry() {
+        let observer = Arc::new(CountingObserver::default());
+        let cell = RefreshingCredentials::bootstrap(
+            ScriptedFetch {
+                calls: AtomicU32::new(0),
+                fail_from: u32::MAX,
+                lifetime: Duration::from_millis(50),
+            },
+            fast_policy(),
+            Arc::clone(&observer) as Arc<dyn CredentialsObserver>,
+        )
+        .await
+        .unwrap();
+        assert_eq!(cell.current().access_key_id, "AKID0");
+        assert!(cell.expires_at().is_some());
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while cell.current().access_key_id == "AKID0" {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("credentials must rotate");
+        assert!(observer.succeeded.load(Ordering::SeqCst) >= 2);
+    }
+
+    #[tokio::test]
+    async fn failed_refresh_retains_last_credentials_and_counts() {
+        let observer = Arc::new(CountingObserver::default());
+        let cell = RefreshingCredentials::bootstrap(
+            ScriptedFetch {
+                calls: AtomicU32::new(0),
+                fail_from: 1,
+                lifetime: Duration::from_millis(30),
+            },
+            fast_policy(),
+            Arc::clone(&observer) as Arc<dyn CredentialsObserver>,
+        )
+        .await
+        .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while observer.failed.load(Ordering::SeqCst) < 2 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("failures must be observed");
+        // The last good snapshot survives every failed refresh.
+        assert_eq!(cell.current().access_key_id, "AKID0");
+        assert_eq!(cell.current().session_token.as_deref(), Some("token0"));
+    }
+
+    #[tokio::test]
+    async fn failed_initial_fetch_is_a_startup_error() {
+        let result = RefreshingCredentials::bootstrap(
+            ScriptedFetch {
+                calls: AtomicU32::new(0),
+                fail_from: 0,
+                lifetime: Duration::from_secs(1),
+            },
+            RefreshPolicy::default(),
+            Arc::new(NoopObserver),
+        )
+        .await;
+        let error = result.err().unwrap();
+        assert!(error.contains("scripted"));
+        assert!(!error.contains("AKID"));
+    }
+
+    #[tokio::test]
+    async fn refresh_loop_exits_when_the_cell_is_dropped() {
+        let observer = Arc::new(CountingObserver::default());
+        let cell = RefreshingCredentials::bootstrap(
+            ScriptedFetch {
+                calls: AtomicU32::new(0),
+                fail_from: u32::MAX,
+                lifetime: Duration::from_millis(20),
+            },
+            fast_policy(),
+            Arc::clone(&observer) as Arc<dyn CredentialsObserver>,
+        )
+        .await
+        .unwrap();
+        drop(cell);
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let after_drop = observer.succeeded.load(Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        // At most one in-flight refresh lands after the drop; the loop must
+        // then stop fetching.
+        assert!(observer.succeeded.load(Ordering::SeqCst) <= after_drop + 1);
+    }
+
+    #[test]
+    fn margins_are_clamped_and_never_zero() {
+        let policy = RefreshPolicy::default();
+        let now = SystemTime::now();
+        // 1h lifetime: 20% margin = 12min, clamped nothing → refresh ~48min.
+        let delay = policy.next_delay(now, Some(now + Duration::from_secs(3600)));
+        assert!(delay > Duration::from_secs(40 * 60) && delay < Duration::from_secs(50 * 60));
+        // Expired credential still backs off by the retry interval.
+        assert_eq!(
+            policy.next_delay(now, Some(now - Duration::from_secs(5))),
+            policy.retry_interval
+        );
+        // No expiry → periodic refresh.
+        assert_eq!(policy.next_delay(now, None), policy.unknown_expiry_interval);
+    }
+
+    #[test]
+    fn static_providers_hand_out_the_same_material() {
+        let creds = StaticS3Credentials::new(S3Credentials {
+            access_key_id: "AKID".into(),
+            secret_access_key: "secret".into(),
+            session_token: None,
+        });
+        assert_eq!(creds.current().access_key_id, "AKID");
+        assert!(StaticBearerToken::new(None).current().is_none());
+        assert_eq!(
+            StaticBearerToken::new(Some("tok".into()))
+                .current()
+                .unwrap()
+                .as_str(),
+            "tok"
+        );
+    }
+}

--- a/crates/talon-backend/src/gcs.rs
+++ b/crates/talon-backend/src/gcs.rs
@@ -68,17 +68,31 @@ impl GcsConfig {
 /// A GCS `BackendStore` over a pluggable HTTP client.
 pub struct GcsBackend {
     config: GcsConfig,
-    /// OAuth2 bearer token (short-lived; refreshed by the caller).
-    bearer_token: Option<String>,
+    /// OAuth2 bearer token source (fixed, or workload-identity refreshed).
+    bearer: Arc<dyn crate::credentials::ProvideBearerToken>,
     http: Arc<dyn HttpClient>,
 }
 
 impl GcsBackend {
-    /// Construct a backend from config, an optional bearer token, and a client.
+    /// Construct a backend from config, an optional fixed bearer token, and a
+    /// client.
     pub fn new(config: GcsConfig, bearer_token: Option<String>, http: Arc<dyn HttpClient>) -> Self {
+        Self::with_bearer_provider(
+            config,
+            Arc::new(crate::credentials::StaticBearerToken::new(bearer_token)),
+            http,
+        )
+    }
+
+    /// Construct a backend whose bearer token comes from a snapshot provider.
+    pub fn with_bearer_provider(
+        config: GcsConfig,
+        bearer: Arc<dyn crate::credentials::ProvideBearerToken>,
+        http: Arc<dyn HttpClient>,
+    ) -> Self {
         Self {
             config,
-            bearer_token,
+            bearer,
             http,
         }
     }
@@ -168,7 +182,7 @@ impl GcsBackend {
     }
 
     fn auth_headers(&self) -> Vec<(String, String)> {
-        match &self.bearer_token {
+        match self.bearer.current() {
             Some(t) => vec![("Authorization".to_string(), format!("Bearer {t}"))],
             None => Vec::new(),
         }

--- a/crates/talon-backend/src/lib.rs
+++ b/crates/talon-backend/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod azure;
 pub mod azure_sharedkey;
+pub mod credentials;
 pub mod delay;
 pub mod gcs;
 pub mod http;
@@ -16,9 +17,14 @@ pub mod reqwest_client;
 pub mod retry;
 pub mod s3;
 pub mod sigv4;
+pub mod workload_identity;
 pub mod xml;
 
 pub use azure::{AzureBackend, AzureConfig};
+pub use credentials::{
+    CredentialsFetch, CredentialsObserver, NoopObserver, ProvideBearerToken, ProvideS3Credentials,
+    RefreshPolicy, RefreshingCredentials, StaticBearerToken, StaticS3Credentials,
+};
 pub use delay::{DelayConfig, DelayingHttpClient};
 pub use gcs::{GcsBackend, GcsConfig};
 pub use http::{
@@ -29,3 +35,7 @@ pub use reqwest_client::ReqwestClient;
 pub use retry::{RetryConfig, RetryObserver, RetryingHttpClient};
 pub use s3::{S3Backend, S3Config, S3Credentials, S3MultipartRequest};
 pub use sigv4::{sign_request, AmzDate};
+pub use workload_identity::{
+    resolve_azure_bearer, resolve_gcs_bearer, resolve_s3_credentials, ResolvedBearerToken,
+    ResolvedS3Credentials,
+};

--- a/crates/talon-backend/src/s3.rs
+++ b/crates/talon-backend/src/s3.rs
@@ -100,16 +100,30 @@ pub struct S3Credentials {
 /// An S3 `BackendStore` over a pluggable HTTP client.
 pub struct S3Backend {
     config: S3Config,
-    creds: S3Credentials,
+    credentials: Arc<dyn crate::credentials::ProvideS3Credentials>,
     http: Arc<dyn HttpClient>,
 }
 
 impl S3Backend {
-    /// Construct a backend from config, credentials, and an HTTP client.
+    /// Construct a backend from config, fixed credentials, and an HTTP client.
     pub fn new(config: S3Config, creds: S3Credentials, http: Arc<dyn HttpClient>) -> Self {
+        Self::with_credentials_provider(
+            config,
+            Arc::new(crate::credentials::StaticS3Credentials::new(creds)),
+            http,
+        )
+    }
+
+    /// Construct a backend whose credentials come from a snapshot provider
+    /// (static or background-refreshed workload identity).
+    pub fn with_credentials_provider(
+        config: S3Config,
+        credentials: Arc<dyn crate::credentials::ProvideS3Credentials>,
+        http: Arc<dyn HttpClient>,
+    ) -> Self {
         Self {
             config,
-            creds,
+            credentials,
             http,
         }
     }
@@ -207,7 +221,7 @@ impl S3Backend {
         if_match: Option<&Version>,
     ) -> HttpRequest {
         let mut headers = vec![("Range".to_string(), Self::range_header(offset, len))];
-        if let Some(tok) = &self.creds.session_token {
+        if let Some(tok) = &self.credentials.current().session_token {
             headers.push(("x-amz-security-token".to_string(), tok.clone()));
         }
         if let Some(version) = if_match {
@@ -225,7 +239,7 @@ impl S3Backend {
     /// Build the HEAD request for a stat (exposed for testing).
     pub fn build_head(&self, obj: &ObjectId) -> HttpRequest {
         let mut headers = Vec::new();
-        if let Some(tok) = &self.creds.session_token {
+        if let Some(tok) = &self.credentials.current().session_token {
             headers.push(("x-amz-security-token".to_string(), tok.clone()));
         }
         HttpRequest {
@@ -247,7 +261,7 @@ impl S3Backend {
         if_match: Option<&Version>,
     ) -> HttpRequest {
         let mut headers = vec![("Content-Length".to_string(), body.len().to_string())];
-        if let Some(tok) = &self.creds.session_token {
+        if let Some(tok) = &self.credentials.current().session_token {
             headers.push(("x-amz-security-token".to_string(), tok.clone()));
         }
         if let Some(version) = if_match {
@@ -264,7 +278,7 @@ impl S3Backend {
     /// Build the DELETE request (exposed for testing).
     pub fn build_delete(&self, obj: &ObjectId) -> HttpRequest {
         let mut headers = Vec::new();
-        if let Some(tok) = &self.creds.session_token {
+        if let Some(tok) = &self.credentials.current().session_token {
             headers.push(("x-amz-security-token".to_string(), tok.clone()));
         }
         HttpRequest {
@@ -277,17 +291,24 @@ impl S3Backend {
 
     /// Sign `req` with AWS SigV4 for this backend's region, stamping the current
     /// wall-clock time. Called on every request just before it is executed.
+    ///
+    /// The credential snapshot is taken here, and `sign_request` re-stamps the
+    /// session-token header from the same snapshot it signs with, so a
+    /// concurrent refresh can never pair one snapshot's token with another's
+    /// signature.
     fn signed(&self, mut req: HttpRequest) -> HttpRequest {
         let date = crate::sigv4::AmzDate::from_system_time(std::time::SystemTime::now());
-        crate::sigv4::sign_request(&mut req, &self.creds, &self.config.region, "s3", &date);
+        let creds = self.credentials.current();
+        crate::sigv4::sign_request(&mut req, &creds, &self.config.region, "s3", &date);
         req
     }
 
     fn signed_with_payload_hash(&self, mut req: HttpRequest, payload_hash: &str) -> HttpRequest {
         let date = crate::sigv4::AmzDate::from_system_time(std::time::SystemTime::now());
+        let creds = self.credentials.current();
         crate::sigv4::sign_request_with_payload_hash(
             &mut req,
-            &self.creds,
+            &creds,
             &self.config.region,
             "s3",
             &date,
@@ -297,7 +318,8 @@ impl S3Backend {
     }
 
     fn session_headers(&self) -> Vec<(String, String)> {
-        self.creds
+        self.credentials
+            .current()
             .session_token
             .as_ref()
             .map(|token| vec![("x-amz-security-token".to_string(), token.clone())])

--- a/crates/talon-backend/src/sigv4.rs
+++ b/crates/talon-backend/src/sigv4.rs
@@ -164,7 +164,7 @@ impl AmzDate {
 }
 
 /// Days since 1970-01-01 → civil (year, month, day). Howard Hinnant's algorithm.
-fn civil_from_days(z: i64) -> (i64, u32, u32) {
+pub(crate) fn civil_from_days(z: i64) -> (i64, u32, u32) {
     let z = z + 719_468;
     let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
     let doe = (z - era * 146_097) as u64; // [0, 146096]

--- a/crates/talon-backend/src/workload_identity.rs
+++ b/crates/talon-backend/src/workload_identity.rs
@@ -1,0 +1,1242 @@
+//! Cloud workload-identity credential acquisition.
+//!
+//! Each cloud's Kubernetes platform hands a pod an identity instead of a
+//! static key: EKS IRSA and its analogues inject a token file plus role
+//! coordinates through env variables, and GKE/CCE expose a metadata endpoint.
+//! The fetchers here exchange that platform identity for short-lived object
+//! store credentials using plain HTTP against documented endpoints — no cloud
+//! SDKs — so every exchange is offline-testable through [`HttpClient`].
+//!
+//! Verification status: the AWS contract is confirmed against a live EKS
+//! deployment; Aliyun, Tencent, and Huawei mirror the contracts used by the
+//! Milvus object-storage providers and remain to be validated against live
+//! clusters. Fetch errors carry the HTTP status and a bounded provider error
+//! code, never token or key material.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+
+use crate::credentials::{
+    CredentialsFetch, CredentialsObserver, ProvideBearerToken, ProvideS3Credentials, RefreshPolicy,
+    RefreshingCredentials, StaticBearerToken, StaticS3Credentials,
+};
+use crate::http::{HttpClient, HttpRequest, Method};
+use crate::s3::S3Credentials;
+
+/// Environment lookup used by source resolution, injectable for tests.
+pub type EnvFn<'a> = &'a dyn Fn(&str) -> Option<String>;
+
+fn env_var(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+fn read_token(path: &PathBuf) -> Result<String, String> {
+    std::fs::read_to_string(path)
+        .map(|token| token.trim().to_string())
+        .map_err(|error| format!("identity token file is unreadable: {error}"))
+}
+
+fn form_body(pairs: &[(&str, &str)]) -> String {
+    let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+    for (name, value) in pairs {
+        serializer.append_pair(name, value);
+    }
+    serializer.finish()
+}
+
+fn json_body(body: &[u8]) -> Result<serde_json::Value, String> {
+    serde_json::from_slice(body).map_err(|_| "response is not valid JSON".to_string())
+}
+
+/// Bounded provider error identifier from a JSON error body, if present.
+fn json_error_code(body: &[u8], pointers: &[&str]) -> Option<String> {
+    let value = serde_json::from_slice::<serde_json::Value>(body).ok()?;
+    pointers
+        .iter()
+        .find_map(|pointer| value.pointer(pointer))
+        .and_then(|code| code.as_str())
+        .map(|code| code.chars().take(64).collect())
+}
+
+fn exchange_error(mechanism: &str, status: u16, code: Option<String>) -> String {
+    match code {
+        Some(code) => format!("{mechanism} exchange returned status {status} ({code})"),
+        None => format!("{mechanism} exchange returned status {status}"),
+    }
+}
+
+// --- UTC calendar helpers -----------------------------------------------
+
+/// Civil (year, month, day) → days since 1970-01-01. Howard Hinnant's
+/// algorithm, the inverse of `sigv4::civil_from_days`.
+fn days_from_civil(y: i64, m: u32, d: u32) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = (y - era * 400) as u64;
+    let mp = ((m as u64) + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + (d as u64) - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146_097 + doe as i64 - 719_468
+}
+
+/// Parse `YYYY-MM-DDTHH:MM:SS[.fraction](Z|+00:00)` into a [`SystemTime`].
+///
+/// This is the only timestamp shape the exchanges emit; fractional seconds
+/// are truncated. Anything else yields `None` and the caller treats the
+/// expiry as unknown rather than failing the exchange.
+pub(crate) fn parse_iso8601_utc(text: &str) -> Option<SystemTime> {
+    let text = text.trim();
+    let digits = |range: std::ops::Range<usize>| -> Option<i64> {
+        let slice = text.get(range)?;
+        if slice.bytes().all(|byte| byte.is_ascii_digit()) {
+            slice.parse().ok()
+        } else {
+            None
+        }
+    };
+    if text.len() < 20 || text.get(4..5)? != "-" || text.get(7..8)? != "-" {
+        return None;
+    }
+    let time_separator = text.get(10..11)?;
+    if time_separator != "T" || text.get(13..14)? != ":" || text.get(16..17)? != ":" {
+        return None;
+    }
+    let tail = text.get(19..)?;
+    if !(tail == "Z" || tail == "+00:00" || (tail.starts_with('.') && tail.ends_with('Z'))) {
+        return None;
+    }
+    let (year, month, day) = (digits(0..4)?, digits(5..7)?, digits(8..10)?);
+    let (hour, minute, second) = (digits(11..13)?, digits(14..16)?, digits(17..19)?);
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+        return None;
+    }
+    if hour > 23 || minute > 59 || second > 60 {
+        return None;
+    }
+    let days = days_from_civil(year, month as u32, day as u32);
+    let seconds = days
+        .checked_mul(86_400)?
+        .checked_add(hour * 3600 + minute * 60 + second)?;
+    u64::try_from(seconds)
+        .ok()
+        .map(|seconds| UNIX_EPOCH + Duration::from_secs(seconds))
+}
+
+/// Format a [`SystemTime`] as `YYYY-MM-DDTHH:MM:SSZ` (Aliyun's `Timestamp`
+/// common parameter).
+fn format_iso8601_utc(time: SystemTime) -> String {
+    let seconds = time
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let (year, month, day) = crate::sigv4::civil_from_days((seconds / 86_400) as i64);
+    let second_of_day = seconds % 86_400;
+    format!(
+        "{year:04}-{month:02}-{day:02}T{:02}:{:02}:{:02}Z",
+        second_of_day / 3600,
+        (second_of_day % 3600) / 60,
+        second_of_day % 60
+    )
+}
+
+fn expires_in_seconds(now: SystemTime, seconds: u64) -> SystemTime {
+    now + Duration::from_secs(seconds)
+}
+
+static NONCE: AtomicU64 = AtomicU64::new(0);
+
+fn signature_nonce() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("talon-{nanos}-{}", NONCE.fetch_add(1, Ordering::Relaxed))
+}
+
+// --- AWS ------------------------------------------------------------------
+
+/// EKS IRSA: exchange the projected service-account token for temporary
+/// credentials through `sts:AssumeRoleWithWebIdentity` (plain form POST,
+/// unsigned, XML response).
+pub struct AwsWebIdentity {
+    role_arn: String,
+    token_file: PathBuf,
+    session_name: String,
+    endpoint: String,
+    http: Arc<dyn HttpClient>,
+}
+
+impl AwsWebIdentity {
+    /// Build from the env contract the EKS pod-identity webhook injects.
+    /// Returns `None` when the contract is absent.
+    pub fn from_env(env: EnvFn<'_>, http: Arc<dyn HttpClient>) -> Option<Self> {
+        let role_arn = env("AWS_ROLE_ARN")?;
+        let token_file = PathBuf::from(env("AWS_WEB_IDENTITY_TOKEN_FILE")?);
+        let region = env("AWS_REGION").or_else(|| env("AWS_DEFAULT_REGION"));
+        // `regional` is what EKS injects; only an explicit `legacy` (or a
+        // missing region) falls back to the global endpoint.
+        let endpoint = match (region, env("AWS_STS_REGIONAL_ENDPOINTS").as_deref()) {
+            (Some(region), mode) if mode != Some("legacy") => {
+                format!("https://sts.{region}.amazonaws.com")
+            }
+            _ => "https://sts.amazonaws.com".to_string(),
+        };
+        Some(Self {
+            role_arn,
+            token_file,
+            session_name: env("AWS_ROLE_SESSION_NAME").unwrap_or_else(|| "talon".to_string()),
+            endpoint,
+            http,
+        })
+    }
+}
+
+#[async_trait]
+impl CredentialsFetch for AwsWebIdentity {
+    type Value = S3Credentials;
+
+    async fn fetch(&self) -> Result<(S3Credentials, Option<SystemTime>), String> {
+        let token = read_token(&self.token_file)?;
+        let body = form_body(&[
+            ("Action", "AssumeRoleWithWebIdentity"),
+            ("Version", "2011-06-15"),
+            ("RoleArn", &self.role_arn),
+            ("RoleSessionName", &self.session_name),
+            ("WebIdentityToken", &token),
+            ("DurationSeconds", "3600"),
+        ]);
+        let request = HttpRequest::with_body(
+            Method::Post,
+            self.endpoint.clone(),
+            vec![(
+                "content-type".to_string(),
+                "application/x-www-form-urlencoded".to_string(),
+            )],
+            bytes::Bytes::from(body),
+        );
+        let response = self.http.execute(request).await?;
+        let text = String::from_utf8_lossy(&response.body);
+        if !response.is_success() {
+            let code = crate::xml::element(&text, "Code").map(|code| code.to_string());
+            return Err(exchange_error(self.source(), response.status, code));
+        }
+        let field = |tag: &str| {
+            crate::xml::element(&text, tag)
+                .map(crate::xml::unescape)
+                .ok_or_else(|| format!("STS response is missing <{tag}>"))
+        };
+        let credentials = S3Credentials {
+            access_key_id: field("AccessKeyId")?,
+            secret_access_key: field("SecretAccessKey")?,
+            session_token: Some(field("SessionToken")?),
+        };
+        let expires_at = field("Expiration").ok().and_then(|t| parse_iso8601_utc(&t));
+        Ok((credentials, expires_at))
+    }
+
+    fn source(&self) -> &'static str {
+        "aws-web-identity"
+    }
+}
+
+// --- Aliyun -----------------------------------------------------------------
+
+/// ACK RRSA: `sts:AssumeRoleWithOIDC` (anonymous RPC-style form POST, JSON
+/// response).
+pub struct AliyunOidc {
+    role_arn: String,
+    provider_arn: String,
+    token_file: PathBuf,
+    session_name: String,
+    endpoint: String,
+    http: Arc<dyn HttpClient>,
+}
+
+impl AliyunOidc {
+    /// Build from the env contract the ACK RRSA webhook injects.
+    pub fn from_env(env: EnvFn<'_>, http: Arc<dyn HttpClient>) -> Option<Self> {
+        Some(Self {
+            role_arn: env("ALIBABA_CLOUD_ROLE_ARN")?,
+            provider_arn: env("ALIBABA_CLOUD_OIDC_PROVIDER_ARN")?,
+            token_file: PathBuf::from(env("ALIBABA_CLOUD_OIDC_TOKEN_FILE")?),
+            session_name: env("ALIBABA_CLOUD_ROLE_SESSION_NAME")
+                .unwrap_or_else(|| "talon".to_string()),
+            endpoint: env("ALIBABA_CLOUD_STS_ENDPOINT")
+                .map(|host| format!("https://{}", host.trim_start_matches("https://")))
+                .unwrap_or_else(|| "https://sts.aliyuncs.com".to_string()),
+            http,
+        })
+    }
+}
+
+#[async_trait]
+impl CredentialsFetch for AliyunOidc {
+    type Value = S3Credentials;
+
+    async fn fetch(&self) -> Result<(S3Credentials, Option<SystemTime>), String> {
+        let token = read_token(&self.token_file)?;
+        let timestamp = format_iso8601_utc(SystemTime::now());
+        let nonce = signature_nonce();
+        let body = form_body(&[
+            ("Action", "AssumeRoleWithOIDC"),
+            ("Version", "2015-04-01"),
+            ("Format", "JSON"),
+            ("Timestamp", &timestamp),
+            ("SignatureNonce", &nonce),
+            ("RoleArn", &self.role_arn),
+            ("OIDCProviderArn", &self.provider_arn),
+            ("OIDCToken", &token),
+            ("RoleSessionName", &self.session_name),
+            ("DurationSeconds", "3600"),
+        ]);
+        let request = HttpRequest::with_body(
+            Method::Post,
+            self.endpoint.clone(),
+            vec![(
+                "content-type".to_string(),
+                "application/x-www-form-urlencoded".to_string(),
+            )],
+            bytes::Bytes::from(body),
+        );
+        let response = self.http.execute(request).await?;
+        if !response.is_success() {
+            let code = json_error_code(&response.body, &["/Code"]);
+            return Err(exchange_error(self.source(), response.status, code));
+        }
+        let value = json_body(&response.body)?;
+        let credential = value
+            .pointer("/Credentials")
+            .ok_or("STS response is missing Credentials")?;
+        let field = |name: &str| {
+            credential
+                .pointer(&format!("/{name}"))
+                .and_then(|field| field.as_str())
+                .map(str::to_string)
+                .ok_or_else(|| format!("STS response is missing Credentials.{name}"))
+        };
+        let credentials = S3Credentials {
+            access_key_id: field("AccessKeyId")?,
+            secret_access_key: field("AccessKeySecret")?,
+            session_token: Some(field("SecurityToken")?),
+        };
+        let expires_at = field("Expiration").ok().and_then(|t| parse_iso8601_utc(&t));
+        Ok((credentials, expires_at))
+    }
+
+    fn source(&self) -> &'static str {
+        "aliyun-oidc"
+    }
+}
+
+// --- Tencent ----------------------------------------------------------------
+
+/// TKE OIDC: `sts:AssumeRoleWithWebIdentity` (signature-exempt JSON POST with
+/// `Authorization: SKIP`, mirroring the Tencent SDK's TKE provider).
+pub struct TencentOidc {
+    role_arn: String,
+    provider_id: String,
+    token_file: PathBuf,
+    session_name: String,
+    region: String,
+    endpoint: String,
+    http: Arc<dyn HttpClient>,
+}
+
+impl TencentOidc {
+    /// Build from the env contract the TKE OIDC webhook injects.
+    pub fn from_env(env: EnvFn<'_>, http: Arc<dyn HttpClient>) -> Option<Self> {
+        Some(Self {
+            role_arn: env("TKE_ROLE_ARN")?,
+            provider_id: env("TKE_PROVIDER_ID")?,
+            token_file: PathBuf::from(env("TKE_WEB_IDENTITY_TOKEN_FILE")?),
+            session_name: env("TKE_ROLE_SESSION_NAME").unwrap_or_else(|| "talon".to_string()),
+            region: env("TKE_REGION")
+                .or_else(|| env("TENCENTCLOUD_REGION"))
+                .unwrap_or_else(|| "ap-guangzhou".to_string()),
+            endpoint: env("TENCENTCLOUD_STS_ENDPOINT")
+                .map(|host| format!("https://{}", host.trim_start_matches("https://")))
+                .unwrap_or_else(|| "https://sts.tencentcloudapi.com".to_string()),
+            http,
+        })
+    }
+}
+
+#[async_trait]
+impl CredentialsFetch for TencentOidc {
+    type Value = S3Credentials;
+
+    async fn fetch(&self) -> Result<(S3Credentials, Option<SystemTime>), String> {
+        let token = read_token(&self.token_file)?;
+        let unix_now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let body = serde_json::json!({
+            "ProviderId": self.provider_id,
+            "WebIdentityToken": token,
+            "RoleArn": self.role_arn,
+            "RoleSessionName": self.session_name,
+            "DurationSeconds": 3600,
+        });
+        let request = HttpRequest::with_body(
+            Method::Post,
+            self.endpoint.clone(),
+            vec![
+                ("content-type".to_string(), "application/json".to_string()),
+                ("authorization".to_string(), "SKIP".to_string()),
+                (
+                    "x-tc-action".to_string(),
+                    "AssumeRoleWithWebIdentity".to_string(),
+                ),
+                ("x-tc-version".to_string(), "2018-08-13".to_string()),
+                ("x-tc-timestamp".to_string(), unix_now.to_string()),
+                ("x-tc-region".to_string(), self.region.clone()),
+            ],
+            bytes::Bytes::from(body.to_string()),
+        );
+        let response = self.http.execute(request).await?;
+        if !response.is_success() {
+            let code = json_error_code(&response.body, &["/Response/Error/Code"]);
+            return Err(exchange_error(self.source(), response.status, code));
+        }
+        let value = json_body(&response.body)?;
+        if let Some(code) = value
+            .pointer("/Response/Error/Code")
+            .and_then(|code| code.as_str())
+        {
+            return Err(exchange_error(
+                self.source(),
+                response.status,
+                Some(code.chars().take(64).collect()),
+            ));
+        }
+        let field = |name: &str| {
+            value
+                .pointer(&format!("/Response/Credentials/{name}"))
+                .and_then(|field| field.as_str())
+                .map(str::to_string)
+                .ok_or_else(|| format!("STS response is missing Credentials.{name}"))
+        };
+        let credentials = S3Credentials {
+            access_key_id: field("TmpSecretId")?,
+            secret_access_key: field("TmpSecretKey")?,
+            session_token: Some(field("Token")?),
+        };
+        let expires_at = value
+            .pointer("/Response/ExpiredTime")
+            .and_then(|time| time.as_u64())
+            .map(|seconds| UNIX_EPOCH + Duration::from_secs(seconds));
+        Ok((credentials, expires_at))
+    }
+
+    fn source(&self) -> &'static str {
+        "tencent-oidc"
+    }
+}
+
+// --- Huawei -----------------------------------------------------------------
+
+/// CCE agency: the node metadata service hands out temporary credentials for
+/// the bound agency directly (`/openstack/latest/securitykey`).
+pub struct HuaweiAgency {
+    endpoint: String,
+    http: Arc<dyn HttpClient>,
+}
+
+impl HuaweiAgency {
+    /// Build against the standard metadata endpoint, honoring an override
+    /// for tests and emulators.
+    pub fn from_env(env: EnvFn<'_>, http: Arc<dyn HttpClient>) -> Self {
+        Self {
+            endpoint: env("HUAWEICLOUD_METADATA_ENDPOINT")
+                .unwrap_or_else(|| "http://169.254.169.254".to_string()),
+            http,
+        }
+    }
+}
+
+#[async_trait]
+impl CredentialsFetch for HuaweiAgency {
+    type Value = S3Credentials;
+
+    async fn fetch(&self) -> Result<(S3Credentials, Option<SystemTime>), String> {
+        let request = HttpRequest::new(
+            Method::Get,
+            format!("{}/openstack/latest/securitykey", self.endpoint),
+            Vec::new(),
+        );
+        let response = self.http.execute(request).await?;
+        if !response.is_success() {
+            return Err(exchange_error(self.source(), response.status, None));
+        }
+        let value = json_body(&response.body)?;
+        let field = |name: &str| {
+            value
+                .pointer(&format!("/credential/{name}"))
+                .and_then(|field| field.as_str())
+                .map(str::to_string)
+                .ok_or_else(|| format!("metadata response is missing credential.{name}"))
+        };
+        let credentials = S3Credentials {
+            access_key_id: field("access")?,
+            secret_access_key: field("secret")?,
+            session_token: Some(field("securitytoken")?),
+        };
+        let expires_at = field("expires_at").ok().and_then(|t| parse_iso8601_utc(&t));
+        Ok((credentials, expires_at))
+    }
+
+    fn source(&self) -> &'static str {
+        "huawei-agency"
+    }
+}
+
+// --- GCP ----------------------------------------------------------------------
+
+/// GKE Workload Identity: the metadata server mints OAuth2 access tokens for
+/// the pod's bound service account; GCS accepts them as `Bearer`.
+pub struct GcpMetadataToken {
+    endpoint: String,
+    http: Arc<dyn HttpClient>,
+}
+
+impl GcpMetadataToken {
+    /// Build against the GKE metadata server, honoring the standard
+    /// `GCE_METADATA_HOST` override.
+    pub fn from_env(env: EnvFn<'_>, http: Arc<dyn HttpClient>) -> Self {
+        let host =
+            env("GCE_METADATA_HOST").unwrap_or_else(|| "metadata.google.internal".to_string());
+        Self {
+            endpoint: format!(
+                "http://{host}/computeMetadata/v1/instance/service-accounts/default/token"
+            ),
+            http,
+        }
+    }
+}
+
+#[async_trait]
+impl CredentialsFetch for GcpMetadataToken {
+    type Value = String;
+
+    async fn fetch(&self) -> Result<(String, Option<SystemTime>), String> {
+        let request = HttpRequest::new(
+            Method::Get,
+            self.endpoint.clone(),
+            vec![("metadata-flavor".to_string(), "Google".to_string())],
+        );
+        let response = self.http.execute(request).await?;
+        if !response.is_success() {
+            return Err(exchange_error(self.source(), response.status, None));
+        }
+        let value = json_body(&response.body)?;
+        let token = value
+            .pointer("/access_token")
+            .and_then(|token| token.as_str())
+            .ok_or("metadata response is missing access_token")?
+            .to_string();
+        let expires_at = value
+            .pointer("/expires_in")
+            .and_then(|seconds| seconds.as_u64())
+            .map(|seconds| expires_in_seconds(SystemTime::now(), seconds));
+        Ok((token, expires_at))
+    }
+
+    fn source(&self) -> &'static str {
+        "gcp-metadata"
+    }
+}
+
+// --- Azure ----------------------------------------------------------------------
+
+/// AKS Workload Identity: exchange the projected federated token for an
+/// Azure AD access token scoped to Azure Storage.
+pub struct AzureWorkloadIdentity {
+    client_id: String,
+    token_url: String,
+    token_file: PathBuf,
+    http: Arc<dyn HttpClient>,
+}
+
+impl AzureWorkloadIdentity {
+    /// Build from the env contract the AKS workload-identity webhook injects.
+    pub fn from_env(env: EnvFn<'_>, http: Arc<dyn HttpClient>) -> Option<Self> {
+        let tenant = env("AZURE_TENANT_ID")?;
+        let authority = env("AZURE_AUTHORITY_HOST")
+            .unwrap_or_else(|| "https://login.microsoftonline.com/".to_string());
+        Some(Self {
+            client_id: env("AZURE_CLIENT_ID")?,
+            token_file: PathBuf::from(env("AZURE_FEDERATED_TOKEN_FILE")?),
+            token_url: format!(
+                "{}/{tenant}/oauth2/v2.0/token",
+                authority.trim_end_matches('/')
+            ),
+            http,
+        })
+    }
+}
+
+#[async_trait]
+impl CredentialsFetch for AzureWorkloadIdentity {
+    type Value = String;
+
+    async fn fetch(&self) -> Result<(String, Option<SystemTime>), String> {
+        let assertion = read_token(&self.token_file)?;
+        let body = form_body(&[
+            ("client_id", &self.client_id),
+            ("grant_type", "client_credentials"),
+            ("scope", "https://storage.azure.com/.default"),
+            (
+                "client_assertion_type",
+                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            ),
+            ("client_assertion", &assertion),
+        ]);
+        let request = HttpRequest::with_body(
+            Method::Post,
+            self.token_url.clone(),
+            vec![(
+                "content-type".to_string(),
+                "application/x-www-form-urlencoded".to_string(),
+            )],
+            bytes::Bytes::from(body),
+        );
+        let response = self.http.execute(request).await?;
+        if !response.is_success() {
+            let code = json_error_code(&response.body, &["/error"]);
+            return Err(exchange_error(self.source(), response.status, code));
+        }
+        let value = json_body(&response.body)?;
+        let token = value
+            .pointer("/access_token")
+            .and_then(|token| token.as_str())
+            .ok_or("token response is missing access_token")?
+            .to_string();
+        let expires_at = value
+            .pointer("/expires_in")
+            .and_then(|seconds| seconds.as_u64())
+            .map(|seconds| expires_in_seconds(SystemTime::now(), seconds));
+        Ok((token, expires_at))
+    }
+
+    fn source(&self) -> &'static str {
+        "azure-workload-identity"
+    }
+}
+
+// --- Source resolution ----------------------------------------------------------
+
+/// A resolved provider plus the bounded source label for startup logs.
+pub struct ResolvedS3Credentials {
+    /// Snapshot source installed into the backend.
+    pub provider: Arc<dyn ProvideS3Credentials>,
+    /// Which mechanism produced it (`static`, `aws-web-identity`, ...).
+    pub source: &'static str,
+}
+
+/// A resolved bearer-token provider plus its source label.
+pub struct ResolvedBearerToken {
+    /// Snapshot source installed into the backend.
+    pub provider: Arc<dyn ProvideBearerToken>,
+    /// Which mechanism produced it.
+    pub source: &'static str,
+}
+
+/// Resolve the S3-family credential source from explicit static material, an
+/// optional explicit selector, and the process environment.
+///
+/// Static credentials always win so existing deployments keep their exact
+/// behavior. With `selector` unset (`auto`), the env contracts injected by
+/// EKS IRSA, ACK RRSA, and TKE OIDC are detected in that order; the Huawei
+/// metadata agency has no env marker and must be selected explicitly.
+pub async fn resolve_s3_credentials(
+    static_credentials: Option<S3Credentials>,
+    selector: Option<&str>,
+    http: Arc<dyn HttpClient>,
+    observer: Arc<dyn CredentialsObserver>,
+) -> Result<ResolvedS3Credentials, String> {
+    resolve_s3_credentials_with_env(&env_var, static_credentials, selector, http, observer).await
+}
+
+/// [`resolve_s3_credentials`] with an injectable environment, for tests.
+pub async fn resolve_s3_credentials_with_env(
+    env: EnvFn<'_>,
+    static_credentials: Option<S3Credentials>,
+    selector: Option<&str>,
+    http: Arc<dyn HttpClient>,
+    observer: Arc<dyn CredentialsObserver>,
+) -> Result<ResolvedS3Credentials, String> {
+    let selector = selector.unwrap_or("auto");
+    let policy = RefreshPolicy::default();
+    let missing =
+        |what: &str| format!("credentials source {selector} requires {what} in the environment");
+    match selector {
+        "static" => {
+            let credentials =
+                static_credentials.ok_or("static origin credentials are not configured")?;
+            Ok(ResolvedS3Credentials {
+                provider: Arc::new(StaticS3Credentials::new(credentials)),
+                source: "static",
+            })
+        }
+        "aws-web-identity" => {
+            let fetcher = AwsWebIdentity::from_env(env, http)
+                .ok_or_else(|| missing("AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE"))?;
+            let source = fetcher.source();
+            let cell = RefreshingCredentials::bootstrap(fetcher, policy, observer).await?;
+            Ok(ResolvedS3Credentials {
+                provider: cell,
+                source,
+            })
+        }
+        "aliyun-oidc" => {
+            let fetcher = AliyunOidc::from_env(env, http).ok_or_else(|| {
+                missing("ALIBABA_CLOUD_ROLE_ARN, ALIBABA_CLOUD_OIDC_PROVIDER_ARN, and ALIBABA_CLOUD_OIDC_TOKEN_FILE")
+            })?;
+            let source = fetcher.source();
+            let cell = RefreshingCredentials::bootstrap(fetcher, policy, observer).await?;
+            Ok(ResolvedS3Credentials {
+                provider: cell,
+                source,
+            })
+        }
+        "tencent-oidc" => {
+            let fetcher = TencentOidc::from_env(env, http).ok_or_else(|| {
+                missing("TKE_ROLE_ARN, TKE_PROVIDER_ID, and TKE_WEB_IDENTITY_TOKEN_FILE")
+            })?;
+            let source = fetcher.source();
+            let cell = RefreshingCredentials::bootstrap(fetcher, policy, observer).await?;
+            Ok(ResolvedS3Credentials {
+                provider: cell,
+                source,
+            })
+        }
+        "huawei-agency" => {
+            let fetcher = HuaweiAgency::from_env(env, http);
+            let source = fetcher.source();
+            let cell = RefreshingCredentials::bootstrap(fetcher, policy, observer).await?;
+            Ok(ResolvedS3Credentials {
+                provider: cell,
+                source,
+            })
+        }
+        "auto" => {
+            if let Some(credentials) = static_credentials {
+                return Ok(ResolvedS3Credentials {
+                    provider: Arc::new(StaticS3Credentials::new(credentials)),
+                    source: "static",
+                });
+            }
+            if let Some(fetcher) = AwsWebIdentity::from_env(env, Arc::clone(&http)) {
+                let source = fetcher.source();
+                let cell = RefreshingCredentials::bootstrap(fetcher, policy, observer).await?;
+                return Ok(ResolvedS3Credentials {
+                    provider: cell,
+                    source,
+                });
+            }
+            if let Some(fetcher) = AliyunOidc::from_env(env, Arc::clone(&http)) {
+                let source = fetcher.source();
+                let cell = RefreshingCredentials::bootstrap(fetcher, policy, observer).await?;
+                return Ok(ResolvedS3Credentials {
+                    provider: cell,
+                    source,
+                });
+            }
+            if let Some(fetcher) = TencentOidc::from_env(env, Arc::clone(&http)) {
+                let source = fetcher.source();
+                let cell = RefreshingCredentials::bootstrap(fetcher, policy, observer).await?;
+                return Ok(ResolvedS3Credentials {
+                    provider: cell,
+                    source,
+                });
+            }
+            Err(
+                "no origin S3 credentials: configure static keys, or a workload \
+                 identity (AWS IRSA, ACK RRSA, TKE OIDC via env; huawei-agency or \
+                 gcp-metadata via the explicit credentials-source setting)"
+                    .to_string(),
+            )
+        }
+        other => Err(format!(
+            "unknown origin credentials source {other:?}; expected auto, static, \
+             aws-web-identity, aliyun-oidc, tencent-oidc, or huawei-agency"
+        )),
+    }
+}
+
+/// Resolve a bearer-token source for GCS: explicit static token, the GKE
+/// metadata service when selected, or unauthenticated (emulators).
+pub async fn resolve_gcs_bearer(
+    static_token: Option<String>,
+    selector: Option<&str>,
+    http: Arc<dyn HttpClient>,
+    observer: Arc<dyn CredentialsObserver>,
+) -> Result<ResolvedBearerToken, String> {
+    resolve_gcs_bearer_with_env(&env_var, static_token, selector, http, observer).await
+}
+
+/// [`resolve_gcs_bearer`] with an injectable environment, for tests.
+pub async fn resolve_gcs_bearer_with_env(
+    env: EnvFn<'_>,
+    static_token: Option<String>,
+    selector: Option<&str>,
+    http: Arc<dyn HttpClient>,
+    observer: Arc<dyn CredentialsObserver>,
+) -> Result<ResolvedBearerToken, String> {
+    match selector.unwrap_or("auto") {
+        "gcp-metadata" => {
+            let fetcher = GcpMetadataToken::from_env(env, http);
+            let source = fetcher.source();
+            let cell =
+                RefreshingCredentials::bootstrap(fetcher, RefreshPolicy::default(), observer)
+                    .await?;
+            Ok(ResolvedBearerToken {
+                provider: cell,
+                source,
+            })
+        }
+        "static" | "auto" => Ok(ResolvedBearerToken {
+            source: if static_token.is_some() {
+                "static"
+            } else {
+                "unauthenticated"
+            },
+            provider: Arc::new(StaticBearerToken::new(static_token)),
+        }),
+        other => Err(format!(
+            "unknown GCS credentials source {other:?}; expected auto, static, or gcp-metadata"
+        )),
+    }
+}
+
+/// Resolve the Azure AD workload-identity bearer source from the environment.
+///
+/// Callers only reach this when neither a shared key nor a SAS is configured;
+/// the env contract must therefore be present.
+pub async fn resolve_azure_bearer(
+    http: Arc<dyn HttpClient>,
+    observer: Arc<dyn CredentialsObserver>,
+) -> Result<ResolvedBearerToken, String> {
+    resolve_azure_bearer_with_env(&env_var, http, observer).await
+}
+
+/// [`resolve_azure_bearer`] with an injectable environment, for tests.
+pub async fn resolve_azure_bearer_with_env(
+    env: EnvFn<'_>,
+    http: Arc<dyn HttpClient>,
+    observer: Arc<dyn CredentialsObserver>,
+) -> Result<ResolvedBearerToken, String> {
+    let fetcher = AzureWorkloadIdentity::from_env(env, http).ok_or(
+        "Azure workload identity requires AZURE_CLIENT_ID, AZURE_TENANT_ID, \
+         and AZURE_FEDERATED_TOKEN_FILE in the environment",
+    )?;
+    let source = fetcher.source();
+    let cell =
+        RefreshingCredentials::bootstrap(fetcher, RefreshPolicy::default(), observer).await?;
+    Ok(ResolvedBearerToken {
+        provider: cell,
+        source,
+    })
+}
+
+/// Whether the AKS workload-identity env contract is present.
+pub fn azure_workload_identity_available() -> bool {
+    azure_workload_identity_available_with_env(&env_var)
+}
+
+/// [`azure_workload_identity_available`] with an injectable environment.
+pub fn azure_workload_identity_available_with_env(env: EnvFn<'_>) -> bool {
+    env("AZURE_CLIENT_ID").is_some()
+        && env("AZURE_TENANT_ID").is_some()
+        && env("AZURE_FEDERATED_TOKEN_FILE").is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::HttpResponse;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    struct MockHttp {
+        response: HttpResponse,
+        requests: Mutex<Vec<HttpRequest>>,
+    }
+
+    impl MockHttp {
+        fn new(status: u16, body: &str) -> Arc<Self> {
+            Arc::new(Self {
+                response: HttpResponse {
+                    status,
+                    headers: Vec::new(),
+                    body: bytes::Bytes::from(body.to_string()),
+                },
+                requests: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn request(&self) -> HttpRequest {
+            self.requests.lock().unwrap()[0].clone()
+        }
+    }
+
+    #[async_trait]
+    impl HttpClient for MockHttp {
+        async fn execute(&self, req: HttpRequest) -> Result<HttpResponse, String> {
+            self.requests.lock().unwrap().push(req);
+            Ok(self.response.clone())
+        }
+    }
+
+    fn env_map(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(name, value)| (name.to_string(), value.to_string()))
+            .collect();
+        move |name: &str| map.get(name).cloned()
+    }
+
+    // The credential types deliberately lack Debug, so unwrap through
+    // helpers that surface the error text without requiring it.
+    fn ok<T>(result: Result<T, String>) -> T {
+        match result {
+            Ok(value) => value,
+            Err(error) => panic!("unexpected error: {error}"),
+        }
+    }
+
+    fn err<T>(result: Result<T, String>) -> String {
+        match result {
+            Ok(_) => panic!("unexpected success"),
+            Err(error) => error,
+        }
+    }
+
+    fn token_file(dir: &tempfile::TempDir, token: &str) -> String {
+        let path = dir.path().join("token");
+        std::fs::write(&path, token).unwrap();
+        path.to_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn iso8601_parses_the_shapes_the_exchanges_emit() {
+        let parsed = parse_iso8601_utc("2026-08-10T01:02:03Z").unwrap();
+        assert_eq!(format_iso8601_utc(parsed), "2026-08-10T01:02:03Z");
+        // Huawei stamps fractional seconds.
+        assert_eq!(
+            parse_iso8601_utc("2026-08-10T01:02:03.000000Z").unwrap(),
+            parsed
+        );
+        assert_eq!(
+            parse_iso8601_utc("2026-08-10T01:02:03+00:00").unwrap(),
+            parsed
+        );
+        assert!(parse_iso8601_utc("garbage").is_none());
+        assert!(parse_iso8601_utc("2026-13-10T01:02:03Z").is_none());
+        assert!(parse_iso8601_utc("2026-08-10 01:02:03Z").is_none());
+    }
+
+    const AWS_STS_OK: &str = r#"<AssumeRoleWithWebIdentityResponse>
+      <AssumeRoleWithWebIdentityResult><Credentials>
+        <AccessKeyId>ASIAEXAMPLE</AccessKeyId>
+        <SecretAccessKey>temp-secret</SecretAccessKey>
+        <SessionToken>temp-token</SessionToken>
+        <Expiration>2026-08-10T13:00:00Z</Expiration>
+      </Credentials></AssumeRoleWithWebIdentityResult>
+    </AssumeRoleWithWebIdentityResponse>"#;
+
+    #[tokio::test]
+    async fn aws_web_identity_exchanges_and_parses() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let http = MockHttp::new(200, AWS_STS_OK);
+        let env = env_map(&[
+            ("AWS_ROLE_ARN", "arn:aws:iam::1:role/talon"),
+            ("AWS_WEB_IDENTITY_TOKEN_FILE", &token_file(&temp, "jwt-abc")),
+            ("AWS_REGION", "us-west-2"),
+            ("AWS_STS_REGIONAL_ENDPOINTS", "regional"),
+        ]);
+        let fetcher = AwsWebIdentity::from_env(&env, http.clone() as Arc<dyn HttpClient>).unwrap();
+        let (creds, expires) = ok(fetcher.fetch().await);
+        assert_eq!(creds.access_key_id, "ASIAEXAMPLE");
+        assert_eq!(creds.secret_access_key, "temp-secret");
+        assert_eq!(creds.session_token.as_deref(), Some("temp-token"));
+        assert_eq!(expires, parse_iso8601_utc("2026-08-10T13:00:00Z"));
+        let request = http.request();
+        assert_eq!(request.url, "https://sts.us-west-2.amazonaws.com");
+        let body = String::from_utf8(request.body.to_vec()).unwrap();
+        assert!(body.contains("Action=AssumeRoleWithWebIdentity"));
+        assert!(body.contains("WebIdentityToken=jwt-abc"));
+        assert!(body.contains("RoleArn=arn%3Aaws%3Aiam%3A%3A1%3Arole%2Ftalon"));
+    }
+
+    #[tokio::test]
+    async fn aws_errors_expose_the_code_but_never_the_token() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let http = MockHttp::new(
+            403,
+            "<ErrorResponse><Error><Code>ExpiredTokenException</Code>\
+             <Message>Token expired: jwt-abc</Message></Error></ErrorResponse>",
+        );
+        let env = env_map(&[
+            ("AWS_ROLE_ARN", "arn:aws:iam::1:role/talon"),
+            ("AWS_WEB_IDENTITY_TOKEN_FILE", &token_file(&temp, "jwt-abc")),
+        ]);
+        let fetcher = AwsWebIdentity::from_env(&env, http as Arc<dyn HttpClient>).unwrap();
+        let error = err(fetcher.fetch().await);
+        assert!(error.contains("ExpiredTokenException"));
+        assert!(error.contains("403"));
+        assert!(!error.contains("jwt-abc"));
+    }
+
+    #[tokio::test]
+    async fn aliyun_oidc_exchanges_and_parses() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let http = MockHttp::new(
+            200,
+            r#"{"RequestId":"r","Credentials":{"AccessKeyId":"STS.ali","AccessKeySecret":"ali-secret","SecurityToken":"ali-token","Expiration":"2026-08-10T13:00:00Z"}}"#,
+        );
+        let env = env_map(&[
+            ("ALIBABA_CLOUD_ROLE_ARN", "acs:ram::1:role/talon"),
+            (
+                "ALIBABA_CLOUD_OIDC_PROVIDER_ARN",
+                "acs:ram::1:oidc-provider/ack",
+            ),
+            (
+                "ALIBABA_CLOUD_OIDC_TOKEN_FILE",
+                &token_file(&temp, "oidc-jwt"),
+            ),
+        ]);
+        let fetcher = AliyunOidc::from_env(&env, http.clone() as Arc<dyn HttpClient>).unwrap();
+        let (creds, expires) = ok(fetcher.fetch().await);
+        assert_eq!(creds.access_key_id, "STS.ali");
+        assert_eq!(creds.session_token.as_deref(), Some("ali-token"));
+        assert!(expires.is_some());
+        let request = http.request();
+        assert_eq!(request.url, "https://sts.aliyuncs.com");
+        let body = String::from_utf8(request.body.to_vec()).unwrap();
+        assert!(body.contains("Action=AssumeRoleWithOIDC"));
+        assert!(body.contains("OIDCToken=oidc-jwt"));
+        assert!(body.contains("Timestamp="));
+    }
+
+    #[tokio::test]
+    async fn tencent_oidc_exchanges_and_surfaces_in_band_errors() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let success = MockHttp::new(
+            200,
+            r#"{"Response":{"Credentials":{"TmpSecretId":"tc-id","TmpSecretKey":"tc-key","Token":"tc-token"},"ExpiredTime":1786500000,"RequestId":"r"}}"#,
+        );
+        let env_pairs = [
+            ("TKE_ROLE_ARN", "qcs::cam::uin/1:roleName/talon".to_string()),
+            ("TKE_PROVIDER_ID", "oidc-provider".to_string()),
+            ("TKE_WEB_IDENTITY_TOKEN_FILE", token_file(&temp, "tke-jwt")),
+            ("TKE_REGION", "ap-shanghai".to_string()),
+        ];
+        let pairs: Vec<(&str, &str)> = env_pairs
+            .iter()
+            .map(|(name, value)| (*name, value.as_str()))
+            .collect();
+        let env = env_map(&pairs);
+        let fetcher = TencentOidc::from_env(&env, success.clone() as Arc<dyn HttpClient>).unwrap();
+        let (creds, expires) = ok(fetcher.fetch().await);
+        assert_eq!(creds.access_key_id, "tc-id");
+        assert_eq!(creds.session_token.as_deref(), Some("tc-token"));
+        assert_eq!(
+            expires,
+            Some(UNIX_EPOCH + Duration::from_secs(1_786_500_000))
+        );
+        let request = success.request();
+        assert_eq!(
+            request.header("x-tc-action"),
+            Some("AssumeRoleWithWebIdentity")
+        );
+        assert_eq!(request.header("authorization"), Some("SKIP"));
+        assert_eq!(request.header("x-tc-region"), Some("ap-shanghai"));
+
+        // Tencent reports failures inside a 200 body.
+        let failed = MockHttp::new(
+            200,
+            r#"{"Response":{"Error":{"Code":"InvalidParameter.Token","Message":"bad tke-jwt"},"RequestId":"r"}}"#,
+        );
+        let fetcher = TencentOidc::from_env(&env, failed as Arc<dyn HttpClient>).unwrap();
+        let error = err(fetcher.fetch().await);
+        assert!(error.contains("InvalidParameter.Token"));
+        assert!(!error.contains("tke-jwt"));
+    }
+
+    #[tokio::test]
+    async fn huawei_agency_reads_the_metadata_credential() {
+        let http = MockHttp::new(
+            200,
+            r#"{"credential":{"access":"hw-ak","secret":"hw-sk","securitytoken":"hw-token","expires_at":"2026-08-10T13:00:00.531000Z"}}"#,
+        );
+        let env = env_map(&[]);
+        let fetcher = HuaweiAgency::from_env(&env, http.clone() as Arc<dyn HttpClient>);
+        let (creds, expires) = ok(fetcher.fetch().await);
+        assert_eq!(creds.access_key_id, "hw-ak");
+        assert_eq!(creds.session_token.as_deref(), Some("hw-token"));
+        assert!(expires.is_some());
+        assert_eq!(
+            http.request().url,
+            "http://169.254.169.254/openstack/latest/securitykey"
+        );
+    }
+
+    #[tokio::test]
+    async fn gcp_metadata_token_sets_the_flavor_header() {
+        let http = MockHttp::new(
+            200,
+            r#"{"access_token":"ya29.token","expires_in":3599,"token_type":"Bearer"}"#,
+        );
+        let env = env_map(&[]);
+        let fetcher = GcpMetadataToken::from_env(&env, http.clone() as Arc<dyn HttpClient>);
+        let (token, expires) = ok(fetcher.fetch().await);
+        assert_eq!(token, "ya29.token");
+        assert!(expires.unwrap() > SystemTime::now() + Duration::from_secs(3000));
+        let request = http.request();
+        assert_eq!(request.header("metadata-flavor"), Some("Google"));
+        assert!(request.url.contains("metadata.google.internal"));
+    }
+
+    #[tokio::test]
+    async fn azure_workload_identity_exchanges_the_federated_token() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let http = MockHttp::new(
+            200,
+            r#"{"token_type":"Bearer","expires_in":3600,"access_token":"aad-token"}"#,
+        );
+        let env = env_map(&[
+            ("AZURE_CLIENT_ID", "client-1"),
+            ("AZURE_TENANT_ID", "tenant-1"),
+            ("AZURE_FEDERATED_TOKEN_FILE", &token_file(&temp, "fed-jwt")),
+        ]);
+        let fetcher =
+            AzureWorkloadIdentity::from_env(&env, http.clone() as Arc<dyn HttpClient>).unwrap();
+        let (token, expires) = ok(fetcher.fetch().await);
+        assert_eq!(token, "aad-token");
+        assert!(expires.is_some());
+        let request = http.request();
+        assert_eq!(
+            request.url,
+            "https://login.microsoftonline.com/tenant-1/oauth2/v2.0/token"
+        );
+        let body = String::from_utf8(request.body.to_vec()).unwrap();
+        assert!(body.contains("client_assertion=fed-jwt"));
+        assert!(body.contains("scope=https%3A%2F%2Fstorage.azure.com%2F.default"));
+
+        let failed = MockHttp::new(
+            401,
+            r#"{"error":"invalid_client","error_description":"AADSTS700016 fed-jwt"}"#,
+        );
+        let fetcher = AzureWorkloadIdentity::from_env(&env, failed as Arc<dyn HttpClient>).unwrap();
+        let error = err(fetcher.fetch().await);
+        assert!(error.contains("invalid_client"));
+        assert!(!error.contains("fed-jwt"));
+    }
+
+    #[tokio::test]
+    async fn resolution_prefers_static_then_detects_workload_identity() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let http = MockHttp::new(200, AWS_STS_OK);
+        let aws_env_token = token_file(&temp, "jwt");
+        let env = env_map(&[
+            ("AWS_ROLE_ARN", "arn:aws:iam::1:role/talon"),
+            ("AWS_WEB_IDENTITY_TOKEN_FILE", &aws_env_token),
+        ]);
+
+        // Static credentials win even with IRSA env present.
+        let resolved = ok(resolve_s3_credentials_with_env(
+            &env,
+            Some(S3Credentials {
+                access_key_id: "AKIDSTATIC".into(),
+                secret_access_key: "s".into(),
+                session_token: None,
+            }),
+            None,
+            http.clone() as Arc<dyn HttpClient>,
+            Arc::new(crate::credentials::NoopObserver),
+        )
+        .await);
+        assert_eq!(resolved.source, "static");
+        assert_eq!(resolved.provider.current().access_key_id, "AKIDSTATIC");
+        assert!(http.requests.lock().unwrap().is_empty());
+
+        // Without static material the IRSA contract is detected and used.
+        let resolved = ok(resolve_s3_credentials_with_env(
+            &env,
+            None,
+            None,
+            http.clone() as Arc<dyn HttpClient>,
+            Arc::new(crate::credentials::NoopObserver),
+        )
+        .await);
+        assert_eq!(resolved.source, "aws-web-identity");
+        assert_eq!(resolved.provider.current().access_key_id, "ASIAEXAMPLE");
+
+        // Nothing configured is a startup error naming the options.
+        let empty = env_map(&[]);
+        let error = err(resolve_s3_credentials_with_env(
+            &empty,
+            None,
+            None,
+            http.clone() as Arc<dyn HttpClient>,
+            Arc::new(crate::credentials::NoopObserver),
+        )
+        .await);
+        assert!(error.contains("workload identity"));
+
+        // Unknown selectors are rejected loudly.
+        let error = err(resolve_s3_credentials_with_env(
+            &empty,
+            None,
+            Some("magic"),
+            http as Arc<dyn HttpClient>,
+            Arc::new(crate::credentials::NoopObserver),
+        )
+        .await);
+        assert!(error.contains("magic"));
+    }
+
+    #[tokio::test]
+    async fn gcs_resolution_covers_static_metadata_and_unauthenticated() {
+        let http = MockHttp::new(200, r#"{"access_token":"ya29","expires_in":600}"#);
+        let env = env_map(&[]);
+        let resolved = ok(resolve_gcs_bearer_with_env(
+            &env,
+            Some("fixed".into()),
+            None,
+            http.clone() as Arc<dyn HttpClient>,
+            Arc::new(crate::credentials::NoopObserver),
+        )
+        .await);
+        assert_eq!(resolved.source, "static");
+        assert_eq!(resolved.provider.current().unwrap().as_str(), "fixed");
+
+        let resolved = ok(resolve_gcs_bearer_with_env(
+            &env,
+            None,
+            Some("gcp-metadata"),
+            http.clone() as Arc<dyn HttpClient>,
+            Arc::new(crate::credentials::NoopObserver),
+        )
+        .await);
+        assert_eq!(resolved.source, "gcp-metadata");
+        assert_eq!(resolved.provider.current().unwrap().as_str(), "ya29");
+
+        let resolved = ok(resolve_gcs_bearer_with_env(
+            &env,
+            None,
+            None,
+            http as Arc<dyn HttpClient>,
+            Arc::new(crate::credentials::NoopObserver),
+        )
+        .await);
+        assert_eq!(resolved.source, "unauthenticated");
+        assert!(resolved.provider.current().is_none());
+    }
+}

--- a/crates/talon-gateway/src/main.rs
+++ b/crates/talon-gateway/src/main.rs
@@ -6,7 +6,10 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use serde::Deserialize;
-use talon_backend::{AzureBackend, AzureConfig, ReqwestClient, S3Backend, S3Config, S3Credentials};
+use talon_backend::{
+    resolve_azure_bearer, resolve_s3_credentials, AzureBackend, AzureConfig, CredentialsObserver,
+    ProvideBearerToken, ProvideS3Credentials, ReqwestClient, S3Backend, S3Config, S3Credentials,
+};
 use talon_cache_client::{BlockReader, CoordinatorClient, PlacementCache};
 use talon_gateway::azure::{AzureAdapterConfig, AzureBlobAdapter, AzureCache};
 use talon_gateway::azure_auth::{AzureClientIdentity, AzureStorageAuthenticator};
@@ -53,11 +56,13 @@ struct Settings {
     s3_secret_key: Option<String>,
     s3_session_token: Option<String>,
     s3_client_identities_path: Option<PathBuf>,
+    s3_origin_path_style: bool,
     s3_max_clock_skew_ms: u64,
     s3_max_multipart_uploads: usize,
     s3_multipart_ttl_ms: u64,
     authorization_path: Option<PathBuf>,
     auth_reload_ms: u64,
+    origin_credentials_source: Option<String>,
     tls: Option<GatewayTlsConfig>,
 }
 
@@ -283,6 +288,13 @@ impl Settings {
             s3_session_token: value(&mut get, "AWS_SESSION_TOKEN"),
             s3_client_identities_path: value(&mut get, "TALON_GATEWAY_S3_CLIENT_IDENTITIES_PATH")
                 .map(PathBuf::from),
+            // OSS and COS S3-compatible endpoints require virtual-host
+            // addressing; MinIO/Ceph-style stores require path style.
+            s3_origin_path_style: parse_bool(
+                value(&mut get, "TALON_GATEWAY_S3_ORIGIN_PATH_STYLE").as_deref(),
+                true,
+                "TALON_GATEWAY_S3_ORIGIN_PATH_STYLE",
+            )?,
             s3_max_clock_skew_ms: parse_or(
                 value(&mut get, "TALON_GATEWAY_S3_MAX_CLOCK_SKEW_MS"),
                 "900000",
@@ -301,6 +313,7 @@ impl Settings {
             authorization_path: value(&mut get, "TALON_GATEWAY_AUTHORIZATION_PATH")
                 .map(PathBuf::from),
             auth_reload_ms,
+            origin_credentials_source: value(&mut get, "TALON_ORIGIN_CREDENTIALS_SOURCE"),
             tls,
         };
         settings.validate_origin_auth()?;
@@ -376,7 +389,35 @@ fn cache_reader(settings: &Settings) -> Arc<BlockReader> {
     ))
 }
 
-fn azure_adapter(settings: &Settings) -> MainResult<Arc<dyn GatewayAdapter>> {
+/// The origin credential a gateway Azure adapter signs with.
+enum AzureOriginAuth {
+    /// Base64 account key (`Authorization: SharedKey`).
+    SharedKey(String),
+    /// SAS token appended to every URL.
+    Sas(String),
+    /// Azure AD bearer tokens from AKS workload identity.
+    Bearer(Arc<dyn ProvideBearerToken>),
+}
+
+/// The statically configured Azure credential, `None` when the environment
+/// configures neither form and workload identity should be resolved.
+fn azure_static_auth(settings: &Settings) -> MainResult<Option<AzureOriginAuth>> {
+    match (&settings.azure_shared_key, &settings.azure_sas) {
+        (Some(_), Some(_)) => Err(invalid(
+            "set only one of TALON_GATEWAY_AZURE_SHARED_KEY or TALON_GATEWAY_AZURE_SAS",
+        )),
+        (Some(key), None) => Ok(Some(AzureOriginAuth::SharedKey(key.clone()))),
+        (None, Some(sas)) => Ok(Some(AzureOriginAuth::Sas(
+            sas.trim_start_matches('?').to_string(),
+        ))),
+        (None, None) => Ok(None),
+    }
+}
+
+fn azure_adapter(
+    settings: &Settings,
+    auth: AzureOriginAuth,
+) -> MainResult<Arc<dyn GatewayAdapter>> {
     if settings.origin_auth == OriginAuthMode::TrustedPassthrough {
         return Err(invalid(
             "trusted-passthrough Azure routing is not available in this build",
@@ -386,14 +427,6 @@ fn azure_adapter(settings: &Settings) -> MainResult<Arc<dyn GatewayAdapter>> {
         .azure_account
         .clone()
         .ok_or_else(|| invalid("TALON_GATEWAY_AZURE_ACCOUNT is required"))?;
-    if settings.azure_shared_key.is_some() && settings.azure_sas.is_some() {
-        return Err(invalid(
-            "set only one of TALON_GATEWAY_AZURE_SHARED_KEY or TALON_GATEWAY_AZURE_SAS",
-        ));
-    }
-    if settings.azure_shared_key.is_none() && settings.azure_sas.is_none() {
-        return Err(invalid("an Azure shared key or SAS credential is required"));
-    }
     let mut origin_config = match settings.azure_endpoint.as_deref() {
         Some(endpoint) => {
             let (host, tls) = split_endpoint(endpoint);
@@ -407,14 +440,14 @@ fn azure_adapter(settings: &Settings) -> MainResult<Arc<dyn GatewayAdapter>> {
         }
     }
     let http = Arc::new(ReqwestClient::new());
-    let origin = match settings.azure_shared_key.as_deref() {
-        Some(key) => Arc::new(AzureBackend::with_shared_key(origin_config, key, http)),
-        None => Arc::new(AzureBackend::new(
+    let origin = match auth {
+        AzureOriginAuth::SharedKey(key) => {
+            Arc::new(AzureBackend::with_shared_key(origin_config, key, http))
+        }
+        AzureOriginAuth::Sas(sas) => Arc::new(AzureBackend::new(origin_config, Some(sas), http)),
+        AzureOriginAuth::Bearer(bearer) => Arc::new(AzureBackend::with_bearer_provider(
             origin_config,
-            settings
-                .azure_sas
-                .as_deref()
-                .map(|token| token.trim_start_matches('?').to_string()),
+            bearer,
             http,
         )),
     };
@@ -440,7 +473,26 @@ fn azure_adapter(settings: &Settings) -> MainResult<Arc<dyn GatewayAdapter>> {
     )?))
 }
 
-fn s3_adapter(settings: &Settings) -> MainResult<Arc<dyn GatewayAdapter>> {
+/// The statically configured S3 origin keys, `None` when the environment
+/// sets none and workload identity should be resolved.
+fn static_s3_credentials(settings: &Settings) -> MainResult<Option<S3Credentials>> {
+    match (&settings.s3_access_key, &settings.s3_secret_key) {
+        (Some(access_key), Some(secret_key)) => Ok(Some(S3Credentials {
+            access_key_id: access_key.clone(),
+            secret_access_key: secret_key.clone(),
+            session_token: settings.s3_session_token.clone(),
+        })),
+        (None, None) => Ok(None),
+        _ => Err(invalid(
+            "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set together",
+        )),
+    }
+}
+
+fn s3_adapter(
+    settings: &Settings,
+    credentials: Arc<dyn ProvideS3Credentials>,
+) -> MainResult<Arc<dyn GatewayAdapter>> {
     if settings.origin_auth == OriginAuthMode::TrustedPassthrough {
         return Err(invalid(
             "trusted-passthrough S3 routing is not available in this build",
@@ -450,33 +502,21 @@ fn s3_adapter(settings: &Settings) -> MainResult<Arc<dyn GatewayAdapter>> {
         .s3_region
         .clone()
         .unwrap_or_else(|| "us-east-1".to_string());
-    let access_key = settings
-        .s3_access_key
-        .clone()
-        .ok_or_else(|| invalid("AWS_ACCESS_KEY_ID is required"))?;
-    let secret_key = settings
-        .s3_secret_key
-        .clone()
-        .ok_or_else(|| invalid("AWS_SECRET_ACCESS_KEY is required"))?;
     let origin_config = match settings.s3_endpoint.as_deref() {
         Some(endpoint) => {
             let (host, tls) = split_endpoint(endpoint);
             S3Config {
                 region: region.clone(),
                 endpoint: host,
-                path_style: true,
+                path_style: settings.s3_origin_path_style,
                 tls,
             }
         }
         None => S3Config::aws(&region),
     };
-    let origin = Arc::new(S3Backend::new(
+    let origin = Arc::new(S3Backend::with_credentials_provider(
         origin_config,
-        S3Credentials {
-            access_key_id: access_key,
-            secret_access_key: secret_key,
-            session_token: settings.s3_session_token.clone(),
-        },
+        credentials,
         Arc::new(ReqwestClient::new()),
     ));
     let mut config = if settings.incoming_path_style {
@@ -813,6 +853,23 @@ fn spawn_auth_reload(
     });
 }
 
+/// Bridges origin credential refresh outcomes into the gateway registry.
+struct OriginCredentialsObserver(GatewayMetrics);
+
+impl CredentialsObserver for OriginCredentialsObserver {
+    fn refresh_succeeded(&self, expires_at: Option<std::time::SystemTime>) {
+        self.0.record_origin_credentials("refresh_success");
+        let unix_seconds = expires_at
+            .and_then(|at| at.duration_since(std::time::UNIX_EPOCH).ok())
+            .map_or(0.0, |since_epoch| since_epoch.as_secs_f64());
+        self.0.set_origin_credentials_expiry(unix_seconds);
+    }
+
+    fn refresh_failed(&self) {
+        self.0.record_origin_credentials("refresh_failure");
+    }
+}
+
 fn load_mtls_identities(
     path: &Path,
     ca_certificate_path: PathBuf,
@@ -861,12 +918,71 @@ async fn main() -> MainResult<()> {
         .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
         .init();
     let settings = Settings::from_env()?;
+    let metrics = GatewayMetrics::new();
+    let credentials_observer: Arc<dyn CredentialsObserver> =
+        Arc::new(OriginCredentialsObserver(metrics.clone()));
+    let exchange_http: Arc<dyn talon_backend::HttpClient> = Arc::new(ReqwestClient::new());
     let adapter = match settings.protocol.as_str() {
-        "azure" => azure_adapter(&settings)?,
-        "s3" => s3_adapter(&settings)?,
+        "azure" => {
+            if settings.origin_auth == OriginAuthMode::TrustedPassthrough {
+                return Err(invalid(
+                    "trusted-passthrough Azure routing is not available in this build",
+                ));
+            }
+            let auth = match azure_static_auth(&settings)? {
+                Some(auth) => {
+                    info!(source = "static", "origin Azure credentials resolved");
+                    auth
+                }
+                None => match settings.origin_credentials_source.as_deref() {
+                    None | Some("auto") | Some("azure-workload-identity") => {
+                        let resolved = resolve_azure_bearer(
+                            Arc::clone(&exchange_http),
+                            Arc::clone(&credentials_observer),
+                        )
+                        .await
+                        .map_err(|error| {
+                            invalid(format!(
+                                "an Azure shared key or SAS credential is required, \
+                                 or AKS workload identity must be available: {error}"
+                            ))
+                        })?;
+                        info!(
+                            source = resolved.source,
+                            "origin Azure credentials resolved"
+                        );
+                        AzureOriginAuth::Bearer(resolved.provider)
+                    }
+                    Some(other) => {
+                        return Err(invalid(format!(
+                            "an Azure shared key or SAS credential is required \
+                             (origin credentials source {other:?} does not apply to azure)"
+                        )))
+                    }
+                },
+            };
+            azure_adapter(&settings, auth)?
+        }
+        "s3" => {
+            if settings.origin_auth == OriginAuthMode::TrustedPassthrough {
+                return Err(invalid(
+                    "trusted-passthrough S3 routing is not available in this build",
+                ));
+            }
+            let resolved = resolve_s3_credentials(
+                static_s3_credentials(&settings)?,
+                settings.origin_credentials_source.as_deref(),
+                Arc::clone(&exchange_http),
+                Arc::clone(&credentials_observer),
+            )
+            .await
+            .map_err(invalid)?;
+            info!(source = resolved.source, "origin S3 credentials resolved");
+            s3_adapter(&settings, resolved.provider)?
+        }
         _ => unreachable!("validated protocol"),
     };
-    let runtime = Arc::new(GatewayRuntime::new(
+    let runtime = Arc::new(GatewayRuntime::new_with_metrics(
         GatewayConfig {
             bind: settings.bind,
             mode: settings.mode,
@@ -877,6 +993,7 @@ async fn main() -> MainResult<()> {
         },
         adapter,
         GatewaySecurity::default(),
+        metrics,
     )?);
     let reload_targets = configure_auth(&runtime, &settings)?;
     if !reload_targets.is_empty() {
@@ -936,6 +1053,7 @@ mod tests {
         assert!(!settings.incoming_path_style);
         assert!(settings.tls.is_none());
         assert!(settings.s3_client_identities_path.is_none());
+        assert!(settings.s3_origin_path_style);
         assert_eq!(settings.s3_max_clock_skew_ms, 900_000);
         assert_eq!(settings.s3_max_multipart_uploads, 1024);
         assert_eq!(settings.s3_multipart_ttl_ms, 86_400_000);
@@ -988,6 +1106,11 @@ mod tests {
             ("TALON_GATEWAY_PATH_STYLE", "maybe"),
         ])
         .is_err());
+        assert!(settings(&[
+            ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
+            ("TALON_GATEWAY_S3_ORIGIN_PATH_STYLE", "maybe"),
+        ])
+        .is_err());
     }
 
     #[test]
@@ -998,7 +1121,7 @@ mod tests {
         ])
         .unwrap();
         assert_eq!(trusted.origin_auth, OriginAuthMode::TrustedPassthrough);
-        assert!(s3_adapter(&trusted).is_err());
+        assert!(s3_adapter(&trusted, test_s3_provider()).is_err());
 
         assert!(settings(&[
             ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
@@ -1033,10 +1156,26 @@ mod tests {
         assert_eq!(split_endpoint("s3.example"), ("s3.example".into(), true));
     }
 
+    fn test_s3_provider() -> Arc<dyn ProvideS3Credentials> {
+        Arc::new(talon_backend::StaticS3Credentials::new(S3Credentials {
+            access_key_id: "AKIDTEST".into(),
+            secret_access_key: "secret".into(),
+            session_token: None,
+        }))
+    }
+
     #[test]
     fn provider_credentials_are_required_and_mutually_exclusive() {
+        // No static keys means workload identity must resolve at startup.
         let s3 = settings(&[("TALON_COORDINATOR_ADDR", "coordinator:7411")]).unwrap();
-        assert!(s3_adapter(&s3).is_err());
+        assert!(static_s3_credentials(&s3).unwrap().is_none());
+        // Half a static key pair is a configuration error, not auto-detection.
+        let half = settings(&[
+            ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
+            ("AWS_ACCESS_KEY_ID", "AKIDONLY"),
+        ])
+        .unwrap();
+        assert!(static_s3_credentials(&half).is_err());
 
         let azure = settings(&[
             ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
@@ -1044,7 +1183,14 @@ mod tests {
             ("TALON_GATEWAY_AZURE_ACCOUNT", "account"),
         ])
         .unwrap();
-        assert!(azure_adapter(&azure).is_err());
+        assert!(azure_static_auth(&azure).unwrap().is_none());
+
+        let no_account = settings(&[
+            ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
+            ("TALON_GATEWAY_PROTOCOL", "azure"),
+        ])
+        .unwrap();
+        assert!(azure_adapter(&no_account, AzureOriginAuth::Sas("sig=x".into())).is_err());
 
         let both = settings(&[
             ("TALON_COORDINATOR_ADDR", "coordinator:7411"),
@@ -1054,7 +1200,7 @@ mod tests {
             ("TALON_GATEWAY_AZURE_SAS", "sas"),
         ])
         .unwrap();
-        assert!(azure_adapter(&both).is_err());
+        assert!(azure_static_auth(&both).is_err());
     }
 
     #[test]

--- a/crates/talon-gateway/src/metrics.rs
+++ b/crates/talon-gateway/src/metrics.rs
@@ -43,6 +43,32 @@ impl GatewayMetrics {
             .inc();
     }
 
+    /// Count one origin credential refresh outcome (workload identity).
+    ///
+    /// Public because credentials are resolved in the gateway binary before
+    /// the runtime exists; `result` is `refresh_success` or `refresh_failure`.
+    pub fn record_origin_credentials(&self, result: &'static str) {
+        self.registry
+            .counter(
+                "talon_gateway_origin_credentials_total",
+                "Origin credential refresh outcomes.",
+                labels(&[("result", result)]),
+            )
+            .inc();
+    }
+
+    /// Publish when the current origin credentials expire (unix seconds,
+    /// `0` when the mechanism reports no expiry or credentials are static).
+    pub fn set_origin_credentials_expiry(&self, unix_seconds: f64) {
+        self.registry
+            .gauge(
+                "talon_gateway_origin_credentials_expiry_seconds",
+                "Unix time when the current origin credentials expire.",
+                labels(&[]),
+            )
+            .set(unix_seconds);
+    }
+
     /// Count one identity or authorization file reload poll outcome.
     ///
     /// Public because the reload loop lives in the gateway binary; both label
@@ -213,5 +239,16 @@ mod tests {
         ));
         assert!(!rendered.contains("object"));
         assert!(!rendered.contains("credential"));
+    }
+
+    #[test]
+    fn origin_credential_metrics_render_bounded_labels() {
+        let metrics = GatewayMetrics::new();
+        metrics.record_origin_credentials("refresh_failure");
+        metrics.set_origin_credentials_expiry(1_754_000_000.0);
+        let rendered = metrics.render();
+        assert!(rendered
+            .contains("talon_gateway_origin_credentials_total{result=\"refresh_failure\"} 1"));
+        assert!(rendered.contains("talon_gateway_origin_credentials_expiry_seconds"));
     }
 }

--- a/crates/talon-gateway/src/runtime.rs
+++ b/crates/talon-gateway/src/runtime.rs
@@ -128,7 +128,19 @@ impl GatewayRuntime {
     pub fn new(
         config: GatewayConfig,
         adapter: Arc<dyn GatewayAdapter>,
+        security: GatewaySecurity,
+    ) -> Result<Self, GatewayConfigError> {
+        Self::new_with_metrics(config, adapter, security, GatewayMetrics::new())
+    }
+
+    /// Construct a runtime that records into an externally created registry,
+    /// so events counted before construction (origin credential resolution in
+    /// the binary) land in the registry `/metrics` serves.
+    pub fn new_with_metrics(
+        config: GatewayConfig,
+        adapter: Arc<dyn GatewayAdapter>,
         mut security: GatewaySecurity,
+        metrics: GatewayMetrics,
     ) -> Result<Self, GatewayConfigError> {
         config.validate()?;
         security.authentication = false;
@@ -143,7 +155,7 @@ impl GatewayRuntime {
             readiness: Arc::new(GatewayReadiness::new(config.mode, security)),
             config,
             adapter,
-            metrics: GatewayMetrics::new(),
+            metrics,
             authorization: RwLock::new(None),
             authentication: RwLock::new(None),
             audit: RwLock::new(Arc::new(TracingAuditSink)),

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -70,6 +70,31 @@ struct MetricsRetryObserver {
     observability: Arc<WorkerObservability>,
 }
 
+/// Bridges origin credential refresh outcomes to the worker's registry.
+struct CredentialsMetricsObserver {
+    observability: Arc<WorkerObservability>,
+}
+
+impl talon_backend::CredentialsObserver for CredentialsMetricsObserver {
+    fn refresh_succeeded(&self, expires_at: Option<std::time::SystemTime>) {
+        self.observability
+            .metrics()
+            .record_origin_credentials("refresh_success");
+        let unix_seconds = expires_at
+            .and_then(|at| at.duration_since(std::time::UNIX_EPOCH).ok())
+            .map_or(0.0, |since_epoch| since_epoch.as_secs_f64());
+        self.observability
+            .metrics()
+            .set_origin_credentials_expiry(unix_seconds);
+    }
+
+    fn refresh_failed(&self) {
+        self.observability
+            .metrics()
+            .record_origin_credentials("refresh_failure");
+    }
+}
+
 impl talon_backend::RetryObserver for MetricsRetryObserver {
     fn on_retry(&self, _attempt: u32, _status: Option<u16>) {
         self.observability.metrics().record_backend_retry();
@@ -186,17 +211,27 @@ fn split_scheme(endpoint: &str) -> (String, bool) {
     }
 }
 
-/// Build the Azure backend from account (config/env) + SAS (env only), honoring
-/// an optional endpoint override (Azurite/proxy).
-fn build_azure_backend(
+/// Explicit origin credential mechanism (`static`, `aws-web-identity`,
+/// `aliyun-oidc`, `tencent-oidc`, `huawei-agency`, `gcp-metadata`); unset
+/// means static material first, then auto-detected workload identity. Read
+/// from the environment like the secrets themselves.
+fn origin_credentials_source() -> Option<String> {
+    std::env::var("TALON_ORIGIN_CREDENTIALS_SOURCE")
+        .ok()
+        .filter(|value| !value.is_empty())
+}
+
+/// Build the Azure backend from account (config/env) plus a SAS token (env)
+/// or, when no SAS is set, AKS workload identity, honoring an optional
+/// endpoint override (Azurite/proxy).
+async fn build_azure_backend(
     cfg: &WorkerConfig,
     http: Arc<dyn talon_backend::http::HttpClient>,
+    observer: Arc<dyn talon_backend::CredentialsObserver>,
 ) -> anyhow::Result<AzureBackend> {
     let account = cfg.azure_account.clone().ok_or_else(|| {
         anyhow::anyhow!("azure_account is required (set TALON_WORKER_AZURE_ACCOUNT)")
     })?;
-    let sas = azure_sas_from_env()
-        .ok_or_else(|| anyhow::anyhow!("TALON_WORKER_AZURE_SAS must be set (SAS token)"))?;
     let azure_config = match cfg.azure_endpoint.clone() {
         Some(endpoint) => {
             let (host, tls) = split_scheme(&endpoint);
@@ -204,25 +239,59 @@ fn build_azure_backend(
         }
         None => AzureConfig::new(account),
     };
-    Ok(AzureBackend::new(azure_config, Some(sas), http))
+    match azure_sas_from_env() {
+        Some(sas) => {
+            tracing::info!(source = "sas", "origin Azure credentials resolved");
+            Ok(AzureBackend::new(azure_config, Some(sas), http))
+        }
+        None => {
+            let resolved = talon_backend::resolve_azure_bearer(Arc::clone(&http), observer)
+                .await
+                .map_err(|error| {
+                    anyhow::anyhow!(
+                        "TALON_WORKER_AZURE_SAS must be set (SAS token), or AKS \
+                         workload identity must be available: {error}"
+                    )
+                })?;
+            tracing::info!(
+                source = resolved.source,
+                "origin Azure credentials resolved"
+            );
+            Ok(AzureBackend::with_bearer_provider(
+                azure_config,
+                resolved.provider,
+                http,
+            ))
+        }
+    }
 }
 
-/// Build the S3 backend from region/endpoint/access-key (config) + secret key
-/// and optional session token (env only).
-fn build_s3_backend(
+/// Build the S3 backend from region/endpoint (config) plus either static keys
+/// (config + env) or a cloud workload identity (EKS IRSA, ACK RRSA, TKE OIDC
+/// auto-detected; Huawei agency via `TALON_ORIGIN_CREDENTIALS_SOURCE`).
+async fn build_s3_backend(
     cfg: &WorkerConfig,
     http: Arc<dyn talon_backend::http::HttpClient>,
+    observer: Arc<dyn talon_backend::CredentialsObserver>,
 ) -> anyhow::Result<S3Backend> {
     let region = cfg
         .s3_region
         .clone()
         .ok_or_else(|| anyhow::anyhow!("s3_region is required (set TALON_WORKER_S3_REGION)"))?;
-    let access_key_id = cfg.s3_access_key_id.clone().ok_or_else(|| {
-        anyhow::anyhow!("s3_access_key_id is required (set TALON_WORKER_S3_ACCESS_KEY_ID)")
-    })?;
-    let secret_access_key = s3_secret_key_from_env().ok_or_else(|| {
-        anyhow::anyhow!("TALON_WORKER_S3_SECRET_ACCESS_KEY must be set (secret key)")
-    })?;
+    let static_credentials = match (cfg.s3_access_key_id.clone(), s3_secret_key_from_env()) {
+        (Some(access_key_id), Some(secret_access_key)) => Some(S3Credentials {
+            access_key_id,
+            secret_access_key,
+            session_token: s3_session_token_from_env(),
+        }),
+        (None, None) => None,
+        (Some(_), None) => {
+            anyhow::bail!("TALON_WORKER_S3_SECRET_ACCESS_KEY must be set (secret key)")
+        }
+        (None, Some(_)) => {
+            anyhow::bail!("s3_access_key_id is required (set TALON_WORKER_S3_ACCESS_KEY_ID)")
+        }
+    };
     let mut config = S3Config::aws(&region);
     if let Some(endpoint) = cfg.s3_endpoint.clone() {
         let (host, tls) = split_scheme(&endpoint);
@@ -232,19 +301,29 @@ fn build_s3_backend(
     if let Some(path_style) = cfg.s3_path_style {
         config.path_style = path_style;
     }
-    let creds = S3Credentials {
-        access_key_id,
-        secret_access_key,
-        session_token: s3_session_token_from_env(),
-    };
-    Ok(S3Backend::new(config, creds, http))
+    let resolved = talon_backend::resolve_s3_credentials(
+        static_credentials,
+        origin_credentials_source().as_deref(),
+        Arc::clone(&http),
+        observer,
+    )
+    .await
+    .map_err(|error| anyhow::anyhow!(error))?;
+    tracing::info!(source = resolved.source, "origin S3 credentials resolved");
+    Ok(S3Backend::with_credentials_provider(
+        config,
+        resolved.provider,
+        http,
+    ))
 }
 
-/// Build the GCS backend from an optional endpoint override (fake-gcs-server) +
-/// bearer token (env only).
-fn build_gcs_backend(
+/// Build the GCS backend from an optional endpoint override (fake-gcs-server)
+/// plus a bearer token (env) or the GKE metadata service
+/// (`TALON_ORIGIN_CREDENTIALS_SOURCE=gcp-metadata`).
+async fn build_gcs_backend(
     cfg: &WorkerConfig,
     http: Arc<dyn talon_backend::http::HttpClient>,
+    observer: Arc<dyn talon_backend::CredentialsObserver>,
 ) -> anyhow::Result<GcsBackend> {
     let config = match cfg.gcs_endpoint.clone() {
         Some(endpoint) => {
@@ -253,7 +332,20 @@ fn build_gcs_backend(
         }
         None => GcsConfig::default(),
     };
-    Ok(GcsBackend::new(config, gcs_bearer_from_env(), http))
+    let resolved = talon_backend::resolve_gcs_bearer(
+        gcs_bearer_from_env(),
+        origin_credentials_source().as_deref(),
+        Arc::clone(&http),
+        observer,
+    )
+    .await
+    .map_err(|error| anyhow::anyhow!(error))?;
+    tracing::info!(source = resolved.source, "origin GCS credentials resolved");
+    Ok(GcsBackend::with_bearer_provider(
+        config,
+        resolved.provider,
+        http,
+    ))
 }
 
 #[tokio::main]
@@ -475,11 +567,17 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // Select the object-store backend from config (default: azure). Each backend
-    // reads its endpoint from config and its secret from the environment only.
+    // reads its endpoint from config and its credentials from the environment
+    // only — static secrets, or a cloud workload identity refreshed in the
+    // background and counted through the worker registry.
+    let credentials_observer: Arc<dyn talon_backend::CredentialsObserver> =
+        Arc::new(CredentialsMetricsObserver {
+            observability: Arc::clone(&observability),
+        });
     let backend: Arc<dyn BackendStore> = match backend_kind {
-        "azure" => Arc::new(build_azure_backend(&cfg, http)?),
-        "s3" => Arc::new(build_s3_backend(&cfg, http)?),
-        "gcs" => Arc::new(build_gcs_backend(&cfg, http)?),
+        "azure" => Arc::new(build_azure_backend(&cfg, http, credentials_observer).await?),
+        "s3" => Arc::new(build_s3_backend(&cfg, http, credentials_observer).await?),
+        "gcs" => Arc::new(build_gcs_backend(&cfg, http, credentials_observer).await?),
         other => {
             anyhow::bail!("unknown TALON_WORKER_BACKEND {other:?}; expected azure, s3, or gcs")
         }

--- a/crates/talon-worker/src/observability.rs
+++ b/crates/talon-worker/src/observability.rs
@@ -403,6 +403,29 @@ impl WorkerMetrics {
         self.backend_timeouts_total.inc();
     }
 
+    /// Record one origin credential refresh outcome (workload identity).
+    pub fn record_origin_credentials(&self, result: &'static str) {
+        self.registry
+            .counter(
+                "talon_worker_origin_credentials_total",
+                "Origin credential refresh outcomes.",
+                labels(&[("result", result)]),
+            )
+            .inc();
+    }
+
+    /// Publish when the current origin credentials expire (unix seconds,
+    /// `0` when the mechanism reports no expiry or credentials are static).
+    pub fn set_origin_credentials_expiry(&self, unix_seconds: f64) {
+        self.registry
+            .gauge(
+                "talon_worker_origin_credentials_expiry_seconds",
+                "Unix time when the current origin credentials expire.",
+                labels(&[]),
+            )
+            .set(unix_seconds);
+    }
+
     /// Record a successful write-through PUT of `bytes` to the origin backend.
     pub fn record_backend_write_success(&self, bytes: u64) {
         self.backend_write_bytes_total.add(bytes);

--- a/docs/operations/cloud-backends.md
+++ b/docs/operations/cloud-backends.md
@@ -75,6 +75,50 @@ export TALON_WORKER_AZURE_SAS="sv=...&sig=..."     # env-only
 talon-worker --coordinator talon-coordinator:7000 --cluster-id demo
 ```
 
+## Workload identity (keyless)
+
+On Kubernetes, every major cloud can hand the pod an identity instead of a
+static key. When no static credential is configured, the worker and the
+gateway resolve one of these mechanisms at startup and then refresh the
+short-lived credentials in the background (at roughly 80% of their lifetime,
+clamped between 1 and 15 minutes of margin). A failed refresh keeps the last
+credentials, logs a warning without secret material, and retries every 30
+seconds; a failed **initial** resolution is a startup error, exactly like a
+missing static key.
+
+| Cloud | Mechanism | Detection | Verified |
+|---|---|---|---|
+| AWS EKS | IRSA: `sts:AssumeRoleWithWebIdentity` | auto: `AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE` (webhook-injected) | live EKS: exchange + signed request |
+| Alibaba ACK | RRSA: `sts:AssumeRoleWithOIDC` | auto: `ALIBABA_CLOUD_ROLE_ARN` + `ALIBABA_CLOUD_OIDC_PROVIDER_ARN` + `ALIBABA_CLOUD_OIDC_TOKEN_FILE` | live ACK: exchange + signed request |
+| Tencent TKE | OIDC: `sts:AssumeRoleWithWebIdentity` | auto: `TKE_ROLE_ARN` + `TKE_PROVIDER_ID` + `TKE_WEB_IDENTITY_TOKEN_FILE` | protocol-level |
+| Huawei CCE | agency metadata (`/openstack/latest/securitykey`) | explicit: `TALON_ORIGIN_CREDENTIALS_SOURCE=huawei-agency` | protocol-level; requires an agency bound to the node |
+| GCP GKE | Workload Identity metadata token (GCS `Bearer`) | explicit: `TALON_ORIGIN_CREDENTIALS_SOURCE=gcp-metadata` | protocol-level |
+| Azure AKS | Workload Identity: Azure AD token (`Bearer`) | auto when no SAS/key: `AZURE_CLIENT_ID` + `AZURE_TENANT_ID` + `AZURE_FEDERATED_TOKEN_FILE`; pods also need the `azure.workload.identity/use: "true"` label | protocol-level; injected env contract verified on live AKS |
+
+Static credentials always win, so existing deployments are unaffected.
+`TALON_ORIGIN_CREDENTIALS_SOURCE` (shared by the worker and the gateway)
+forces one mechanism — `static`, `aws-web-identity`, `aliyun-oidc`,
+`tencent-oidc`, `huawei-agency`, or `gcp-metadata` — instead of
+auto-detection; the GCP and Huawei metadata endpoints have no env marker and
+are never probed implicitly. Aliyun, Tencent, and Huawei OBS are consumed
+through their S3-compatible endpoints with SigV4 plus the temporary security
+token, the same shape their official Milvus storage integrations use. OSS and
+COS require virtual-host addressing (path style is rejected with `403`) and a
+bare region in the signing scope (`cn-hangzhou`, not `oss-cn-hangzhou`).
+"Protocol-level" means the exchange is implemented and tested against the
+documented API shape but has not yet been validated against a live cluster.
+To validate a cluster, build the verification probe
+(`cargo build -p talon-backend --example credentials_probe`) and run it in a
+pod bound to the target ServiceAccount: it resolves the production chain and
+HEADs one key with the resolved credentials, printing only redacted material.
+A `NotFound` answer proves the exchange and the signature end to end.
+
+Refresh outcomes are counted as
+`talon_worker_origin_credentials_total{result="refresh_success"|"refresh_failure"}`
+(the gateway equivalent is `talon_gateway_origin_credentials_total`), and
+`talon_worker_origin_credentials_expiry_seconds` publishes the current
+credentials' hard expiry so an alert can fire before it passes.
+
 ## Testing against emulators
 
 Each backend has an end-to-end test that reads a real object through the actual
@@ -109,4 +153,6 @@ Azurite is included in the [latency lab](../testing/latency-lab.md) stack.
 Credentials (`*_SECRET_ACCESS_KEY`, `*_SESSION_TOKEN`, `*_BEARER_TOKEN`,
 `*_AZURE_SAS`) are read **only** from the environment — never from a config file,
 and never logged. Inject them with your platform's secret mechanism (Kubernetes
-Secrets, a secrets manager) rather than baking them into images or manifests.
+Secrets, a secrets manager) rather than baking them into images or manifests —
+or configure no static credential at all and let
+[workload identity](#workload-identity-keyless) keep the cluster keyless.

--- a/docs/operations/object-store-gateway.md
+++ b/docs/operations/object-store-gateway.md
@@ -33,8 +33,8 @@ with the process's origin identity.
 |---|---|---|
 | Client to S3 gateway | SigV4 access key, optional STS token, or presigned query | Identity file mounted read-only; never logged or forwarded. |
 | Client to Azure gateway | Shared Key, service SAS, or account SAS | Identity file mounted read-only; never logged or forwarded. |
-| Gateway to S3 | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN` | Environment/secret injection only. |
-| Gateway to Azure | Exactly one of `TALON_GATEWAY_AZURE_SHARED_KEY` or `TALON_GATEWAY_AZURE_SAS` | Environment/secret injection only. |
+| Gateway to S3 | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN` — or a [cloud workload identity](cloud-backends.md#workload-identity-keyless) when no static keys are set | Environment/secret injection only; workload-identity credentials are refreshed in-process and never stored. |
+| Gateway to Azure | Exactly one of `TALON_GATEWAY_AZURE_SHARED_KEY` or `TALON_GATEWAY_AZURE_SAS` — or AKS workload identity when neither is set | Environment/secret injection only. |
 | Gateway to Talon | Coordinator and worker data-plane connection | Existing Talon cache-client boundary; mTLS integration is part of #446. |
 
 Use an origin identity limited to the advertised read and mutation operations
@@ -102,6 +102,7 @@ Common variables:
 | `TALON_GATEWAY_MTLS_IDENTITIES_PATH` | unset | JSON URI SAN to principal mapping file. |
 | `TALON_GATEWAY_AUTHORIZATION_PATH` | unset | JSON allow-grant file. Required for production readiness. |
 | `TALON_GATEWAY_AUTH_RELOAD_MS` | `5000` | Client identity and authorization file poll interval. |
+| `TALON_ORIGIN_CREDENTIALS_SOURCE` | `auto` | Origin credential mechanism (`static`, `aws-web-identity`, `aliyun-oidc`, `tencent-oidc`, `huawei-agency`, `gcp-metadata`); see [workload identity](cloud-backends.md#workload-identity-keyless). Static keys always win under `auto`. |
 
 The listener permits TLS 1.3 only and advertises HTTP/2 and HTTP/1.1. A bad
 rotation increments `talon_gateway_tls_events_total{event="reload_failure"}`
@@ -161,7 +162,8 @@ S3 variables:
 | Variable | Default | Meaning |
 |---|---|---|
 | `TALON_GATEWAY_S3_REGION` | `us-east-1` | Origin signing region, required incoming SigV4 scope region, `GetBucketLocation` answer, and the `x-amz-bucket-region` value stamped on `HeadBucket` responses. |
-| `TALON_GATEWAY_S3_ENDPOINT` | AWS regional endpoint | Optional `http[s]://host[:port]`; custom endpoints use path addressing. |
+| `TALON_GATEWAY_S3_ENDPOINT` | AWS regional endpoint | Optional `http[s]://host[:port]` for S3-compatible origins. |
+| `TALON_GATEWAY_S3_ORIGIN_PATH_STYLE` | `true` | Origin addressing for custom endpoints: `true` for MinIO/Ceph, `false` (virtual-host) for OSS and COS. |
 | `AWS_ACCESS_KEY_ID` | required | Scoped origin access key. |
 | `AWS_SECRET_ACCESS_KEY` | required | Scoped origin secret. |
 | `AWS_SESSION_TOKEN` | unset | Optional STS token. |

--- a/typos.toml
+++ b/typos.toml
@@ -10,6 +10,9 @@
 mis = "mis"
 # Accepted English spelling used in doc comments.
 clonable = "clonable"
+# Managed Kubernetes product names (Azure AKS, Tencent TKE), not "ask"/"take".
+AKS = "AKS"
+TKE = "TKE"
 
 [files]
 # Generated and vendored content should not be spell-checked.


### PR DESCRIPTION
## Summary

The gateway and the worker signed origin requests with static credentials captured once at startup, so temporary STS material expired mid-run and every cluster had to keep long-lived keys in Secrets. This PR makes both binaries resolve origin credentials the way cloud platforms hand identity to pods:

- Backends take a per-request credential snapshot from a provider. Static env material wraps into a fixed provider — behavior unchanged, and static always wins — while workload-identity fetchers exchange the platform-injected pod identity for short-lived credentials and refresh them in the background at ~80% of their lifetime, retaining the last good value when a refresh fails (a failed *initial* resolution refuses startup, like a missing static key).
- Acquisition covers six clouds with plain HTTP through the existing `HttpClient` abstraction, no cloud SDKs: AWS EKS IRSA (`AssumeRoleWithWebIdentity`), Alibaba ACK RRSA (`AssumeRoleWithOIDC`), Tencent TKE OIDC, Huawei CCE agency metadata, GKE metadata tokens for GCS `Bearer` auth, and AKS workload identity feeding a new Azure Blob `Bearer` mode alongside the untouched SharedKey/SAS paths.
- `TALON_ORIGIN_CREDENTIALS_SOURCE` selects a mechanism explicitly; the env-markerless GCP and Huawei metadata endpoints are never probed implicitly. Exchange errors carry only the HTTP status and a bounded provider code, never token or key material.
- Refresh outcomes count into `talon_gateway_origin_credentials_total` / `talon_worker_origin_credentials_total` plus an expiry gauge, so a stalled refresh alerts before credentials hard-expire.
- Fixes the gateway hardcoding `path_style: true` for custom S3 endpoints, which 403s against OSS/COS: new `TALON_GATEWAY_S3_ORIGIN_PATH_STYLE` (default `true` keeps MinIO/Ceph behavior).
- Adds `examples/credentials_probe`, the tool used for the live verification below; it resolves the production chain in a pod and proves the credentials with one HEAD, printing only redacted material.

## Live verification (UAT)

| Cloud | Result |
|---|---|
| AWS EKS | **Verified end to end**: probe pod bound to a Milvus instance ServiceAccount resolved `aws-web-identity`, exchanged the projected token at regional STS for `ASIA…` credentials, and a signed HEAD against the instance bucket returned `NotFound` (signature and authorization accepted). |
| Alibaba ACK | **Verified end to end**: `aliyun-oidc` resolved via RRSA, exchanged for `STS.…` credentials, signed HEAD against the internal OSS endpoint returned `NotFound`. Found and encoded two contract facts: OSS rejects path-style addressing (403) and the SigV4 scope wants the bare region (`cn-hangzhou`). |
| Azure AKS | Injected env contract verified against live AKS Milvus pods (`AZURE_CLIENT_ID`/`TENANT_ID`/`FEDERATED_TOKEN_FILE`, `azure.workload.identity/use` label, `api://AzureADTokenExchange` audience); the exchange itself is stub-tested — cluster RBAC there allows no pod create/exec. |
| Huawei CCE | Fetcher fail-fast path verified live: UAT nodes have no agency binding, the metadata `securitykey` endpoint answers 400, and the process correctly refuses startup. Exchange pending an agency-bound environment. |
| GCP GKE | Implementation stub-tested; the UAT cluster API is on a private endpoint unreachable from the dev environment. |
| Tencent TKE | Stub-tested against the documented TKE OIDC contract; no reachable TKE Milvus cluster. |

## Testing

- 319 tests pass (backend 170, gateway 125 lib + 18 bin + 6 e2e/stub), zero clippy warnings, rustfmt clean; all 159 pre-existing talon-backend tests pass unmodified.
- Refresher semantics (rotation, failure retention, drop-exit, margin clamps) and all six exchange protocols are covered offline with injected `HttpClient` mocks, including error-hygiene assertions that token material never reaches error strings.
- talon-worker compiles only on Linux (io_uring/splice); `cargo check`/`clippy -p talon-worker --all-targets` were run clean in a Linux container.

## Notes for reviewers

- `GatewayRuntime::new_with_metrics` is added so credential events counted before runtime construction land in the registry `/metrics` serves; `new()` delegates to it.
- Two gateway tests were rewritten equivalently (`s3_adapter`/`azure_adapter` grew a credential parameter); assertions preserved.
- The Huawei fetcher takes the agency credentials directly from node metadata rather than Milvus's heavier SDK-chain + IAM token exchange; revisit if a per-pod (not per-node) identity is required there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
