### PR TITLE
doc: drop the stale follow-up skeleton section from DESIGN.md

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -281,8 +281,11 @@ Two items that were previously listed here have since been measured (#273):
   capacity. Sharding the eviction *policy* is free; sharding the *budget* is
   not.
 
-The measured conclusion is to keep worker state **shared with lock-free reads**
-(`BlockIndex` is read-mostly), a per-ring buffer for LRU access marking, a
+The measured conclusion is to keep worker state **shared behind a single
+read-write lock** (`BlockIndex` is read-mostly, so presence and lookup take the
+shared side and only commit/remove/page updates take the exclusive side; a
+sharded map can replace it if the lock ever becomes hot), a per-ring buffer for
+LRU access marking, a
 **global** byte account for eviction, and a global `InFlightLoads` for miss
 dedup (a correctness requirement — per-shard dedup would refetch the same
 256 MiB block once per ring).
@@ -348,13 +351,20 @@ dedup (a correctness requirement — per-shard dedup would refetch the same
     data-plane path.
   - **Paged virtual block:** only the hot pages within a block are materialized
     on demand. Best for point-query workloads (database lookups). Page size is
-    configurable **256KB–4MB** (per-namespace default). A 256MB block therefore
-    holds up to 1024 pages (256KB) or 64 pages (4MB). Addressed logically as
-    `block_id/page_index`.
-  - **Form is decided at LOAD time via a hint** (per-namespace or per-LOAD
-    request); e.g. checkpoint prefixes load as whole, database prefixes load as
-    paged. Dynamic promotion (paged → whole on detected sequential scan) is
-    deferred to a later version to keep the v1 state machine simple.
+    set by the worker's `l2_page_size_bytes`; a 256MB block holds up to 1024
+    pages at 256KB or 64 pages at 4MB. Addressed logically as
+    `block_id/page_index`. *As implemented*, the only constraints enforced are
+    that the page size divides `block_size` and matches `l1_page_size_bytes`
+    when L1 is enabled — 256KB–4MB is a sizing recommendation, not a validated
+    bound.
+  - **Form is chosen per worker, not per block.** *Target state:* the form is
+    decided at LOAD time via a hint (per-namespace or per-LOAD request), so
+    checkpoint prefixes load as whole and database prefixes load as paged.
+    *As implemented:* a worker is either whole-block or paged for every block it
+    caches, selected by `l2_page_size_bytes` (`0` = whole). `LoadHint` exists in
+    `talon-core` and the coordinator's load plan, but it is not carried on the
+    `Load` control message and no worker reads it. Dynamic promotion (paged →
+    whole on detected sequential scan) is likewise deferred.
   - **Page-level miss / in-flight / eviction:** for paged blocks, miss handling,
     `demand_loads_in_flight` tracking, and LRU accounting all descend to
     `(block_id, page_index)` granularity — a point query fetches only the pages
@@ -423,21 +433,3 @@ block cache, custom TCP data plane, read-only FUSE, and pluggable blob backends
 Add RF=2 and a protobuf control API once miss cost and compatibility
 requirements are demonstrated. Coordinator HA follows
 [`ADR 0001`](docs/adr/0001-management-plane-ha.md).
-
-## Follow-up skeleton changes
-
-Decisions above that diverge from the current code, to be addressed in later PRs:
-
-- Replace `CacheKey(String)` with a structured, reversible key
-  (`backend + bucket/container + object_path + offset + block_size + etag/version`).
-- Add a `BackendStore` trait in `talon-core`, distinct from `ObjectStore`
-  (cache access) — S3 / GCS / Azure Blob implementations to follow.
-- Adjust `ObjectStore` for block-level, byte-accounted access and an fd/offset
-  path for `sendfile`, rather than only returning `Bytes`.
-- Model block materialization as `enum { Whole, Paged { page_size,
-  present_bitmap } }` in the block index, decided by a LOAD-time hint; add
-  page-level miss / in-flight / eviction for paged blocks.
-- Replace control-plane `serde_json` with framed `bincode`; define a data-plane
-  frame header.
-- Extend `RendezvousPlacement` to top-K + epoch.
-- Introduce layered configuration (`CLI > env > config file > default`).

--- a/crates/talon-coordinator/Cargo.toml
+++ b/crates/talon-coordinator/Cargo.toml
@@ -6,6 +6,10 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 description = "Cluster coordinator: metadata, membership, and object placement for Talon"
+# The crate ships doc generators alongside the server, so a bare
+# `cargo run -p talon-coordinator` is otherwise ambiguous. Name the server so
+# the documented command works without `--bin`.
+default-run = "talon-coordinator"
 
 [[bin]]
 name = "talon-coordinator"

--- a/crates/talon-coordinator/src/config.rs
+++ b/crates/talon-coordinator/src/config.rs
@@ -427,7 +427,8 @@ pub const COORDINATOR_ENV_SCHEMA: &[ConfigVar] = &[
         default: Some("false"),
         cli: false,
         secret: false,
-        help: "Honor X-Forwarded-For for audit attribution behind a trusted proxy.",
+        help: "Reserved for X-Forwarded-For audit attribution; currently inert \
+               because request audit logging is not implemented.",
     },
     #[cfg(feature = "etcd")]
     ConfigVar {

--- a/crates/talon-coordinator/src/main.rs
+++ b/crates/talon-coordinator/src/main.rs
@@ -801,8 +801,9 @@ async fn build_store(config: &CoordinatorConfig) -> anyhow::Result<Arc<dyn Clust
 ///
 /// `TALON_COORDINATOR_AUTH_TOKEN` (>= 16 chars) enables bearer-token auth;
 /// unset means authentication is disabled (proxy-terminated deployments).
-/// `TALON_COORDINATOR_TRUST_FORWARDED=1` honors `X-Forwarded-For` for audit
-/// attribution behind a trusted proxy. TLS is reverse-proxy terminated.
+/// `TALON_COORDINATOR_TRUST_FORWARDED=1` is parsed into the config but has no
+/// effect yet: request audit logging is not implemented, so nothing reads
+/// `X-Forwarded-For`. TLS is reverse-proxy terminated.
 fn build_security_config() -> anyhow::Result<talon_coordinator::security::SecurityConfig> {
     use talon_coordinator::config::env_names;
     use talon_coordinator::security::{AuthMode, SecurityConfig};

--- a/crates/talon-coordinator/src/security.rs
+++ b/crates/talon-coordinator/src/security.rs
@@ -66,6 +66,10 @@ pub struct SecurityConfig {
     /// Authentication mode for `/api/v1` and the UI.
     pub auth: AuthMode,
     /// Whether to honor `X-Forwarded-For` from a trusted proxy for audit logs.
+    ///
+    /// Currently inert: audit logging is not implemented, so no code path reads
+    /// this field or inspects the header. Kept so the operator-facing setting
+    /// does not change shape when auditing lands.
     pub trust_forwarded_headers: bool,
 }
 
@@ -149,8 +153,10 @@ pub fn apply_security_headers(resp: &mut Response, protected: bool) {
         header::REFERRER_POLICY,
         HeaderValue::from_static("no-referrer"),
     );
-    // Protected (data/UI) responses must not be stored by shared caches; the UI
-    // asset layer sets its own long-lived caching and is exempt via `protected`.
+    // Protected (data/UI) responses must not be stored by shared caches. This
+    // runs as an outer layer and overwrites whatever the handler set, so UI
+    // assets get `no-store` too despite the asset handler's own `max-age`:
+    // only `is_public_path` routes keep their caching.
     if protected {
         h.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
     }

--- a/crates/talon-coordinator/src/ui.rs
+++ b/crates/talon-coordinator/src/ui.rs
@@ -136,6 +136,10 @@ mod tests {
             css.headers().get(header::CONTENT_TYPE).unwrap(),
             "text/css; charset=utf-8"
         );
+        // Note: this exercises the bare asset router. In a running coordinator
+        // the security layer wraps it and overwrites this header with
+        // `no-store` (see `security::apply_security_headers`), so this asserts
+        // what the handler sets, not what a client receives.
         assert!(css
             .headers()
             .get(header::CACHE_CONTROL)

--- a/crates/talon-worker/Cargo.toml
+++ b/crates/talon-worker/Cargo.toml
@@ -6,6 +6,10 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 description = "Worker node: stores and serves cached object data for Talon"
+# The crate ships the `talon-loadgen` benchmark driver alongside the server, so
+# a bare `cargo run -p talon-worker` is otherwise ambiguous. Name the server so
+# the documented command works without `--bin`.
+default-run = "talon-worker"
 
 [[bin]]
 name = "talon-worker"

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -61,11 +61,15 @@ Every management response carries:
 - `X-Content-Type-Options: nosniff`
 - `X-Frame-Options: DENY` (plus the UI's `frame-ancestors 'none'` CSP)
 - `Referrer-Policy: no-referrer`
-- `Cache-Control: no-store` on protected data (the UI asset layer sets its own
-  long-lived caching for static files only)
+- `Cache-Control: no-store` on every non-public response. Only `/healthz`,
+  `/readyz`, and `/metrics` are exempt, so UI static assets are served
+  `no-store` as well: the asset handler sets a long-lived `max-age`, but the
+  security layer runs outside it and overwrites the header.
 
-Request bodies are capped at 64 KiB (the API is read-only), and each request is
-handled under the coordinator's bounded state-store timeout.
+Request bodies are capped at 64 KiB (the API is read-only). Individual
+state-store calls are bounded by `request_timeout_ms` (default 3000), so
+handlers that reach the store inherit that bound; there is no separate
+per-request timeout layer on the management router.
 
 ## Secret redaction
 
@@ -78,6 +82,11 @@ in logs, the management API, metrics, or error bodies.
 Brute-force protection against the bearer token is bounded by the constant-time
 comparison plus the request-size/timeout limits; for internet-facing
 deployments, configure connection/request rate limiting at the proxy (e.g.
-nginx `limit_req`). Audit fields for a protected request are: timestamp, method,
-path, response status, and — when `trust_forwarded_headers` is on — the
-forwarded client address. The token value is never part of an audit record.
+nginx `limit_req`).
+
+Request audit logging is **not implemented**. The coordinator emits no
+per-request record of method, path, or response status, and
+`TALON_COORDINATOR_TRUST_FORWARDED` is currently inert: the value is parsed and
+stored, but nothing reads it and no `X-Forwarded-For` header is consulted. If
+you need an audit trail today, collect it at the proxy in front of the
+management port. The token value is never logged.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -161,7 +161,7 @@ Bearer token (>= 16 chars) enabling API/UI authentication; unset disables auth.
 
 ### `(env only)`
 
-Honor X-Forwarded-For for audit attribution behind a trusted proxy.
+Reserved for X-Forwarded-For audit attribution; currently inert because request audit logging is not implemented.
 
 - **Environment variable:** `TALON_COORDINATOR_TRUST_FORWARDED`
 - **Default:** `false`

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -52,7 +52,7 @@ cargo run -p talon-coordinator -- \
 - `--listen` is the control plane workers and clients connect to.
 - `--admin-listen` serves health, metrics, the management API, and the UI.
 
-Leave it running. You'll see it log `coordinator serving control plane`.
+Leave it running. You'll see it log `coordinator serving public control plane`.
 
 > The memory backend is development-only. It refuses to start in HA mode
 > (`ha_enabled` or `coordinator_replicas > 1`). For active-active coordinators
@@ -82,8 +82,14 @@ cargo run -p talon-worker -- \
   --node-id worker-0
 ```
 
-The worker logs `registered with coordinator`. Over on the coordinator you'll
-see `worker registered id=worker-0`.
+The worker logs `registered with coordinator`. The coordinator does not log a
+line per worker — membership is authoritative in the state store, kept fresh by
+status heartbeats — so confirm the worker arrived by asking the management API
+instead:
+
+```sh
+curl -s "http://127.0.0.1:8000/api/v1/nodes"
+```
 
 > **Placeholder credentials** are fine for exploring the control plane, the API,
 > and the UI. To read real objects you need genuine credentials for your blob

--- a/docs/use-cases/analytics.md
+++ b/docs/use-cases/analytics.md
@@ -49,28 +49,34 @@ scratch.
 If shuffle is the primary workload, measure hit rate before committing to it.
 The per-worker metrics exposed to Prometheus make this straightforward.
 
-## Current limitation: block granularity
+## Block granularity: whole blocks by default, pages on request
 
-This is the most important caveat on this page, and it is a real one today.
+By default a worker materialises blocks **whole**. A read that touches a block
+fetches the entire block — 256 MiB at the default size — even if the query
+wanted a few kilobytes of one column chunk. For a sequential scan that is
+exactly right, and the cost is amortised immediately. For sparse random access
+across a large file it is not: the first touch of each block pays a full block
+fetch.
 
-Blocks are currently materialised **whole**. A read that touches a block fetches
-the entire block — 256 MiB at the default size — even if the query wanted a few
-kilobytes of one column chunk. For a sequential scan that is exactly right, and
-the cost is amortised immediately. For sparse random access across a large file
-it is not: the first touch of each block pays a full block fetch.
+For that second shape, a worker can cache **per page** instead. Set
+[`l2_page_size_bytes`](../reference/configuration.md#l2_page_size_bytes) to a
+non-zero page size and a block is materialised page by page against a present
+bitmap: a range touching absent pages fetches only those pages' byte ranges
+from the origin, not the whole block. Each present page is its own file on
+disk, served by its own `sendfile`, and both miss dedup and LRU accounting
+descend to `(block, page)` granularity.
 
-The design anticipates this. `DESIGN.md` specifies **paged blocks**, where a
-block is materialised page by page against a present bitmap, and a range
-touching absent pages fetches only those pages' byte ranges rather than the
-whole block. The supporting pieces exist in the tree — the block form enum, the
-present bitmap, a paged store implementation — but the serve path does not yet
-resolve reads through them, so the behaviour above is what actually ships.
+The setting defaults to `0`, which keeps the whole-block behaviour above. Two
+constraints apply when you enable it: the page size must divide `block_size`,
+and when the L1 DRAM cache is also enabled `l1_page_size_bytes` must equal
+`l2_page_size_bytes` (L1 is filled one L2 page at a time, so mismatched sizes
+would leave L1 entries unfillable). The worker validates both at startup.
 
-Practical consequence: **Talon suits analytics workloads that scan more than
-they seek.** Full-partition scans, repeated reads of hot dimension tables, and
-range reads that align with block boundaries all benefit now. Highly selective
-point lookups scattered across a large file will over-fetch until paged blocks
-are wired through.
+Practical consequence: **with the default settings Talon suits analytics
+workloads that scan more than they seek.** Full-partition scans, repeated reads
+of hot dimension tables, and range reads that align with block boundaries all
+benefit as shipped. For highly selective point lookups scattered across a large
+file, enable paged caching so a lookup costs one page rather than 256 MiB.
 
 ## Practical notes
 

--- a/docs/use-cases/checkpointing.md
+++ b/docs/use-cases/checkpointing.md
@@ -26,8 +26,9 @@ Concurrent misses for the same block are deduplicated, so a stampede produces
 **Range reads without whole-file transfer.** `GET_RANGE` is served with
 `sendfile` at an offset, so once a block is resident, reading a checkpoint
 footer transfers the footer — not the checkpoint, and not through userspace.
-Note that the *first* touch of a block still fetches the whole block from the
-origin; see [the granularity note](./analytics.md#current-limitation-block-granularity).
+Note that by default the *first* touch of a block fetches the whole block from
+the origin; see
+[the granularity note](./analytics.md#block-granularity-whole-blocks-by-default-pages-on-request).
 
 **Version-correct caching.** Blocks are keyed by the object's real ETag, and the
 worker sends a conditional `If-Match` on the miss path. Overwriting a checkpoint


### PR DESCRIPTION
## Summary

Reconciles docs and inline comments with the current implementation — several docs described things that are either inert (audit logging, `X-Forwarded-For` attribution), missing (per-worker registration log line), or already shipped but undocumented (paged block caching). Also drops a stale "follow-up skeleton" section from `DESIGN.md` and adds `default-run` to two `Cargo.toml`s for unambiguous `cargo run`.

## Related issues

## Type of change

- [ ] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [X] Docs / tests / tooling

## Design alignment

Corrects `DESIGN.md`'s `BlockIndex` locking description and paged-block section to match code (single RW lock; per-worker page form via `l2_page_size_bytes`, not per-LOAD hint). Drops the stale "Follow-up skeleton changes" section.

## Changes

- `DESIGN.md`: fix `BlockIndex` concurrency description, clarify paged-block form selection, drop stale follow-up section.
- `Cargo.toml` (coordinator, worker): add `default-run` so `cargo run -p <crate>` is unambiguous.
- `config.rs` / `main.rs` / `security.rs`: doc-comment fixes — `trust_forwarded_headers` is parsed but currently inert; no functional change.
- `ui.rs`: test comment clarifying `Cache-Control` is overwritten by the security layer.
- `docs/operations/security.md`: state that audit logging is not implemented; clarify timeout source.
- `docs/reference/configuration.md`: same `trust_forwarded_headers` correction.
- `docs/tutorials/getting-started.md`: fix stale log message; point to `GET /api/v1/nodes` for worker confirmation.
- `docs/use-cases/analytics.md`: paged block caching is implemented via `l2_page_size_bytes`, not just designed — document constraints.
- `docs/use-cases/checkpointing.md`: fix cross-reference link.

## Test plan

- [ ] `just ci` passes locally (fmt + clippy + test)
- [ ] Workspace compiles (`cargo build --workspace`)
- [ ] Doc/comment-only changes; no behavioral code paths affected

## Performance impact

- [X] Not performance-sensitive

## Checklist

- [ ] PR title follows Conventional Commits
- [X] Public items are documented; no broken intra-doc links
- [X] No new dependencies without discussion
- [ ] Rebased on the latest `main`

Note: the current title only mentions "drop the stale follow-up skeleton section," but the diff also rewrites analytics.md content and changes Cargo.toml build behavior — worth a broader title if you want it to match scope.
