### PR TITLE
chore: ignore JetBrains project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 # Editor / OS
 *.swp
 .DS_Store
+# JetBrains project files: per-developer, and regenerated on open.
+.idea/
 
 # Secrets / credentials — never commit these.
 # The Azure SAS token and account are supplied via environment variables at


### PR DESCRIPTION
## What

Adds `.idea/` to the `Editor / OS` section of `.gitignore`.

## Why

That section covers vim (`*.swp`) and macOS (`.DS_Store`) but not JetBrains. A contributor running CLion/IDEA picks up an untracked `.idea/` on first open, and a plain `git add -A` sweeps it into the commit — which is exactly how five of them landed in #535 before being stripped back out.

The files are per-developer (module paths, JSON schema mappings, local VCS config) and the IDE regenerates them, so nothing in the tree needs them.

`.vscode/` is deliberately left out: those are often shared launch configs a project *does* want committed, whereas `.idea/` is personal.

## Verification

`origin/main` tracks no `.idea` files today (`git ls-files | grep -c '^\.idea/'` → 0), so this only affects future working trees — no untracking, no history rewrite.

```
$ git check-ignore -v .idea/jsonSchemas.xml
.gitignore:16:.idea/    .idea/jsonSchemas.xml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)