### PR TITLE
doc: add tenant rate-limit and traffic-observability designs

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -51,6 +51,8 @@
 
 - [Design (v1)](./explanation/design.md)
 - [Data-plane runtime: choosing io_uring](./explanation/data-plane-runtime.md)
+- [Eventual global tenant rate limits](./explanation/eventual-global-tenant-rate-limits.md)
+- [Real-time tenant traffic observability](./explanation/tenant-traffic-observability.md)
 - [ADR 0001: Management-plane HA](./explanation/adr-0001-management-plane-ha.md)
 - [ADR 0002: Write-cache durability](./explanation/adr-0002-write-cache-durability.md)
 - [ADR 0003: Optional metadata store](./explanation/adr-0003-optional-metadata-store.md)

--- a/docs/book/src/explanation/eventual-global-tenant-rate-limits.md
+++ b/docs/book/src/explanation/eventual-global-tenant-rate-limits.md
@@ -1,0 +1,1 @@
+{{#include ../../../explanation/eventual-global-tenant-rate-limits.md}}

--- a/docs/book/src/explanation/tenant-traffic-observability.md
+++ b/docs/book/src/explanation/tenant-traffic-observability.md
@@ -1,0 +1,1 @@
+{{#include ../../../explanation/tenant-traffic-observability.md}}

--- a/docs/explanation/eventual-global-tenant-rate-limits.md
+++ b/docs/explanation/eventual-global-tenant-rate-limits.md
@@ -1,0 +1,254 @@
+# Eventual Global Tenant Rate Limits
+
+## Status
+
+Design proposal. This document describes a high-throughput, eventually
+consistent tenant rate-limiting mode. It intentionally does **not** provide a
+strict, never-exceed global limit.
+
+## Problem
+
+A Talon cluster may serve requests for many tenants from many workers. A noisy
+tenant must not be able to consume all request processing capacity, client
+egress bandwidth, or object-store origin bandwidth. The policy must apply to
+the aggregate of all workers, rather than independently permitting the full
+limit on every worker.
+
+A synchronous, strongly consistent global counter would place a control-plane
+round trip on the data path. That conflicts with Talon's low-latency,
+zero-copy read path. This proposal instead follows the asynchronous `GLOBAL`
+model used by [Gubernator](https://github.com/gubernator-io/gubernator): local
+decisions on the hot path, asynchronously aggregated consumption, and
+owner-published state snapshots.
+
+## Contract
+
+This mode is a bounded, eventually consistent limit. It is appropriate for
+tenant fairness and noisy-neighbour protection, not for a contractual hard
+cap on billable origin egress.
+
+For a metric with target rate `R`, configured global burst `B`, `N` active
+workers, local burst cap `b`, and propagation delay `d`, the implementation
+must expose and size for a conservative excess envelope:
+
+```
+excess <= N * b + R * d
+```
+
+The exact observed excess depends on batching, membership convergence, and
+network loss. This is deliberately a sizing rule and SLO, not a strict safety
+proof. Policies that require a never-exceed bound need a synchronous credit or
+lease mode instead.
+
+## Rate keys and ownership
+
+Each independently limited resource has a key:
+
+```
+RateKey = (tenant_id, metric, policy_generation)
+```
+
+Initially, metrics are:
+
+- `read_iops`: client read requests admitted by workers;
+- `client_egress_bytes`: bytes sent from a worker to a client;
+- `origin_read_bytes`: bytes fetched from an object store on cache misses;
+- `write_iops`, `client_ingress_bytes`, and `origin_write_bytes` when the
+  relevant write paths are enabled.
+
+Every Talon worker runs a QoS peer service. A consistent-hash ring over the
+worker membership selects one logical owner for each `RateKey`. There is no
+fixed central limiter: different tenants and metrics distribute across the
+peer fleet. The owner is authoritative only for its current in-memory view of
+the key.
+
+The membership ring has an epoch. Rate messages include that epoch and the
+owner rejects messages for a key it no longer owns. Owner restart and ring
+migration are explicitly sources of bounded inaccuracy; this mode does not
+persist buckets.
+
+## Policy distribution and owner bootstrap
+
+The coordinator is the authoritative control-plane source for tenant rate
+*policy*, distinct from an owner's ephemeral bucket state. It stores or fronts
+a durable, versioned policy record such as:
+
+```
+TenantRatePolicy {
+  tenant_id,
+  metric,
+  generation,
+  target_rate,
+  global_burst,
+  local_burst_cap,
+  enabled,
+}
+```
+
+The coordinator distributes policy updates to workers by watch/push or by
+short-TTL polling. Workers keep a local, versioned policy cache, so request
+admission never reads the coordinator. `policy_generation` in `RateKey`
+selects an immutable cached policy version; a policy update creates a new
+generation rather than changing the meaning of an existing key. A worker must
+not admit work for an unknown generation: it queues within the tenant bound or
+rejects until it has obtained the policy. This makes a control-plane outage
+restrict traffic instead of silently applying a permissive default.
+
+When membership chooses a new owner, that owner resolves the `RateKey` from
+its local policy cache or, if necessary, fetches it from the coordinator. Only
+after it has the matching policy may it accept reports and publish snapshots.
+It initializes a fresh, conservative bucket (exhausted, then refilling at the
+configured target rate), rather than synthesizing a full global burst. Retried
+usage reports can be applied to that new bucket; duplicate reports after a
+restart can only make the limiter more restrictive. The new owner's first
+snapshot establishes the new `owner_epoch` and lets reporting workers resume.
+
+The coordinator does not reconstruct `remaining`, unacknowledged local use,
+or the old owner's idempotency state. Those are deliberately ephemeral runtime
+state. Consequently, this bootstrap minimizes a new burst after failover but
+does not turn the mode into a strict global limit; the bounded inaccuracy in
+the contract still applies.
+
+## Hot path
+
+Authentication resolves a request to a non-forgeable `TenantContext` before
+it reaches the worker. The worker uses that tenant identity for all QoS
+decisions.
+
+The hot path never contacts the rate owner.
+
+1. A request consumes one unit from the local `read_iops` view. If no unit is
+   available, it waits in the bounded tenant queue or receives a rate-limit
+   response when its deadline expires.
+2. A response is split into bounded transfer chunks. Each chunk consumes bytes
+   from the local `client_egress_bytes` view before it is submitted.
+3. The chunk is still served through `sendfile`; splitting the transfer only
+   gives the scheduler points at which to switch tenants.
+4. A cache miss additionally consumes local `origin_read_bytes` capacity and
+   a bounded origin-loader concurrency slot before it is started.
+
+Each worker uses sharded or atomic local state so that the io_uring data-plane
+rings do not serialize on a global QoS lock. A failed or short `sendfile`
+returns the unused part of the locally charged byte amount.
+
+## Asynchronous usage reporting
+
+Each worker accumulates use per active `RateKey`. It reports aggregated deltas
+to the key owner every `sync_interval`, or earlier after a byte/request
+threshold is reached:
+
+```
+UsageReport {
+  rate_key,
+  worker_id,
+  worker_epoch,
+  sequence,
+  iops_delta,
+  byte_delta,
+}
+```
+
+Reports are retried until acknowledged. `worker_epoch` and `sequence` make
+reports idempotent at the owner. Reporting must be batched by owner and key,
+so peer traffic scales with active workers and sync intervals, not with Talon
+IOPS.
+
+For egress, a worker pre-charges its local view before submitting a chunk and
+reports the actual bytes accepted by `sendfile`. A short send refunds local
+capacity; the resulting correction is included in a later report.
+
+## Owner and snapshot propagation
+
+The owner applies aggregated deltas to a leaky bucket or GCRA-style meter for
+the `RateKey`. It maintains the target rate, burst, remaining capacity, owner
+timestamp, and a monotonically increasing version.
+
+The owner pushes `RateSnapshot` updates at the sync interval, on important
+threshold crossings (especially exhaustion), and after a batch reaches its
+size limit:
+
+```
+RateSnapshot {
+  rate_key,
+  owner_epoch,
+  version,
+  remaining,
+  observed_at,
+  ack_sequence_for_receiver,
+}
+```
+
+Unlike a broadcast to every cluster member, Talon should send snapshots only
+to workers that reported this key recently. A worker keeps an active-reporter
+lease for a short interval at the owner. This limits fan-out for tenant keys
+that are used by only a subset of the fleet.
+
+A worker does not overwrite its local state with `remaining` directly. Its
+effective local availability is:
+
+```
+snapshot_remaining - locally consumed, not-yet-acknowledged usage
+```
+
+This avoids forgetting consumption performed after the snapshot was created.
+
+## Bounding drift
+
+The principal trade-off of this design is that multiple workers can act on
+stale state. To keep this controlled:
+
+- configure a per-worker local burst cap;
+- divide or cap that burst by the owner-observed active-worker count;
+- use short reporting and snapshot intervals (initially 2--5 ms);
+- immediately publish exhaustion transitions instead of waiting for the next
+  normal batch;
+- use a snapshot TTL. A worker with a stale view must stop expanding traffic,
+  queue requests, or reject them; it must not continue spending an old,
+  positive view indefinitely;
+- use a small bootstrap allowance for a previously inactive worker, rather
+  than allowing every new worker to spend the whole global burst before it has
+  received an owner snapshot.
+
+Chunk size is part of the envelope. A smaller egress chunk lowers the maximum
+unreported overshoot but increases scheduling and syscall overhead. This value
+must be chosen alongside the permitted excess SLO.
+
+## Failure semantics
+
+| Event | Behaviour |
+|---|---|
+| Worker cannot reach owner | It can consume only its non-stale local view. At TTL expiry it slows or rejects new work. |
+| Usage report is lost | It is retried with the same worker epoch and sequence. |
+| Owner fails or ownership moves | Workers use their non-stale view briefly, then fail closed or slow down until the new owner publishes a snapshot. A bounded excess is possible. |
+| Owner restarts | In-memory bucket state is lost. This mode accepts the resulting temporary inaccuracy. |
+| Policy is reduced | New snapshots apply the smaller rate. The old local views remain valid only until their short TTL. |
+
+## Initial parameters
+
+The first implementation should expose conservative defaults and make the
+excess envelope visible in telemetry:
+
+```
+sync interval:                 2--5 ms
+usage-report threshold:        32 IOPS or 64 KiB
+snapshot TTL:                  10--20 ms
+tenant queue bound:            1,024 requests
+egress scheduling chunk:       256 KiB--1 MiB
+```
+
+Telemetry must include local decisions, owner-applied use, report/snapshot
+delay, active reporter count, stale-view rejections, and estimated excess.
+
+## Non-goals
+
+- A strict, never-exceed cluster-wide rate cap.
+- Persistent quota accounting or billing-grade origin usage.
+- Per-tenant physical NVMe IOPS accounting. The initial controls are request,
+  client egress, and origin traffic; Linux page cache and `sendfile` make
+  exact physical-device attribution a different problem.
+
+## References
+
+- [gubernator-io/gubernator](https://github.com/gubernator-io/gubernator):
+  reference implementation of the asynchronous `GLOBAL` rate-limiting model
+  that informed this proposal.

--- a/docs/explanation/tenant-traffic-observability.md
+++ b/docs/explanation/tenant-traffic-observability.md
@@ -1,0 +1,256 @@
+# Real-Time Tenant Traffic Observability
+
+## Status
+
+Design proposal. Companion to
+[Eventual Global Tenant Rate Limits](eventual-global-tenant-rate-limits.md).
+That document defines how a tenant's aggregate traffic is *bounded*; this one
+defines how operators *see* each tenant's live traffic across the cluster. The
+two share signal sources and the same eventual-consistency envelope.
+
+## Problem
+
+A Talon cluster serves many tenants from many workers. Operators need a
+near-real-time answer to "what is each tenant doing right now, cluster-wide?":
+
+- read IOPS admitted,
+- client egress bytes,
+- origin (cache-miss) read bytes,
+- how close the tenant is to its configured limits (headroom), and
+- whether the tenant is currently being throttled, and by how much.
+
+Two properties of the system make this non-trivial:
+
+1. A tenant's traffic is spread across the whole fleet, and in the
+   eventually-consistent limiter no single node holds a tenant's global state
+   on the hot path. "Current global rate for tenant X" is therefore not
+   directly readable from any one worker.
+2. The metrics stack enforces low cardinality. A raw tenant identifier must not
+   become an unbounded Prometheus label (the same rule that already bans
+   `bucket`, `object_path`, and `block_id` labels). Per-tenant drill-down has to
+   go through an aggregate-plus-top-N path, not a label explosion.
+
+The aggregation must not put a synchronous query on the data hot path, must
+respect the cardinality rule, and should work *both* before and after the
+distributed rate-limit owner layer exists — so that per-tenant visibility can
+ship alongside the first, local-only limiter stage.
+
+## Tenant identity model
+
+For the purpose of this design a **tenant** is the authenticated resource owner
+carried by `TenantContext`, established at the object-store gateway from the
+request credential (the gateway's provider-account / principal). The gateway
+attaches it to each request and it is propagated to the worker on the data
+plane. Clients that connect directly to a worker and bypass the gateway (FUSE
+and the native clients) carry no credential; their traffic is attributed to a
+single reserved **`unattributed`** tenant so that it is still visible and
+bounded rather than silently uncounted. Tenant identity, its propagation, and
+the unattributed fallback are specified by the rate-limit design; this document
+only consumes the resulting `(tenant, metric)` signal.
+
+## Contract
+
+This is a *monitoring* view: near-real-time, eventually consistent, and
+bounded-stale. It is explicitly **not** a billing ledger or an exact historical
+meter.
+
+- Reported values lag reality by at most one aggregation period — on the order
+  of the heartbeat interval (Tier 1) or the rate-limit owner sync interval
+  (Tier 2).
+- The view is top-N per source. A tenant that is individually small on every
+  worker but collectively non-trivial may be summarized into an `other`
+  aggregate rather than named. Truncation is reported, never silent.
+- Numbers are rates over a sliding window, not cumulative billable totals.
+
+Anything that needs exact, durable, never-dropped per-tenant accounting (usage
+billing, chargeback) belongs in a separate metering pipeline and is out of
+scope here.
+
+## Signals measured on each worker
+
+Every worker already owns atomic per-`(tenant, metric)` counters for the
+limiter. Observability reuses them; it introduces no new hot-path work beyond a
+periodic read. For each active `(tenant, metric)` the worker maintains a
+windowed rate meter (EWMA or fixed-window counter) over the same events the
+limiter charges:
+
+- `read_iops` — client read requests admitted;
+- `client_egress_bytes` — bytes sent to clients;
+- `origin_read_bytes` — bytes fetched from the object store on miss;
+- write-path metrics when those paths are enabled.
+
+Alongside the rates, the worker tracks per tenant:
+
+- admission outcome counts: `admitted`, `queued`, `rejected_rate`, `bypass`;
+- current local view `remaining` and tenant queue depth;
+- a `throttled` flag (queue non-empty or recent rate rejections).
+
+These are cheap reads off counters that already exist for enforcement.
+
+## Two aggregation tiers
+
+Cluster-wide per-tenant state is assembled from workers in two tiers. Tier 1
+works from day one and is always available; Tier 2 becomes available once the
+rate-limit owner layer exists and supersedes Tier 1 for keys with an active
+owner.
+
+### Tier 1 — heartbeat top-N summaries (available in the local-only stage)
+
+Each worker already reports a `NodeMetricsSnapshot` into the coordinator's
+leased cluster-state store on the heartbeat cadence. Tier 1 adds a **bounded
+per-tenant traffic summary**: each worker selects its top-N tenants by recent
+traffic (N small and configurable, initially 32–64) and reports, per tenant, a
+compact record:
+
+```text
+TenantTrafficSample {
+  tenant,
+  read_iops,
+  client_egress_bytes,
+  origin_read_bytes,
+  throttled,
+  window_ms,
+}
+```
+
+Because the node-status record is size-bounded (a hard 16 KiB cap), the summary
+is carried as its own bounded control message on the heartbeat cadence rather
+than inflating `NodeStatus`; the top-N cap and a byte ceiling keep it bounded
+regardless of tenant count.
+
+The coordinator merges the per-worker summaries into a cluster view: for each
+tenant it sums the per-worker rates to a cluster-wide rate and records the
+contributing worker set. A tenant hot on a few workers is captured exactly; a
+tenant spread thinly below every worker's top-N is approximated and the
+truncation is surfaced (an `other` aggregate plus a "N tenants omitted" count).
+This costs one small periodic message per worker, scales with workers × N (not
+with IOPS), and adds nothing to the data hot path.
+
+### Tier 2 — owner-authoritative view (with the rate-limit owner layer)
+
+Once `RateKey` owners exist, each owner already holds the *exact* aggregated
+global consumption for its tenant×metric keys — it sums every worker's usage
+reports to maintain the authoritative meter. A management aggregator on the
+coordinator pulls each owner's current per-key meter state (remaining, target
+rate, observed rate, active-reporter count) at the owner snapshot cadence. This
+yields an **exact** cluster-wide per-tenant rate for every key with an active
+owner, at 2–5 ms freshness, and reuses the same consistent-hash ring and
+membership epoch the limiter already computes to know which worker owns which
+key.
+
+Tier 2 supersedes Tier 1 for keys that have an active owner; Tier 1 remains the
+fallback for keys with no recent activity and during owner failover, when the
+authoritative meter is briefly unavailable. The exposure layer marks each
+tenant's numbers as `exact` or `approximate` accordingly.
+
+## Exposure
+
+### Management API (coordinator)
+
+New read-only endpoints on the existing coordinator management API, mirroring
+the shape and safety of the current `/api/v1/nodes` surface (bounded page size,
+fail-closed to 503, a response envelope carrying snapshot age and revision):
+
+```text
+GET /api/v1/tenants
+    -> paged list of tenants with cluster-wide current rates per metric,
+       configured limits, headroom, throttle state, freshness (exact|approx),
+       sorted by a requested metric (top-N by rate), filterable.
+
+GET /api/v1/tenants/{tenant}
+    -> per-tenant drill-down: per-metric rates, per-worker breakdown,
+       headroom vs policy, recent throttle/reject counts, contributing owners.
+```
+
+This is the primary path for high-cardinality per-tenant inspection, precisely
+because it does not live in the Prometheus label space.
+
+### Prometheus (`/metrics`)
+
+Only aggregate and enum-labeled series are exported — never a raw tenant label:
+
+- cluster totals per metric (`read_iops`, `client_egress_bytes`,
+  `origin_read_bytes`);
+- count of currently-throttled tenants;
+- the estimated-excess gauge (the limiter's `N*b + R*d` envelope);
+- report/snapshot aggregation delay histograms and aggregation staleness.
+
+For the handful of tenants an operator wants on a dashboard, a small
+operator-configured **allow-list** grants those specific tenants their own
+labeled series; every other tenant rolls into an `other` bucket, with the full
+ranking available through the API. This bounded-label allow-list is the one
+net-new piece the metrics layer needs, and it keeps the existing
+"no unbounded tenant labels" guardrail intact.
+
+### Dashboards and alerts
+
+A cluster dashboard shows per-metric totals, a top-N tenant table (sourced from
+the management API or the allow-listed series), throttle rate, and the excess
+envelope. Alerts cover sustained per-tenant throttling, an excess-envelope
+breach, and aggregation staleness. Dashboard panels obey the banned-label rule;
+no raw tenant identifier appears in a panel except an allow-listed one.
+
+## Cardinality and safety
+
+- No unbounded tenant identifier is ever emitted as a Prometheus label; the
+  drill-down path is the management API plus top-N, with an explicit allow-list
+  for named series.
+- Every per-worker summary and per-owner pull is size-bounded (top-N plus a
+  byte ceiling), so a tenant-count spike cannot blow up control-plane traffic.
+- The management API reads coordinator snapshots only. It never touches the data
+  hot path and never issues a per-request query.
+
+## Failure semantics
+
+| Event | Behaviour |
+|---|---|
+| Worker unreachable | Its last summary ages out; cluster totals for affected tenants are marked partial and the stale worker is dropped from the contributing set. |
+| Coordinator failover | Aggregation state is transient and rebuilt from the next heartbeat round; no durable per-tenant store is kept. |
+| Owner missing (Tier 2) | Fall back to the Tier 1 approximation for that key and mark the tenant `approximate`. |
+| Summary truncated (tenant below every top-N) | Rolled into `other` with an omitted-tenant count; never silently dropped. |
+| Metrics scrape during a reconfigure | `/metrics` renders from the last consistent snapshot; it never blocks on the store. |
+
+## Initial parameters
+
+```text
+per-worker top-N tenants:        32--64
+summary report cadence:          heartbeat interval (Tier 1)
+owner pull cadence:              owner snapshot interval, 2--5 ms (Tier 2)
+rate window:                     1--5 s sliding window
+management API page limit:       reuse the existing bounded default
+allow-listed tenant series:      operator-configured, small
+```
+
+## Non-goals
+
+- Billing-grade or exact historical per-tenant accounting. That is a separate
+  metering pipeline, not this monitoring view.
+- Per-request, per-tenant tracing on the hot path. Hot-path decisions stay as
+  counters, consistent with the zero-copy data-plane design.
+- Sub-millisecond global accuracy. The view is bounded-stale by construction.
+- Enforcement. This document only observes; bounding is defined by the
+  rate-limit design.
+
+## Delivery plan
+
+Staged so that visibility ships with, and slightly behind, the corresponding
+enforcement stage:
+
+1. With the local-limiter stage: per-`(tenant, metric)` windowed rate meters on
+   the worker, the bounded top-N summary, and its heartbeat-cadence carrier.
+2. Coordinator aggregation of summaries and the `/api/v1/tenants[/{tenant}]`
+   endpoints.
+3. Bounded Prometheus aggregates, the allow-list helper, and the dashboard and
+   alerts.
+4. With the owner stage: the Tier 2 owner-authoritative pull, with the API and
+   dashboards preferring exact values when an owner is present.
+
+## References
+
+- [Eventual Global Tenant Rate Limits](eventual-global-tenant-rate-limits.md) —
+  the enforcement design and the source of the `(tenant, metric)` signal, the
+  consistent-hash owner ring, and the excess envelope.
+- Distributed Tenant Cache Quotas (the companion cache-capacity design) — its
+  observability section defines the same bounded-label, top-N, and
+  management-API drill-down discipline that this document follows for traffic
+  metrics.


### PR DESCRIPTION
## Summary

First change in a staged series that adds **eventually-consistent per-tenant
rate limiting** and **real-time per-tenant traffic monitoring** to Talon. This
PR lands the design docs only — no behaviour change.

- `docs/explanation/eventual-global-tenant-rate-limits.md` — the accepted spec
  for the per-tenant QoS work (local hot-path decisions, consistent-hash
  `RateKey` owners, asynchronous usage reporting, owner snapshot propagation,
  and the bounded excess envelope).
- `docs/explanation/tenant-traffic-observability.md` — **new** companion
  design for real-time, cluster-wide per-tenant traffic visibility. It reuses
  the limiter's per-`(tenant, metric)` signal and the coordinator's
  heartbeat/aggregation path, and exposes per-tenant drill-down through a
  bounded management API plus top-N, deliberately avoiding high-cardinality
  Prometheus tenant labels (the same discipline the docs already enforce for
  `bucket`/`object_path`/`block_id`).

Both are wired into the mdBook `SUMMARY.md` via include stubs, matching the
existing explanation-doc pattern.

## Why docs first

The implementation follows in reviewable stages (foundation + local
enforcement first, then coordinator policy distribution, then the
consistent-hash owner/peer layer, then the Tier-2 owner-authoritative
monitoring pull). Landing the contract first keeps those PRs small and
anchored to an agreed design.

## Testing

- `mdbook build docs/book` (SUMMARY + include stubs resolve).
- `lychee --offline` over `docs/**/*.md` (all relative links resolve).
- `typos` (British spellings already accepted across tracked docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)