### PR TITLE
fix(fuse): track byte ranges for readahead

### DIFF
--- a/bench/baselines/main.json
+++ b/bench/baselines/main.json
@@ -20,5 +20,6 @@
   "read_path_benches::plan_eof_clamp": 77.62,
   "read_path_benches::plan_multi_block": 395.4,
   "read_path_benches::plan_single_block": 91.44,
+  "read_path_benches::readahead_byte_range_sequential_run": 157.3,
   "read_path_benches::readahead_sequential_run": 956.4
 }

--- a/crates/talon-fuse/benches/read_path_benches.rs
+++ b/crates/talon-fuse/benches/read_path_benches.rs
@@ -1,10 +1,11 @@
 //! Read-path microbenchmarks for the FUSE client.
 //!
-//! These measure the CPU cost of the per-read planning that runs on every
-//! `read(2)` before any I/O: splitting a POSIX byte range into per-block fetch
-//! segments ([`plan_read`]) and the sequential-detection / readahead planner
-//! ([`ReadaheadState::on_read`]). They are deterministic (no network, no disk)
-//! so they can be committed as a baseline and diffed by `scripts/bench.py`.
+//! These measure the CPU cost of per-read planning around `read(2)`: splitting
+//! a POSIX byte range into per-block fetch segments ([`plan_read`]) before I/O,
+//! and sequential detection / readahead planning after a successful read
+//! ([`ReadaheadState::on_read`] and [`ReadaheadState::on_read_range`]). They are
+//! deterministic (no network, no disk) so they can be committed as a baseline
+//! and diffed by `scripts/bench.py`.
 //!
 //! The end-to-end read *throughput* wins from sendfile (#179) and connection
 //! pooling (#181) are measured separately by real-loopback comparison benches
