### PR TITLE
fix(backend): keep the root path on virtual-host bucket URLs

### DIFF
--- a/crates/talon-backend/src/endpoint.rs
+++ b/crates/talon-backend/src/endpoint.rs
@@ -1,0 +1,83 @@
+//! Normalization for operator-supplied blob-store endpoints.
+
+/// Split an operator-supplied endpoint into its `(host, tls)` parts.
+///
+/// Operators write endpoints as URLs -- `https://minio:9000/`, copied from a
+/// browser or a provider console -- while every config type in this crate
+/// documents its endpoint as a bare host: [`S3Config::endpoint`],
+/// [`GcsConfig::endpoint`], [`AzureConfig::endpoint_host`]. The URL builders
+/// rely on that: each one supplies its own separator, so `{host}/{bucket}` and
+/// `{bucket}.{host}/{key}` double up their slash if the host kept one.
+///
+/// A doubled slash is not a cosmetic difference. It reaches the signer as part
+/// of the canonical URI, so the request is signed for `//key` and addresses an
+/// object that is not the one asked for.
+///
+/// Trailing slashes are stripped; any other path is left alone, since a
+/// path-style endpoint may legitimately sit behind a prefix
+/// (`gateway.internal/minio`).
+///
+/// [`S3Config::endpoint`]: crate::S3Config::endpoint
+/// [`GcsConfig::endpoint`]: crate::GcsConfig::endpoint
+/// [`AzureConfig::endpoint_host`]: crate::AzureConfig::endpoint_host
+pub fn endpoint_host(endpoint: &str) -> (String, bool) {
+    let (host, tls) = match endpoint.strip_prefix("http://") {
+        Some(rest) => (rest, false),
+        None => (endpoint.strip_prefix("https://").unwrap_or(endpoint), true),
+    };
+    (host.trim_end_matches('/').to_string(), tls)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_scheme_selects_tls_and_is_removed() {
+        assert_eq!(
+            endpoint_host("http://minio:9000"),
+            ("minio:9000".into(), false)
+        );
+        assert_eq!(
+            endpoint_host("https://blob.example"),
+            ("blob.example".into(), true)
+        );
+    }
+
+    #[test]
+    fn a_bare_host_defaults_to_tls() {
+        assert_eq!(endpoint_host("s3.example"), ("s3.example".into(), true));
+    }
+
+    #[test]
+    fn trailing_slashes_are_stripped_so_url_builders_cannot_double_up() {
+        // The URL builders append their own separator, so a host that kept one
+        // would sign `//bucket` or `//key` and address the wrong object.
+        for endpoint in [
+            "https://s3.example/",
+            "https://s3.example//",
+            "s3.example/",
+            "http://minio:9000/",
+        ] {
+            let (host, _) = endpoint_host(endpoint);
+            assert!(
+                !host.ends_with('/'),
+                "{endpoint} left a trailing slash on the host: {host}"
+            );
+        }
+        assert_eq!(
+            endpoint_host("http://minio:9000/"),
+            ("minio:9000".into(), false)
+        );
+    }
+
+    #[test]
+    fn a_path_prefix_survives() {
+        // Path-style endpoints may sit behind a prefix; only the trailing
+        // separator is ours to remove.
+        assert_eq!(
+            endpoint_host("https://gateway.internal/minio/"),
+            ("gateway.internal/minio".into(), true)
+        );
+    }
+}

--- a/crates/talon-backend/src/lib.rs
+++ b/crates/talon-backend/src/lib.rs
@@ -15,6 +15,7 @@ pub mod azure;
 pub mod azure_sharedkey;
 pub mod credentials;
 pub mod delay;
+pub mod endpoint;
 pub mod gcs;
 pub mod http;
 mod query_auth;
@@ -32,6 +33,7 @@ pub use credentials::{
     RefreshPolicy, RefreshingCredentials, StaticBearerToken, StaticS3Credentials,
 };
 pub use delay::{DelayConfig, DelayingHttpClient};
