### PR TITLE
fix(cache-client): retry pooled connections only on I/O errors

### DIFF
--- a/crates/talon-cache-client/src/coordinator_client.rs
+++ b/crates/talon-cache-client/src/coordinator_client.rs
@@ -80,6 +80,24 @@ pub enum CoordinatorError {
     },
 }
 
+impl CoordinatorError {
+    /// True when the failure is transport-level (the socket died) rather than
+    /// the coordinator answering with a refusal.
+    ///
+    /// This is the retry gate for pooled connections — see
+    /// [`WorkerError::is_transport_failure`](crate::WorkerError) for the full
+    /// rationale. Matched exhaustively on purpose: a new variant has to be
+    /// classified here rather than silently defaulting at the call site.
+    pub(crate) fn is_transport_failure(&self) -> bool {
+        match self {
+            CoordinatorError::Io(_) => true,
+            CoordinatorError::Codec(_)
+            | CoordinatorError::PayloadTooLarge { .. }
+            | CoordinatorError::Unexpected { .. } => false,
+        }
+    }
+}
+
 /// A thin control-plane client bound to one coordinator address.
 ///
 /// Reuses connections from a shared [`ConnectionPool`] so warm lookups skip the
@@ -282,7 +300,7 @@ impl CoordinatorClient {
         let out = talon_transport::encode(0, &msg)?;
         match self.exchange(&out, expected).await {
             Ok(reply) => Ok(reply),
-            Err((true, CoordinatorError::Io(_))) => {
+            Err((true, err)) if err.is_transport_failure() => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 let reply = self
                     .pool
@@ -603,7 +621,7 @@ mod tests {
     /// same coordinator and re-ask.
     #[tokio::test]
     async fn not_control_reply_is_not_retried_on_the_coordinator() {
-        use std::sync::atomic::{AtomicU32, Ordering};
+        use std::sync::atomic::AtomicU32;
         let accepts = Arc::new(AtomicU32::new(0));
         let requests = Arc::new(AtomicU32::new(0));
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/crates/talon-cache-client/src/coordinator_client.rs
+++ b/crates/talon-cache-client/src/coordinator_client.rs
@@ -267,11 +267,13 @@ impl CoordinatorClient {
 
     /// Send one control message and read exactly one control reply.
     ///
-    /// Uses a pooled connection when warm; a reused connection that fails (the
-    /// peer may have closed it while idle) is retried once on a fresh dial, so a
-    /// stale pooled socket never turns a healthy coordinator into a spurious
-    /// failure. The connection is returned to the pool only after a fully
-    /// successful exchange.
+    /// Uses a pooled connection when warm; a reused connection that fails with
+    /// an I/O error (the peer may have closed it while idle) is retried once on
+    /// a fresh dial, so a stale pooled socket never turns a healthy coordinator
+    /// into a spurious failure. A non-I/O failure (a codec/protocol refusal)
+    /// propagates immediately rather than re-asking the same coordinator. The
+    /// connection is returned to the pool only after a fully successful
+    /// exchange.
     async fn round_trip(
         &self,
         msg: ControlMessage,
@@ -280,7 +282,7 @@ impl CoordinatorClient {
         let out = talon_transport::encode(0, &msg)?;
         match self.exchange(&out, expected).await {
             Ok(reply) => Ok(reply),
-            Err((true, _stale)) => {
+            Err((true, CoordinatorError::Io(_))) => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 let reply = self
                     .pool
@@ -293,7 +295,7 @@ impl CoordinatorClient {
                 self.pool.release(&self.addr, stream);
                 Ok(reply)
             }
-            Err((false, err)) => Err(err),
+            Err((_, err)) => Err(err),
         }
     }
 
@@ -593,6 +595,78 @@ mod tests {
         assert_eq!(
             resolved.address_of(&NodeId::new("w1")),
             Some("10.0.0.1:7001")
+        );
+    }
+
+    /// A codec-level refusal (e.g. a reply that isn't even a `Control` frame)
+    /// on a reused connection must propagate immediately, not re-dial the
+    /// same coordinator and re-ask.
+    #[tokio::test]
+    async fn not_control_reply_is_not_retried_on_the_coordinator() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let accepts = Arc::new(AtomicU32::new(0));
+        let requests = Arc::new(AtomicU32::new(0));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let accepts_srv = Arc::clone(&accepts);
+        let requests_srv = Arc::clone(&requests);
+        tokio::spawn(async move {
+            loop {
+                let (mut sock, _) = match listener.accept().await {
+                    Ok(v) => v,
+                    Err(_) => return,
+                };
+                accepts_srv.fetch_add(1, Ordering::SeqCst);
+                let requests = Arc::clone(&requests_srv);
+                tokio::spawn(async move {
+                    loop {
+                        let mut hdr = [0u8; HEADER_LEN];
+                        if sock.read_exact(&mut hdr).await.is_err() {
+                            return;
+                        }
+                        let header = FrameHeader::decode(&hdr).unwrap();
+                        let mut body = vec![0u8; header.length as usize];
+                        sock.read_exact(&mut body).await.unwrap();
+                        let n = requests.fetch_add(1, Ordering::SeqCst);
+                        if n == 0 {
+                            let reply = ControlMessage::MembershipList {
+                                nodes: vec![worker("w1", "10.0.0.1:7001")],
+                            };
+                            sock.write_all(
+                                &talon_transport::encode(header.request_id, &reply).unwrap(),
+                            )
+                            .await
+                            .unwrap();
+                        } else {
+                            let bad =
+                                FrameHeader::new(MsgType::GetRange, header.request_id, 0).encode();
+                            sock.write_all(&bad).await.unwrap();
+                        }
+                        sock.flush().await.unwrap();
+                    }
+                });
+            }
+        });
+        let client = CoordinatorClient::new(addr);
+
+        let members = client.membership().await.unwrap();
+        assert_eq!(members.len(), 1);
+
+        let err = client.membership().await.unwrap_err();
+        assert!(matches!(
+            err,
+            CoordinatorError::Codec(talon_transport::CodecError::NotControl(MsgType::GetRange))
+        ));
+
+        assert_eq!(
+            accepts.load(Ordering::SeqCst),
+            1,
+            "a codec-level refusal must not re-dial the same coordinator"
+        );
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            2,
+            "the refused round trip must not be doubled"
         );
     }
 

--- a/crates/talon-cache-client/src/pool.rs
+++ b/crates/talon-cache-client/src/pool.rs
@@ -168,7 +168,8 @@ impl ConnectionPool {
     /// Returns the stream and whether it came from the pool (`reused == true`).
     /// A reused connection may have been closed by the peer since it was pooled
     /// (server idle timeout, restart); callers should retry once on a fresh dial
-    /// if a reused connection errors — see [`fresh`](Self::fresh).
+    /// if a reused connection fails with an I/O error — see
+    /// [`fresh`](Self::fresh).
     pub async fn checkout(&self, addr: &str) -> std::io::Result<(TcpStream, bool)> {
         if let Some(stream) = self.take_idle(addr) {
             return Ok((stream, true));

--- a/crates/talon-cache-client/src/worker_client.rs
+++ b/crates/talon-cache-client/src/worker_client.rs
@@ -125,13 +125,15 @@ impl WorkerClient {
         // logs for this fetch can be joined with the client's (#304).
         let req_id = RequestId::next();
         let out = encode_request(req_id.0, &req)?;
-        // Try a pooled connection first; if it was reused and fails (the peer may
-        // have closed it while idle), retry once on a fresh dial so a stale
-        // pooled socket never turns a healthy peer into a spurious failure. A
-        // failure on a *fresh* connection is a real peer error and propagates.
+        // Try a pooled connection first; if it was reused and fails with an I/O
+        // error (the peer may have closed it while idle), retry once on a fresh
+        // dial so a stale pooled socket never turns a healthy peer into a
+        // spurious failure. A failure on a fresh connection, or a non-I/O error
+        // on a reused one (the peer answered but refused/rejected the request),
+        // propagates immediately rather than re-asking the same peer.
         match self.exchange(&out, len).await {
             Ok(bytes) => Ok(bytes),
-            Err((true, _stale)) => {
+            Err((true, WorkerError::Io(_))) => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 let bytes = self
                     .pool
@@ -144,7 +146,7 @@ impl WorkerClient {
                 self.pool.release(&self.addr, stream);
                 Ok(bytes)
             }
-            Err((false, err)) => {
+            Err((_, err)) => {
                 tracing::error!(
                     req = %req_id,
                     worker = %self.addr,
@@ -178,7 +180,7 @@ impl WorkerClient {
         let output = encode_request(request_id.0, &request)?;
         match self.exchange_into(&output, dst).await {
             Ok(n) => Ok(n),
-            Err((true, _)) => {
+            Err((true, WorkerError::Io(_))) => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 let n = self
                     .pool
@@ -191,7 +193,7 @@ impl WorkerClient {
                 self.pool.release(&self.addr, stream);
                 Ok(n)
             }
-            Err((false, error)) => {
+            Err((_, error)) => {
                 tracing::error!(
                     req = %request_id,
                     worker = %self.addr,
@@ -227,7 +229,7 @@ impl WorkerClient {
         let output = encode_cached_request(request_id.0, &request)?;
         match self.exchange(&output, len).await {
             Ok(bytes) => Ok(bytes),
-            Err((true, _)) => {
+            Err((true, WorkerError::Io(_))) => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 let bytes = self
                     .pool
@@ -240,7 +242,7 @@ impl WorkerClient {
                 self.pool.release(&self.addr, stream);
                 Ok(bytes)
             }
-            Err((false, error)) => Err(error),
+            Err((_, error)) => Err(error),
         }
     }
 
@@ -263,7 +265,7 @@ impl WorkerClient {
         )?;
         match self.admit_exchange(&header, body).await {
             Ok(()) => Ok(()),
-            Err((true, _)) => {
+            Err((true, WorkerError::Io(_))) => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 self.pool
                     .with_deadline(
@@ -280,7 +282,7 @@ impl WorkerClient {
                 self.pool.release(&self.addr, stream);
                 Ok(())
             }
-            Err((false, error)) => Err(error),
+            Err((_, error)) => Err(error),
         }
     }
 
@@ -414,10 +416,12 @@ impl WriteClient {
     /// `body` bytes, and returns the backend-committed [`Version`]. A worker- or
     /// backend-side failure surfaces as [`WorkerError::Remote`].
     ///
-    /// Retries once on a *stale pooled* connection (the peer may have closed it
-    /// while idle): because a retry re-sends the full header+body on a fresh
-    /// connection, it is safe — the first attempt sent nothing the backend
-    /// committed (a mid-stream failure is not retried, it propagates).
+    /// Retries once when a *reused* pooled connection fails with an I/O error
+    /// (the peer may have closed it while idle): because a retry re-sends the
+    /// full header+body on a fresh connection, it is safe — the first attempt
+    /// sent nothing the backend committed. A non-I/O failure (the worker
+    /// replied with a refusal) propagates immediately instead of re-sending
+    /// the body to a peer that already rejected it.
     pub async fn put_object(&self, object: &ObjectId, body: &[u8]) -> Result<Version, WorkerError> {
         let req_id = RequestId::next();
         let header = encode_put_header(
@@ -429,8 +433,9 @@ impl WriteClient {
         )?;
         match self.put_exchange(&header, body).await {
             Ok(version) => Ok(version),
-            Err((true, _stale)) => {
-                // Stale pooled connection: retry once on a fresh dial.
+            Err((true, WorkerError::Io(_))) => {
+                // Reused pooled connection failed with an I/O error: retry
+                // once on a fresh dial.
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 let version = self
                     .pool
@@ -444,7 +449,7 @@ impl WriteClient {
                 self.pool.release(&self.addr, stream);
                 Ok(version)
             }
-            Err((false, err)) => {
+            Err((_, err)) => {
                 tracing::error!(
                     req = %req_id,
                     worker = %self.addr,
@@ -475,7 +480,7 @@ impl WriteClient {
         )?;
         match self.put_file_exchange(&header, path, len).await {
             Ok(version) => Ok(version),
-            Err((true, _stale)) => {
+            Err((true, WorkerError::Io(_))) => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 let version = self
                     .pool
@@ -492,7 +497,7 @@ impl WriteClient {
                 self.pool.release(&self.addr, stream);
                 Ok(version)
             }
-            Err((false, error)) => {
+            Err((_, error)) => {
                 tracing::error!(
                     req = %req_id,
                     worker = %self.addr,
@@ -575,7 +580,7 @@ impl WriteClient {
         )?;
         match self.delete_exchange(&frame).await {
             Ok(()) => Ok(()),
-            Err((true, _stale)) => {
+            Err((true, WorkerError::Io(_))) => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 self.pool
                     .with_request_deadline("worker delete_object retry", async {
@@ -587,7 +592,7 @@ impl WriteClient {
                 self.pool.release(&self.addr, stream);
                 Ok(())
             }
-            Err((false, err)) => {
+            Err((_, err)) => {
                 tracing::error!(
                     req = %req_id,
                     worker = %self.addr,
@@ -1071,6 +1076,81 @@ mod tests {
         assert_eq!(b, vec![7u8; 8]);
         // Two connections were accepted (the retry dialed a fresh one).
         assert_eq!(accepts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn remote_error_is_not_retried_on_the_same_replica() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        // A worker that serves one request per connection successfully, then
+        // errors every request after that on the SAME (now reused) connection.
+        // A remote refusal must propagate on the first try, not re-dial the
+        // replica that just told us it doesn't have the block.
+        let accepts = Arc::new(AtomicU32::new(0));
+        let requests = Arc::new(AtomicU32::new(0));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let accepts_srv = Arc::clone(&accepts);
+        let requests_srv = Arc::clone(&requests);
+        tokio::spawn(async move {
+            loop {
+                let (mut sock, _) = match listener.accept().await {
+                    Ok(v) => v,
+                    Err(_) => return,
+                };
+                accepts_srv.fetch_add(1, Ordering::SeqCst);
+                let requests = Arc::clone(&requests_srv);
+                tokio::spawn(async move {
+                    loop {
+                        let mut hdr = [0u8; HEADER_LEN];
+                        if sock.read_exact(&mut hdr).await.is_err() {
+                            return;
+                        }
+                        let header = FrameHeader::decode(&hdr).unwrap();
+                        let mut body = vec![0u8; header.length as usize];
+                        sock.read_exact(&mut body).await.unwrap();
+                        let n = requests.fetch_add(1, Ordering::SeqCst);
+                        if n == 0 {
+                            let mut out = response_header_ok(header.request_id, 8).to_vec();
+                            out.extend_from_slice(&[7u8; 8]);
+                            sock.write_all(&out).await.unwrap();
+                        } else {
+                            sock.write_all(&encode_error(header.request_id, "block not present"))
+                                .await
+                                .unwrap();
+                        }
+                        sock.flush().await.unwrap();
+                    }
+                });
+            }
+        });
+        let client = WorkerClient::new(addr);
+
+        // Warm the pool with a successful fetch.
+        let first = client.fetch_range(&object(), 0, 8).await.unwrap();
+        assert_eq!(first, vec![7u8; 8]);
+
+        // Second fetch reuses the pooled connection and gets a remote refusal.
+        let err = client.fetch_range(&object(), 0, 8).await.unwrap_err();
+        match err {
+            WorkerError::Remote(error) => {
+                assert_eq!(error.code, talon_transport::DataErrorCode::Unknown);
+                assert_eq!(error.message, "block not present");
+            }
+            other => panic!("expected Remote, got {other:?}"),
+        }
+
+        // The load-bearing assertions: a remote error on a reused connection
+        // must not open a second connection or double the request.
+        assert_eq!(
+            accepts.load(Ordering::SeqCst),
+            1,
+            "a remote error must not re-dial the same replica"
+        );
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            2,
+            "the wrong-owner round trip must not be doubled"
+        );
     }
 
     #[tokio::test]

--- a/crates/talon-cache-client/src/worker_client.rs
+++ b/crates/talon-cache-client/src/worker_client.rs
@@ -65,6 +65,32 @@ pub enum WorkerError {
     Remote(DataPlaneError),
 }
 
+impl WorkerError {
+    /// True when the failure is transport-level (the socket died) rather than
+    /// the worker answering with a refusal.
+    ///
+    /// This is the retry gate for pooled connections. A *reused* connection may
+    /// have been closed by the peer while it sat idle (server idle timeout,
+    /// restart), so a transport failure on one is retried once on a fresh dial
+    /// — see [`ConnectionPool::checkout`]. Every other variant means the worker
+    /// answered and refused; re-asking the same peer would only repeat the
+    /// refusal, so those propagate immediately.
+    ///
+    /// Matched exhaustively on purpose: a new variant has to be classified
+    /// here, in one place, instead of silently defaulting at each call site.
+    pub(crate) fn is_transport_failure(&self) -> bool {
+        match self {
+            WorkerError::Io(_) => true,
+            WorkerError::Encode(_)
+            | WorkerError::Frame(_)
+            | WorkerError::NotGetRange(_)
+            | WorkerError::RangeLengthMismatch { .. }
+            | WorkerError::PayloadTooLarge { .. }
+            | WorkerError::Remote(_) => false,
+        }
+    }
+}
+
 /// A thin data-plane client bound to one worker address.
 ///
 /// Reuses connections from a shared [`ConnectionPool`] so warm fetches skip the
@@ -133,7 +159,7 @@ impl WorkerClient {
         // propagates immediately rather than re-asking the same peer.
         match self.exchange(&out, len).await {
             Ok(bytes) => Ok(bytes),
-            Err((true, WorkerError::Io(_))) => {
+            Err((true, err)) if err.is_transport_failure() => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 let bytes = self
                     .pool
@@ -180,7 +206,7 @@ impl WorkerClient {
         let output = encode_request(request_id.0, &request)?;
         match self.exchange_into(&output, dst).await {
             Ok(n) => Ok(n),
-            Err((true, WorkerError::Io(_))) => {
+            Err((true, err)) if err.is_transport_failure() => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 let n = self
                     .pool
@@ -229,7 +255,7 @@ impl WorkerClient {
         let output = encode_cached_request(request_id.0, &request)?;
         match self.exchange(&output, len).await {
             Ok(bytes) => Ok(bytes),
-            Err((true, WorkerError::Io(_))) => {
+            Err((true, err)) if err.is_transport_failure() => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 let bytes = self
                     .pool
@@ -265,7 +291,7 @@ impl WorkerClient {
         )?;
         match self.admit_exchange(&header, body).await {
             Ok(()) => Ok(()),
-            Err((true, WorkerError::Io(_))) => {
+            Err((true, err)) if err.is_transport_failure() => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 self.pool
                     .with_deadline(
@@ -433,9 +459,7 @@ impl WriteClient {
         )?;
         match self.put_exchange(&header, body).await {
             Ok(version) => Ok(version),
-            Err((true, WorkerError::Io(_))) => {
-                // Reused pooled connection failed with an I/O error: retry
-                // once on a fresh dial.
+            Err((true, err)) if err.is_transport_failure() => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 let version = self
                     .pool
@@ -480,7 +504,7 @@ impl WriteClient {
         )?;
         match self.put_file_exchange(&header, path, len).await {
             Ok(version) => Ok(version),
-            Err((true, WorkerError::Io(_))) => {
+            Err((true, err)) if err.is_transport_failure() => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 let version = self
                     .pool
@@ -580,7 +604,7 @@ impl WriteClient {
         )?;
         match self.delete_exchange(&frame).await {
             Ok(()) => Ok(()),
-            Err((true, WorkerError::Io(_))) => {
+            Err((true, err)) if err.is_transport_failure() => {
                 let mut stream = self.pool.fresh(&self.addr).await?;
                 self.pool
                     .with_request_deadline("worker delete_object retry", async {
@@ -978,10 +1002,21 @@ mod tests {
     }
 
     /// A mock worker that loops, serving many sequential requests on the SAME
-    /// connection, and counts accepted connections.
-    async fn looping_mock_worker(accepts: Arc<std::sync::atomic::AtomicU32>) -> String {
+    /// connection. Counts accepted connections and requests served, and lets
+    /// the caller build each reply: `respond` gets the request header, the
+    /// decoded request, and the 0-based index of this request across all
+    /// connections.
+    async fn looping_mock_worker_with<F>(
+        accepts: Arc<std::sync::atomic::AtomicU32>,
+        requests: Arc<std::sync::atomic::AtomicU32>,
+        respond: F,
+    ) -> String
+    where
+        F: Fn(&FrameHeader, &RangeRequest, u32) -> Vec<u8> + Send + Sync + 'static,
+    {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap().to_string();
+        let respond = Arc::new(respond);
         tokio::spawn(async move {
             loop {
                 let (mut sock, _) = match listener.accept().await {
@@ -989,6 +1024,8 @@ mod tests {
                     Err(_) => return,
                 };
                 accepts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let requests = Arc::clone(&requests);
+                let respond = Arc::clone(&respond);
                 tokio::spawn(async move {
                     loop {
                         let mut hdr = [0u8; HEADER_LEN];
@@ -1001,16 +1038,26 @@ mod tests {
                         let mut full = hdr.to_vec();
                         full.extend_from_slice(&body);
                         let (_h, req): (_, RangeRequest) = decode_request(&full).unwrap();
-                        let payload: Vec<u8> = (0..req.len).map(|i| (i % 251) as u8).collect();
-                        let mut out = response_header_ok(0, payload.len() as u32).to_vec();
-                        out.extend_from_slice(&payload);
-                        sock.write_all(&out).await.unwrap();
+                        let n = requests.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        sock.write_all(&respond(&header, &req, n)).await.unwrap();
                         sock.flush().await.unwrap();
                     }
                 });
             }
         });
         addr
+    }
+
+    /// A looping mock worker that serves every request successfully.
+    async fn looping_mock_worker(accepts: Arc<std::sync::atomic::AtomicU32>) -> String {
+        let requests = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        looping_mock_worker_with(accepts, requests, |_header, req, _n| {
+            let payload: Vec<u8> = (0..req.len).map(|i| (i % 251) as u8).collect();
+            let mut out = response_header_ok(0, payload.len() as u32).to_vec();
+            out.extend_from_slice(&payload);
+            out
+        })
+        .await
     }
 
     #[tokio::test]
@@ -1081,48 +1128,26 @@ mod tests {
     #[tokio::test]
     async fn remote_error_is_not_retried_on_the_same_replica() {
         use std::sync::atomic::{AtomicU32, Ordering};
-        // A worker that serves one request per connection successfully, then
-        // errors every request after that on the SAME (now reused) connection.
-        // A remote refusal must propagate on the first try, not re-dial the
+        // A worker that serves the first request successfully, then refuses
+        // every request after that on the SAME (now reused) connection. A
+        // remote refusal must propagate on the first try, not re-dial the
         // replica that just told us it doesn't have the block.
         let accepts = Arc::new(AtomicU32::new(0));
         let requests = Arc::new(AtomicU32::new(0));
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap().to_string();
-        let accepts_srv = Arc::clone(&accepts);
-        let requests_srv = Arc::clone(&requests);
-        tokio::spawn(async move {
-            loop {
-                let (mut sock, _) = match listener.accept().await {
-                    Ok(v) => v,
-                    Err(_) => return,
-                };
-                accepts_srv.fetch_add(1, Ordering::SeqCst);
-                let requests = Arc::clone(&requests_srv);
-                tokio::spawn(async move {
-                    loop {
-                        let mut hdr = [0u8; HEADER_LEN];
-                        if sock.read_exact(&mut hdr).await.is_err() {
-                            return;
-                        }
-                        let header = FrameHeader::decode(&hdr).unwrap();
-                        let mut body = vec![0u8; header.length as usize];
-                        sock.read_exact(&mut body).await.unwrap();
-                        let n = requests.fetch_add(1, Ordering::SeqCst);
-                        if n == 0 {
-                            let mut out = response_header_ok(header.request_id, 8).to_vec();
-                            out.extend_from_slice(&[7u8; 8]);
-                            sock.write_all(&out).await.unwrap();
-                        } else {
-                            sock.write_all(&encode_error(header.request_id, "block not present"))
-                                .await
-                                .unwrap();
-                        }
-                        sock.flush().await.unwrap();
-                    }
-                });
-            }
-        });
+        let addr = looping_mock_worker_with(
+            Arc::clone(&accepts),
+            Arc::clone(&requests),
+            |header, _req, n| {
+                if n == 0 {
+                    let mut out = response_header_ok(header.request_id, 8).to_vec();
+                    out.extend_from_slice(&[7u8; 8]);
+                    out
+                } else {
+                    encode_error(header.request_id, "block not present")
+                }
+            },
+        )
+        .await;
         let client = WorkerClient::new(addr);
 
         // Warm the pool with a successful fetch.


### PR DESCRIPTION
## Summary

The retry-on-reused-connection path in `WorkerClient` and `CoordinatorClient` fired for *any* error on a reused pooled connection, not just a stale/closed socket. A worker's `Remote`/`NotGetRange` refusal, or a coordinator's codec-level rejection (`CodecError::NotControl`), on a reused connection re-dialed the *same* peer and re-asked before propagating — doubling the wrong-owner round trip for every replica in the fallback list.

Gates the retry on the reused connection failing with an I/O error specifically; any other error now propagates immediately, matching how a fresh-connection failure already behaved.

## Related issues

Part of milvus-io/talon#257 (item 2 of 3). Not closing #257: item 1 (no cap on total outstanding connections) is a separate, larger change (a semaphore-gated `checkout`/`fresh`, plus making the FUSE prefetch cap global), and item 3 (lock-poisoning on `.lock().unwrap()`) is already resolved elsewhere via a poison-tolerant `lock_recover()` helper in `crates/talon-cache-client/src/lock.rs`.

## Type of change

- [X] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [ ] Docs / tests / tooling

## Design alignment

No design doc change needed — this is an internal client retry policy, not a wire-protocol or architecture change.

## Changes

- `crates/talon-cache-client/src/worker_client.rs`: gate the pooled-connection retry on `WorkerError::Io(_)` at all 7 retry sites (`fetch_range`, `fetch_range_into`, `fetch_cached_range`, `admit_cached_block`, `WriteClient::put_object`, `put_object_file`, `delete_object`); tighten the doc comments that described the old (looser) behavior.
- `crates/talon-cache-client/src/coordinator_client.rs`: same gate on `CoordinatorError::Io(_)` in `round_trip`; new regression test `not_control_reply_is_not_retried_on_the_coordinator` (the coordinator side had no retry-path test coverage at all before this).
- `crates/talon-cache-client/src/pool.rs`: doc-only fix to `checkout`'s comment, which previously licensed the bug ("retry once ... if a reused connection errors").
- New test `remote_error_is_not_retried_on_the_same_replica` (named in the original issue): asserts a remote refusal on a reused connection does not open a second connection or double the request.

## Test plan

- [X] `cargo test -p talon-cache-client --all-features --locked` passes locally: 88/88, including both new tests. Confirmed both new tests **fail** on the pre-fix code (`accepts == 2` instead of `1`) before applying the fix, so they're load-bearing.
- [X] `cargo clippy -p talon-cache-client --all-targets --all-features -- -D warnings` passes locally.
- [X] `cargo fmt --all --check` passes locally (workspace-wide).
- [ ] Full `just ci` (workspace-wide clippy/test) — not runnable locally on this macOS devbox: `talon-worker` requires Linux (io_uring, Linux `sendfile` signature) and `talon-fuse` requires macFUSE, neither installed here. This diff only touches `talon-cache-client` and changes no public signatures, so nothing outside this crate is affected; deferring to upstream CI (Linux) for the full-workspace gate.

## Performance impact

- [X] Not performance-sensitive

## Checklist

- [X] PR title follows Conventional Commits
- [X] Public items are documented; no broken intra-doc links
- [X] No new dependencies without discussion
- [X] Rebased on the latest `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Sonnet 5)