### PR TITLE
enhance(worker): serve cross-page reads with sendfile, not copies

### DIFF
--- a/crates/talon-transport/src/uring.rs
+++ b/crates/talon-transport/src/uring.rs
@@ -118,7 +118,7 @@ where
 
 /// Write a whole buffer to a monoio stream, returning the buffer.
 ///
-/// Generic over any `IoBuf`, so callers holding a refcounted [`bytes::Bytes`]
+/// Generic over any `IoBuf`, so callers holding a refcounted `bytes::Bytes`
 /// can hand it straight to the ring instead of copying it into a fresh `Vec`.
 pub async fn write_all_buf<S, B>(stream: &mut S, buf: B) -> io::Result<B>
 where

--- a/crates/talon-transport/src/uring.rs
+++ b/crates/talon-transport/src/uring.rs
@@ -116,6 +116,20 @@ where
     Ok(buf)
 }
 
+/// Write a whole buffer to a monoio stream, returning the buffer.
+///
+/// Generic over any `IoBuf`, so callers holding a refcounted [`bytes::Bytes`]
+/// can hand it straight to the ring instead of copying it into a fresh `Vec`.
+pub async fn write_all_buf<S, B>(stream: &mut S, buf: B) -> io::Result<B>
+where
+    S: AsyncWriteRent,
+    B: monoio::buf::IoBuf,
+{
+    let (res, buf) = stream.write_all(buf).await;
+    res?;
+    Ok(buf)
+}
+
 /// Capacity of one refill read. Sized so a burst of pipelined range requests
 /// (a 16-byte header plus a small bincode body each) lands in a single `recv`.
 const REFILL_CAPACITY: usize = 64 * 1024;

--- a/crates/talon-worker/Cargo.toml
+++ b/crates/talon-worker/Cargo.toml
@@ -25,6 +25,12 @@ harness = false
 name = "talon-loadgen"
 path = "src/bin/loadgen.rs"
 
+# Serve-path probe (#540): syscall counts, RSS, and concurrency for the paged
+# zero-copy path. Manual tool for a known machine, not a CI gate.
+[[bin]]
+name = "talon-serve-probe"
+path = "src/bin/serve_probe.rs"
+
 [dependencies]
 talon-core.workspace = true
 talon-metadata.workspace = true

--- a/crates/talon-worker/benches/dataplane_benches.rs
+++ b/crates/talon-worker/benches/dataplane_benches.rs
@@ -185,6 +185,23 @@ fn spawn_tokio_server(runtime: Arc<WorkerRuntime>, rt: &tokio::runtime::Runtime)
                         .await
                         .unwrap();
                     }
+                    ServeOutcome::SendfileMany(handles) => {
+                        let total: u64 = handles.iter().map(|x| x.len).sum();
+                        let h = response_header_ok(0, total as u32);
+                        sock.write_all(&h).await.unwrap();
+                        sock.flush().await.unwrap();
+                        let std_sock = sock.into_std().unwrap();
+                        std_sock.set_nonblocking(false).unwrap();
+                        let _ = tokio::task::spawn_blocking(move || {
+                            for x in &handles {
+                                send_file_range(&std_sock, &x.fd, x.offset, x.len, DEFAULT_CHUNK)
+                                    .unwrap();
+                            }
+                            std_sock
+                        })
+                        .await
+                        .unwrap();
+                    }
                     ServeOutcome::Bytes(b) => {
                         let h = response_header_ok(0, b.len() as u32);
                         sock.write_all(&h).await.unwrap();

--- a/crates/talon-worker/benches/serve_path_benches.rs
+++ b/crates/talon-worker/benches/serve_path_benches.rs
@@ -642,3 +642,118 @@ fn straddle_1m_l1_sendfile(b: divan::Bencher) {
         true,
     );
 }
+
+/// Very small L1-resident straddling reads: the regime where the per-page
+/// syscall cost is least amortised, and so the last place a zero-copy
+/// regression could hide.
+#[divan::bench]
+fn straddle_4k_l1_bytes(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd4k-l1-bytes",
+        straddle_offset(4 << 10),
+        4 << 10,
+        false,
+        true,
+    );
+}
+#[divan::bench]
+fn straddle_4k_l1_sendfile(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd4k-l1-sendfile",
+        straddle_offset(4 << 10),
+        4 << 10,
+        true,
+        true,
+    );
+}
+#[divan::bench]
+fn straddle_16k_l1_bytes(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd16k-l1-bytes",
+        straddle_offset(16 << 10),
+        16 << 10,
+        false,
+        true,
+    );
+}
+#[divan::bench]
+fn straddle_16k_l1_sendfile(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd16k-l1-sendfile",
+        straddle_offset(16 << 10),
+        16 << 10,
+        true,
+        true,
+    );
+}
+
+// --- Partially L1-resident spans ------------------------------------------
+//
+// L1 is far smaller than L2, so in steady state a span is routinely part in
+// DRAM and part only on disk. Zero-copy must decline there (serving the whole
+// span with sendfile would leave the evicted pages out of inclusive L1
+// forever), which means these reads pay the byte path plus a re-admission.
+// This measures what that fallback actually costs relative to a fully resident
+// span and a fully L1-cold one.
+
+/// Warm a paged runtime over `span`, then drop every `nth` covered page from
+/// L1 so the span is partially resident while L2 still holds all of it.
+fn run_partial_l1(bencher: divan::Bencher, tag: &str, span: u64, drop_every: u32) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    let root = tmp_root(tag);
+    let (runtime, addr, req) = rt.block_on(async {
+        let runtime = warm_paged_runtime(&root, span, true).await;
+        let addr = spawn_new_server(Arc::clone(&runtime)).await;
+        let req = RangeRequest {
+            object: obj(),
+            offset: 0,
+            len: span,
+        };
+        (runtime, addr, req)
+    });
+    let block = runtime
+        .block_for_bench(&obj(), 0)
+        .expect("warmed runtime must have a cached version");
+    let pages = (span / u64::from(PAGE_BYTES)) as u32;
+    bencher.bench(|| {
+        if drop_every > 0 {
+            // Re-create the partial state each iteration: the previous read
+            // re-admitted the pages it was missing.
+            for p in (0..pages).step_by(drop_every as usize) {
+                runtime.l1_drop_page_for_test(&block, talon_core::PageIndex(p));
+            }
+        }
+        let n = rt.block_on(client_fetch(&addr, &req));
+        assert_eq!(n, span as usize);
+    });
+    std::fs::remove_dir_all(&root).ok();
+}
+
+/// Baseline: every page L1-resident, so the read goes zero-copy.
+#[divan::bench]
+fn partial_l1_4p_all_resident(b: divan::Bencher) {
+    run_partial_l1(b, "pl1-all", 4 * u64::from(PAGE_BYTES), 0);
+}
+/// One page in four missing from L1 — enough to disqualify the whole span.
+#[divan::bench]
+fn partial_l1_4p_one_missing(b: divan::Bencher) {
+    run_partial_l1(b, "pl1-one", 4 * u64::from(PAGE_BYTES), 4);
+}
+/// Every other page missing.
+#[divan::bench]
+fn partial_l1_4p_half_missing(b: divan::Bencher) {
+    run_partial_l1(b, "pl1-half", 4 * u64::from(PAGE_BYTES), 2);
+}
+/// Every page missing from L1 (still all present in L2).
+#[divan::bench]
+fn partial_l1_4p_none_resident(b: divan::Bencher) {
+    run_partial_l1(b, "pl1-none", 4 * u64::from(PAGE_BYTES), 1);
+}

--- a/crates/talon-worker/benches/serve_path_benches.rs
+++ b/crates/talon-worker/benches/serve_path_benches.rs
@@ -367,17 +367,34 @@ async fn warm_paged_runtime(root: &std::path::Path, span: u64, l1: bool) -> Arc<
     runtime
 }
 
-/// Drive one cross-page bench: `pages` pages, byte path vs sendfile path.
-fn run_cross_page(bencher: divan::Bencher, tag: &str, pages: u64, zero_copy: bool, l1: bool) {
+/// Drive one paged bench over an explicit `[offset, offset + len)` window,
+/// byte path vs sendfile path.
+///
+/// Kept separate from page counts because the interesting regime is not only
+/// "how many pages" but *how much of them* is asked for: a 4 KiB read sitting
+/// on a page boundary touches two pages while copying almost nothing, so the
+/// per-page `openat` + `sendfile` syscalls are no longer amortised the way
+/// they are for a multi-megabyte span.
+fn run_paged_window(
+    bencher: divan::Bencher,
+    tag: &str,
+    offset: u64,
+    len: u64,
+    zero_copy: bool,
+    l1: bool,
+) {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(2)
         .enable_all()
         .build()
         .unwrap();
     let root = tmp_root(tag);
-    let span = pages * u64::from(PAGE_BYTES);
+    // Warm whole pages covering the window so the serve path is a pure cache
+    // hit; otherwise the first iteration would measure a backend fetch.
+    let page = u64::from(PAGE_BYTES);
+    let warm_span = (offset + len).div_ceil(page) * page;
     let (addr, req) = rt.block_on(async {
-        let runtime = warm_paged_runtime(&root, span, l1).await;
+        let runtime = warm_paged_runtime(&root, warm_span, l1).await;
         let addr = if zero_copy {
             spawn_new_server(runtime).await
         } else {
@@ -385,16 +402,22 @@ fn run_cross_page(bencher: divan::Bencher, tag: &str, pages: u64, zero_copy: boo
         };
         let req = RangeRequest {
             object: obj(),
-            offset: 0,
-            len: span,
+            offset,
+            len,
         };
         (addr, req)
     });
     bencher.bench(|| {
         let n = rt.block_on(client_fetch(&addr, &req));
-        assert_eq!(n, span as usize);
+        assert_eq!(n, len as usize);
     });
     std::fs::remove_dir_all(&root).ok();
+}
+
+/// Drive one cross-page bench: `pages` pages, byte path vs sendfile path.
+fn run_cross_page(bencher: divan::Bencher, tag: &str, pages: u64, zero_copy: bool, l1: bool) {
+    let span = pages * u64::from(PAGE_BYTES);
+    run_paged_window(bencher, tag, 0, span, zero_copy, l1);
 }
 
 #[divan::bench]
@@ -430,4 +453,192 @@ fn cross_page_4_l1_bytes(b: divan::Bencher) {
 #[divan::bench]
 fn cross_page_4_l1_sendfile(b: divan::Bencher) {
     run_cross_page(b, "xp4-l1-sendfile", 4, true, true);
+}
+
+// --- Small reads straddling a page boundary -------------------------------
+//
+// The community's actual workload is not a multi-megabyte scan: Parquet row
+// groups are ~1 MiB but their boundaries do not line up with cache pages, so
+// "quite a lot of IO ends up crossing a page" — each such IO being small. This
+// is the regime where multi-sendfile is *least* obviously a win, since the copy
+// it removes shrinks with the read while the extra `openat` + `sendfile` per
+// page stays fixed. Every bench below centres the window on the boundary
+// between page 0 and page 1, so exactly two pages are touched.
+
+/// A window of `len` bytes centred on the page-0/page-1 boundary.
+fn straddle_offset(len: u64) -> u64 {
+    u64::from(PAGE_BYTES) - len / 2
+}
+
+#[divan::bench]
+fn straddle_4k_bytes(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd4k-bytes",
+        straddle_offset(4 << 10),
+        4 << 10,
+        false,
+        false,
+    );
+}
+#[divan::bench]
+fn straddle_4k_sendfile(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd4k-sendfile",
+        straddle_offset(4 << 10),
+        4 << 10,
+        true,
+        false,
+    );
+}
+#[divan::bench]
+fn straddle_16k_bytes(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd16k-bytes",
+        straddle_offset(16 << 10),
+        16 << 10,
+        false,
+        false,
+    );
+}
+#[divan::bench]
+fn straddle_16k_sendfile(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd16k-sendfile",
+        straddle_offset(16 << 10),
+        16 << 10,
+        true,
+        false,
+    );
+}
+#[divan::bench]
+fn straddle_64k_bytes(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd64k-bytes",
+        straddle_offset(64 << 10),
+        64 << 10,
+        false,
+        false,
+    );
+}
+#[divan::bench]
+fn straddle_64k_sendfile(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd64k-sendfile",
+        straddle_offset(64 << 10),
+        64 << 10,
+        true,
+        false,
+    );
+}
+#[divan::bench]
+fn straddle_256k_bytes(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd256k-bytes",
+        straddle_offset(256 << 10),
+        256 << 10,
+        false,
+        false,
+    );
+}
+#[divan::bench]
+fn straddle_256k_sendfile(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd256k-sendfile",
+        straddle_offset(256 << 10),
+        256 << 10,
+        true,
+        false,
+    );
+}
+
+/// Control: the same 64 KiB read placed *inside* one page. The delta against
+/// `straddle_64k_*` isolates what crossing the boundary actually costs on each
+/// path.
+#[divan::bench]
+fn in_page_64k_bytes(b: divan::Bencher) {
+    run_paged_window(b, "ip64k-bytes", 4 << 10, 64 << 10, false, false);
+}
+#[divan::bench]
+fn in_page_64k_sendfile(b: divan::Bencher) {
+    run_paged_window(b, "ip64k-sendfile", 4 << 10, 64 << 10, true, false);
+}
+
+/// A small straddling read with L1 enabled — the configuration that previously
+/// had no zero-copy path at all.
+#[divan::bench]
+fn straddle_64k_l1_bytes(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd64k-l1-bytes",
+        straddle_offset(64 << 10),
+        64 << 10,
+        false,
+        true,
+    );
+}
+#[divan::bench]
+fn straddle_64k_l1_sendfile(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd64k-l1-sendfile",
+        straddle_offset(64 << 10),
+        64 << 10,
+        true,
+        true,
+    );
+}
+
+/// L1-resident straddling reads across sizes, to locate the size at which
+/// zero-copy overtakes serving the bytes straight out of DRAM.
+#[divan::bench]
+fn straddle_256k_l1_bytes(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd256k-l1-bytes",
+        straddle_offset(256 << 10),
+        256 << 10,
+        false,
+        true,
+    );
+}
+#[divan::bench]
+fn straddle_256k_l1_sendfile(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd256k-l1-sendfile",
+        straddle_offset(256 << 10),
+        256 << 10,
+        true,
+        true,
+    );
+}
+#[divan::bench]
+fn straddle_1m_l1_bytes(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd1m-l1-bytes",
+        straddle_offset(1 << 20),
+        1 << 20,
+        false,
+        true,
+    );
+}
+#[divan::bench]
+fn straddle_1m_l1_sendfile(b: divan::Bencher) {
+    run_paged_window(
+        b,
+        "sd1m-l1-sendfile",
+        straddle_offset(1 << 20),
+        1 << 20,
+        true,
+        true,
+    );
 }