@@ -98,6 +99,27 @@ fn readahead_sequential_run(bencher: divan::Bencher) {
         let mut emitted = 0usize;
         for i in 0..64u64 {
             emitted += state.on_read(divan::black_box(i)).len();
+        }
+        emitted
+    });
+}
+
+/// Drive realistic byte-range reads through one large block, exercising the
+/// production detector path fixed by issue #256.
+#[divan::bench]
+fn readahead_byte_range_sequential_run(bencher: divan::Bencher) {
+    bencher.bench(|| {
+        let mut state = ReadaheadState::new(ReadaheadConfig::default());
+        let mut emitted = 0usize;
+        const READ_LEN: u64 = 128 << 10;
+        for i in 0..64u64 {
+            emitted += state
+                .on_read_range(
+                    divan::black_box(i * READ_LEN),
+                    divan::black_box(READ_LEN),
+                    BLOCK_SIZE,
+                )
+                .len();
         }
         emitted
     });

--- a/crates/talon-fuse/src/mount.rs
+++ b/crates/talon-fuse/src/mount.rs
@@ -299,9 +299,10 @@ impl TalonFuse {
         self
     }
 
-    /// Feed a read at `offset` on handle `fh` to that handle's prefetcher,
-    /// lazily creating it, and return the block indices a prefetch was spawned
-    /// for (empty until a sequential run is detected, or if readahead is off).
+    /// Feed a successful read at `offset` on handle `fh` to that handle's
+    /// prefetcher, lazily creating it, and return the block indices a prefetch
+    /// was spawned for (empty until a sequential run is detected, or if
+    /// readahead is off). `read_len` is the number of bytes actually returned.
     ///
     /// Split out of the `read` callback so the wiring is unit-testable without a
     /// kernel mount: the prefetcher only fires after `trigger_run` consecutive
@@ -310,18 +311,18 @@ impl TalonFuse {
         &self,
         fh: u64,
         offset: u64,
+        read_len: u64,
         file_size: u64,
         object: Option<ObjectId>,
         now_ms: u64,
     ) -> Vec<u64> {
-        if self.readahead.window == 0 {
+        if self.readahead.window == 0 || read_len == 0 {
             return Vec::new();
         }
         let object = match object {
             Some(o) => o,
             None => return Vec::new(),
         };
-        let block_index = offset / self.block_size as u64;
         let mut prefetchers = self.prefetchers.lock_recover();
         let prefetcher = prefetchers.entry(fh).or_insert_with(|| {
             Prefetcher::new(
@@ -337,7 +338,7 @@ impl TalonFuse {
         // The prefetcher spawns fetches on the runtime; enter it so the spawns
         // have a reactor even though we may be on a sync FUSE thread.
         let _guard = self.runtime.enter();
-        prefetcher.on_read(block_index, now_ms)
+        prefetcher.on_read_range(offset, read_len, now_ms)
     }
 
     /// Write `bytes` back to the object at mount-relative `path` through its
@@ -826,14 +827,23 @@ impl fuser::Filesystem for TalonFuse {
             reader.read(&view, offset, size as u64, now_ms).await
         });
 
-        // Drive client-side readahead: feed this read's starting block index to
-        // the per-handle prefetcher, which warms the next blocks on the owning
-        // worker only once a sequential run is detected (issue #206). Prefetch is
-        // fire-and-forget and bounded, so this never delays the reply.
-        self.drive_readahead(fh, offset, file_size, object_for_prefetch, now_ms);
-
         match result {
-            Ok(bytes) => reply.data(&bytes),
+            Ok(bytes) => {
+                // Feed the successful byte range to the per-handle prefetcher.
+                // Using the returned length keeps short reads sequential, while
+                // EOF-empty and failed reads leave detection untouched (#256).
+                // Prefetch is fire-and-forget and bounded, so this never delays
+                // the reply.
+                self.drive_readahead(
+                    fh,
+                    offset,
+                    bytes.len() as u64,
+                    file_size,
+                    object_for_prefetch,
+                    now_ms,
+                );
+                reply.data(&bytes);
+            }
             Err(_) => reply.error(libc::EIO),
         }
     }
@@ -1718,6 +1728,10 @@ mod tests {
     /// whether the speculative fetches succeed — they are fire-and-forget — so
     /// this exercises the mount→prefetcher wiring without any live server.
     fn adapter_with_readahead(window: u32) -> TalonFuse {
+        adapter_with_readahead_and_block_size(window, 8)
+    }
+
+    fn adapter_with_readahead_and_block_size(window: u32, block_size: u32) -> TalonFuse {
         let fs = Arc::new(ReadOnlyFs::new());
         let reader = BlockReader::new(
             CoordinatorClient::new("127.0.0.1:9"), // unused; prefetch fetches just fail
@@ -1728,7 +1742,7 @@ mod tests {
             fs,
             reader,
             tokio::runtime::Handle::current(),
-            8, // block_size
+            block_size,
             talon_core::Version::new(CANONICAL_MOUNT_VERSION),
         )
         .with_readahead(window)
@@ -1747,10 +1761,10 @@ mod tests {
         let size = 64 * 8; // 64 blocks of 8 bytes
         let o = Some(obj());
         // Reads at block 0,1 (offsets 0,8): run building, no prefetch yet.
-        assert!(fuse.drive_readahead(1, 0, size, o.clone(), 0).is_empty());
-        assert!(fuse.drive_readahead(1, 8, size, o.clone(), 0).is_empty());
+        assert!(fuse.drive_readahead(1, 0, 8, size, o.clone(), 0).is_empty());
+        assert!(fuse.drive_readahead(1, 8, 8, size, o.clone(), 0).is_empty());
         // Block 2: run reaches trigger_run=3 → prefetch the next blocks.
-        let spawned = fuse.drive_readahead(1, 16, size, o.clone(), 0);
+        let spawned = fuse.drive_readahead(1, 16, 8, size, o.clone(), 0);
         assert!(!spawned.is_empty(), "sequential run must prefetch");
         assert_eq!(spawned, vec![3, 4, 5, 6], "window of 4 ahead of block 2");
     }
@@ -1763,7 +1777,8 @@ mod tests {
         // Jumping around (0, 5, 2, 9) is never a sequential run → no prefetch.
         for off in [0u64, 40, 16, 72] {
             assert!(
-                fuse.drive_readahead(1, off, size, o.clone(), 0).is_empty(),
+                fuse.drive_readahead(1, off, 8, size, o.clone(), 0)
+                    .is_empty(),
                 "random access must not prefetch (offset {off})"
             );
         }
@@ -1778,7 +1793,7 @@ mod tests {
         let o = Some(obj());
         for i in 0..6u64 {
             assert!(
-                fuse.drive_readahead(1, i * 8, size, o.clone(), 0)
+                fuse.drive_readahead(1, i * 8, 8, size, o.clone(), 0)
                     .is_empty(),
                 "window 0 must never prefetch"
             );
@@ -1792,11 +1807,52 @@ mod tests {
         let fuse = adapter_with_readahead(4);
         let size = 64 * 8;
         let o = Some(obj());
-        let _ = fuse.drive_readahead(7, 0, size, o.clone(), 0);
+        let _ = fuse.drive_readahead(7, 0, 8, size, o.clone(), 0);
         assert!(fuse.prefetchers.lock().unwrap().contains_key(&7));
         // Simulate the release callback's cleanup.
         fuse.prefetchers.lock().unwrap().remove(&7);
         assert!(!fuse.prefetchers.lock().unwrap().contains_key(&7));
+    }
+
+    #[tokio::test]
+    async fn readahead_tracks_contiguous_reads_within_one_block() {
+        const READ_LEN: u64 = 128 << 10;
+        const BLOCK_SIZE: u32 = 256 << 20;
+        let fuse = adapter_with_readahead_and_block_size(4, BLOCK_SIZE);
+        let size = 8 * u64::from(BLOCK_SIZE);
+        let o = Some(obj());
+
+        assert!(fuse
+            .drive_readahead(1, 0, READ_LEN, size, o.clone(), 0)
+            .is_empty());
+        assert!(fuse
+            .drive_readahead(1, READ_LEN, READ_LEN, size, o.clone(), 0)
+            .is_empty());
+        assert_eq!(
+            fuse.drive_readahead(1, 2 * READ_LEN, READ_LEN, size, o, 0),
+            vec![1, 2, 3, 4]
+        );
+    }
+
+    #[tokio::test]
+    async fn readahead_uses_actual_short_read_length() {
+        let fuse = adapter_with_readahead(4);
+        let size = 64 * 8;
+        let o = Some(obj());
+
+        assert!(fuse.drive_readahead(1, 0, 3, size, o.clone(), 0).is_empty());
+        assert!(fuse.drive_readahead(1, 3, 5, size, o.clone(), 0).is_empty());
+        assert_eq!(fuse.drive_readahead(1, 8, 8, size, o, 0), vec![2, 3, 4, 5]);
+    }
+
+    #[tokio::test]
+    async fn readahead_empty_read_does_not_create_state() {
+        let fuse = adapter_with_readahead(4);
+
+        assert!(fuse
+            .drive_readahead(11, 0, 0, 64, Some(obj()), 0)
+            .is_empty());
+        assert!(!fuse.prefetchers.lock().unwrap().contains_key(&11));
     }
 
     #[test]

--- a/crates/talon-fuse/src/prefetch.rs
+++ b/crates/talon-fuse/src/prefetch.rs
@@ -2,10 +2,11 @@
 //!
 //! [`crate::readahead::ReadaheadState`] *detects* sequential
 //! access and *plans* which block indices to prefetch; this module *executes*
-//! that plan. On each read the caller feeds the block index to
-//! [`Prefetcher::on_read`], which asks the detector for the next-N block
-//! indices and issues a small, **fire-and-forget** warm-up read for each
-//! through a cloned [`BlockReader`].
+//! that plan. On each read the caller feeds the successful byte range to
+//! [`Prefetcher::on_read_range`], which asks the detector for the next-N block
+//! indices and issues a small, **fire-and-forget** warm-up read for each through
+//! a cloned [`BlockReader`]. [`Prefetcher::on_read`] remains available for
+//! block-granular callers.
 //!
 //! # Why a warm-up read warms anything
 //!
@@ -87,10 +88,28 @@ impl Prefetcher {
     /// Never blocks on the prefetch itself.
     pub fn on_read(&mut self, block_index: u64, now_ms: u64) -> Vec<u64> {
         let planned = self.state.on_read(block_index);
+        self.spawn_planned(planned, now_ms)
+    }
+
+    /// Record a successful foreground byte-range read and fire off prefetches.
+    ///
+    /// `read_len` must be the number of bytes actually returned. Empty reads are
+    /// no-ops. Returns the block indices for which a task was actually spawned.
+    pub fn on_read_range(&mut self, offset: u64, read_len: u64, now_ms: u64) -> Vec<u64> {
+        let planned = self.state.on_read_range(offset, read_len, self.block_size);
+        self.spawn_planned(planned, now_ms)
+    }
+
+    fn spawn_planned(&self, planned: Vec<u64>, now_ms: u64) -> Vec<u64> {
         let mut spawned = Vec::new();
-        let bs = self.block_size as u64;
+        let bs = u64::from(self.block_size);
+        if bs == 0 {
+            return spawned;
+        }
         for idx in planned {
-            let block_start = idx * bs;
+            let Some(block_start) = idx.checked_mul(bs) else {
+                continue;
+            };
             // Never prefetch a block that starts at or past EOF.
             if block_start >= self.size {
                 continue;
@@ -282,6 +301,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn contiguous_byte_ranges_prefetch_next_blocks() {
+        let count = Arc::new(AtomicU32::new(0));
+        let worker = mock_worker(Arc::clone(&count)).await;
+        let coord = mock_coordinator(worker).await;
+        let mut pf = prefetcher(reader(coord));
+
+        assert!(pf.on_read_range(0, 128, 0).is_empty());
+        let spawned = pf.on_read_range(128, 128, 0);
+        assert_eq!(spawned, vec![1, 2, 3]);
+        assert!(pf.is_sequential());
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(count.load(Ordering::SeqCst), spawned.len() as u32);
+    }
+
+    #[tokio::test]
+    async fn zero_length_byte_range_does_not_advance_detection() {
+        let count = Arc::new(AtomicU32::new(0));
+        let worker = mock_worker(Arc::clone(&count)).await;
+        let coord = mock_coordinator(worker).await;
+        let mut pf = prefetcher(reader(coord));
+
+        assert!(pf.on_read_range(0, 128, 0).is_empty());
+        assert!(pf.on_read_range(128, 0, 0).is_empty());
+        assert_eq!(pf.on_read_range(128, 128, 0), vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
     async fn prefetch_skips_blocks_past_eof() {
         let count = Arc::new(AtomicU32::new(0));
         let worker = mock_worker(Arc::clone(&count)).await;
@@ -309,5 +356,23 @@ mod tests {
         );
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         assert_eq!(count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn unrepresentable_block_start_is_skipped() {
+        let mut pf = Prefetcher::new(
+            reader("127.0.0.1:9".to_owned()),
+            ReadaheadConfig {
+                trigger_run: 1,
+                window: 1,
+            },
+            1,
+            ObjectId::new(Backend::S3, "b", "o/1"),
+            1024,
+            Version::new("v1"),
+            u64::MAX,
+        );
+
+        assert!(pf.on_read(u64::MAX / 1024, 0).is_empty());
     }
 }

--- a/crates/talon-fuse/src/readahead.rs
+++ b/crates/talon-fuse/src/readahead.rs
@@ -6,10 +6,11 @@
 //! consecutive reads it prefetches the next N block indices ahead of the
 //! cursor. Random access never triggers prefetch, so no bandwidth is wasted.
 //!
-//! [`ReadaheadState::on_read`] is called for each read (by block index) and
-//! returns the block indices to prefetch — empty until a sequential run is
-//! established, and bounded by the configured window so prefetch memory can't
-//! grow unbounded.
+//! [`ReadaheadState::on_read_range`] is called with each successful read's byte
+//! range and returns the block indices to prefetch — empty until a sequential
+//! run is established, and bounded by the configured window so prefetch memory
+//! can't grow unbounded. [`ReadaheadState::on_read`] remains available for
+//! block-granular callers.
 
 /// Tunable readahead parameters.
 #[derive(Debug, Clone, Copy)]
@@ -37,12 +38,20 @@ impl Default for ReadaheadConfig {
 #[derive(Debug)]
 pub struct ReadaheadState {
     config: ReadaheadConfig,
-    /// The block index expected next if the pattern is sequential.
+    /// Cursor expected next, in the units selected by `mode`.
     expected_next: Option<u64>,
+    /// Whether the current run tracks block indices or byte ranges.
+    mode: Option<TrackingMode>,
     /// Current run length of consecutive in-order reads.
     run: u32,
     /// Highest block index already scheduled for prefetch (exclusive frontier).
     prefetched_upto: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TrackingMode {
+    Block,
+    ByteRange { block_size: u32 },
 }
 
 impl ReadaheadState {
@@ -51,6 +60,7 @@ impl ReadaheadState {
         Self {
             config,
             expected_next: None,
+            mode: None,
             run: 0,
             prefetched_upto: 0,
         }
@@ -68,22 +78,70 @@ impl ReadaheadState {
 
     /// Record a read at `block_index` and return blocks to prefetch.
     ///
-    /// A read is "sequential" if it lands on the block immediately after the
-    /// previous one. Once the run reaches `trigger_run`, this returns the next
-    /// up-to-`window` block indices ahead of the cursor that haven't already
-    /// been scheduled (deduplicated via a frontier, so re-reads don't re-issue).
-    /// Any non-consecutive read resets the run and returns nothing.
+    /// This block-granular API is retained for compatibility. Byte-range callers
+    /// should use [`Self::on_read_range`]. Switching between the two APIs resets
+    /// the current sequential run.
     pub fn on_read(&mut self, block_index: u64) -> Vec<u64> {
-        let sequential = self.expected_next == Some(block_index);
+        let Some(next_block) = block_index.checked_add(1) else {
+            self.reset();
+            return Vec::new();
+        };
+        self.observe(TrackingMode::Block, block_index, next_block, next_block)
+    }
+
+    /// Record a successful byte-range read and return blocks to prefetch.
+    ///
+    /// A read is sequential when `offset` is the first byte after the previous
+    /// successful read. `read_len` must be the number of bytes actually returned,
+    /// not merely requested. Prefetch starts after the final block touched by the
+    /// range. Zero-length reads are no-ops. A zero or changed `block_size`, an
+    /// overflowing range, or switching from [`Self::on_read`] safely resets the
+    /// current run.
+    pub fn on_read_range(&mut self, offset: u64, read_len: u64, block_size: u32) -> Vec<u64> {
+        if read_len == 0 {
+            return Vec::new();
+        }
+        if block_size == 0 {
+            self.reset();
+            return Vec::new();
+        }
+        let Some(next_byte) = offset.checked_add(read_len) else {
+            self.reset();
+            return Vec::new();
+        };
+        let last_block = (next_byte - 1) / u64::from(block_size);
+        let next_block = last_block + 1;
+        self.observe(
+            TrackingMode::ByteRange { block_size },
+            offset,
+            next_byte,
+            next_block,
+        )
+    }
+
+    fn observe(
+        &mut self,
+        mode: TrackingMode,
+        cursor: u64,
+        next_cursor: u64,
+        next_block: u64,
+    ) -> Vec<u64> {
+        if self.mode != Some(mode) {
+            self.expected_next = None;
+            self.run = 0;
+            self.prefetched_upto = next_block;
+            self.mode = Some(mode);
+        }
+
+        let sequential = self.expected_next == Some(cursor);
         if sequential {
             self.run = self.run.saturating_add(1);
         } else {
-            // Reset the pattern; a re-read of the same block or a jump is not a
-            // sequential step.
+            // Reset the pattern; a re-read or jump is not a sequential step.
             self.run = 1;
-            self.prefetched_upto = block_index + 1;
+            self.prefetched_upto = next_block;
         }
-        self.expected_next = Some(block_index + 1);
+        self.expected_next = Some(next_cursor);
 
         if !self.is_sequential() || self.config.window == 0 {
             return Vec::new();
@@ -91,13 +149,20 @@ impl ReadaheadState {
 
         // Prefetch the window ahead of the cursor, past what we've already
         // scheduled, so overlapping reads don't re-issue the same prefetch.
-        let start = self.prefetched_upto.max(block_index + 1);
-        let end = block_index + 1 + self.config.window as u64;
+        let start = self.prefetched_upto.max(next_block);
+        let end = next_block.saturating_add(self.config.window as u64);
         if start >= end {
             return Vec::new();
         }
         self.prefetched_upto = end;
         (start..end).collect()
+    }
+
+    fn reset(&mut self) {
+        self.expected_next = None;
+        self.mode = None;
+        self.run = 0;
+        self.prefetched_upto = 0;
     }
 }
 
@@ -181,5 +246,99 @@ mod tests {
         // Re-reading block 5 is not a sequential step; run resets.
         assert!(s.on_read(5).is_empty());
         assert!(!s.is_sequential());
+    }
+
+    #[test]
+    fn sequential_scan_with_production_block_size_triggers_prefetch() {
+        let mut s = ReadaheadState::new(ReadaheadConfig::default());
+        const BLOCK_SIZE: u32 = 256 << 20;
+        const READ_LEN: u64 = 128 << 10;
+
+        assert!(s.on_read_range(0, READ_LEN, BLOCK_SIZE).is_empty());
+        assert!(s.on_read_range(READ_LEN, READ_LEN, BLOCK_SIZE).is_empty());
+        assert_eq!(
+            s.on_read_range(2 * READ_LEN, READ_LEN, BLOCK_SIZE),
+            vec![1, 2, 3, 4]
+        );
+    }
+
+    #[test]
+    fn repeated_or_gapped_ranges_reset_the_run() {
+        const BLOCK_SIZE: u32 = 1024;
+        let mut s = state();
+
+        assert!(s.on_read_range(0, 128, BLOCK_SIZE).is_empty());
+        assert_eq!(s.on_read_range(128, 128, BLOCK_SIZE), vec![1, 2, 3, 4]);
+        assert!(s.on_read_range(128, 128, BLOCK_SIZE).is_empty());
+        assert_eq!(s.run(), 1);
+
+        assert!(s.on_read_range(512, 128, BLOCK_SIZE).is_empty());
+        assert_eq!(s.run(), 1);
+    }
+
+    #[test]
+    fn zero_length_range_is_a_noop() {
+        const BLOCK_SIZE: u32 = 1024;
+        let mut s = state();
+
+        assert!(s.on_read_range(0, 128, BLOCK_SIZE).is_empty());
+        assert!(s.on_read_range(128, 0, BLOCK_SIZE).is_empty());
+        assert_eq!(s.run(), 1);
+        assert_eq!(s.on_read_range(128, 128, BLOCK_SIZE), vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn range_spanning_blocks_prefetches_after_final_block() {
+        let mut s = ReadaheadState::new(ReadaheadConfig {
+            trigger_run: 1,
+            window: 4,
+        });
+
+        assert_eq!(s.on_read_range(512, 1536, 1024), vec![2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn invalid_or_overflowing_ranges_reset_detection() {
+        const BLOCK_SIZE: u32 = 1024;
+        let mut s = state();
+
+        s.on_read_range(0, 128, BLOCK_SIZE);
+        assert!(s.on_read_range(u64::MAX, 1, BLOCK_SIZE).is_empty());
+        assert_eq!(s.run(), 0);
+
+        s.on_read_range(0, 128, BLOCK_SIZE);
+        assert!(s.on_read_range(128, 128, 0).is_empty());
+        assert_eq!(s.run(), 0);
+    }
+
+    #[test]
+    fn valid_range_ending_at_u64_max_is_safe() {
+        let mut s = ReadaheadState::new(ReadaheadConfig {
+            trigger_run: 1,
+            window: 4,
+        });
+
+        assert!(s.on_read_range(u64::MAX - 1, 1, 1).is_empty());
+        assert_eq!(s.run(), 1);
+    }
+
+    #[test]
+    fn changing_block_size_starts_a_new_run() {
+        let mut s = state();
+
+        s.on_read_range(0, 128, 1024);
+        assert!(s.on_read_range(128, 128, 2048).is_empty());
+        assert_eq!(s.run(), 1);
+        assert_eq!(s.on_read_range(256, 128, 2048), vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn switching_tracking_apis_starts_a_new_run() {
+        let mut s = state();
+
+        s.on_read(0);
+        assert!(s.on_read_range(1, 1, 1).is_empty());
+        assert_eq!(s.run(), 1);
+        assert_eq!(s.on_read_range(2, 1, 1), vec![3, 4, 5, 6]);
     }
 }


### PR DESCRIPTION
## Summary

Fix FUSE readahead so sequential detection follows successful byte ranges instead of block indices. With the default 256 MiB blocks, three contiguous 128 KiB reads now establish the run and prefetch blocks 1-4 instead of repeatedly resetting.

## Related issues

Closes #256.

Connection concurrency remains unchanged; #257 tracks the global-cap follow-up.

## Type of change

- [x] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no behavior change)
- [x] Performance
- [x] Docs / tests / tooling

## Design alignment

Implements the FUSE client caching/readahead contract in DESIGN.md section 4. This corrects the detector input without changing the next-N-block design.

## Changes

- Add byte-range planner and prefetch APIs while retaining the public block-index APIs for compatibility.
- Advance per-handle detection only after successful, nonempty reads and use the actual returned length, including short and cross-block reads.
- Safely handle zero or changed block sizes, range arithmetic overflow, and unrepresentable block starts.
- Add realistic 256 MiB / 128 KiB regressions plus a separately named deterministic benchmark and baseline.

## Test plan

- [ ] `just ci` passes locally (fmt + clippy + test)
- [ ] Workspace compiles (`cargo build --workspace`)
- [x] Added/updated tests for new behavior

Validated locally:

- `cargo fmt --all --check`
- `cargo test -p talon-fuse --locked` — 96 passed
- `cargo clippy -p talon-fuse --all-targets --locked -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p talon-fuse --no-deps --locked`
- `PKG_CONFIG=/bin/echo cargo check -p talon-fuse --locked --features mount,fuser/libfuse`
- The same mount-feature shim ran all six `mount::tests::readahead*` tests successfully. Full mount-feature CI remains Linux-only because `fuser` without system libfuse does not build natively on macOS.

## Performance impact

- [ ] Not performance-sensitive
- [x] Targeted paired benchmark run; new deterministic baseline committed

| benchmark | upstream/main | this branch | delta | verdict |
|---|---:|---:|---:|---|
| legacy block planner | 1.281 µs | 1.353 µs | +5.6% | within 10% threshold |
| byte-range planner | — | 157.3 ns | — | new baseline |

## Checklist

- [x] PR title follows Conventional Commits
- [x] Public items are documented; no broken intra-doc links
- [x] No new dependencies
- [x] Rebased on the latest `main`