### PR TITLE
fix(deploy): set TALON_WORKER_ADVERTISE_ADDR in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,10 @@ services:
       # plane / UI work, but reading real objects needs real credentials.
       TALON_WORKER_AZURE_ACCOUNT: demo
       TALON_WORKER_AZURE_SAS: "sv=demo&sig=demo"
+      # Routable address other containers use to reach this worker's RPC port;
+      # the default (the listen address, 0.0.0.0:7001) is an unreachable
+      # wildcard bind, so the worker refuses to start without this.
+      TALON_WORKER_ADVERTISE_ADDR: "worker:7001"
     ports:
       - "8001:8001" # worker admin (metrics/health/status)
     depends_on:
@@ -132,6 +136,8 @@ services:
     environment:
       TALON_WORKER_AZURE_ACCOUNT: demo
       TALON_WORKER_AZURE_SAS: "sv=demo&sig=demo"
+      # See the default worker's TALON_WORKER_ADVERTISE_ADDR comment above.
+      TALON_WORKER_ADVERTISE_ADDR: "worker-ha:7001"
     ports:
       - "8001:8001"
     depends_on:


### PR DESCRIPTION
## Summary
- `docker compose up` on a fresh clone brought up a healthy coordinator but the worker exited immediately: `advertise_addr "0.0.0.0:7001" is a wildcard bind and is unreachable by clients`.
- Neither the default (`worker`) nor HA (`worker-ha`) service set `TALON_WORKER_ADVERTISE_ADDR`, so both fell back to the listen address — always a wildcard bind, always rejected by `WorkerConfig::validate`. Not platform-specific.
- Sets it to the worker's own compose service name + RPC port (`worker:7001` / `worker-ha:7001`) in both profiles.

Fixes #545.

## Test plan
- [x] `docker compose config --quiet` and `docker compose --profile ha config --quiet` — valid YAML
- [x] `docker compose up -d` — coordinator and worker both come up healthy; worker log shows `registered with coordinator`; `curl http://127.0.0.1:8000/api/v1/nodes` lists both `coord-0` and `worker-0` as healthy
- [x] `docker compose down` — clean teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Sonnet 5)