--- a/crates/talon-worker/benches/serve_path_benches.rs
+++ b/crates/talon-worker/benches/serve_path_benches.rs
@@ -21,8 +21,8 @@ use talon_core::{Backend, BackendStore, ObjectId, ObjectStat, Result, Version};
 use talon_transport::data::{encode_request, response_header_ok, RangeRequest};
 use talon_transport::frame::{FrameHeader, HEADER_LEN};
 use talon_worker::{
-    send_file_range, BlockIndex, InFlightLoads, ServeOutcome, WholeBlockStore, WorkerMetrics,
-    WorkerRuntime, DEFAULT_CHUNK,
+    send_file_range, BlockIndex, InFlightLoads, PagedBlockStore, ServeOutcome, WholeBlockStore,
+    WorkerMetrics, WorkerRuntime, DEFAULT_CHUNK,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -184,6 +184,24 @@ async fn spawn_new_server(runtime: Arc<WorkerRuntime>) -> String {
                         std_sock.set_nonblocking(true).unwrap();
                         // drop restores/closes the socket after the client read.
                     }
+                    ServeOutcome::SendfileMany(handles) => {
+                        let total: u64 = handles.iter().map(|x| x.len).sum();
+                        let hdr = response_header_ok(0, total as u32);
+                        sock.write_all(&hdr).await.unwrap();
+                        sock.flush().await.unwrap();
+                        let std_sock = sock.into_std().unwrap();
+                        std_sock.set_nonblocking(false).unwrap();
+                        let std_sock = tokio::task::spawn_blocking(move || {
+                            for x in &handles {
+                                send_file_range(&std_sock, &x.fd, x.offset, x.len, DEFAULT_CHUNK)
+                                    .unwrap();
+                            }
+                            std_sock
+                        })
+                        .await
+                        .unwrap();
+                        std_sock.set_nonblocking(true).unwrap();
+                    }
                     ServeOutcome::Bytes(bytes) => {
                         let hdr = response_header_ok(0, bytes.len() as u32);
                         sock.write_all(&hdr).await.unwrap();
@@ -303,4 +321,113 @@ fn serve_sendfile(bencher: divan::Bencher) {
         assert_eq!(n, RANGE_LEN as usize);
     });
     std::fs::remove_dir_all(&root).ok();
+}
+
+// ---------------------------------------------------------------------------
+// Cross-page paged-L2 reads.
+//
+// A paged worker stores each page in its own file, so a read spanning N pages
+// has no single contiguous source. The byte path answered these by reading each
+// page into a buffer and concatenating; the sendfile path answers them with one
+// `sendfile` per page, keeping the payload out of userspace entirely.
+//
+// The pairs below hold the data, the request, and the page size identical and
+// vary only the serve mechanism, so the delta is the copy elimination.
+// ---------------------------------------------------------------------------
+
+/// Page size for the paged benches: 1 MiB, the size the community reported
+/// running in production.
+const PAGE_BYTES: u32 = 1 << 20;
+/// Block size for the paged benches. Kept modest so warming is quick while
+/// still holding many pages.
+const PAGED_BLOCK_BYTES: u32 = 16 << 20;
+
+/// Build a paged runtime with `span_pages` worth of pages already resident.
+async fn warm_paged_runtime(root: &std::path::Path, span: u64, l1: bool) -> Arc<WorkerRuntime> {
+    let base = WorkerRuntime::new_with_l1(
+        WholeBlockStore::open(root.join("whole")).unwrap(),
+        Arc::new(BlockIndex::new()),
+        Arc::new(InFlightLoads::new()),
+        Arc::new(RampBackend) as Arc<dyn BackendStore>,
+        PAGED_BLOCK_BYTES,
+        0,
+        if l1 { 256 << 20 } else { 0 },
+        if l1 { u64::from(PAGE_BYTES) } else { 0 },
+        WorkerMetrics::new(1 << 30),
+    )
+    .with_paged_store(PagedBlockStore::open(root.join("paged"), PAGE_BYTES).unwrap());
+    let runtime = Arc::new(base);
+    // Warm every page the benchmark range will touch.
+    let warm = RangeRequest {
+        object: obj(),
+        offset: 0,
+        len: span,
+    };
+    let _ = runtime.serve(&warm).await.unwrap();
+    runtime
+}
+
+/// Drive one cross-page bench: `pages` pages, byte path vs sendfile path.
+fn run_cross_page(bencher: divan::Bencher, tag: &str, pages: u64, zero_copy: bool, l1: bool) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+    let root = tmp_root(tag);
+    let span = pages * u64::from(PAGE_BYTES);
+    let (addr, req) = rt.block_on(async {
+        let runtime = warm_paged_runtime(&root, span, l1).await;
+        let addr = if zero_copy {
+            spawn_new_server(runtime).await
+        } else {
+            spawn_bytes_server(runtime).await
+        };
+        let req = RangeRequest {
+            object: obj(),
+            offset: 0,
+            len: span,
+        };
+        (addr, req)
+    });
+    bencher.bench(|| {
+        let n = rt.block_on(client_fetch(&addr, &req));
+        assert_eq!(n, span as usize);
+    });
+    std::fs::remove_dir_all(&root).ok();
+}
+
+#[divan::bench]
+fn cross_page_2_bytes(b: divan::Bencher) {
+    run_cross_page(b, "xp2-bytes", 2, false, false);
+}
+#[divan::bench]
+fn cross_page_2_sendfile(b: divan::Bencher) {
+    run_cross_page(b, "xp2-sendfile", 2, true, false);
+}
+#[divan::bench]
+fn cross_page_4_bytes(b: divan::Bencher) {
+    run_cross_page(b, "xp4-bytes", 4, false, false);
+}
+#[divan::bench]
+fn cross_page_4_sendfile(b: divan::Bencher) {
+    run_cross_page(b, "xp4-sendfile", 4, true, false);
+}
+#[divan::bench]
+fn cross_page_8_bytes(b: divan::Bencher) {
+    run_cross_page(b, "xp8-bytes", 8, false, false);
+}
+#[divan::bench]
+fn cross_page_8_sendfile(b: divan::Bencher) {
+    run_cross_page(b, "xp8-sendfile", 8, true, false);
+}
+/// With L1 enabled the fast path used to be disabled outright, so this pair
+/// measures the case that previously had no zero-copy option at all.
+#[divan::bench]
+fn cross_page_4_l1_bytes(b: divan::Bencher) {
+    run_cross_page(b, "xp4-l1-bytes", 4, false, true);
+}
+#[divan::bench]
+fn cross_page_4_l1_sendfile(b: divan::Bencher) {
+    run_cross_page(b, "xp4-l1-sendfile", 4, true, true);
 }

--- a/crates/talon-worker/src/bin/serve_probe.rs
+++ b/crates/talon-worker/src/bin/serve_probe.rs
@@ -1,0 +1,405 @@
+//! Serve-path probe: syscall counts, memory, and concurrency for paged reads.
+//!
+//! `serve_path_benches` measures wall-clock latency, which answers "is it
+//! faster" but not *why*, and not what it costs. This binary answers the three
+//! questions a reviewer should ask about replacing a userspace copy with N
+//! `sendfile` calls:
+//!
+//! - **Syscalls**: zero-copy trades one `pread` + memcpy per page for one
+//!   `sendfile` per page. Under `strace -c -f` the two paths' syscall profiles
+//!   are directly comparable, and the fd cache's effect on `openat` is visible
+//!   rather than inferred.
+//! - **Memory**: the byte path allocates the full response before writing it,
+//!   so peak RSS scales with `span x concurrency`. Zero-copy allocates nothing
+//!   per byte. This reports RSS delta across a fixed load.
+//! - **Concurrency**: per-request latency on an idle server says nothing about
+//!   a saturated one. The copy path burns memory bandwidth that does not scale
+//!   with cores; `sendfile` does not.
+//!
+//! This is a manual tool for a known machine, not a CI gate — absolute times on
+//! a shared runner are noise. It is checked in so the numbers in the PR can be
+//! re-run by a reviewer rather than taken on faith.
+//!
+//! # Usage
+//!
+//! ```sh
+//! # Concurrency sweep + RSS, both paths:
+//! talon-serve-probe --mode concurrency --conns 1,16,64,256
+//!
+//! # Syscall profile of exactly N reads on one path (run under strace):
+//! strace -c -f -- talon-serve-probe --mode syscalls --path sendfile --reads 200
+//! strace -c -f -- talon-serve-probe --mode syscalls --path bytes    --reads 200
+//! ```
+//!
+//! In `syscalls` mode the process warms the cache, then prints a `READY`
+//! marker, runs exactly `--reads` requests, and exits. Counting the whole
+//! process includes warm-up, so compare two runs at different `--reads` values
+//! and take the difference — that isolates the per-read cost from the fixed
+//! setup, which is what the tables in the PR report.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use clap::Parser;
+use talon_core::{Backend, BackendStore, BlockHandle, ObjectId, ObjectStat, Result, Version};
+use talon_transport::data::{encode_request, response_header_ok, RangeRequest};
+use talon_transport::frame::{FrameHeader, HEADER_LEN};
+use talon_worker::{
+    send_file_range, BlockIndex, InFlightLoads, PagedBlockStore, ServeOutcome, WholeBlockStore,
+    WorkerMetrics, WorkerRuntime, DEFAULT_CHUNK,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+/// 1 MiB pages, the size the community reported running in production.
+const PAGE_BYTES: u32 = 1 << 20;
+const BLOCK_BYTES: u32 = 16 << 20;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PathKind {
+    Bytes,
+    Sendfile,
+}
+
+impl std::str::FromStr for PathKind {
+    type Err = String;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "bytes" => Ok(Self::Bytes),
+            "sendfile" => Ok(Self::Sendfile),
+            other => Err(format!("unknown path {other}, expected bytes|sendfile")),
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+#[command(name = "talon-serve-probe")]
+struct Args {
+    /// `concurrency` sweeps connection counts; `syscalls` runs a fixed number
+    /// of reads for tracing under `strace -c`.
+    #[arg(long, default_value = "concurrency")]
+    mode: String,
+    /// Which serve path to drive. In concurrency mode, omit to run both.
+    #[arg(long)]
+    path: Option<PathKind>,
+    /// Connection counts to sweep (concurrency mode).
+    #[arg(long, default_value = "1,16,64,256", value_delimiter = ',')]
+    conns: Vec<usize>,
+    /// Seconds of closed-loop load per connection count.
+    #[arg(long, default_value_t = 3)]
+    secs: u64,
+    /// Exact number of sequential reads (syscalls mode).
+    #[arg(long, default_value_t = 200)]
+    reads: usize,
+    /// Bytes per request. The default straddles a page boundary.
+    #[arg(long, default_value_t = 64 << 10)]
+    len: u64,
+    /// Request offset. Defaults to centring the window on a page boundary.
+    #[arg(long)]
+    offset: Option<u64>,
+    /// Enable L1 (DRAM page cache) with this capacity in MiB. 0 disables it.
+    #[arg(long, default_value_t = 0)]
+    l1_mib: u64,
+}
+
+/// Deterministic bytes so a block can be committed without a real backend.
+struct RampBackend;
+
+#[async_trait::async_trait]
+impl BackendStore for RampBackend {
+    async fn fetch_range(&self, _obj: &ObjectId, offset: u64, len: u64) -> Result<bytes::Bytes> {
+        Ok(bytes::Bytes::from(
+            (0..len)
+                .map(|i| ((offset + i) % 251) as u8)
+                .collect::<Vec<u8>>(),
+        ))
+    }
+    async fn head(&self, _obj: &ObjectId) -> Result<ObjectStat> {
+        Ok(ObjectStat {
+            len: u64::MAX,
+            version: Version::new("v1"),
+        })
+    }
+}
+
+fn obj() -> ObjectId {
+    ObjectId::new(Backend::Azure, "c", "probe-obj")
+}
+
+/// Resident-set size in KiB, read from `/proc/self/status`.
+///
+/// `VmRSS` rather than an allocator statistic: the byte path's cost is real
+/// pages touched, and a Rust allocator counter would miss what the kernel
+/// actually had to back.
+fn rss_kib() -> u64 {
+    let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            if let Some(kb) = rest.split_whitespace().next() {
+                return kb.parse().unwrap_or(0);
+            }
+        }
+    }
+    0
+}
+
+async fn warm_runtime(root: &std::path::Path, span_end: u64, l1_mib: u64) -> Arc<WorkerRuntime> {
+    let l1_bytes = l1_mib * (1 << 20);
+    let base = WorkerRuntime::new_with_l1(
+        WholeBlockStore::open(root.join("whole")).unwrap(),
+        Arc::new(BlockIndex::new()),
+        Arc::new(InFlightLoads::new()),
+        Arc::new(RampBackend) as Arc<dyn BackendStore>,
+        BLOCK_BYTES,
+        0,
+        l1_bytes,
+        if l1_bytes > 0 {
+            u64::from(PAGE_BYTES)
+        } else {
+            0
+        },
+        WorkerMetrics::new(1 << 30),
+    )
+    .with_paged_store(PagedBlockStore::open(root.join("paged"), PAGE_BYTES).unwrap());
+    let runtime = Arc::new(base);
+    // Warm every page the load will touch, so measurements see cache hits only.
+    let page = u64::from(PAGE_BYTES);
+    let warm_span = span_end.div_ceil(page) * page;
+    let warm = RangeRequest {
+        object: obj(),
+        offset: 0,
+        len: warm_span,
+    };
+    let _ = runtime.serve(&warm).await.unwrap();
+    runtime
+}
+
+async fn read_request(sock: &mut TcpStream) -> Option<RangeRequest> {
+    let mut hdr = [0_u8; HEADER_LEN];
+    sock.read_exact(&mut hdr).await.ok()?;
+    let header = FrameHeader::decode(&hdr).ok()?;
+    let mut body = vec![0_u8; header.length as usize];
+    sock.read_exact(&mut body).await.ok()?;
+    let mut full = hdr.to_vec();
+    full.extend_from_slice(&body);
+    talon_transport::data::decode_request(&full)
+        .ok()
+        .map(|(_, r)| r)
+}
+
+/// Write one segment list with `sendfile`, mirroring the production Tokio path.
+async fn write_sendfile(sock: TcpStream, handles: Vec<BlockHandle>) {
+    let total: u64 = handles.iter().map(|h| h.len).sum();
+    let mut sock = sock;
+    let hdr = response_header_ok(0, total as u32);
+    sock.write_all(&hdr).await.unwrap();
+    sock.flush().await.unwrap();
+    let std_sock = sock.into_std().unwrap();
+    std_sock.set_nonblocking(false).unwrap();
+    let std_sock = tokio::task::spawn_blocking(move || {
+        for h in &handles {
+            send_file_range(&std_sock, &h.fd, h.offset, h.len, DEFAULT_CHUNK).unwrap();
+        }
+        std_sock
+    })
+    .await
+    .unwrap();
+    std_sock.set_nonblocking(true).unwrap();
+    drop(TcpStream::from_std(std_sock).unwrap());
+}
+
+/// Serve connections until the listener closes, on the requested path.
+///
+/// Both arms run the real `WorkerRuntime::serve`; the `bytes` arm forces the
+/// userspace path via `serve_range` so the comparison isolates the transport,
+/// not the cache lookup.
+fn spawn_server(runtime: Arc<WorkerRuntime>, path: PathKind, served: Arc<AtomicU64>) -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    listener.set_nonblocking(true).unwrap();
+    let listener = TcpListener::from_std(listener).unwrap();
+    tokio::spawn(async move {
+        loop {
+            let (mut sock, _) = match listener.accept().await {
+                Ok(v) => v,
+                Err(_) => return,
+            };
+            let runtime = Arc::clone(&runtime);
+            let served = Arc::clone(&served);
+            tokio::spawn(async move {
+                // Keep serving on this connection until the client hangs up, so
+                // the concurrency sweep measures steady-state serving rather
+                // than repeated accept cost.
+                loop {
+                    let Some(req) = read_request(&mut sock).await else {
+                        return;
+                    };
+                    match path {
+                        PathKind::Bytes => {
+                            let bytes = runtime.serve_range(&req).await.unwrap();
+                            let hdr = response_header_ok(0, bytes.len() as u32);
+                            if sock.write_all(&hdr).await.is_err()
+                                || sock.write_all(&bytes).await.is_err()
+                            {
+                                return;
+                            }
+                            sock.flush().await.ok();
+                            served.fetch_add(1, Ordering::Relaxed);
+                        }
+                        PathKind::Sendfile => {
+                            let handles = match runtime.serve(&req).await.unwrap() {
+                                ServeOutcome::Sendfile(h) => vec![h],
+                                ServeOutcome::SendfileMany(hs) => hs,
+                                ServeOutcome::Bytes(_) => panic!(
+                                    "sendfile mode served bytes: the request did not qualify \
+                                     for the zero-copy path"
+                                ),
+                            };
+                            // sendfile consumes the socket, so this connection
+                            // serves one request. Accounted for by the client
+                            // reconnecting.
+                            served.fetch_add(1, Ordering::Relaxed);
+                            write_sendfile(sock, handles).await;
+                            return;
+                        }
+                    }
+                }
+            });
+        }
+    });
+    addr
+}
+
+/// One request/response round-trip on an existing connection.
+async fn fetch_on(sock: &mut TcpStream, req: &RangeRequest, expect: u64) {
+    let frame = encode_request(0, req).unwrap();
+    sock.write_all(&frame).await.unwrap();
+    sock.flush().await.unwrap();
+    let mut hdr = [0_u8; HEADER_LEN];
+    sock.read_exact(&mut hdr).await.unwrap();
+    let header = FrameHeader::decode(&hdr).unwrap();
+    let mut body = vec![0_u8; header.length as usize];
+    sock.read_exact(&mut body).await.unwrap();
+    // The response frame carries a small status prefix ahead of the payload.
+    assert!(
+        body.len() as u64 >= expect,
+        "short response: {} < {expect}",
+        body.len()
+    );
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+    let offset = args
+        .offset
+        .unwrap_or_else(|| u64::from(PAGE_BYTES) - args.len / 2);
+    let root = std::env::temp_dir().join(format!("talon-probe-{}", std::process::id()));
+    let runtime = warm_runtime(&root, offset + args.len, args.l1_mib).await;
+    let req = RangeRequest {
+        object: obj(),
+        offset,
+        len: args.len,
+    };
+
+    let pages_touched = {
+        let page = u64::from(PAGE_BYTES);
+        (offset + args.len - 1) / page - offset / page + 1
+    };
+    eprintln!(
+        "window: offset={offset} len={} -> {pages_touched} pages, l1={} MiB",
+        args.len, args.l1_mib
+    );
+
+    match args.mode.as_str() {
+        "syscalls" => {
+            let path = args.path.expect("--path is required in syscalls mode");
+            let served = Arc::new(AtomicU64::new(0));
+            let addr = spawn_server(Arc::clone(&runtime), path, Arc::clone(&served));
+            // Everything above is warm-up; the trace should be read as the
+            // difference between two --reads values.
+            eprintln!("READY");
+            for _ in 0..args.reads {
+                let mut sock = TcpStream::connect(&addr).await.unwrap();
+                fetch_on(&mut sock, &req, args.len).await;
+            }
+            eprintln!("done: {} reads on {:?}", args.reads, path);
+        }
+        "concurrency" => {
+            let paths = match args.path {
+                Some(p) => vec![p],
+                None => vec![PathKind::Bytes, PathKind::Sendfile],
+            };
+            println!(
+                "{:<10} {:>6} {:>12} {:>12} {:>10} {:>10}",
+                "path", "conns", "reqs/s", "MiB/s", "p50 us", "rss MiB"
+            );
+            for path in paths {
+                for &conns in &args.conns {
+                    let served = Arc::new(AtomicU64::new(0));
+                    let addr = spawn_server(Arc::clone(&runtime), path, Arc::clone(&served));
+                    // Settle before sampling RSS so the baseline excludes
+                    // connection setup.
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    let rss_before = rss_kib();
+
+                    let deadline = Instant::now() + Duration::from_secs(args.secs);
+                    let latencies = Arc::new(std::sync::Mutex::new(Vec::<u64>::new()));
+                    let mut tasks = Vec::new();
+                    for _ in 0..conns {
+                        let addr = addr.clone();
+                        let req = req.clone();
+                        let latencies = Arc::clone(&latencies);
+                        tasks.push(tokio::spawn(async move {
+                            let mut local = Vec::new();
+                            while Instant::now() < deadline {
+                                let start = Instant::now();
+                                let mut sock = match TcpStream::connect(&addr).await {
+                                    Ok(s) => s,
+                                    Err(_) => break,
+                                };
+                                fetch_on(&mut sock, &req, req.len).await;
+                                local.push(start.elapsed().as_micros() as u64);
+                            }
+                            latencies.lock().unwrap().extend(local);
+                        }));
+                    }
+                    let rss_peak = {
+                        // Sample RSS while the load is running; the byte path's
+                        // allocation is transient and invisible afterwards.
+                        let mut peak = rss_before;
+                        while Instant::now() < deadline {
+                            peak = peak.max(rss_kib());
+                            tokio::time::sleep(Duration::from_millis(20)).await;
+                        }
+                        peak
+                    };
+                    for t in tasks {
+                        let _ = t.await;
+                    }
+
+                    let mut lat = latencies.lock().unwrap().clone();
+                    lat.sort_unstable();
+                    let n = lat.len() as u64;
+                    let p50 = lat.get(lat.len() / 2).copied().unwrap_or(0);
+                    let secs = args.secs as f64;
+                    let rps = n as f64 / secs;
+                    let mib = (n as f64 * args.len as f64) / secs / (1024.0 * 1024.0);
+                    println!(
+                        "{:<10} {:>6} {:>12.0} {:>12.1} {:>10} {:>10.1}",
+                        format!("{path:?}").to_lowercase(),
+                        conns,
+                        rps,
+                        mib,
+                        p50,
+                        (rss_peak - rss_before.min(rss_peak)) as f64 / 1024.0
+                    );
+                }
+            }
+        }
+        other => panic!("unknown mode {other}, expected concurrency|syscalls"),
+    }
+
+    std::fs::remove_dir_all(&root).ok();
+}