+pub use endpoint::endpoint_host;
 pub use gcs::{GcsBackend, GcsConfig};
 pub use http::{
     HttpClient, HttpRequest, HttpRequestBody, HttpResponse, HttpStreamResponse, Method,

--- a/crates/talon-backend/src/s3.rs
+++ b/crates/talon-backend/src/s3.rs
@@ -140,13 +140,18 @@ impl S3Backend {
         }
     }
 
-    /// Build the bucket URL (no key), used by listing.
+    /// Build the bucket URL (no key), used by listing and bucket sub-resources.
+    ///
+    /// Both styles end in a path segment, like [`Self::object_url`]: virtual-host
+    /// addressing puts the bucket in the host, leaving the root path, which must
+    /// still be written. Callers append `?query`, and a URL whose authority ran
+    /// straight into `?` would carry the query into the signed `Host` header.
     pub fn bucket_url(&self, bucket: &str) -> String {
         let scheme = if self.config.tls { "https" } else { "http" };
         if self.config.path_style {
             format!("{scheme}://{}/{bucket}", self.config.endpoint)
         } else {
-            format!("{scheme}://{bucket}.{}", self.config.endpoint)
+            format!("{scheme}://{bucket}.{}/", self.config.endpoint)
         }
     }
 
@@ -1144,6 +1149,45 @@ mod tests {
         assert!(request
             .header("authorization")
             .is_some_and(|value| value.starts_with("AWS4-HMAC-SHA256")));
+    }
+
+    #[tokio::test]
+    async fn virtual_host_bucket_requests_sign_the_bare_authority() {
+        // Virtual-host addressing leaves the bucket URL with no path segment of
+        // its own. Without the root path the appended `?query` runs straight
+        // into the authority, and the signer -- which splits the host off at the
+        // first `/` -- would carry the whole query into the signed `Host`
+        // header, so the origin resolves a bucket name that does not exist.
+        let http = MockHttp::new(HttpResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: bytes::Bytes::new(),
+        });
+        let backend = S3Backend::new(
+            S3Config {
+                region: "us-west-2".into(),
+                endpoint: "s3.us-west-2.amazonaws.com".into(),
+                path_style: false,
+                tls: true,
+            },
+            creds(),
+            http.clone(),
+        );
+        backend
+            .execute_list_v1_raw("my-bucket", "prefix/", None, None, 1000, None)
+            .await
+            .unwrap();
+        let request = http.last.lock().unwrap().take().unwrap();
+        assert_eq!(
+            request.url,
+            "https://my-bucket.s3.us-west-2.amazonaws.com/?max-keys=1000&prefix=prefix%2F",
+            "the bucket URL keeps its root path so the query stays out of the authority"
+        );
+        assert_eq!(
+            request.header("host"),
+            Some("my-bucket.s3.us-west-2.amazonaws.com"),
+            "the signed Host is the authority alone"
+        );
     }
 
     #[tokio::test]

--- a/crates/talon-backend/tests/azure_e2e.rs
+++ b/crates/talon-backend/tests/azure_e2e.rs
@@ -12,7 +12,7 @@ mod conformance;
 
 use std::sync::Arc;
 
-use talon_backend::{AzureBackend, AzureConfig, ReqwestClient};
+use talon_backend::{endpoint_host, AzureBackend, AzureConfig, ReqwestClient};
 use talon_core::{Backend, ObjectId};
 
 const DEV_ACCOUNT: &str = "devstoreaccount1";
