### PR TITLE
feat(worker): bound paged miss run concurrency

### DIFF
--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -141,6 +141,10 @@ pub struct WorkerConfig {
     /// where a miss fetches and stores only the pages a read touches — far less
     /// backend traffic and disk for point-query workloads.
     pub l2_page_size_bytes: u64,
+    /// Maximum independent paged-miss runs one read may fetch and commit at
+    /// once. This bounds a fragmented block's fan-out to the backend and local
+    /// cache while still overlapping unrelated misses.
+    pub paged_miss_run_concurrency: usize,
     /// Object-store backend selector: `azure` (default), `s3`, or `gcs`. The
     /// per-backend endpoint/credential fields below apply to the selected one.
     pub backend: Option<String>,
@@ -269,6 +273,7 @@ impl Default for WorkerConfig {
             l1_capacity_bytes: 0,
             l1_page_size_bytes: 256 << 10,
             l2_page_size_bytes: 0,
+            paged_miss_run_concurrency: 8,
             backend: None,
             azure_account: None,
             azure_endpoint: None,
@@ -329,6 +334,8 @@ pub struct WorkerConfigPatch {
     pub l1_page_size_bytes: Option<u64>,
     /// Override for [`WorkerConfig::l2_page_size_bytes`].
     pub l2_page_size_bytes: Option<u64>,
+    /// Override for [`WorkerConfig::paged_miss_run_concurrency`].
+    pub paged_miss_run_concurrency: Option<usize>,
     /// Override for [`WorkerConfig::backend`].
     pub backend: Option<String>,
     /// Override for [`WorkerConfig::azure_account`].
@@ -384,6 +391,9 @@ impl Patch for WorkerConfigPatch {
             l1_capacity_bytes: self.l1_capacity_bytes.or(base.l1_capacity_bytes),
             l1_page_size_bytes: self.l1_page_size_bytes.or(base.l1_page_size_bytes),
             l2_page_size_bytes: self.l2_page_size_bytes.or(base.l2_page_size_bytes),
+            paged_miss_run_concurrency: self
+                .paged_miss_run_concurrency
+                .or(base.paged_miss_run_concurrency),
             backend: self.backend.or(base.backend),
             azure_account: self.azure_account.or(base.azure_account),
             azure_endpoint: self.azure_endpoint.or(base.azure_endpoint),
@@ -568,6 +578,14 @@ pub const WORKER_ENV_SCHEMA: &[ConfigVar] = &[
         cli: false,
         secret: false,
         help: "L2 page size in bytes; 0 keeps whole-block L2, non-zero enables paged L2.",
+    },
+    ConfigVar {
+        env: "TALON_WORKER_PAGED_MISS_RUN_CONCURRENCY",
+        key: "paged_miss_run_concurrency",
+        default: Some("8"),
+        cli: false,
+        secret: false,
+        help: "Maximum independent paged-miss runs fetched concurrently per read.",
     },
     ConfigVar {
         env: "TALON_WORKER_BACKEND",
@@ -759,6 +777,7 @@ pub(crate) mod worker_env {
     pub const L1_CAPACITY_BYTES: &str = "TALON_WORKER_L1_CAPACITY_BYTES";
     pub const L1_PAGE_SIZE_BYTES: &str = "TALON_WORKER_L1_PAGE_SIZE_BYTES";
     pub const L2_PAGE_SIZE_BYTES: &str = "TALON_WORKER_L2_PAGE_SIZE_BYTES";
+    pub const PAGED_MISS_RUN_CONCURRENCY: &str = "TALON_WORKER_PAGED_MISS_RUN_CONCURRENCY";
     pub const BACKEND: &str = "TALON_WORKER_BACKEND";
     pub const AZURE_ACCOUNT: &str = "TALON_WORKER_AZURE_ACCOUNT";
     pub const AZURE_ENDPOINT: &str = "TALON_WORKER_AZURE_ENDPOINT";
@@ -862,6 +881,9 @@ impl WorkerConfigPatch {
             l2_page_size_bytes: get(worker_env::L2_PAGE_SIZE_BYTES)
                 .map(|v| parse_u64(v, worker_env::L2_PAGE_SIZE_BYTES))
                 .transpose()?,
+            paged_miss_run_concurrency: get(worker_env::PAGED_MISS_RUN_CONCURRENCY)
+                .map(|v| parse_usize(v, worker_env::PAGED_MISS_RUN_CONCURRENCY))
+                .transpose()?,
             azure_account: get(worker_env::AZURE_ACCOUNT),
             azure_endpoint: get(worker_env::AZURE_ENDPOINT),
             backend: get(worker_env::BACKEND),
@@ -949,6 +971,9 @@ impl WorkerConfig {
             l1_capacity_bytes: merged.l1_capacity_bytes.unwrap_or(d.l1_capacity_bytes),
             l1_page_size_bytes: merged.l1_page_size_bytes.unwrap_or(d.l1_page_size_bytes),
             l2_page_size_bytes: merged.l2_page_size_bytes.unwrap_or(d.l2_page_size_bytes),
+            paged_miss_run_concurrency: merged
+                .paged_miss_run_concurrency
+                .unwrap_or(d.paged_miss_run_concurrency),
             azure_account: merged.azure_account.or(d.azure_account),
             azure_endpoint: merged.azure_endpoint.or(d.azure_endpoint),
             backend: merged.backend.or(d.backend),
@@ -1069,6 +1094,11 @@ impl WorkerConfig {
         }
         if self.block_size == 0 {
             return Err(Error::Other("block_size must be > 0".into()));
+        }
+        if self.paged_miss_run_concurrency == 0 {
+            return Err(Error::Other(
+                "paged_miss_run_concurrency must be > 0".into(),
+            ));
         }
         if self.cache_dirs.is_empty() {
             return Err(Error::Other("at least one cache_dir is required".into()));
@@ -1581,13 +1611,15 @@ mod tests {
     fn from_toml_parses_and_rejects_unknown() {
         let patch = WorkerConfigPatch::from_toml(
             "listen = \"0.0.0.0:9000\"\ncache_dirs = [\"/a\", \"/b\"]\n\
-             l1_capacity_bytes = 67108864\nl1_page_size_bytes = 1048576\n",
+             l1_capacity_bytes = 67108864\nl1_page_size_bytes = 1048576\n\
+             paged_miss_run_concurrency = 4\n",
         )
         .unwrap();
         assert_eq!(patch.listen.as_deref(), Some("0.0.0.0:9000"));
         assert_eq!(patch.cache_dirs.unwrap().len(), 2);
         assert_eq!(patch.l1_capacity_bytes, Some(64 << 20));
         assert_eq!(patch.l1_page_size_bytes, Some(1 << 20));
+        assert_eq!(patch.paged_miss_run_concurrency, Some(4));
         assert!(WorkerConfigPatch::from_toml("bogus_key = 1").is_err());
     }
 
@@ -1604,6 +1636,7 @@ mod tests {
             "TALON_WORKER_BACKEND_THROUGHPUT_BYTES" => Some("1048576".to_string()),
             "TALON_WORKER_L1_CAPACITY_BYTES" => Some("67108864".to_string()),
             "TALON_WORKER_L1_PAGE_SIZE_BYTES" => Some("1048576".to_string()),
+            "TALON_WORKER_PAGED_MISS_RUN_CONCURRENCY" => Some("4".to_string()),
             "TALON_WORKER_BACKEND" => Some("s3".to_string()),
             "TALON_WORKER_S3_REGION" => Some("us-east-1".to_string()),
             "TALON_WORKER_S3_PATH_STYLE" => Some("true".to_string()),
@@ -1624,6 +1657,7 @@ mod tests {
         assert_eq!(patch.backend_throughput_bytes, Some(1 << 20));
         assert_eq!(patch.l1_capacity_bytes, Some(64 << 20));
         assert_eq!(patch.l1_page_size_bytes, Some(1 << 20));
+        assert_eq!(patch.paged_miss_run_concurrency, Some(4));
         assert_eq!(patch.backend.as_deref(), Some("s3"));
         assert_eq!(patch.s3_region.as_deref(), Some("us-east-1"));
         assert_eq!(patch.s3_path_style, Some(true));
@@ -1682,6 +1716,13 @@ mod tests {
         };
         let err = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
         assert!(err.to_string().contains("must be > 0"));
+
+        let cli = WorkerConfigPatch {
+            paged_miss_run_concurrency: Some(0),
+            ..Default::default()
+        };
+        let err = WorkerConfig::resolve(Default::default(), Default::default(), cli).unwrap_err();
+        assert!(err.to_string().contains("paged_miss_run_concurrency"));
 
         let cli = WorkerConfigPatch {
             block_size: Some(1024),

--- a/crates/talon-worker/src/bin/paged-miss-bench.rs
+++ b/crates/talon-worker/src/bin/paged-miss-bench.rs
@@ -1,0 +1,136 @@
+//! Local latency probe for the paged miss-run concurrency limit.
+//!
+//! It warms the middle page of a three-page read, leaving two one-page misses
+//! separated by the resident page. The samples directly compare a worker limit
+//! of one run with a limit of two runs; setup and warming are outside the
+//! recorded interval.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use talon_core::{Backend, BackendStore, ObjectId, ObjectStat, Result, Version};
+use talon_transport::data::RangeRequest;
+use talon_worker::{
+    BlockIndex, InFlightLoads, PagedBlockStore, WholeBlockStore, WorkerMetrics, WorkerRuntime,
+};
+
+const PAGE_SIZE: u32 = 64 << 10;
+const OBJECT_LEN: u64 = 3 * PAGE_SIZE as u64;
+const BACKEND_DELAY: Duration = Duration::from_millis(20);
+const SAMPLES: usize = 21;
+static ROOT_SEQ: AtomicUsize = AtomicUsize::new(0);
+
+struct LatencyBackend;
+
+#[async_trait]
+impl BackendStore for LatencyBackend {
+    async fn fetch_range(&self, _object: &ObjectId, offset: u64, len: u64) -> Result<Bytes> {
+        tokio::time::sleep(BACKEND_DELAY).await;
+        Ok(Bytes::from(
+            (0..len)
+                .map(|i| ((offset + i) % 251) as u8)
+                .collect::<Vec<_>>(),
+        ))
+    }
+
+    async fn head(&self, _object: &ObjectId) -> Result<ObjectStat> {
+        Ok(ObjectStat {
+            len: OBJECT_LEN,
+            version: Version::new("v1"),
+        })
+    }
+}
+
+fn object() -> ObjectId {
+    ObjectId::new(Backend::Azure, "bench", "paged-miss-runs")
+}
+
+fn tmp_root(limit: usize) -> PathBuf {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after Unix epoch")
+        .as_nanos();
+    let seq = ROOT_SEQ.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "talon-paged-miss-bench-limit-{limit}-{}-{now}-{seq}",
+        std::process::id()
+    ))
+}
+
+async fn sample(limit: usize) -> Duration {
+    let root = tmp_root(limit);
+    let runtime = WorkerRuntime::new(
+        WholeBlockStore::open(root.join("whole")).expect("open whole store"),
+        Arc::new(BlockIndex::new()),
+        Arc::new(InFlightLoads::new()),
+        Arc::new(LatencyBackend),
+        4 * PAGE_SIZE,
+        0,
+        WorkerMetrics::new(1 << 30),
+    )
+    .with_paged_store(
+        PagedBlockStore::open(root.join("paged"), PAGE_SIZE).expect("open paged store"),
+    )
+    .with_paged_miss_run_concurrency(limit);
+
+    // Keep page 1 resident: pages 0 and 2 then form two leader runs for the
+    // measured three-page request.
+    runtime
+        .serve_range(&RangeRequest {
+            object: object(),
+            offset: u64::from(PAGE_SIZE),
+            len: 1,
+        })
+        .await
+        .expect("warm middle page");
+
+    let started = Instant::now();
+    let bytes = runtime
+        .serve_range(&RangeRequest {
+            object: object(),
+            offset: 0,
+            len: OBJECT_LEN,
+        })
+        .await
+        .expect("read split miss runs");
+    let elapsed = started.elapsed();
+    assert_eq!(bytes.len(), OBJECT_LEN as usize);
+    drop(runtime);
+    std::fs::remove_dir_all(root).ok();
+    elapsed
+}
+
+fn percentile(samples: &mut [Duration], numerator: usize, denominator: usize) -> Duration {
+    samples.sort_unstable();
+    samples[(samples.len() - 1) * numerator / denominator]
+}
+
+fn describe(label: &str, samples: &[Duration]) -> (Duration, Duration) {
+    let mut median = samples.to_vec();
+    let mut p95 = samples.to_vec();
+    let median = percentile(&mut median, 50, 100);
+    let p95 = percentile(&mut p95, 95, 100);
+    println!("{label:8} p50={median:?} p95={p95:?}");
+    (median, p95)
+}
+
+fn main() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("build Tokio runtime");
+    let limit_one: Vec<_> = (0..SAMPLES).map(|_| runtime.block_on(sample(1))).collect();
+    let limit_two: Vec<_> = (0..SAMPLES).map(|_| runtime.block_on(sample(2))).collect();
+    let (limit_one_p50, _) = describe("limit=1", &limit_one);
+    let (limit_two_p50, _) = describe("limit=2", &limit_two);
+    let improvement = (1.0 - limit_two_p50.as_secs_f64() / limit_one_p50.as_secs_f64()) * 100.0;
+    println!(
+        "limit=2 p50 latency reduction: {improvement:.1}% (backend delay {:?}, {SAMPLES} samples)",
+        BACKEND_DELAY
+    );
+}

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -174,6 +174,7 @@ impl Args {
             l1_capacity_bytes: None,
             l1_page_size_bytes: None,
             l2_page_size_bytes: None,
+            paged_miss_run_concurrency: None,
             backend: None,
             azure_account: None,
             azure_endpoint: None,
@@ -363,6 +364,7 @@ async fn main() -> anyhow::Result<()> {
         l1_capacity_bytes = cfg.l1_capacity_bytes,
         l1_page_size_bytes = cfg.l1_page_size_bytes,
         l2_page_size_bytes = cfg.l2_page_size_bytes,
+        paged_miss_run_concurrency = cfg.paged_miss_run_concurrency,
         azure_account = ?cfg.azure_account,
         azure_endpoint = ?cfg.azure_endpoint,
         "starting talon-worker"
@@ -589,7 +591,8 @@ async fn main() -> anyhow::Result<()> {
         cfg.l1_page_size_bytes,
         observability.metrics().clone(),
     )
-    .with_backend_kind(configured_backend);
+    .with_backend_kind(configured_backend)
+    .with_paged_miss_run_concurrency(cfg.paged_miss_run_concurrency);
     if let Some(paged) = paged {
         runtime = runtime.with_paged_store(paged);
     }

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -39,6 +39,10 @@ const MAX_LIST_PAGES: usize = 20;
 /// Objects requested per backend page.
 const LIST_PAGE_SIZE: u32 = 1000;
 
+/// Default maximum number of independent miss runs one paged read may poll at
+/// once. This bounds a heavily fragmented block's backend and page-commit I/O.
+const DEFAULT_PAGED_MISS_RUN_CONCURRENCY: usize = 8;
+
 /// A per-object resolved version with the instant it was resolved.
 struct CachedVersion {
     version: Version,
@@ -94,6 +98,10 @@ pub struct WorkerRuntime {
     /// Maximum resident cache bytes before eviction reclaims the coldest blocks.
     /// `0` disables capacity enforcement (unbounded — tests/dev only).
     capacity_bytes: u64,
+    /// Maximum independent paged miss runs a single read may fetch and commit
+    /// concurrently. This is a per-read bound; backend-wide connection and I/O
+    /// scheduling remains owned by the shared client/runtime.
+    paged_miss_run_concurrency: usize,
     /// Short-TTL cache of resolved object versions, so a warm read does not pay
     /// a backend `HEAD` per request (issue #163).
     version_cache: Mutex<HashMap<ObjectId, CachedVersion>>,
@@ -169,6 +177,7 @@ impl WorkerRuntime {
             metrics,
             lru,
             capacity_bytes,
+            paged_miss_run_concurrency: DEFAULT_PAGED_MISS_RUN_CONCURRENCY,
             version_cache: Mutex::new(HashMap::new()),
             version_ttl: DEFAULT_VERSION_TTL,
         }
@@ -183,6 +192,15 @@ impl WorkerRuntime {
     /// pages, leaving the block's other pages intact.
     pub fn with_paged_store(mut self, paged: PagedBlockStore) -> Self {
         self.paged = Some(paged);
+        self
+    }
+
+    /// Bound independent page-miss runs polled concurrently by one read.
+    ///
+    /// Production configuration rejects zero; clamping here keeps compact unit
+    /// test runtimes safe when they construct a runtime directly.
+    pub fn with_paged_miss_run_concurrency(mut self, concurrency: usize) -> Self {
+        self.paged_miss_run_concurrency = concurrency.max(1);
         self
     }
 
@@ -830,19 +848,26 @@ impl WorkerRuntime {
         // can use the cache. Drain all started runs even after an error: a
         // dropped future can otherwise release its guards while an already
         // spawned blocking page write is still finishing.
+        let mut leader_runs = leader_runs.into_iter();
         let mut pending = FuturesUnordered::new();
-        for leader_run in leader_runs {
-            pending.push(async move {
-                let run_pages: Vec<_> = leader_run.iter().map(|(_, page, _)| *page).collect();
-                let fetched = self
-                    .fetch_and_commit_pages(request, block, &run_pages, block_len)
-                    .await;
-                (leader_run, fetched)
-            });
-        }
-
         let mut first_error = None;
-        while let Some((leader_run, result)) = pending.next().await {
+        loop {
+            while pending.len() < self.paged_miss_run_concurrency {
+                let Some(leader_run) = leader_runs.next() else {
+                    break;
+                };
+                pending.push(async move {
+                    let run_pages: Vec<_> = leader_run.iter().map(|(_, page, _)| *page).collect();
+                    let fetched = self
+                        .fetch_and_commit_pages(request, block, &run_pages, block_len)
+                        .await;
+                    (leader_run, fetched)
+                });
+            }
+
+            let Some((leader_run, result)) = pending.next().await else {
+                break;
+            };
             match result {
                 Ok(fetched) => {
                     debug_assert_eq!(leader_run.len(), fetched.len());
@@ -3569,6 +3594,9 @@ mod tests {
         object_len: u64,
         ranges: Mutex<Vec<(u64, u64)>>,
         fetch_barrier: Mutex<Option<Arc<tokio::sync::Barrier>>>,
+        fetch_delay: Duration,
+        active_fetches: AtomicUsize,
+        peak_fetches: AtomicUsize,
     }
 
     impl PagedRampBackend {
@@ -3577,7 +3605,15 @@ mod tests {
                 object_len,
                 ranges: Mutex::new(Vec::new()),
                 fetch_barrier: Mutex::new(None),
+                fetch_delay: Duration::ZERO,
+                active_fetches: AtomicUsize::new(0),
+                peak_fetches: AtomicUsize::new(0),
             }
+        }
+
+        fn with_fetch_delay(mut self, delay: Duration) -> Self {
+            self.fetch_delay = delay;
+            self
         }
 
         fn ranges(&self) -> Vec<(u64, u64)> {
@@ -3586,6 +3622,14 @@ mod tests {
 
         fn fetched_bytes(&self) -> u64 {
             self.ranges.lock().unwrap().iter().map(|(_, l)| l).sum()
+        }
+
+        fn reset_peak_fetches(&self) {
+            self.peak_fetches.store(0, Ordering::SeqCst);
+        }
+
+        fn peak_fetches(&self) -> usize {
+            self.peak_fetches.load(Ordering::SeqCst)
         }
 
         /// Make the next two fetches wait with the caller at a three-party
@@ -3606,6 +3650,10 @@ mod tests {
             if let Some(barrier) = barrier {
                 barrier.wait().await;
             }
+            let active = self.active_fetches.fetch_add(1, Ordering::SeqCst) + 1;
+            self.peak_fetches.fetch_max(active, Ordering::SeqCst);
+            tokio::time::sleep(self.fetch_delay).await;
+            self.active_fetches.fetch_sub(1, Ordering::SeqCst);
             let end = (offset + len).min(self.object_len);
             let n = end.saturating_sub(offset) as usize;
             Ok(Bytes::from(
@@ -3791,6 +3839,40 @@ mod tests {
             .await
             .expect("the two independent leader runs should start together");
         assert_eq!(read.await.unwrap().unwrap(), expected(0, 3 * 64));
+        assert_eq!(runtime.inflight_loads(), 0);
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[tokio::test]
+    async fn paged_miss_run_concurrency_caps_peak_backend_fetches() {
+        let root = tmp_root();
+        let backend =
+            Arc::new(PagedRampBackend::new(4096).with_fetch_delay(Duration::from_millis(25)));
+        let runtime = paged_runtime(
+            Arc::clone(&backend),
+            &root,
+            1024,
+            64,
+            0,
+            WorkerMetrics::new(1024),
+        )
+        .with_paged_miss_run_concurrency(2);
+        let object = ObjectId::new(Backend::Azure, "bucket", "fragmented-obj");
+
+        // Warm every other page. The seven-page read below therefore has four
+        // one-page leader runs (0, 2, 4, 6), enough to exercise the bound.
+        for page in [1, 3, 5] {
+            runtime
+                .serve_range(&req(&object, page * 64, 1))
+                .await
+                .unwrap();
+        }
+        backend.reset_peak_fetches();
+
+        let got = runtime.serve_range(&req(&object, 0, 7 * 64)).await.unwrap();
+
+        assert_eq!(got, expected(0, 7 * 64));
+        assert_eq!(backend.peak_fetches(), 2);
         assert_eq!(runtime.inflight_loads(), 0);
         std::fs::remove_dir_all(root).ok();
     }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -394,6 +394,14 @@ L2 page size in bytes; 0 keeps whole-block L2, non-zero enables paged L2.
 - **Default:** `0`
 - **CLI flag:** not settable via CLI (config file or environment only)
 
+### `paged_miss_run_concurrency`
+
+Maximum independent paged-miss runs fetched concurrently per read.
+
+- **Environment variable:** `TALON_WORKER_PAGED_MISS_RUN_CONCURRENCY`
+- **Default:** `8`
+- **CLI flag:** not settable via CLI (config file or environment only)
+
 ### `backend`
 
 Object-store backend: azure (default), s3, or gcs.


### PR DESCRIPTION
## Summary
- cap independent paged cache-miss runs per read with a configurable worker limit (default: 8)
- expose `TALON_WORKER_PAGED_MISS_RUN_CONCURRENCY` / `paged_miss_run_concurrency` and document it
- add a peak-concurrency regression test and a local limit=1 vs limit=2 benchmark

## Validation
- `cargo test -p talon-core config::tests --lib`
- `cargo test -p talon-worker runtime::tests --lib`
- `cargo check -p talon-worker --bin paged-miss-bench`
- config reference generation with `--features etcd,kubernetes`

## Benchmark
Local 20 ms synthetic backend delay, 21 samples: p50 52.0 ms (`limit=1`) -> 29.9 ms (`limit=2`), a 42.4% reduction.