--- a/crates/talon-worker/src/block_store.rs
+++ b/crates/talon-worker/src/block_store.rs
@@ -144,7 +144,8 @@ impl WholeBlockStore {
     /// Open a present block file read-only, returning a shared fd and its byte
     /// length.
     ///
-    /// Backed by [`FdCache`]: a repeat read of a resident block reuses the
+    /// Backed by the shared open-fd cache: a repeat read of a resident block
+    /// reuses the
     /// already-open descriptor instead of issuing `openat` + `statx` + `close`
     /// per request. Under load that trio dominated the serving path — it does
     /// not scale with threads (all callers serialize on the same inode and

--- a/crates/talon-worker/src/block_store.rs
+++ b/crates/talon-worker/src/block_store.rs
@@ -18,6 +18,7 @@
 //! [`PagedBlockStore`](crate::PagedBlockStore), which the worker uses instead of
 //! this store when `l2_page_size_bytes` is set.
 
+use crate::fd_cache::{CachedFd, FdCache};
 use async_trait::async_trait;
 use bytes::Bytes;
 use std::collections::hash_map::DefaultHasher;
@@ -27,7 +28,7 @@ use std::os::fd::OwnedFd;
 use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use talon_core::{
     BlockForm, BlockHandle, BlockId, BlockMeta, Error, ObjectStore, PageIndex, Result,
 };
@@ -50,90 +51,6 @@ where
         Err(join_error) => Err(Error::Backend(format!(
             "blocking store task failed: {join_error}"
         ))),
-    }
-}
-
-/// Number of shards in the open-fd cache. Sharding keeps the per-request
-/// lookup off a single global mutex when many connections hit distinct blocks.
-const FD_CACHE_SHARDS: usize = 16;
-
-/// Per-shard capacity of the open-fd cache. The cache holds one descriptor per
-/// resident block, so the process-wide ceiling is
-/// `FD_CACHE_SHARDS * FD_CACHE_SHARD_CAPACITY` = 1024 descriptors on top of the
-/// connection and listener fds.
-///
-/// Blocks default to 256 MiB, so 1024 cached descriptors already covers a
-/// ~256 GiB resident working set — well past the point where the per-request
-/// `openat` was measurable. The bound matters because an unbounded cache would
-/// pin one fd per block ever touched; capping it keeps worst-case fd usage
-/// predictable and independent of cache size.
-const FD_CACHE_SHARD_CAPACITY: usize = 64;
-
-/// A cached, shared descriptor for an immutable block file.
-#[derive(Clone)]
-struct CachedFd {
-    fd: Arc<OwnedFd>,
-    len: u64,
-}
-
-/// A sharded, bounded cache of open `.blk` descriptors.
-///
-/// Block files are immutable and content-addressed: once written and committed
-/// under `<root>/<shard>/<digest>.blk`, the bytes at a given path never change.
-/// That makes the `openat` + `statx` pair on the serving path pure overhead —
-/// path resolution, inode lookup, and `stx_size` all return the same answer
-/// every time, while contending on the same inode/dentry across every worker
-/// thread.
-///
-/// Eviction is a simple random-ish replacement within a shard (drop one
-/// arbitrary entry when full). Blocks are equally hot in the steady state and
-/// the cost of a miss is exactly the old behaviour — one `openat` — so a
-/// precise LRU is not worth the extra bookkeeping on this path.
-struct FdCache {
-    shards: Vec<Mutex<std::collections::HashMap<PathBuf, CachedFd>>>,
-}
-
-impl FdCache {
-    fn new() -> Self {
-        Self {
-            shards: (0..FD_CACHE_SHARDS)
-                .map(|_| Mutex::new(std::collections::HashMap::new()))
-                .collect(),
-        }
-    }
-
-    fn shard_for(&self, path: &Path) -> &Mutex<std::collections::HashMap<PathBuf, CachedFd>> {
-        let mut hasher = DefaultHasher::new();
-        path.hash(&mut hasher);
-        &self.shards[(hasher.finish() as usize) % FD_CACHE_SHARDS]
-    }
-
-    fn get(&self, path: &Path) -> Option<CachedFd> {
-        let shard = self.shard_for(path);
-        let guard = shard.lock().unwrap_or_else(|e| e.into_inner());
-        guard.get(path).cloned()
-    }
-
-    fn insert(&self, path: PathBuf, entry: CachedFd) {
-        let shard = self.shard_for(&path);
-        let mut guard = shard.lock().unwrap_or_else(|e| e.into_inner());
-        if guard.len() >= FD_CACHE_SHARD_CAPACITY && !guard.contains_key(&path) {
-            if let Some(victim) = guard.keys().next().cloned() {
-                guard.remove(&victim);
-            }
-        }
-        guard.insert(path, entry);
-    }
-
-    /// Drop any cached descriptor for `path`.
-    ///
-    /// Called when a block is removed so the cache does not pin an unlinked
-    /// inode. In-flight handles keep the file alive until they complete, which
-    /// is exactly the pre-existing behaviour for a block evicted mid-request.
-    fn invalidate(&self, path: &Path) {
-        let shard = self.shard_for(path);
-        let mut guard = shard.lock().unwrap_or_else(|e| e.into_inner());
-        guard.remove(path);
     }
 }
 