@@ -33,12 +33,7 @@ async fn azure_backend_conformance_end_to_end() {
         env("TALON_AZURE_TEST_CONTAINER").expect("TALON_AZURE_TEST_CONTAINER must be set");
     let key = env("TALON_AZURE_TEST_KEY").unwrap_or_else(|| "e2e/object.bin".to_string());
 
-    let host = endpoint
-        .strip_prefix("http://")
-        .or_else(|| endpoint.strip_prefix("https://"))
-        .unwrap_or(&endpoint)
-        .to_string();
-    let tls = !endpoint.starts_with("http://");
+    let (host, tls) = endpoint_host(&endpoint);
     let config = AzureConfig::emulator(DEV_ACCOUNT, host, tls);
     let backend = Arc::new(AzureBackend::with_shared_key(
         config,

--- a/crates/talon-backend/tests/gcs_e2e.rs
+++ b/crates/talon-backend/tests/gcs_e2e.rs
@@ -11,7 +11,7 @@ mod conformance;
 
 use std::sync::Arc;
 
-use talon_backend::{GcsBackend, GcsConfig, ReqwestClient};
+use talon_backend::{endpoint_host, GcsBackend, GcsConfig, ReqwestClient};
 use talon_core::{Backend, ObjectId};
 
 fn env(name: &str) -> Option<String> {
@@ -27,12 +27,7 @@ async fn gcs_backend_conformance_end_to_end() {
     let bucket = env("TALON_GCS_TEST_BUCKET").expect("TALON_GCS_TEST_BUCKET must be set");
     let key = env("TALON_GCS_TEST_KEY").unwrap_or_else(|| "e2e/object.bin".to_string());
 
-    let host = endpoint
-        .strip_prefix("http://")
-        .or_else(|| endpoint.strip_prefix("https://"))
-        .unwrap_or(&endpoint)
-        .to_string();
-    let tls = !endpoint.starts_with("http://");
+    let (host, tls) = endpoint_host(&endpoint);
     let config = GcsConfig::emulator(host, tls);
     let backend = Arc::new(GcsBackend::new(
         config,

--- a/crates/talon-backend/tests/s3_e2e.rs
+++ b/crates/talon-backend/tests/s3_e2e.rs
@@ -12,7 +12,7 @@ mod conformance;
 
 use std::sync::Arc;
 
-use talon_backend::{ReqwestClient, S3Backend, S3Config, S3Credentials};
+use talon_backend::{endpoint_host, ReqwestClient, S3Backend, S3Config, S3Credentials};
 use talon_core::{Backend, ObjectId};
 
 fn env(name: &str) -> Option<String> {
@@ -32,12 +32,7 @@ async fn s3_backend_conformance_end_to_end() {
     let secret_access_key =
         env("AWS_SECRET_ACCESS_KEY").expect("AWS_SECRET_ACCESS_KEY must be set");
 
-    let host = endpoint
-        .strip_prefix("http://")
-        .or_else(|| endpoint.strip_prefix("https://"))
-        .unwrap_or(&endpoint)
-        .to_string();
-    let tls = !endpoint.starts_with("http://");
+    let (host, tls) = endpoint_host(&endpoint);
     let config = S3Config {
         region,
         endpoint: host,

--- a/crates/talon-gateway/src/main.rs
+++ b/crates/talon-gateway/src/main.rs
@@ -7,8 +7,9 @@ use std::sync::Arc;
 
 use serde::Deserialize;
 use talon_backend::{
-    resolve_azure_bearer, resolve_s3_credentials, AzureBackend, AzureConfig, CredentialsObserver,
-    ProvideBearerToken, ProvideS3Credentials, ReqwestClient, S3Backend, S3Config, S3Credentials,
+    endpoint_host, resolve_azure_bearer, resolve_s3_credentials, AzureBackend, AzureConfig,
+    CredentialsObserver, ProvideBearerToken, ProvideS3Credentials, ReqwestClient, S3Backend,
+    S3Config, S3Credentials,
 };
 use talon_cache_client::{
     BlockReader, CoordinatorClient, PlacementCache, ZoneMatch, ZoneReadObserver,
@@ -375,20 +376,6 @@ fn parse_bool(value: Option<&str>, default: bool, name: &str) -> MainResult<bool
     }
 }
 
-fn split_endpoint(endpoint: &str) -> (String, bool) {
-    if let Some(host) = endpoint.strip_prefix("http://") {
-        (host.to_string(), false)
-    } else {
-        (
-            endpoint
-                .strip_prefix("https://")
-                .unwrap_or(endpoint)
-                .to_string(),
-            true,
-        )
-    }
-}
-
 /// Bridges zone-classified cache reads into the gateway registry.
 struct ZoneReadMetrics(GatewayMetrics);
 
@@ -462,7 +449,7 @@ fn azure_adapter(
         .ok_or_else(|| invalid("TALON_GATEWAY_AZURE_ACCOUNT is required"))?;
     let mut origin_config = match settings.azure_endpoint.as_deref() {
         Some(endpoint) => {
-            let (host, tls) = split_endpoint(endpoint);
+            let (host, tls) = endpoint_host(endpoint);
             AzureConfig::emulator(&account, host, tls)
         }
         None => AzureConfig::new(&account),
@@ -537,7 +524,7 @@ fn s3_adapter(
         .unwrap_or_else(|| "us-east-1".to_string());
     let origin_config = match settings.s3_endpoint.as_deref() {
         Some(endpoint) => {
-            let (host, tls) = split_endpoint(endpoint);
+            let (host, tls) = endpoint_host(endpoint);
             S3Config {
                 region: region.clone(),
                 endpoint: host,
@@ -1181,19 +1168,6 @@ mod tests {
             ("TALON_GATEWAY_AUTHORIZATION_PATH", "/policy.json"),
         ])
         .is_err());
-    }
-
-    #[test]
-    fn endpoint_scheme_selects_transport_without_retaining_the_scheme() {
-        assert_eq!(
-            split_endpoint("http://minio:9000"),
-            ("minio:9000".into(), false)
-        );
-        assert_eq!(
-            split_endpoint("https://blob.example"),
-            ("blob.example".into(), true)
-        );
-        assert_eq!(split_endpoint("s3.example"), ("s3.example".into(), true));
     }
 
     fn test_cache(settings: &Settings) -> Arc<BlockReader> {

--- a/crates/talon-gateway/tests/azure_sdk_e2e.rs
+++ b/crates/talon-gateway/tests/azure_sdk_e2e.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
-use talon_backend::{AzureBackend, AzureConfig, ReqwestClient};
+use talon_backend::{endpoint_host, AzureBackend, AzureConfig, ReqwestClient};
 use talon_cache_client::CacheReadError;
 use talon_core::{ObjectId, Version};
 use talon_gateway::azure::{AzureAdapterConfig, AzureBlobAdapter, AzureCache, AzureCacheRequest};
@@ -122,20 +122,6 @@ impl AzureCache for ReadThroughCache {
 
 fn env(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|value| !value.is_empty())
-}
-
-fn endpoint_host(endpoint: &str) -> (String, bool) {
-    if let Some(host) = endpoint.strip_prefix("http://") {
-        (host.to_string(), false)
-    } else {
-        (
-            endpoint
-                .strip_prefix("https://")
-                .unwrap_or(endpoint)
-                .to_string(),
-            true,
-        )
-    }
 }
 
 #[tokio::test]

--- a/crates/talon-gateway/tests/s3_sdk_e2e.rs
+++ b/crates/talon-gateway/tests/s3_sdk_e2e.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
-use talon_backend::{ReqwestClient, S3Backend, S3Config, S3Credentials};
+use talon_backend::{endpoint_host, ReqwestClient, S3Backend, S3Config, S3Credentials};
 use talon_cache_client::CacheReadError;
 use talon_core::{ObjectId, Version};
 use talon_gateway::s3::{S3Adapter, S3AdapterConfig, S3Cache, S3CacheRequest};
@@ -114,20 +114,6 @@ impl S3Cache for ReadThroughCache {
 
 fn env(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|value| !value.is_empty())
-}
-
-fn endpoint_host(endpoint: &str) -> (String, bool) {
-    if let Some(host) = endpoint.strip_prefix("http://") {
-        (host.to_string(), false)
-    } else {
-        (
-            endpoint
-                .strip_prefix("https://")
-                .unwrap_or(endpoint)
-                .to_string(),
-            true,
-        )
-    }
 }
 
 #[tokio::test]

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -27,8 +27,8 @@ use std::time::Duration;
 
 use clap::Parser;
 use talon_backend::{
-    AzureBackend, AzureConfig, GcsBackend, GcsConfig, ReqwestClient, S3Backend, S3Config,
-    S3Credentials,
+    endpoint_host, AzureBackend, AzureConfig, GcsBackend, GcsConfig, ReqwestClient, S3Backend,
+    S3Config, S3Credentials,
 };
 use talon_core::{
     azure_sas_from_env, gcs_bearer_from_env, s3_secret_key_from_env, s3_session_token_from_env,
@@ -196,21 +196,6 @@ impl Args {
     }
 }
 
-/// Split an endpoint URL into `(host, tls)`: an `http://` scheme selects
-/// plaintext, `https://` or a bare host keeps TLS.
-fn split_scheme(endpoint: &str) -> (String, bool) {
-    match endpoint.strip_prefix("http://") {
-        Some(rest) => (rest.to_string(), false),
-        None => (
-            endpoint
-                .strip_prefix("https://")
-                .unwrap_or(endpoint)
-                .to_string(),
-            true,
-        ),
-    }
-}
-
 /// Explicit origin credential mechanism (`static`, `aws-web-identity`,
 /// `aliyun-oidc`, `tencent-oidc`, `huawei-agency`, `gcp-metadata`); unset
 /// means static material first, then auto-detected workload identity. Read
@@ -234,7 +219,7 @@ async fn build_azure_backend(
     })?;
     let azure_config = match cfg.azure_endpoint.clone() {
         Some(endpoint) => {
-            let (host, tls) = split_scheme(&endpoint);
+            let (host, tls) = endpoint_host(&endpoint);
             AzureConfig::emulator(account, host, tls)
         }
         None => AzureConfig::new(account),
@@ -294,7 +279,7 @@ async fn build_s3_backend(
     };
     let mut config = S3Config::aws(&region);
     if let Some(endpoint) = cfg.s3_endpoint.clone() {
-        let (host, tls) = split_scheme(&endpoint);
+        let (host, tls) = endpoint_host(&endpoint);
         config.endpoint = host;
         config.tls = tls;
     }
@@ -327,7 +312,7 @@ async fn build_gcs_backend(
 ) -> anyhow::Result<GcsBackend> {
     let config = match cfg.gcs_endpoint.clone() {
         Some(endpoint) => {
-            let (host, tls) = split_scheme(&endpoint);
+            let (host, tls) = endpoint_host(&endpoint);
             GcsConfig::emulator(host, tls)
         }
         None => GcsConfig::default(),


### PR DESCRIPTION
Two commits: the outage fix, then the normalization gap a review question exposed underneath it.

## 1. `fix(backend): keep the root path on virtual-host bucket URLs`

`object_url` ends in a path segment in both addressing styles; `bucket_url` did not. Under virtual-host addressing the bucket moves into the host and the root path was left unwritten, so every caller that appends `?query` produced a URL whose authority ran straight into the query:

```
https://my-bucket.s3.us-west-2.amazonaws.com?max-keys=1000&prefix=…
```

`sigv4::split_url` takes the authority as everything up to the first `/`, so this signs and sends

```
Host: my-bucket.s3.us-west-2.amazonaws.com?max-keys=1000&prefix=…
```

and the origin resolves a bucket name that cannot exist. One character fixes it — the root path the URL always had.

### Blast radius

Every **bucket-level** request under virtual-host addressing: `ListObjectsV2`, `ListObjects V1` (#524), `GetBucketLocation`, and the batch `POST /bucket?delete` in #533. Object requests were never affected — `object_url` always writes `/{key}`.

This is the **default AWS path**, not an exotic configuration: `S3Config::aws()` sets `path_style = false`, and a gateway started without an explicit `TALON_GATEWAY_S3_ENDPOINT` takes that branch, so `TALON_GATEWAY_S3_ORIGIN_PATH_STYLE` (default `true`) never applies.

### How it was found

Reproduced end to end on a UAT cluster while pointing a real milvus instance's S3 endpoint at the gateway. Its C++ storage layer cannot pass the startup `ListObjects` precheck and the standalone pod crash-loops:

```
InvalidBucketName: The specified bucket is not valid.
<BucketName>zilliz-aws-….s3.us-west-2.amazonaws.com?max-keys=1000&prefix=…</BucketName>
server: AmazonS3          ← the origin rejected it
x-talon-request-id: …     ← passed back through the gateway
```

The echoed `<BucketName>` is the corrupted authority verbatim, including the `max-keys=1000` the gateway itself adds.

### Why the existing tests missed it

`list_v1_targets_the_bucket_url_without_a_list_type` covers path-style only, and asserts the URL string rather than the signed `Host`. The new `virtual_host_bucket_requests_sign_the_bare_authority` asserts the header; reverting the one-character fix turns it red with exactly the corrupted authority above.

## 2. `refactor(backend): one endpoint normalizer, and it strips trailing slashes`

Review question on the commit above: *the `/` is appended unconditionally — what if the endpoint already carries one?*

It would double up. Chasing that turned up the real defect, which is larger than the fix that exposed it.

Every config type here documents its endpoint as a bare host — `S3Config::endpoint` "Endpoint host, e.g. `s3.us-east-1.amazonaws.com`", `GcsConfig::endpoint` "Download host", `AzureConfig::endpoint_host` — and every URL builder relies on that by supplying its own separator. Nothing enforced it. The endpoint arrives as an operator-written URL, so each construction site normalized it itself, and the rule ended up in **seven copies**: `split_endpoint` in the gateway (S3 + Azure), `split_scheme` in the worker (S3 + GCS + Azure), and five more inlined across the S3, GCS and Azure e2e tests.

All seven stripped the scheme. **None stripped a trailing slash.** So `…_S3_ENDPOINT=https://host/` silently produces:

```
[virtual-host] object_url = https://bucket.host//key          ← every object read and write
[path-style]   object_url = https://host//bucket/key          ← every object read and write
[path-style]   bucket_url = https://host//bucket              ← every listing
```

Not cosmetic: the doubled slash reaches the signer as part of the canonical URI, so the request is signed for `//key` and addresses an object nobody asked for. And the endpoint override is exactly the knob an operator reaches for to pin a gateway to a specific origin.

This commit moves the rule to `talon-backend`, next to the config types whose contract it serves, and points all seven sites at it. Trailing slashes go; any other path stays, since a path-style endpoint may legitimately sit behind a prefix (`gateway.internal/minio`).

The duplication was the symptom. The cause was a contract stated in a doc comment and enforced nowhere, which is why seven sites could each remember half of it. Net `+103/-100`.

## Testing

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features` — clean
- `talon-backend` 175 and `talon-gateway` 143 tests pass, including all five e2e targets compiling
- Full `cargo build --workspace --all-targets --all-features` and `cargo test --workspace --all-features` in a `rust:1.96.1` Linux container: **875 passed**. The only failures are `talon-transport`'s `uring::tests`, which fail with `io_uring runtime: PermissionDenied` under Docker's seccomp profile — that crate depends on `talon-core` alone, so nothing here reaches it. CI runs io_uring in its own job.

## Note for #533

The batch delete builds `format!("{}?delete=", self.bucket_url(bucket))` — the same shape — so it needs commit 1 to work against a default AWS origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
