### PR TITLE
fix(fuse): reject paths with multiple leading slashes

### DIFF
--- a/crates/talon-fuse/src/mapping.rs
+++ b/crates/talon-fuse/src/mapping.rs
@@ -34,11 +34,11 @@ pub struct ReadTarget {
 
 /// Parse a mount-relative path into an [`ObjectId`].
 ///
-/// The path must be `/<backend>/<bucket>/<object key...>` with at least one
-/// non-empty object-key component. Returns [`Error::Other`] for malformed or
-/// ambiguous paths.
+/// The path must be `<backend>/<bucket>/<object key...>` with zero or one
+/// leading slash and at least one non-empty object-key component. Returns
+/// [`Error::Other`] for malformed or ambiguous paths.
 pub fn path_to_object(path: &str) -> Result<ObjectId> {
-    let trimmed = path.trim_start_matches('/');
+    let trimmed = path.strip_prefix('/').unwrap_or(path);
     let mut parts = trimmed.split('/');
 
     let backend: Backend = parts
@@ -105,6 +105,12 @@ mod tests {
     }
 
     #[test]
+    fn accepts_mount_relative_listing_paths() {
+        let obj = path_to_object("s3/bucket/key").unwrap();
+        assert_eq!(obj.to_path(), "/s3/bucket/key");
+    }
+
+    #[test]
     fn rejects_ambiguous_paths() {
         for bad in [
             "/s3/bucket",          // no object key
@@ -113,6 +119,7 @@ mod tests {
             "/s3/bucket/a//b",     // empty middle component
             "/s3/bucket/../etc",   // parent escape
             "/s3/bucket/./x",      // current-dir component
+            "//s3/bucket/key",     // multiple leading slashes
             "/unknown/bucket/key", // bad backend
             "/",                   // empty
         ] {

--- a/crates/talon-fuse/src/ops.rs
+++ b/crates/talon-fuse/src/ops.rs
@@ -610,21 +610,19 @@ impl ReadOnlyFs {
     /// Convenience over [`insert_object`](Self::insert_object) for populating the
     /// namespace from a coordinator `ObjectList`. Idempotent: re-inserting an
     /// existing object is a no-op for the tree shape (the path already resolves).
-    /// Returns the number of entries processed.
+    /// Malformed and reserved entries are skipped. Returns the number of entries
+    /// successfully registered.
     pub fn populate_from_listing<'a, I>(&self, entries: I) -> usize
     where
         I: IntoIterator<Item = (&'a str, u64)>,
     {
         let mut n = 0;
         for (path, size) in entries {
-            if Self::is_internal_object_path(path) {
-                continue;
-            }
             if path.ends_with('/') {
                 if self.insert_directory_marker(path).is_ok() {
                     n += 1;
                 }
-            } else {
+            } else if Self::validate_visible_object_path(path).is_ok() {
                 self.insert_object(path, size);
                 n += 1;
             }
@@ -2356,12 +2354,6 @@ impl ReadOnlyFs {
         }
         Ok(())
     }
-
-    fn is_internal_object_path(path: &str) -> bool {
-        path_to_object(path).is_ok_and(|object| {
-            object.object_path.split('/').next() == Some(INTERNAL_OBJECT_PREFIX)
-        })
-    }
 }
 
 #[cfg(test)]
@@ -2593,6 +2585,33 @@ mod tests {
         assert_eq!(
             fs.mkdir(bucket.ino, INTERNAL_OBJECT_PREFIX),
             Err(FsError::Invalid)
+        );
+    }
+
+    #[test]
+    fn populate_from_listing_rejects_multiply_rooted_paths() {
+        let fs = ReadOnlyFs::new();
+        let count = fs.populate_from_listing([
+            ("s3/bkt/visible.bin", 1u64),
+            ("//s3/bkt/ambiguous.bin", 2u64),
+            ("//s3/bkt/ambiguous-dir/", 0u64),
+            ("//s3/bkt/.__talon_internal/unlinked/stale/7", 5u64),
+        ]);
+        assert_eq!(count, 1);
+
+        let s3 = fs.lookup(ROOT_INO, "s3").unwrap();
+        let bucket = fs.lookup(s3.ino, "bkt").unwrap();
+        assert_eq!(
+            fs.lookup(bucket.ino, "ambiguous.bin"),
+            Err(FsError::NotFound)
+        );
+        assert_eq!(
+            fs.lookup(bucket.ino, "ambiguous-dir"),
+            Err(FsError::NotFound)
+        );
+        assert_eq!(
+            fs.lookup(bucket.ino, INTERNAL_OBJECT_PREFIX),
+            Err(FsError::NotFound)
         );
     }
 


### PR DESCRIPTION
## Summary

Reject FUSE object paths with more than one leading slash instead of silently normalizing them to a canonical object path. Validate regular listing entries before insertion so malformed aliases cannot become visible, while preserving supported relative paths.

## Related issues

Part of #259.

## Type of change

- [x] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [ ] Docs / tests / tooling

## Design alignment

This tightens the deterministic, reversible key-to-path mapping in `DESIGN.md` section 4. Ambiguous multiply rooted paths are rejected instead of being collapsed onto a canonical path; there is no design divergence.

## Changes

- Strip at most one optional leading slash when parsing FUSE object paths.
- Apply the same visible-path validation to regular listing entries that directory markers already use.
- Cover multiple-root rejection for parsed paths, listed files, directory markers, and reserved internal objects, plus compatibility with relative listing paths.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p talon-fuse --all-targets -- -D warnings`
- [x] `cargo test -p talon-fuse --locked`
- [x] Added/updated tests for new behavior
- [ ] Full `just ci` locally: its all-features workspace build requires Linux (`fuser` and `monoio` io_uring paths do not compile on macOS); upstream CI will exercise it.

## Performance impact

- [x] Not performance-sensitive

## Checklist

- [x] PR title follows Conventional Commits
- [x] Public items are documented; no broken intra-doc links
- [x] No new dependencies
- [x] Based on the latest `upstream/main`