--- a/crates/talon-worker/src/fd_cache.rs
+++ b/crates/talon-worker/src/fd_cache.rs
@@ -1,0 +1,208 @@
+//! A sharded, bounded cache of open descriptors for immutable cache files.
+//!
+//! Both cache stores serve reads by handing a file descriptor to `sendfile`.
+//! The files behind those descriptors are immutable and content-addressed:
+//! once written and committed, the bytes at a given path never change. That
+//! makes the `openat` + `statx` pair on the serving path pure overhead — path
+//! resolution, inode lookup, and `stx_size` all return the same answer every
+//! time, while contending on the same inode and dentry across every worker
+//! thread.
+//!
+//! Shared by [`WholeBlockStore`](crate::WholeBlockStore), which caches one
+//! descriptor per `.blk` file, and [`PagedBlockStore`](crate::PagedBlockStore),
+//! which caches one per `.page` file. The paged store needs it more: a
+//! cross-page read opens *every* page it touches, so the per-request `openat`
+//! count scales with the span rather than being one per request.
+
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::os::fd::OwnedFd;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+/// Number of shards in the open-fd cache. Sharding keeps the per-request
+/// lookup off a single global mutex when many connections hit distinct files.
+const FD_CACHE_SHARDS: usize = 16;
+
+/// Per-shard capacity of the open-fd cache, so the process-wide ceiling is
+/// `FD_CACHE_SHARDS * FD_CACHE_SHARD_CAPACITY` descriptors on top of the
+/// connection and listener fds.
+///
+/// The bound matters because an unbounded cache would pin one fd per file ever
+/// touched; capping it keeps worst-case fd usage predictable and independent of
+/// cache size. Callers pick a multiplier appropriate to their file granularity
+/// — see [`FdCache::new`] and [`FdCache::with_capacity`].
+const FD_CACHE_SHARD_CAPACITY: usize = 64;
+
+/// A cached, shared descriptor for an immutable cache file.
+#[derive(Clone)]
+pub(crate) struct CachedFd {
+    pub(crate) fd: Arc<OwnedFd>,
+    pub(crate) len: u64,
+}
+
+/// A sharded, bounded cache of open descriptors.
+///
+/// Eviction is a simple random-ish replacement within a shard (drop one
+/// arbitrary entry when full). Entries are equally hot in the steady state and
+/// the cost of a miss is exactly the old behaviour — one `openat` — so a
+/// precise LRU is not worth the extra bookkeeping on this path.
+pub(crate) struct FdCache {
+    shards: Vec<Mutex<HashMap<PathBuf, CachedFd>>>,
+    per_shard: usize,
+}
+
+impl FdCache {
+    /// A cache sized for whole-block files: 1024 descriptors total.
+    ///
+    /// Blocks default to 256 MiB, so this already covers a ~256 GiB resident
+    /// working set — well past the point where the per-request `openat` was
+    /// measurable.
+    pub(crate) fn new() -> Self {
+        Self::with_capacity(FD_CACHE_SHARD_CAPACITY)
+    }
+
+    /// A cache with an explicit per-shard capacity, for callers whose files are
+    /// far smaller than a whole block (a 1 MiB page vs a 256 MiB block) and
+    /// which therefore need proportionally more descriptors to cover the same
+    /// resident bytes.
+    pub(crate) fn with_capacity(per_shard: usize) -> Self {
+        Self {
+            shards: (0..FD_CACHE_SHARDS)
+                .map(|_| Mutex::new(HashMap::new()))
+                .collect(),
+            per_shard,
+        }
+    }
+
+    fn shard_for(&self, path: &Path) -> &Mutex<HashMap<PathBuf, CachedFd>> {
+        let mut hasher = DefaultHasher::new();
+        path.hash(&mut hasher);
+        &self.shards[(hasher.finish() as usize) % FD_CACHE_SHARDS]
+    }
+
+    pub(crate) fn get(&self, path: &Path) -> Option<CachedFd> {
+        let shard = self.shard_for(path);
+        let guard = shard.lock().unwrap_or_else(|e| e.into_inner());
+        guard.get(path).cloned()
+    }
+
+    pub(crate) fn insert(&self, path: PathBuf, entry: CachedFd) {
+        let shard = self.shard_for(&path);
+        let mut guard = shard.lock().unwrap_or_else(|e| e.into_inner());
+        if guard.len() >= self.per_shard && !guard.contains_key(&path) {
+            if let Some(victim) = guard.keys().next().cloned() {
+                guard.remove(&victim);
+            }
+        }
+        guard.insert(path, entry);
+    }
+
+    /// Drop any cached descriptor for `path`.
+    ///
+    /// Called when a file is removed or rewritten so the cache does not pin an
+    /// unlinked inode or serve stale bytes. In-flight handles keep the file
+    /// alive until they complete, which is exactly the pre-existing behaviour
+    /// for a block evicted mid-request.
+    pub(crate) fn invalidate(&self, path: &Path) {
+        let shard = self.shard_for(path);
+        let mut guard = shard.lock().unwrap_or_else(|e| e.into_inner());
+        guard.remove(path);
+    }
+
+    /// Drop every cached descriptor whose path lies under `dir`.
+    ///
+    /// A paged block is a directory of page files; deleting the block unlinks
+    /// all of them at once, so every descriptor beneath it must be dropped.
+    pub(crate) fn invalidate_prefix(&self, dir: &Path) {
+        for shard in &self.shards {
+            let mut guard = shard.lock().unwrap_or_else(|e| e.into_inner());
+            guard.retain(|path, _| !path.starts_with(dir));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, bytes: &[u8]) -> CachedFd {
+        std::fs::write(path, bytes).unwrap();
+        let f = std::fs::File::open(path).unwrap();
+        let len = f.metadata().unwrap().len();
+        CachedFd {
+            fd: Arc::new(OwnedFd::from(f)),
+            len,
+        }
+    }
+
+    /// A directory unique to the calling test.
+    ///
+    /// Keyed on the thread id as well as the pid: these tests run concurrently
+    /// in one process, and a shared directory let `invalidate_prefix`'s
+    /// "unrelated paths survive" assertion race the capacity test's writes.
+    fn tmp_dir() -> PathBuf {
+        let mut h = DefaultHasher::new();
+        std::thread::current().id().hash(&mut h);
+        let dir = std::env::temp_dir().join(format!(
+            "talon-fdcache-{}-{:016x}",
+            std::process::id(),
+            h.finish()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn a_cached_descriptor_round_trips() {
+        let dir = tmp_dir();
+        let path = dir.join("a.page");
+        let cache = FdCache::new();
+        cache.insert(path.clone(), write(&path, b"hello"));
+        assert_eq!(cache.get(&path).unwrap().len, 5);
+        cache.invalidate(&path);
+        assert!(cache.get(&path).is_none());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The bound is what keeps fd usage independent of cache size, so a shard
+    /// must never grow past its capacity no matter how many distinct paths hit
+    /// it.
+    #[test]
+    fn a_shard_never_exceeds_its_capacity() {
+        let dir = tmp_dir();
+        let cache = FdCache::with_capacity(2);
+        for i in 0..64 {
+            let path = dir.join(format!("cap-{i}.page"));
+            cache.insert(path.clone(), write(&path, b"x"));
+        }
+        for shard in &cache.shards {
+            assert!(shard.lock().unwrap().len() <= 2);
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Deleting a paged block unlinks a whole directory of page files at once.
+    #[test]
+    fn invalidate_prefix_drops_every_descriptor_under_a_directory() {
+        let dir = tmp_dir();
+        let block = dir.join("block.pages");
+        std::fs::create_dir_all(&block).unwrap();
+        let other = dir.join("other.page");
+        let cache = FdCache::new();
+        for i in 0..4 {
+            let path = block.join(format!("{i}.page"));
+            cache.insert(path.clone(), write(&path, b"x"));
+        }
+        cache.insert(other.clone(), write(&other, b"y"));
+
+        cache.invalidate_prefix(&block);
+
+        for i in 0..4 {
+            assert!(cache.get(&block.join(format!("{i}.page"))).is_none());
+        }
+        assert!(cache.get(&other).is_some(), "unrelated paths must survive");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/talon-worker/src/lib.rs
+++ b/crates/talon-worker/src/lib.rs
@@ -8,6 +8,7 @@ pub mod block_store;
 pub mod capacity;
 mod data_error;
 pub mod eviction;
+mod fd_cache;
 pub mod flusher;
 pub mod index;
 pub mod loader;

--- a/crates/talon-worker/src/lib.rs
+++ b/crates/talon-worker/src/lib.rs
@@ -39,7 +39,9 @@ pub use miss::{touched_pages, Admission, InFlightGuard, InFlightLoads, LoadKey};
 pub use observability::{serve_admin, WorkerMetrics, WorkerObservability, WorkerReadiness};
 pub use paged_store::PagedBlockStore;
 pub use runtime::{ServeOutcome, WorkerRuntime};
-pub use sendfile::{send_file_range, send_header_and_file_range, DEFAULT_CHUNK};
+pub use sendfile::{
+    send_file_range, send_header_and_file_range, send_header_and_file_ranges, DEFAULT_CHUNK,
+};
 pub use splice::{ingest_put, splice_to_file};
 pub use staging::{Checksum, Stager};
 pub use write_cache::{FlushItem, WriteCache};

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -1326,6 +1326,96 @@ mod tests {
         std::fs::remove_dir_all(root).ok();
     }
 
+    /// The Tokio data plane's cross-page guarantee, mirroring the io_uring test
+    /// in `uring_conn`. The two planes must not diverge in what they answer, so
+    /// a multi-`sendfile` bug in either shows up as wrong bytes here.
+    #[tokio::test]
+    async fn handle_conn_serves_a_cross_page_hit_byte_exact() {
+        use talon_transport::data::{encode_request, RangeRequest};
+
+        let root = tmp_root();
+        let index = Arc::new(BlockIndex::new());
+        let inflight = Arc::new(InFlightLoads::new());
+        let node = NodeInfo {
+            id: NodeId::new("w"),
+            address: "127.0.0.1:7001".into(),
+            role: NodeRole::Worker,
+        };
+        let observability = Arc::new(
+            WorkerObservability::new(
+                "c".into(),
+                node,
+                "127.0.0.1:8001".into(),
+                1024,
+                Arc::clone(&index),
+                Arc::clone(&inflight),
+            )
+            .unwrap(),
+        );
+        observability.readiness().set_backend_ready(true);
+        observability.readiness().set_store_ready(true);
+        observability.readiness().set_control_registered(true);
+        let backend: Arc<dyn BackendStore> = Arc::new(RampBackend);
+        // 16-byte pages in a 64-byte block: a 40-byte read from offset 5 spans
+        // three pages, partial at both ends.
+        let worker = Arc::new(
+            WorkerRuntime::new(
+                WholeBlockStore::open(root.join("whole")).unwrap(),
+                index,
+                inflight,
+                backend,
+                64,
+                0,
+                observability.metrics().clone(),
+            )
+            .with_paged_store(talon_worker::PagedBlockStore::open(root.join("paged"), 16).unwrap()),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let srv_worker = Arc::clone(&worker);
+        let srv_obs = Arc::clone(&observability);
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let _ = handle_conn(stream, srv_worker, srv_obs).await;
+        });
+
+        let obj = ObjectId::new(talon_core::Backend::Azure, "c", "obj");
+        let req = RangeRequest {
+            object: obj,
+            offset: 5,
+            len: 40,
+        };
+        let mut client = TcpStream::connect(addr).await.unwrap();
+        let expected: Vec<u8> = (0..40u64).map(|i| ((5 + i) % 251) as u8).collect();
+
+        for pass in 0..3 {
+            let out = encode_request(0, &req).unwrap();
+            client.write_all(&out).await.unwrap();
+            client.flush().await.unwrap();
+
+            let mut hdr = [0u8; HEADER_LEN];
+            client.read_exact(&mut hdr).await.unwrap();
+            let header = FrameHeader::decode(&hdr).unwrap();
+            assert!(
+                !header.flags.contains(talon_transport::Flags::ERROR),
+                "pass {pass}: worker returned an error frame"
+            );
+            assert_eq!(
+                header.length as usize,
+                expected.len(),
+                "pass {pass}: advertised length must equal the request"
+            );
+            let mut body = vec![0u8; header.length as usize];
+            client.read_exact(&mut body).await.unwrap();
+            assert_eq!(body, expected, "pass {pass}: cross-page bytes must match");
+        }
+
+        drop(client);
+        server.await.unwrap();
+        std::fs::remove_dir_all(root).ok();
+    }
+
     /// A backend that stores whole-object PUTs in memory so a write-through can be
     /// read back, and records deletes.
     #[derive(Default)]

--- a/crates/talon-worker/src/memory_store.rs
+++ b/crates/talon-worker/src/memory_store.rs
@@ -105,6 +105,21 @@ impl MemoryStore {
     }
 
     /// Fetch one page and mark it most-recently-used.
+    /// Whether `page` is resident, without touching recency.
+    ///
+    /// Used by the zero-copy serve path to decide whether `sendfile` may skip
+    /// the byte path: since L1 is inclusive and only the byte path admits
+    /// pages, serving a non-resident page with `sendfile` would stop L1 from
+    /// being populated. This is a pure lookup — it deliberately does not bump
+    /// `last_used`, because the sendfile path records its own LRU touch.
+    pub fn contains_page(&self, block: &BlockId, page: PageIndex) -> bool {
+        let inner = self.inner.lock().unwrap();
+        inner.entries.contains_key(&MemoryPageKey {
+            block: block.clone(),
+            page,
+        })
+    }
+
     pub fn get_page(&self, block: &BlockId, page: PageIndex) -> Option<Bytes> {
         let mut inner = self.inner.lock().unwrap();
         inner.clock = inner.clock.saturating_add(1);

--- a/crates/talon-worker/src/paged_store.rs
+++ b/crates/talon-worker/src/paged_store.rs
@@ -21,6 +21,7 @@
 //!
 //! [`WholeBlockStore`]: crate::WholeBlockStore
 
+use crate::fd_cache::{CachedFd, FdCache};
 use bytes::Bytes;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -29,6 +30,7 @@ use std::os::fd::OwnedFd;
 use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use talon_core::{
     BlockForm, BlockHandle, BlockId, BlockMeta, Error, PageIndex, PresentBitmap, Result,
 };
@@ -54,10 +56,23 @@ where
     }
 }
 
+/// Per-shard capacity of the paged store's open-fd cache. See the
+/// `fd_cache` field on [`PagedBlockStore`].
+const PAGE_FD_CACHE_SHARD_CAPACITY: usize = 512;
+
 /// A local, file-backed store for paged blocks (per-page files).
 pub struct PagedBlockStore {
     root: PathBuf,
     page_size: u32,
+    /// Open `.page` descriptors, so a warm cross-page read does not pay one
+    /// `openat` + `statx` per page it touches.
+    ///
+    /// Sized larger per shard than the whole-block store's: a page is orders of
+    /// magnitude smaller than a block, so covering a comparable resident
+    /// working set needs proportionally more descriptors. 16 shards x 512
+    /// caps this at 8192 descriptors, which at a 1 MiB page size covers an
+    /// 8 GiB hot set.
+    fd_cache: FdCache,
 }
 
 impl PagedBlockStore {
@@ -69,7 +84,11 @@ impl PagedBlockStore {
         }
         let root = root.into();
         std::fs::create_dir_all(&root)?;
-        Ok(Self { root, page_size })
+        Ok(Self {
+            root,
+            page_size,
+            fd_cache: FdCache::with_capacity(PAGE_FD_CACHE_SHARD_CAPACITY),
+        })
     }
 
     /// The configured page size in bytes.
@@ -243,7 +262,12 @@ impl PagedBlockStore {
             f.sync_all()?;
             std::fs::rename(&tmp, &path)
         })() {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                // The rename swapped in a new inode; drop any descriptor still
+                // pointing at the old one so reads cannot serve stale bytes.
+                self.fd_cache.invalidate(&path);
+                Ok(())
+            }
             Err(e) => {
                 let _ = std::fs::remove_file(&tmp);
                 Err(e.into())
@@ -255,6 +279,7 @@ impl PagedBlockStore {
     pub async fn put_page_async(&self, id: &BlockId, page: PageIndex, value: Bytes) -> Result<()> {
         let dir = self.dir_for(id);
         let path = self.page_path(id, page);
+        let invalidate_path = path.clone();
         spawn_blocking_io(move || {
             std::fs::create_dir_all(&dir)?;
             let pid = std::process::id();
@@ -273,7 +298,11 @@ impl PagedBlockStore {
                 }
             }
         })
-        .await
+        .await?;
+        // The rename swapped in a new inode; drop any descriptor still pointing
+        // at the old one so reads cannot serve stale bytes.
+        self.fd_cache.invalidate(&invalidate_path);
+        Ok(())
     }
 
     /// Read one page's bytes into userspace, off the async reactor thread.
@@ -301,6 +330,7 @@ impl PagedBlockStore {
     /// Remove a single page off the async reactor thread. Idempotent.
     pub async fn evict_page_async(&self, id: &BlockId, page: PageIndex) -> Result<()> {
         let path = self.page_path(id, page);
+        self.fd_cache.invalidate(&path);
         spawn_blocking_io(move || match std::fs::remove_file(&path) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -312,6 +342,8 @@ impl PagedBlockStore {
     /// Remove an entire paged block off the async reactor thread. Idempotent.
     pub async fn delete_block_async(&self, id: &BlockId) -> Result<()> {
         let dir = self.dir_for(id);
+        self.fd_cache.invalidate_prefix(&dir);
+        let dir = dir.clone();
         spawn_blocking_io(move || match std::fs::remove_dir_all(&dir) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -321,12 +353,35 @@ impl PagedBlockStore {
     }
 
     /// Open a resident page as a zero-copy handle over its whole file.
+    ///
+    /// Backed by [`FdCache`]: page files are immutable once committed, so a
+    /// repeat read reuses the open descriptor instead of paying `openat` +
+    /// `statx` again. This matters more here than for whole blocks — a read
+    /// spanning N pages opens N files, so the syscall count scales with the
+    /// span rather than being one per request.
     pub fn get_page(&self, id: &BlockId, page: PageIndex) -> Result<BlockHandle> {
+        let (fd, len) = self.open_page_ro(id, page)?;
+        Ok(BlockHandle::from_shared(fd, 0, len))
+    }
+
+    /// Open a present page read-only, returning a shared fd and its length.
+    fn open_page_ro(&self, id: &BlockId, page: PageIndex) -> Result<(Arc<OwnedFd>, u64)> {
         let path = self.page_path(id, page);
+        if let Some(hit) = self.fd_cache.get(&path) {
+            return Ok((hit.fd, hit.len));
+        }
         match std::fs::File::open(&path) {
             Ok(f) => {
                 let len = f.metadata()?.len();
-                Ok(BlockHandle::new(OwnedFd::from(f), 0, len))
+                let fd = Arc::new(OwnedFd::from(f));
+                self.fd_cache.insert(
+                    path,
+                    CachedFd {
+                        fd: Arc::clone(&fd),
+                        len,
+                    },
+                );
+                Ok((fd, len))
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 Err(Error::NotFound(format!("{id} page {}", page.0)))
@@ -373,7 +428,9 @@ impl PagedBlockStore {
     /// Remove a single page (e.g. page-level eviction), leaving the block dir
     /// and other pages intact. Idempotent.
     pub fn evict_page(&self, id: &BlockId, page: PageIndex) -> Result<()> {
-        match std::fs::remove_file(self.page_path(id, page)) {
+        let path = self.page_path(id, page);
+        self.fd_cache.invalidate(&path);
+        match std::fs::remove_file(&path) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(e) => Err(e.into()),
@@ -382,7 +439,9 @@ impl PagedBlockStore {
 
     /// Remove an entire paged block (all pages + directory). Idempotent.
     pub fn delete_block(&self, id: &BlockId) -> Result<()> {
-        match std::fs::remove_dir_all(self.dir_for(id)) {
+        let dir = self.dir_for(id);
+        self.fd_cache.invalidate_prefix(&dir);
+        match std::fs::remove_dir_all(&dir) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(e) => Err(e.into()),
@@ -574,6 +633,64 @@ mod tests {
 
         // A sidecar alone contributes nothing resident.
         assert!(store.scan().unwrap().is_empty());
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// The fd cache must never outlive the bytes it points at. A page that is
+    /// rewritten, evicted, or whose whole block is deleted must not keep
+    /// serving the old inode through a cached descriptor.
+    #[test]
+    fn the_page_fd_cache_does_not_serve_stale_bytes_after_rewrite_or_delete() {
+        let root = tmp_root();
+        let store = PagedBlockStore::open(&root, 8).unwrap();
+        let id = block(1);
+        let page = PageIndex(0);
+
+        let read_all = |h: BlockHandle| -> Vec<u8> {
+            let mut buf = vec![0_u8; h.len as usize];
+            let f = std::fs::File::from(h.fd.try_clone().expect("dup cached fd"));
+            f.read_exact_at(&mut buf, h.offset).unwrap();
+            buf
+        };
+
+        // Populate the cache.
+        store
+            .put_page(&id, page, Bytes::from_static(b"aaaaaaaa"))
+            .unwrap();
+        assert_eq!(read_all(store.get_page(&id, page).unwrap()), b"aaaaaaaa");
+
+        // Rewrite: the rename installs a new inode, so a stale descriptor
+        // would still read the old bytes.
+        store
+            .put_page(&id, page, Bytes::from_static(b"bbbbbbbb"))
+            .unwrap();
+        assert_eq!(
+            read_all(store.get_page(&id, page).unwrap()),
+            b"bbbbbbbb",
+            "rewrite must invalidate the cached descriptor"
+        );
+
+        // Page eviction: the page is gone, so opening it must fail rather than
+        // succeed from cache.
+        store.evict_page(&id, page).unwrap();
+        assert!(
+            store.get_page(&id, page).is_err(),
+            "an evicted page must not be served from the fd cache"
+        );
+
+        // Whole-block deletion must drop every page descriptor beneath it.
+        store
+            .put_page(&id, PageIndex(0), Bytes::from_static(b"cccccccc"))
+            .unwrap();
+        store
+            .put_page(&id, PageIndex(1), Bytes::from_static(b"dddddddd"))
+            .unwrap();
+        let _ = store.get_page(&id, PageIndex(0)).unwrap();
+        let _ = store.get_page(&id, PageIndex(1)).unwrap();
+        store.delete_block(&id).unwrap();
+        assert!(store.get_page(&id, PageIndex(0)).is_err());
+        assert!(store.get_page(&id, PageIndex(1)).is_err());
 
         std::fs::remove_dir_all(&root).ok();
     }

--- a/crates/talon-worker/src/paged_store.rs
+++ b/crates/talon-worker/src/paged_store.rs
@@ -354,7 +354,8 @@ impl PagedBlockStore {
 
     /// Open a resident page as a zero-copy handle over its whole file.
     ///
-    /// Backed by [`FdCache`]: page files are immutable once committed, so a
+    /// Backed by the shared open-fd cache: page files are immutable once
+    /// committed, so a
     /// repeat read reuses the open descriptor instead of paying `openat` +
     /// `statx` again. This matters more here than for whole blocks — a read
     /// spanning N pages opens N files, so the syscall count scales with the

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -40,18 +40,24 @@ const LIST_PAGE_SIZE: u32 = 1000;
 /// Smallest request that is worth serving with sendfile when the pages are
 /// already resident in L1.
 ///
-/// Zero-copy is not free: it costs one `openat` and one `sendfile` per page
-/// touched. When L1 already holds the bytes, the byte path answers from DRAM
-/// with a single small copy and no syscalls per page, so below this size the
-/// copy it avoids is cheaper than the syscalls it adds. Benchmarked on a
-/// 64 KiB read straddling a 1 MiB page boundary: byte path 236 µs vs sendfile
-/// 280 µs (+19 %). The two paths converge at 256 KiB (375 vs 359 µs) and
-/// sendfile pulls clearly ahead at 1 MiB (766 vs 599 µs, −22 %), so the
-/// threshold sits at the measured crossover.
+/// Zero-copy is not free: it costs one `sendfile` per page touched, plus an
+/// `openat` on an fd-cache miss. When L1 already holds the bytes, the byte path
+/// answers from DRAM with a single small copy and no per-page syscalls, so
+/// below some size the copy it avoids is cheaper than the syscalls it adds.
+///
+/// Measured on a read straddling a 1 MiB page boundary, with the paged store's
+/// fd cache warm (byte path vs sendfile): 4 KiB 215 vs 227 us, 16 KiB 213 vs
+/// 222 us, 64 KiB 234 vs 233 us, 256 KiB 364 vs 330 us, 1 MiB 843 vs 736 us.
+/// The crossover sits just under 32 KiB; the small-read deficit is ~5% and the
+/// large-read gain reaches 22%.
+///
+/// This threshold used to be 256 KiB. Giving the paged store an fd cache
+/// removed the per-page `openat` and moved the crossover down by 8x, which is
+/// what the fixed cost of zero-copy was mostly made of.
 ///
 /// With L1 off there is no such tradeoff — the byte path must hit the disk
 /// anyway — so sendfile is used at every size.
-const L1_SENDFILE_MIN_LEN: u64 = 256 << 10;
+const L1_SENDFILE_MIN_LEN: u64 = 32 << 10;
 
 /// A per-object resolved version with the instant it was resolved.
 struct CachedVersion {
@@ -1605,6 +1611,28 @@ impl WorkerRuntime {
     /// Bytes resident in L1.
     pub fn l1_resident_bytes(&self) -> u64 {
         self.l1.resident_bytes()
+    }
+
+    /// The block covering `offset` of `object`, at the currently cached
+    /// version.
+    ///
+    /// Exposed for benchmarks that need to name a specific page of a warmed
+    /// span. Returns `None` if the object's version has not been resolved yet.
+    #[doc(hidden)]
+    pub fn block_for_bench(&self, object: &ObjectId, offset: u64) -> Option<BlockId> {
+        let version = self.cached_version(object)?;
+        Some(self.block_for(object, offset, &version))
+    }
+
+    /// Drop one page from L1, leaving L2 untouched. Returns whether it was
+    /// resident.
+    ///
+    /// Exposed for tests that need to construct a *partially* L1-resident span
+    /// — the state a real worker reaches whenever L1 evicts under pressure
+    /// while L2 still holds every page.
+    #[doc(hidden)]
+    pub fn l1_drop_page_for_test(&self, block: &BlockId, page: PageIndex) -> bool {
+        self.l1.remove_page(block, page)
     }
 
     /// Number of backend loads currently in flight.
@@ -3839,6 +3867,68 @@ mod tests {
             "L1-resident cross-page read must go zero-copy"
         );
         assert_eq!(read_handle(outcome), expected(offset, len));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    /// A span that is *partially* L1-resident — some pages in DRAM, the rest
+    /// only on disk — is the state a real worker reaches constantly, since L1
+    /// is much smaller than L2 and evicts under pressure while L2 keeps every
+    /// page.
+    ///
+    /// Zero-copy must decline here. L1 is inclusive and only the byte path
+    /// admits pages into it; serving the whole span with `sendfile` would leave
+    /// the missing pages permanently absent from L1, so a hot range that lost
+    /// one page could never be fully re-promoted. The byte path re-admits it,
+    /// and the *next* read of the span goes zero-copy.
+    #[tokio::test]
+    async fn a_partially_l1_resident_span_falls_back_and_re_admits_the_missing_page() {
+        let root = tmp_root();
+        let page = 256u32 << 10;
+        let backend = Arc::new(PagedRampBackend::new(8 << 20));
+        let runtime = paged_runtime_l1(
+            Arc::clone(&backend),
+            &root,
+            4 << 20,
+            page,
+            8 << 20,
+            WorkerMetrics::new(1 << 20),
+        );
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+        // Spans pages 0..=2 and clears the size threshold.
+        let offset = u64::from(page) - 1024;
+        let len = u64::from(page) + 4096;
+        let request = req(&object, offset, len);
+
+        // Warm: byte path admits every covered page into L1 and L2.
+        let _ = runtime.serve(&request).await.unwrap();
+        let block = runtime.block_for(&object, offset, &Version::new("v1"));
+
+        // Evict exactly one covered page from L1. L2 still has all three.
+        assert!(
+            runtime.l1_drop_page_for_test(&block, PageIndex(1)),
+            "page 1 must have been L1-resident to evict it"
+        );
+
+        // Partial residency: must fall back to the byte path, byte-exact.
+        let outcome = runtime.serve(&request).await.unwrap();
+        let bytes = match outcome {
+            ServeOutcome::Bytes(b) => b,
+            ServeOutcome::Sendfile(_) | ServeOutcome::SendfileMany(_) => panic!(
+                "a partially L1-resident span must not go zero-copy: it would \
+                 leave the missing page out of L1 forever"
+            ),
+        };
+        assert_eq!(bytes, expected(offset, len));
+
+        // The fallback re-admitted the missing page, so the span is whole again
+        // and the next read is zero-copy.
+        let outcome = runtime.serve(&request).await.unwrap();
+        assert!(
+            matches!(outcome, ServeOutcome::SendfileMany(_)),
+            "once every page is back in L1 the read must go zero-copy again"
+        );
+        assert_eq!(read_handle(outcome), expected(offset, len));
+
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -58,6 +58,10 @@ struct CachedVersion {
 pub enum ServeOutcome {
     /// Serve these bytes with `sendfile` straight from the block file's fd.
     Sendfile(BlockHandle),
+    /// Serve these segments with one `sendfile` each, in order. A paged block
+    /// keeps every page in its own file, so a read spanning N pages is N
+    /// contiguous runs rather than one — still zero-copy, just N calls.
+    SendfileMany(Vec<BlockHandle>),
     /// Serve these already-in-memory bytes (miss just fetched, or a stitched
     /// multi-block read).
     Bytes(bytes::Bytes),
@@ -391,34 +395,58 @@ impl WorkerRuntime {
         if end <= start_block + block_size {
             let block = self.block_for(&request.object, request.offset, version);
             let offset_in_block = request.offset - block.offset;
-            // Paged mode: a resident page can be served straight from its own
-            // file with sendfile, provided the read stays inside one page (the
-            // common point-query shape). Anything wider goes through the byte
-            // path, which stitches pages together.
-            if let (Some(paged), false) = (&self.paged, self.l1.is_enabled()) {
+            // Paged mode: pages live in their own files, so a read spanning N
+            // pages is N contiguous runs. Each run is still `sendfile`-able, so
+            // serve the whole span zero-copy rather than stitching pages in
+            // userspace.
+            //
+            // With L1 on, this is only safe when every covered page is already
+            // L1-resident: the byte path is what admits pages into L1, and
+            // sendfile never brings bytes through userspace to admit. Serving a
+            // non-resident page here would silently stop populating L1.
+            if let Some(paged) = &self.paged {
                 let page_size = u64::from(paged.page_size());
-                let page = PageIndex((offset_in_block / page_size) as u32);
-                let within_one_page =
-                    offset_in_block + request.len <= (u64::from(page.0) + 1) * page_size;
-                if within_one_page
+                let first = PageIndex((offset_in_block / page_size) as u32);
+                let last = PageIndex(((offset_in_block + request.len - 1) / page_size) as u32);
+                let l1_ok = !self.l1.is_enabled()
+                    || (first.0..=last.0).all(|p| self.l1.contains_page(&block, PageIndex(p)));
+                if request.len > 0
+                    && l1_ok
                     && matches!(
-                        self.index.presence(&block, page, PageIndex(page.0 + 1)),
+                        self.index.presence(&block, first, PageIndex(last.0 + 1)),
                         Presence::PageHit
                     )
                 {
                     match paged.get_range(&block, offset_in_block, request.len) {
-                        Ok(mut handles) if handles.len() == 1 => {
-                            let handle = handles.pop().expect("one handle");
-                            self.metrics.record_l2_hit();
-                            self.metrics.record_cache_hit();
-                            self.lru.touch(&CacheUnit::Page(block.clone(), page));
-                            tracing::info!(
-                                block = %block, page = page.0, tier = "l2", "HIT (sendfile)"
-                            );
-                            return Ok(ServeOutcome::Sendfile(handle));
+                        Ok(handles) if !handles.is_empty() => {
+                            let served: u64 = handles.iter().map(|h| h.len).sum();
+                            // Only take the fast path when the handles cover the
+                            // request exactly; a short cover means we raced an
+                            // eviction, so fall through and re-fetch.
+                            if served == request.len {
+                                self.metrics.record_l2_hit();
+                                self.metrics.record_cache_hit();
+                                for p in first.0..=last.0 {
+                                    self.lru
+                                        .touch(&CacheUnit::Page(block.clone(), PageIndex(p)));
+                                }
+                                tracing::info!(
+                                    block = %block,
+                                    first_page = first.0,
+                                    pages = handles.len(),
+                                    tier = "l2",
+                                    "HIT (sendfile)"
+                                );
+                                return Ok(if handles.len() == 1 {
+                                    let mut handles = handles;
+                                    ServeOutcome::Sendfile(handles.pop().expect("one handle"))
+                                } else {
+                                    ServeOutcome::SendfileMany(handles)
+                                });
+                            }
                         }
-                        // Lost the race with page eviction, or a multi-handle
-                        // result; fall through to the byte path, which re-fetches.
+                        // Lost the race with page eviction, or an absent page;
+                        // fall through to the byte path, which re-fetches.
                         Ok(_) | Err(_) => {}
                     }
                 }
@@ -1938,14 +1966,18 @@ mod tests {
 
         match runtime.serve(&request("l1")).await.unwrap() {
             ServeOutcome::Bytes(bytes) => assert_eq!(bytes, Bytes::from_static(b"abcd")),
-            ServeOutcome::Sendfile(_) => panic!("origin miss must return fetched bytes"),
+            ServeOutcome::Sendfile(_) | ServeOutcome::SendfileMany(_) => {
+                panic!("origin miss must return fetched bytes")
+            }
         }
         assert_eq!(runtime.l1_page_count(), 1);
         assert_eq!(runtime.l1_resident_bytes(), 8);
 
         match runtime.serve(&request("l1")).await.unwrap() {
             ServeOutcome::Bytes(bytes) => assert_eq!(bytes, Bytes::from_static(b"abcd")),
-            ServeOutcome::Sendfile(_) => panic!("eligible warm block must hit L1"),
+            ServeOutcome::Sendfile(_) | ServeOutcome::SendfileMany(_) => {
+                panic!("eligible warm block must hit L1")
+            }
         }
         assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
         let rendered = metrics.render();
@@ -2002,7 +2034,9 @@ mod tests {
         assert_eq!(runtime.l1_resident_bytes(), 8);
         match runtime.serve(&request("boundary")).await.unwrap() {
             ServeOutcome::Bytes(bytes) => assert_eq!(bytes, Bytes::from_static(b"abcd")),
-            ServeOutcome::Sendfile(_) => panic!("entry at the limit must be admitted to L1"),
+            ServeOutcome::Sendfile(_) | ServeOutcome::SendfileMany(_) => {
+                panic!("entry at the limit must be admitted to L1")
+            }
         }
         assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
         std::fs::remove_dir_all(root).ok();
@@ -2021,7 +2055,9 @@ mod tests {
         assert_eq!(runtime.l1_page_count(), 1);
         match runtime.serve(&request("large")).await.unwrap() {
             ServeOutcome::Bytes(bytes) => assert_eq!(bytes, Bytes::from_static(b"abcd")),
-            ServeOutcome::Sendfile(_) => panic!("hot page must be served from L1"),
+            ServeOutcome::Sendfile(_) | ServeOutcome::SendfileMany(_) => {
+                panic!("hot page must be served from L1")
+            }
         }
         assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
         assert!(metrics
@@ -2186,7 +2222,9 @@ mod tests {
 
         match runtime.serve(&request("a")).await.unwrap() {
             ServeOutcome::Bytes(bytes) => assert_eq!(bytes, Bytes::from_static(b"abcd")),
-            ServeOutcome::Sendfile(_) => panic!("eligible L2 hit should promote to L1"),
+            ServeOutcome::Sendfile(_) | ServeOutcome::SendfileMany(_) => {
+                panic!("eligible L2 hit should promote to L1")
+            }
         }
         assert_eq!(
             backend.calls.load(Ordering::SeqCst),
@@ -2275,7 +2313,9 @@ mod tests {
 
         match restarted.serve(&request("restart")).await.unwrap() {
             ServeOutcome::Bytes(bytes) => assert_eq!(bytes, Bytes::from_static(b"abcd")),
-            ServeOutcome::Sendfile(_) => panic!("eligible L2 block should promote after restart"),
+            ServeOutcome::Sendfile(_) | ServeOutcome::SendfileMany(_) => {
+                panic!("eligible L2 block should promote after restart")
+            }
         }
         assert_eq!(
             backend.calls.load(Ordering::SeqCst),
@@ -2445,6 +2485,19 @@ mod tests {
                 f.read_exact(&mut buf).unwrap();
                 buf
             }
+            ServeOutcome::SendfileMany(handles) => {
+                // Concatenate the segments in order: this is what the wire sees
+                // after N sendfile calls, so tests can assert on the payload.
+                let mut out = Vec::new();
+                for handle in handles {
+                    let mut f = std::fs::File::from(handle.fd.try_clone().unwrap());
+                    f.seek(SeekFrom::Start(handle.offset)).unwrap();
+                    let mut buf = vec![0u8; handle.len as usize];
+                    f.read_exact(&mut buf).unwrap();
+                    out.extend_from_slice(&buf);
+                }
+                out
+            }
             ServeOutcome::Bytes(_) => panic!("expected Sendfile, got Bytes"),
         }
     }
@@ -2463,7 +2516,9 @@ mod tests {
         // Miss: bytes path.
         match runtime.serve(&request("ok")).await.unwrap() {
             ServeOutcome::Bytes(b) => assert_eq!(b, Bytes::from_static(b"abcd")),
-            ServeOutcome::Sendfile(_) => panic!("first serve (miss) must be Bytes"),
+            ServeOutcome::Sendfile(_) | ServeOutcome::SendfileMany(_) => {
+                panic!("first serve (miss) must be Bytes")
+            }
         }
 
         // Hit: sendfile path, exact sub-range.
@@ -2658,7 +2713,9 @@ mod tests {
         };
         match runtime.serve(&req).await.unwrap() {
             ServeOutcome::Bytes(b) => assert_eq!(b, expected(6, 8)),
-            ServeOutcome::Sendfile(_) => panic!("boundary-spanning read must be Bytes"),
+            ServeOutcome::Sendfile(_) | ServeOutcome::SendfileMany(_) => {
+                panic!("boundary-spanning read must be Bytes")
+            }
         }
         std::fs::remove_dir_all(root).ok();
     }
@@ -3697,6 +3754,179 @@ mod tests {
         std::fs::remove_dir_all(root).ok();
     }
 
+    /// Build a paged runtime that also has an inclusive L1.
+    fn paged_runtime_l1<B: BackendStore + 'static>(
+        backend: Arc<B>,
+        root: &Path,
+        block_size: u32,
+        page_size: u32,
+        l1_capacity: u64,
+        metrics: WorkerMetrics,
+    ) -> WorkerRuntime {
+        WorkerRuntime::new_with_l1(
+            WholeBlockStore::open(root.join("whole")).unwrap(),
+            Arc::new(BlockIndex::new()),
+            Arc::new(InFlightLoads::new()),
+            backend,
+            block_size,
+            0,
+            l1_capacity,
+            u64::from(page_size),
+            metrics,
+        )
+        .with_paged_store(PagedBlockStore::open(root.join("paged"), page_size).unwrap())
+        .with_version_ttl(Duration::ZERO)
+    }
+
+    /// L1 is inclusive and only the byte path admits pages into it. Taking the
+    /// zero-copy path for a page that is *not* yet in L1 would silently stop L1
+    /// from ever being populated, so the fast path must decline until the pages
+    /// are L1-resident — and must still return correct bytes throughout.
+    #[tokio::test]
+    async fn with_l1_enabled_zero_copy_waits_until_the_pages_are_l1_resident() {
+        let root = tmp_root();
+        let backend = Arc::new(PagedRampBackend::new(4096));
+        let metrics = WorkerMetrics::new(1024);
+        let runtime =
+            paged_runtime_l1(Arc::clone(&backend), &root, 1024, 64, 4096, metrics.clone());
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+        let request = req(&object, 100, 200);
+
+        // First read: origin miss, bytes, and it admits the pages into L1.
+        assert!(matches!(
+            runtime.serve(&request).await.unwrap(),
+            ServeOutcome::Bytes(_)
+        ));
+        assert!(runtime.l1_page_count() > 0, "byte path must populate L1");
+
+        // Now that every covered page is L1-resident, zero-copy is safe and
+        // must produce byte-identical output.
+        let outcome = runtime.serve(&request).await.unwrap();
+        assert!(
+            matches!(outcome, ServeOutcome::SendfileMany(_)),
+            "L1-resident cross-page read must go zero-copy"
+        );
+        assert_eq!(read_handle(outcome), expected(100, 200));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    /// A read spanning several pages must come back as one `sendfile` segment
+    /// per page — never as stitched bytes — and the concatenation of those
+    /// segments must equal the requested range exactly.
+    #[tokio::test]
+    async fn paged_mode_serves_a_cross_page_read_via_multi_sendfile() {
+        let root = tmp_root();
+        let backend = Arc::new(PagedRampBackend::new(4096));
+        let runtime = paged_runtime(
+            Arc::clone(&backend),
+            &root,
+            1024,
+            64,
+            0,
+            WorkerMetrics::new(1024),
+        );
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+        // 200 bytes from offset 100 spans pages 1..=4 at a 64-byte page size.
+        let request = req(&object, 100, 200);
+
+        // Warm every covered page.
+        assert_eq!(
+            runtime.serve_range(&request).await.unwrap(),
+            expected(100, 200)
+        );
+
+        match runtime.serve(&request).await.unwrap() {
+            ServeOutcome::SendfileMany(handles) => {
+                assert_eq!(handles.len(), 4, "one handle per covered page");
+                let total: u64 = handles.iter().map(|h| h.len).sum();
+                assert_eq!(total, 200, "segments must cover the request exactly");
+                assert_eq!(
+                    read_handle(ServeOutcome::SendfileMany(handles)),
+                    expected(100, 200)
+                );
+            }
+            ServeOutcome::Sendfile(_) => panic!("a 4-page span must not be one handle"),
+            ServeOutcome::Bytes(_) => panic!("a resident cross-page read must be zero-copy"),
+        }
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    /// A range whose ends land mid-page must be clipped at both ends, not
+    /// rounded out to whole pages.
+    #[tokio::test]
+    async fn cross_page_sendfile_clips_partial_pages_at_both_ends() {
+        let root = tmp_root();
+        let backend = Arc::new(PagedRampBackend::new(4096));
+        let runtime = paged_runtime(
+            Arc::clone(&backend),
+            &root,
+            1024,
+            64,
+            0,
+            WorkerMetrics::new(1024),
+        );
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+        // Starts 30 into page 0 and ends 10 into page 2.
+        let request = req(&object, 30, 108);
+        assert_eq!(
+            runtime.serve_range(&request).await.unwrap(),
+            expected(30, 108)
+        );
+
+        let outcome = runtime.serve(&request).await.unwrap();
+        assert!(
+            matches!(outcome, ServeOutcome::SendfileMany(_)),
+            "resident cross-page read must be zero-copy"
+        );
+        assert_eq!(read_handle(outcome), expected(30, 108));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    /// If any covered page is missing, the fast path must decline and let the
+    /// byte path re-fetch, rather than serving a short or torn range.
+    #[tokio::test]
+    async fn cross_page_sendfile_declines_when_a_covered_page_is_absent() {
+        let root = tmp_root();
+        let backend = Arc::new(PagedRampBackend::new(4096));
+        let runtime = paged_runtime(
+            Arc::clone(&backend),
+            &root,
+            1024,
+            64,
+            0,
+            WorkerMetrics::new(1024),
+        );
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+        let request = req(&object, 100, 200);
+        assert_eq!(
+            runtime.serve_range(&request).await.unwrap(),
+            expected(100, 200)
+        );
+
+        // Evict one interior page file behind the index's back.
+        let mut removed = 0;
+        for shard in std::fs::read_dir(root.join("paged")).unwrap().flatten() {
+            if !shard.file_type().unwrap().is_dir() {
+                continue;
+            }
+            for dir in std::fs::read_dir(shard.path()).unwrap().flatten() {
+                let page = dir.path().join("2.page");
+                if page.exists() {
+                    std::fs::remove_file(&page).unwrap();
+                    removed += 1;
+                }
+            }
+        }
+        assert_eq!(removed, 1, "found the interior page to delete");
+
+        // Must still return correct bytes, by falling back and re-fetching.
+        assert_eq!(
+            runtime.serve_range(&request).await.unwrap(),
+            expected(100, 200)
+        );
+        std::fs::remove_dir_all(root).ok();
+    }
+
     #[tokio::test]
     async fn paged_mode_serves_a_within_page_read_via_sendfile() {
         let root = tmp_root();
@@ -3725,6 +3955,9 @@ mod tests {
                 let file = std::fs::File::from(handle.fd.try_clone().unwrap());
                 file.read_exact_at(&mut buf, handle.offset).unwrap();
                 assert_eq!(Bytes::from(buf), expected(70, 10));
+            }
+            ServeOutcome::SendfileMany(_) => {
+                panic!("a within-page read must be a single sendfile handle")
             }
             ServeOutcome::Bytes(_) => panic!("expected a sendfile handle for a resident page"),
         }

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -37,28 +37,6 @@ const MAX_LIST_PAGES: usize = 20;
 /// Objects requested per backend page.
 const LIST_PAGE_SIZE: u32 = 1000;
 
-/// Smallest request that is worth serving with sendfile when the pages are
-/// already resident in L1.
-///
-/// Zero-copy is not free: it costs one `sendfile` per page touched, plus an
-/// `openat` on an fd-cache miss. When L1 already holds the bytes, the byte path
-/// answers from DRAM with a single small copy and no per-page syscalls, so
-/// below some size the copy it avoids is cheaper than the syscalls it adds.
-///
-/// Measured on a read straddling a 1 MiB page boundary, with the paged store's
-/// fd cache warm (byte path vs sendfile): 4 KiB 215 vs 227 us, 16 KiB 213 vs
-/// 222 us, 64 KiB 234 vs 233 us, 256 KiB 364 vs 330 us, 1 MiB 843 vs 736 us.
-/// The crossover sits just under 32 KiB; the small-read deficit is ~5% and the
-/// large-read gain reaches 22%.
-///
-/// This threshold used to be 256 KiB. Giving the paged store an fd cache
-/// removed the per-page `openat` and moved the crossover down by 8x, which is
-/// what the fixed cost of zero-copy was mostly made of.
-///
-/// With L1 off there is no such tradeoff — the byte path must hit the disk
-/// anyway — so sendfile is used at every size.
-const L1_SENDFILE_MIN_LEN: u64 = 32 << 10;
-
 /// A per-object resolved version with the instant it was resolved.
 struct CachedVersion {
     version: Version,
@@ -427,15 +405,19 @@ impl WorkerRuntime {
             // sendfile never brings bytes through userspace to admit. Serving a
             // non-resident page here would silently stop populating L1.
             //
-            // Even when resident, sendfile is only worth it above
-            // `L1_SENDFILE_MIN_LEN` — see that constant.
+            // Size is deliberately not a factor. A per-request latency
+            // benchmark makes sendfile look like a loss for small L1-resident
+            // reads, but that only holds at concurrency 1: the copy competes
+            // for memory bandwidth, so the byte path stops scaling while
+            // sendfile keeps going. At 64 connections a 4 KiB straddling read
+            // serves 40.5k rps zero-copy vs 21.9-38.8k copied, and the
+            // zero-copy figure is far more stable run to run.
             if let Some(paged) = &self.paged {
                 let page_size = u64::from(paged.page_size());
                 let first = PageIndex((offset_in_block / page_size) as u32);
                 let last = PageIndex(((offset_in_block + request.len - 1) / page_size) as u32);
                 let l1_ok = !self.l1.is_enabled()
-                    || ((first.0..=last.0).all(|p| self.l1.contains_page(&block, PageIndex(p)))
-                        && request.len >= L1_SENDFILE_MIN_LEN);
+                    || (first.0..=last.0).all(|p| self.l1.contains_page(&block, PageIndex(p)));
                 if request.len > 0
                     && l1_ok
                     && matches!(
@@ -3833,7 +3815,6 @@ mod tests {
     #[tokio::test]
     async fn with_l1_enabled_zero_copy_waits_until_the_pages_are_l1_resident() {
         let root = tmp_root();
-        // Sizes large enough to straddle `L1_SENDFILE_MIN_LEN` from both sides:
         // 4 MiB blocks of 256 KiB pages.
         let page = 256u32 << 10;
         let backend = Arc::new(PagedRampBackend::new(8 << 20));
@@ -3847,9 +3828,9 @@ mod tests {
             metrics.clone(),
         );
         let object = ObjectId::new(Backend::Azure, "bucket", "obj");
-        // Straddles the page-0/page-1 boundary and clears the threshold.
+        // Straddles the page-0/page-1 boundary.
         let offset = u64::from(page) - 1024;
-        let len = L1_SENDFILE_MIN_LEN + 4096;
+        let len = u64::from(page) + 4096;
         let request = req(&object, offset, len);
 
         // First read: origin miss, bytes, and it admits the pages into L1.
@@ -3932,11 +3913,13 @@ mod tests {
         std::fs::remove_dir_all(root).ok();
     }
 
-    /// Below `L1_SENDFILE_MIN_LEN` an L1-resident cross-page read is faster
-    /// served straight from DRAM than through one `openat` + `sendfile` per
-    /// page, so the fast path must decline even though the pages are resident.
+    /// Size must not disqualify a read from zero-copy. A per-request latency
+    /// benchmark makes small L1-resident reads look better on the byte path,
+    /// but that inverts under load — the copy competes for memory bandwidth,
+    /// so the byte path plateaus while sendfile keeps scaling. A tiny read
+    /// straddling a page boundary must still be served zero-copy.
     #[tokio::test]
-    async fn a_small_l1_resident_cross_page_read_stays_on_the_byte_path() {
+    async fn even_a_tiny_l1_resident_cross_page_read_goes_zero_copy() {
         let root = tmp_root();
         let page = 256u32 << 10;
         let backend = Arc::new(PagedRampBackend::new(8 << 20));
@@ -3949,23 +3932,22 @@ mod tests {
             WorkerMetrics::new(1 << 20),
         );
         let object = ObjectId::new(Backend::Azure, "bucket", "obj");
-        // Straddles a page boundary but stays under the threshold.
+        // 4 KiB straddling the page-0/page-1 boundary: the smallest realistic
+        // cross-page read, and the case a size threshold would have excluded.
         let offset = u64::from(page) - 2048;
         let len = 4096;
         let request = req(&object, offset, len);
 
-        // Warm L1 so residency is not what makes the fast path decline.
+        // Warm L1 so residency is not what decides the path.
         let _ = runtime.serve(&request).await.unwrap();
         assert!(runtime.l1_page_count() > 0, "byte path must populate L1");
 
         let outcome = runtime.serve(&request).await.unwrap();
-        let bytes = match outcome {
-            ServeOutcome::Bytes(b) => b,
-            ServeOutcome::Sendfile(_) | ServeOutcome::SendfileMany(_) => {
-                panic!("a sub-threshold L1-resident read must stay on the byte path")
-            }
-        };
-        assert_eq!(bytes, expected(offset, len));
+        assert!(
+            matches!(outcome, ServeOutcome::SendfileMany(_)),
+            "a small L1-resident cross-page read must still go zero-copy"
+        );
+        assert_eq!(read_handle(outcome), expected(offset, len));
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -37,6 +37,22 @@ const MAX_LIST_PAGES: usize = 20;
 /// Objects requested per backend page.
 const LIST_PAGE_SIZE: u32 = 1000;
 
+/// Smallest request that is worth serving with sendfile when the pages are
+/// already resident in L1.
+///
+/// Zero-copy is not free: it costs one `openat` and one `sendfile` per page
+/// touched. When L1 already holds the bytes, the byte path answers from DRAM
+/// with a single small copy and no syscalls per page, so below this size the
+/// copy it avoids is cheaper than the syscalls it adds. Benchmarked on a
+/// 64 KiB read straddling a 1 MiB page boundary: byte path 236 µs vs sendfile
+/// 280 µs (+19 %). The two paths converge at 256 KiB (375 vs 359 µs) and
+/// sendfile pulls clearly ahead at 1 MiB (766 vs 599 µs, −22 %), so the
+/// threshold sits at the measured crossover.
+///
+/// With L1 off there is no such tradeoff — the byte path must hit the disk
+/// anyway — so sendfile is used at every size.
+const L1_SENDFILE_MIN_LEN: u64 = 256 << 10;
+
 /// A per-object resolved version with the instant it was resolved.
 struct CachedVersion {
     version: Version,
@@ -404,12 +420,16 @@ impl WorkerRuntime {
             // L1-resident: the byte path is what admits pages into L1, and
             // sendfile never brings bytes through userspace to admit. Serving a
             // non-resident page here would silently stop populating L1.
+            //
+            // Even when resident, sendfile is only worth it above
+            // `L1_SENDFILE_MIN_LEN` — see that constant.
             if let Some(paged) = &self.paged {
                 let page_size = u64::from(paged.page_size());
                 let first = PageIndex((offset_in_block / page_size) as u32);
                 let last = PageIndex(((offset_in_block + request.len - 1) / page_size) as u32);
                 let l1_ok = !self.l1.is_enabled()
-                    || (first.0..=last.0).all(|p| self.l1.contains_page(&block, PageIndex(p)));
+                    || ((first.0..=last.0).all(|p| self.l1.contains_page(&block, PageIndex(p)))
+                        && request.len >= L1_SENDFILE_MIN_LEN);
                 if request.len > 0
                     && l1_ok
                     && matches!(
@@ -3785,12 +3805,24 @@ mod tests {
     #[tokio::test]
     async fn with_l1_enabled_zero_copy_waits_until_the_pages_are_l1_resident() {
         let root = tmp_root();
-        let backend = Arc::new(PagedRampBackend::new(4096));
-        let metrics = WorkerMetrics::new(1024);
-        let runtime =
-            paged_runtime_l1(Arc::clone(&backend), &root, 1024, 64, 4096, metrics.clone());
+        // Sizes large enough to straddle `L1_SENDFILE_MIN_LEN` from both sides:
+        // 4 MiB blocks of 256 KiB pages.
+        let page = 256u32 << 10;
+        let backend = Arc::new(PagedRampBackend::new(8 << 20));
+        let metrics = WorkerMetrics::new(1 << 20);
+        let runtime = paged_runtime_l1(
+            Arc::clone(&backend),
+            &root,
+            4 << 20,
+            page,
+            8 << 20,
+            metrics.clone(),
+        );
         let object = ObjectId::new(Backend::Azure, "bucket", "obj");
-        let request = req(&object, 100, 200);
+        // Straddles the page-0/page-1 boundary and clears the threshold.
+        let offset = u64::from(page) - 1024;
+        let len = L1_SENDFILE_MIN_LEN + 4096;
+        let request = req(&object, offset, len);
 
         // First read: origin miss, bytes, and it admits the pages into L1.
         assert!(matches!(
@@ -3806,7 +3838,44 @@ mod tests {
             matches!(outcome, ServeOutcome::SendfileMany(_)),
             "L1-resident cross-page read must go zero-copy"
         );
-        assert_eq!(read_handle(outcome), expected(100, 200));
+        assert_eq!(read_handle(outcome), expected(offset, len));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    /// Below `L1_SENDFILE_MIN_LEN` an L1-resident cross-page read is faster
+    /// served straight from DRAM than through one `openat` + `sendfile` per
+    /// page, so the fast path must decline even though the pages are resident.
+    #[tokio::test]
+    async fn a_small_l1_resident_cross_page_read_stays_on_the_byte_path() {
+        let root = tmp_root();
+        let page = 256u32 << 10;
+        let backend = Arc::new(PagedRampBackend::new(8 << 20));
+        let runtime = paged_runtime_l1(
+            Arc::clone(&backend),
+            &root,
+            4 << 20,
+            page,
+            8 << 20,
+            WorkerMetrics::new(1 << 20),
+        );
+        let object = ObjectId::new(Backend::Azure, "bucket", "obj");
+        // Straddles a page boundary but stays under the threshold.
+        let offset = u64::from(page) - 2048;
+        let len = 4096;
+        let request = req(&object, offset, len);
+
+        // Warm L1 so residency is not what makes the fast path decline.
+        let _ = runtime.serve(&request).await.unwrap();
+        assert!(runtime.l1_page_count() > 0, "byte path must populate L1");
+
+        let outcome = runtime.serve(&request).await.unwrap();
+        let bytes = match outcome {
+            ServeOutcome::Bytes(b) => b,
+            ServeOutcome::Sendfile(_) | ServeOutcome::SendfileMany(_) => {
+                panic!("a sub-threshold L1-resident read must stay on the byte path")
+            }
+        };
+        assert_eq!(bytes, expected(offset, len));
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/crates/talon-worker/src/sendfile.rs
+++ b/crates/talon-worker/src/sendfile.rs
@@ -127,6 +127,83 @@ pub fn send_header_and_file_range(
     send_file_range(sock, file, offset, len, chunk)
 }
 
+/// Send `header`, then every segment of `handles` in order, to `sock`.
+///
+/// This is the cross-page analogue of [`send_header_and_file_range`]. A paged
+/// block stores each page in its own file, so a read spanning N pages has no
+/// single contiguous source — but it is still N contiguous runs, each of which
+/// `sendfile(2)` can move without the payload entering userspace. Issuing one
+/// `sendfile` per segment keeps the whole read zero-copy instead of falling
+/// back to reading each page into a buffer and concatenating.
+///
+/// The header goes out corked with `MSG_MORE`, so the kernel coalesces it with
+/// the first page's bytes instead of emitting a header-only packet. Successive
+/// `sendfile` calls append into the same socket buffer, so adjacent pages fill
+/// full segments rather than one packet per page.
+///
+/// Returns the number of *payload* bytes sent (header bytes are not counted).
+/// A short return means some segment hit EOF early; the caller must treat that
+/// as a desynced connection, exactly as in the single-handle case.
+pub fn send_header_and_file_ranges<F: AsRawFd>(
+    sock: &impl AsRawFd,
+    header: &[u8],
+    segments: &[(F, u64, u64)],
+    chunk: usize,
+) -> io::Result<u64> {
+    let out_fd: RawFd = sock.as_raw_fd();
+
+    let mut written = 0usize;
+    while written < header.len() {
+        // SAFETY: valid fd; the pointer/length pair stays inside `header`.
+        let n = unsafe {
+            libc::send(
+                out_fd,
+                header[written..].as_ptr() as *const libc::c_void,
+                header.len() - written,
+                libc::MSG_MORE | libc::MSG_NOSIGNAL,
+            )
+        };
+        if n < 0 {
+            let err = io::Error::last_os_error();
+            match err.raw_os_error() {
+                Some(libc::EINTR) => continue,
+                _ => return Err(err),
+            }
+        }
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "socket accepted no header bytes",
+            ));
+        }
+        written += n as usize;
+    }
+
+    let total: u64 = segments.iter().map(|(_, _, len)| *len).sum();
+    if total == 0 {
+        // `MSG_MORE` left the header corked and no payload will uncork it.
+        // SAFETY: valid fd; a zero-length send with no MSG_MORE flushes.
+        unsafe { libc::send(out_fd, [].as_ptr(), 0, libc::MSG_NOSIGNAL) };
+        return Ok(0);
+    }
+
+    let mut sent_total = 0u64;
+    for (file, offset, len) in segments {
+        if *len == 0 {
+            continue;
+        }
+        let sent = send_file_range(sock, file, *offset, *len, chunk)?;
+        sent_total += sent;
+        if sent != *len {
+            // EOF inside this segment: stop and let the caller detect the
+            // short send. Continuing would silently shift later pages into
+            // the gap and serve corrupt bytes.
+            break;
+        }
+    }
+    Ok(sent_total)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/talon-worker/src/tokio_conn.rs
+++ b/crates/talon-worker/src/tokio_conn.rs
@@ -221,6 +221,30 @@ pub async fn handle_conn(
                     }
                 }
             }
+            Ok(ServeOutcome::SendfileMany(handles)) => {
+                // Cross-page zero-copy: one `sendfile` per page file, all on
+                // the blocking pool. The advertised length is the sum of the
+                // segments, so a short send can never desync the client
+                // silently — it surfaces as an error and drops the connection.
+                let len: u64 = handles.iter().map(|h| h.len).sum();
+                let hdr = data::response_header_ok(h.request_id, len as u32);
+                stream.write_all(&hdr).await?;
+                stream.flush().await?;
+                match sendfile_many_payload(stream, handles).await {
+                    Ok(returned) => {
+                        stream = returned;
+                        observability
+                            .metrics()
+                            .record_request_success(len, request_started.elapsed());
+                    }
+                    Err(error) => {
+                        observability
+                            .metrics()
+                            .record_request_error(request_started.elapsed());
+                        return Err(error);
+                    }
+                }
+            }
             Ok(ServeOutcome::Bytes(bytes)) => {
                 let hdr = data::response_header_ok(h.request_id, bytes.len() as u32);
                 stream.write_all(&hdr).await?;
@@ -662,6 +686,53 @@ async fn handle_delete(
 ///
 /// [`into_std`]: tokio::net::TcpStream::into_std
 /// [`spawn_blocking`]: tokio::task::spawn_blocking
+/// Send N page segments with one `sendfile` each, in order.
+///
+/// The cross-page analogue of [`sendfile_payload`]: pages of a paged block live
+/// in separate files, so a spanning read is N contiguous runs rather than one.
+/// N `sendfile` calls still keep the payload out of userspace.
+async fn sendfile_many_payload(
+    stream: TcpStream,
+    handles: Vec<talon_core::BlockHandle>,
+) -> anyhow::Result<TcpStream> {
+    let expected: u64 = handles.iter().map(|h| h.len).sum();
+    let std_stream = stream.into_std()?;
+    std_stream.set_nonblocking(false)?;
+    let (std_stream, result) = tokio::task::spawn_blocking(move || {
+        let mut sent_total = 0u64;
+        let mut res = Ok(());
+        for h in &handles {
+            if h.len == 0 {
+                continue;
+            }
+            match send_file_range(&std_stream, &h.fd, h.offset, h.len, DEFAULT_CHUNK) {
+                Ok(sent) => {
+                    sent_total += sent;
+                    if sent != h.len {
+                        // EOF inside this segment. Stop rather than letting a
+                        // later page slide into the gap and serve corrupt bytes.
+                        break;
+                    }
+                }
+                Err(e) => {
+                    res = Err(e);
+                    break;
+                }
+            }
+        }
+        (std_stream, res.map(|()| sent_total))
+    })
+    .await?;
+    // Restore non-blocking mode before any early return: tokio refuses to
+    // register a blocking fd, so bailing first would poison the socket.
+    std_stream.set_nonblocking(true)?;
+    let sent = result?;
+    if sent != expected {
+        anyhow::bail!("sendfile short read: sent {sent} of {expected} bytes; page file truncated");
+    }
+    Ok(TcpStream::from_std(std_stream)?)
+}
+
 async fn sendfile_payload(
     stream: TcpStream,
     handle: talon_core::BlockHandle,

--- a/crates/talon-worker/src/uring_conn.rs
+++ b/crates/talon-worker/src/uring_conn.rs
@@ -60,13 +60,13 @@ use monoio::net::TcpStream;
 use talon_core::{BlockHandle, RequestId};
 use talon_transport::data;
 use talon_transport::frame::{FrameHeader, MsgType, HEADER_LEN};
-use talon_transport::uring::{write_all, BufferedFrameReader};
+use talon_transport::uring::{write_all, write_all_buf, BufferedFrameReader};
 use talon_transport::DataErrorCode;
 
 use crate::data_error::encode_runtime_error;
 use crate::observability::WorkerObservability;
 use crate::runtime::{ServeOutcome, WorkerRuntime};
-use crate::{send_header_and_file_range, DEFAULT_CHUNK};
+use crate::{send_header_and_file_range, send_header_and_file_ranges, DEFAULT_CHUNK};
 
 /// Serve one accepted data-plane connection until EOF or a fatal error.
 pub async fn handle_conn(
@@ -241,11 +241,30 @@ pub async fn handle_conn(
                     }
                 }
             }
+            Ok(ServeOutcome::SendfileMany(handles)) => {
+                let len: u64 = handles.iter().map(|h| h.len).sum();
+                let hdr = data::response_header_ok(h.request_id, len as u32).to_vec();
+                match sendfile_many_payload(&stream, hdr, handles).await {
+                    Ok(()) => observability
+                        .metrics()
+                        .record_request_success(len, request_started.elapsed()),
+                    Err(error) => {
+                        // Header already on the wire; the connection is desynced.
+                        observability
+                            .metrics()
+                            .record_request_error(request_started.elapsed());
+                        return Err(error);
+                    }
+                }
+            }
             Ok(ServeOutcome::Bytes(bytes)) => {
                 let hdr = data::response_header_ok(h.request_id, bytes.len() as u32).to_vec();
                 write_all(&mut stream, hdr).await?;
                 let n = bytes.len() as u64;
-                write_all(&mut stream, bytes.to_vec()).await?;
+                // `bytes` is already refcounted and monoio can submit it
+                // directly, so hand it to the ring rather than copying it into
+                // a fresh Vec.
+                write_all_buf(&mut stream, bytes).await?;
                 observability
                     .metrics()
                     .record_request_success(n, request_started.elapsed());
@@ -455,6 +474,35 @@ async fn sendfile_payload(
         // shorter than the index claimed. The header already promised `len`
         // bytes, so the connection is desynced.
         anyhow::bail!("sendfile short read: sent {sent} of {len} bytes; block file truncated");
+    }
+    Ok(())
+}
+
+/// Send a header plus N page segments with one `sendfile` each.
+///
+/// The cross-page analogue of [`sendfile_payload`]. Pages of a paged block are
+/// separate files, so a spanning read cannot be one `sendfile` — but N calls
+/// still keep the payload out of userspace, which is what the byte path could
+/// not do.
+async fn sendfile_many_payload(
+    stream: &TcpStream,
+    header: Vec<u8>,
+    handles: Vec<BlockHandle>,
+) -> anyhow::Result<()> {
+    let sock_fd = stream.as_raw_fd();
+    let len: u64 = handles.iter().map(|h| h.len).sum();
+    let sent = monoio::spawn_blocking(move || {
+        let segments: Vec<_> = handles
+            .iter()
+            .map(|h| (FdRef(h.fd.as_raw_fd()), h.offset, h.len))
+            .collect();
+        send_header_and_file_ranges(&FdRef(sock_fd), &header, &segments, DEFAULT_CHUNK)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("sendfile task failed: {e:?}"))??;
+
+    if sent != len {
+        anyhow::bail!("sendfile short read: sent {sent} of {len} bytes; page file truncated");
     }
     Ok(())
 }
@@ -934,6 +982,71 @@ mod tests {
                     "pass {pass}: worker returned an error frame"
                 );
                 assert_eq!(body, expected, "pass {pass}: range bytes must match");
+            }
+        });
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    /// A paged build for cross-page wire tests.
+    fn build_paged(
+        root: &std::path::Path,
+        backend: Arc<dyn BackendStore>,
+        block_size: u32,
+        page_size: u32,
+    ) -> (Arc<WorkerRuntime>, Arc<WorkerObservability>) {
+        let (worker, obs) = build(&root.join("whole"), backend, block_size);
+        let worker = Arc::new(
+            Arc::try_unwrap(worker)
+                .unwrap_or_else(|_| panic!("sole owner"))
+                .with_paged_store(
+                    crate::PagedBlockStore::open(root.join("paged"), page_size).unwrap(),
+                ),
+        );
+        (worker, obs)
+    }
+
+    /// The cross-page guarantee, end to end over a real socket: a miss (byte
+    /// path) and a subsequent resident hit (N `sendfile` calls) must return
+    /// byte-identical ranges. A bug in segment ordering, offset clipping, or
+    /// short-send handling shows up here as wrong bytes on the wire — which
+    /// unit tests over handles alone cannot catch.
+    #[test]
+    fn serves_a_cross_page_hit_via_multi_sendfile_byte_exact() {
+        let root = tmp_root("xpage");
+        run(async {
+            // 16-byte pages inside a 64-byte block: a 40-byte read from offset
+            // 5 spans pages 0..=2 with partial pages at both ends.
+            let (worker, obs) = build_paged(&root, Arc::new(RampBackend), 64, 16);
+            let l = monoio::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = l.local_addr().unwrap();
+            monoio::spawn(async move {
+                let (s, _) = l.accept().await.unwrap();
+                let _ = handle_conn(s, worker, obs).await;
+            });
+
+            let obj = ObjectId::new(talon_core::Backend::Azure, "c", "obj");
+            let req = RangeRequest {
+                object: obj,
+                offset: 5,
+                len: 40,
+            };
+            let expected: Vec<u8> = (0..40u64).map(|i| ((5 + i) % 251) as u8).collect();
+            let mut c = TcpStream::connect(addr).await.unwrap();
+
+            for pass in 0..3 {
+                let (r, _) = c.write_all(encode_request(0, &req).unwrap()).await;
+                r.unwrap();
+                let (header, body) = read_response(&mut c).await;
+                assert!(
+                    !header.flags.contains(Flags::ERROR),
+                    "pass {pass}: worker returned an error frame"
+                );
+                assert_eq!(
+                    header.length as usize,
+                    expected.len(),
+                    "pass {pass}: advertised length must equal the request"
+                );
+                assert_eq!(body, expected, "pass {pass}: cross-page bytes must match");
             }
         });
         std::fs::remove_dir_all(root).ok();


### PR DESCRIPTION
## Problem

Raised in the community discussion on page-mode overhead: a read spanning multiple pages incurs an extra memcpy. It does — and the scope is wider than reported.

A paged-L2 worker stores every page in its own file, so an N-page read has no single contiguous source. The serve path handled that by declining zero-copy:

- `runtime.rs` gated the sendfile branch on `within_one_page`; anything wider fell through to `paged_block_range()`, which pread each page into a heap buffer and concatenated with `extend_from_slice`.
- The same branch was additionally gated on `!l1.is_enabled()`, so with L1 on, **every** paged read was copied — spanning or not. L1 is the common production configuration, so the zero-copy path was largely unreachable there.

Per cross-page byte that was: pread into a `Vec`, memcpy into a `BytesMut`, then another `to_vec()` before the socket write.

This matters for the reported workload specifically. Parquet row groups are ~1 MiB but their boundaries do not align to cache pages, so real IO is *small* and merely straddles a boundary — the case with the least to gain from avoiding a copy and the most per-page overhead to pay.

## Fix

Serve these reads as N `sendfile` calls. `PagedBlockStore::get_range` already returned one handle per page for precisely this purpose, but its only caller accepted `handles.len() == 1` and discarded anything else — the capability was dead code. This adds `ServeOutcome::SendfileMany` and wires it through both the io_uring and Tokio data planes.

The L1 gate was a real tradeoff rather than an oversight: L1 is inclusive and only the byte path admits pages into it, so serving unconditionally with `sendfile` would stop L1 from ever being populated. This gates on every covered page already being **L1-resident** instead of on L1 being *enabled* — warm reads go zero-copy, and admission still happens on the byte path that precedes them.

Gives the paged store an fd cache. `get_page` called `File::open` on every request, so a cross-page read paid one `openat` + `statx` **per page touched** — the syscall count scaled with the span. `FdCache` (added for whole blocks in #460) is now a shared module used by both stores, sized larger per shard for pages (512 vs 64) since a page is orders of magnitude smaller than a block.

Also drops a redundant `to_vec()` on the uring `Bytes` path (monoio implements `IoBuf` for `Bytes`, so the refcounted buffer goes to the ring directly).

## Measurements

### Latency, cross-page reads

Large spans, L1 off: 2 pages −29%, 4 pages −31%, 8 pages −49%.

Small reads straddling a 1 MiB page boundary, L1 off — the workload from the thread:

| Read size | byte path | sendfile | |
|---|---|---|---|
| 4 KiB | 499 µs | 273 µs | **−45%** |
| 16 KiB | 471 µs | 280 µs | **−41%** |
| 64 KiB | 542 µs | 277 µs | **−49%** |
| 256 KiB | 645 µs | 361 µs | **−44%** |

### Syscalls

Marginal cost **per read**, via `strace -c -f` differencing two `--reads` values so warm-up cancels. 64 KiB straddling two 1 MiB pages:

| | byte path | sendfile |
|---|---|---|
| `pread64` | 2.00 | 0.00 |
| `openat` | 2.00 | **0.00** |
| `sendfile` | 0.00 | 2.00 |
| `write` | 2.00 | 0.94 |
| **total** | **49.0** | **39.4** |

`openat` drops to zero per read — the fd cache eliminates it entirely (18 calls in the whole process, all warm-up).

Note the syscall *count* is only ~20% lower. The win is not fewer syscalls; it is that `sendfile` moves bytes without a userspace round-trip, which is what the concurrency numbers show.

### Concurrency

Closed-loop, 64 KiB straddling reads, L1 off, 16 cores:

| conns | bytes rps | sendfile rps | |
|---|---|---|---|
| 1 | 2,033 | 4,216 | 2.1x |
| 16 | 11,119 | 32,641 | 2.9x |
| 64 | 11,173 | 38,211 | 3.4x |
| 256 | 11,011 | 39,051 | **3.5x** |

**The byte path saturates at ~11k rps by 16 connections and never improves.** Adding cores does nothing for it; memcpy competes for memory bandwidth, which is shared. The single-request gap is 2x, the saturated gap is 3.5x — a benchmark at concurrency 1 understates the effect by ~40%.

At 4 MiB spans, 64 conns: 3,655 vs 10,832 MiB/s, p50 69 ms vs 23 ms.

### Memory

Peak RSS delta under the same load:

| workload | bytes | sendfile |
|---|---|---|
| 64 KiB spans, 64 conns | 215 MiB | **0.0 MiB** |
| 4 MiB spans, 64 conns | 281 MiB | 99 MiB |

The byte path allocates the whole response before writing it, so RSS scales with `span x concurrency`. Zero-copy allocates nothing per byte.

## On size thresholds: tried, measured, removed

An intermediate version of this PR carried an `L1_SENDFILE_MIN_LEN` threshold, so small L1-resident reads stayed on the byte path. That was wrong, and the way it was wrong is worth recording.

The threshold came from per-request latency benchmarks, where small L1-resident reads genuinely do look better copied. But concurrency 1 is the only regime where that holds. A 4 KiB straddling read, every page L1-resident, reqs/s:

| conns | byte path | sendfile |
|---|---|---|
| 1 | 5,723 | 4,452 |
| 8 | 20,188–24,352 | 25,601 |
| 64 | 21,874–38,754 | **40,514** |

At concurrency 1 the byte path is 28% ahead — that is what the threshold was built on. By 64 connections sendfile is up to 86% ahead.

The stability difference matters as much as the mean: across three runs at 64 connections sendfile held 40.5–40.8k rps while the byte path ranged 21.9–38.8k. Serving from DRAM contends with every other copy in the process; sendfile does not.

Keeping the threshold would also have meant carrying a hardware-dependent constant, tuned on one devbox, governing a decision that turns out to depend on **load** rather than size. So: no size threshold. Every qualifying paged read is served with `sendfile`.

### What still declines zero-copy

The L1-residency gate stays, and it is not a missed optimisation. A span that is part in DRAM and part only on disk — the steady state whenever L1 evicts under pressure while L2 keeps every page — must fall back, because L1 is inclusive and only the byte path admits. Serving it with `sendfile` would leave the evicted pages out of L1 permanently, so a hot range that lost one page could never be re-promoted. The fallback re-admits it and the next read is zero-copy.

That gate has a cost, measured on a 4-page span: all resident 1.30 ms, 1 of 4 missing 1.60 ms (**+22%**), 2 of 4 missing 1.71 ms, none resident 2.05 ms. Losing a single page costs the whole span 22%, because the gate is per-span rather than per-page. A hybrid (sendfile the L2-only pages, copy the L1 ones) would reintroduce the admission problem, so it is deliberately left alone here.

## Testing

New tests cover: multi-page sendfile byte-exactness, partial-page clipping at both ends, declining when a covered page is absent, the L1-residency gate and its re-admission, a 4 KiB straddling read going zero-copy, fd cache staleness on the paged path (rewrite / page eviction / block deletion), and the shared cache's shard capacity bound. Wire-level tests on both data planes — one of which caught a real bug where the Tokio path failed to restore non-blocking mode after `sendfile`, which would have broken every tokio-plane cross-page read in production and which handle-level tests could not have caught.

`cargo fmt` / `clippy -D warnings` / `cargo doc -D warnings` / `cargo test --workspace --all-features` all green.

## Reproducing

`talon-serve-probe` (added here, a manual tool rather than a CI gate — absolute times on shared runners are noise) measures syscalls, RSS, and concurrency:

```sh
talon-serve-probe --mode concurrency --conns 1,16,64,256
strace -c -f -- talon-serve-probe --mode syscalls --path sendfile --reads 200
```

Caveat: these are single-host loopback numbers. There is no real NIC or cross-machine RTT here. `sendfile`'s advantage is usually larger on a real NIC, but I have not measured that and am not claiming it.
