### PR TITLE
feat: worker-side per-tenant rate limiting

### DIFF
--- a/crates/talon-cache-client/src/range_stream.rs
+++ b/crates/talon-cache-client/src/range_stream.rs
@@ -49,6 +49,11 @@ pub enum CacheReadError {
     /// A legacy worker returned only an unclassified string.
     #[error("unclassified legacy worker failure: {0}")]
     Unknown(String),
+    /// The tenant exceeded its rate limit; the caller should back off and
+    /// retry. Never origin-fallback-eligible — falling back would evade the
+    /// limit.
+    #[error("tenant rate limit exceeded: {0}")]
+    RateLimited(String),
 }
 
 impl CacheReadError {
@@ -79,6 +84,7 @@ impl From<WorkerError> for CacheReadError {
                 DataErrorCode::VersionMismatch => Self::VersionMismatch(error.message),
                 DataErrorCode::Origin => Self::Origin(error.message),
                 DataErrorCode::Internal => Self::Internal(error.message),
+                DataErrorCode::RateLimited => Self::RateLimited(error.message),
             },
             other => Self::Protocol(other.to_string()),
         }

--- a/crates/talon-cache-client/src/worker_client.rs
+++ b/crates/talon-cache-client/src/worker_client.rs
@@ -21,10 +21,11 @@ use std::time::Duration;
 use talon_core::{BlockId, ObjectId, RequestId, TenantId, Version};
 use talon_transport::frame::{FrameHeader, MsgType, HEADER_LEN};
 use talon_transport::{
-    decode_error_payload, encode_cached_block_put_header, encode_cached_request, encode_delete,
-    encode_put_header, encode_request, encode_tenant_request, CachedBlockPutRequest,
-    CachedRangeRequest, DataPlaneError, DeleteRequest, Flags, PutRequest, RangeRequest,
-    TenantScopedRange, MAX_CONTROL_PAYLOAD_LEN,
+    decode_error_payload, encode_cached_block_put_header, encode_cached_request,
+    encode_cached_tenant_request, encode_delete, encode_put_header, encode_request,
+    encode_tenant_request, CachedBlockPutRequest, CachedRangeRequest, DataPlaneError, DeleteRequest,
+    Flags, PutRequest, RangeRequest, TenantScopedCachedRange, TenantScopedRange,
+    MAX_CONTROL_PAYLOAD_LEN,
 };
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -161,6 +162,28 @@ impl WorkerClient {
         }
     }
 
+    /// Encode a cache-only range request, as a tenant-scoped frame when this
+    /// client is bound to a named tenant, else as a plain `GetCachedRange`. A
+    /// named tenant keeps resident-only reads attributed so they are metered by
+    /// the worker like any other read.
+    fn encode_cached_range_request(
+        &self,
+        request_id: u32,
+        request: CachedRangeRequest,
+    ) -> Result<Vec<u8>, talon_transport::DataError> {
+        if self.tenant.is_unattributed() {
+            encode_cached_request(request_id, &request)
+        } else {
+            encode_cached_tenant_request(
+                request_id,
+                &TenantScopedCachedRange {
+                    tenant: self.tenant.clone(),
+                    request,
+                },
+            )
+        }
+    }
+
     /// Fetch `[offset, offset+len)` of `object` from the worker.
     ///
     /// Returns the raw range bytes on success. A worker-side error (block not
@@ -289,7 +312,7 @@ impl WorkerClient {
             len,
         };
         let request_id = RequestId::next();
-        let output = encode_cached_request(request_id.0, &request)?;
+        let output = self.encode_cached_range_request(request_id.0, request)?;
         match self.exchange(&output, len).await {
             Ok(bytes) => Ok(bytes),
             Err((true, err)) if err.is_transport_failure() => {
@@ -840,8 +863,8 @@ mod tests {
     use std::time::Duration;
     use talon_core::Backend;
     use talon_transport::{
-        decode_cached_block_put_header, decode_cached_request, decode_request,
-        decode_tenant_request, encode_error, response_header_ok,
+        decode_cached_block_put_header, decode_cached_request, decode_cached_tenant_request,
+        decode_request, decode_tenant_request, encode_error, response_header_ok,
     };
     use tokio::net::TcpListener;
 
@@ -1094,6 +1117,42 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(bytes, b"data");
+    }
+
+    #[tokio::test]
+    async fn tenant_client_sends_a_cached_tenant_scoped_frame() {
+        // A tenant-bound client attributes cache-only reads too, so a resident
+        // read cannot slip past per-tenant metering on the worker.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let seen: Arc<std::sync::Mutex<Option<TenantId>>> = Arc::new(std::sync::Mutex::new(None));
+        let recorded = Arc::clone(&seen);
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut hdr = [0u8; HEADER_LEN];
+            sock.read_exact(&mut hdr).await.unwrap();
+            let header = FrameHeader::decode(&hdr).unwrap();
+            assert_eq!(header.msg_type, MsgType::GetCachedRangeTenant);
+            let mut body = vec![0u8; header.length as usize];
+            sock.read_exact(&mut body).await.unwrap();
+            let mut full = hdr.to_vec();
+            full.extend_from_slice(&body);
+            let (_h, scoped) = decode_cached_tenant_request(&full).unwrap();
+            assert_eq!(scoped.request.version, Version::new("etag-v2"));
+            *recorded.lock().unwrap() = Some(scoped.tenant);
+            let mut out = response_header_ok(header.request_id, scoped.request.len as u32).to_vec();
+            out.resize(out.len() + scoped.request.len as usize, 0);
+            sock.write_all(&out).await.unwrap();
+            sock.flush().await.unwrap();
+        });
+
+        let client = WorkerClient::new(addr).with_tenant(TenantId::named("acme"));
+        let bytes = client
+            .fetch_cached_range(&object(), &Version::new("etag-v2"), 0, 16)
+            .await
+            .unwrap();
+        assert_eq!(bytes.len(), 16);
+        assert_eq!(seen.lock().unwrap().take(), Some(TenantId::named("acme")));
     }
 
     #[tokio::test]

--- a/crates/talon-cache-client/src/worker_client.rs
+++ b/crates/talon-cache-client/src/worker_client.rs
@@ -23,8 +23,8 @@ use talon_transport::frame::{FrameHeader, MsgType, HEADER_LEN};
 use talon_transport::{
     decode_error_payload, encode_cached_block_put_header, encode_cached_request,
     encode_cached_tenant_request, encode_delete, encode_put_header, encode_request,
-    encode_tenant_request, CachedBlockPutRequest, CachedRangeRequest, DataPlaneError, DeleteRequest,
-    Flags, PutRequest, RangeRequest, TenantScopedCachedRange, TenantScopedRange,
+    encode_tenant_request, CachedBlockPutRequest, CachedRangeRequest, DataPlaneError,
+    DeleteRequest, Flags, PutRequest, RangeRequest, TenantScopedCachedRange, TenantScopedRange,
     MAX_CONTROL_PAYLOAD_LEN,
 };
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};

--- a/crates/talon-cache-client/src/worker_client.rs
+++ b/crates/talon-cache-client/src/worker_client.rs
@@ -18,12 +18,13 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use talon_core::{BlockId, ObjectId, RequestId, Version};
+use talon_core::{BlockId, ObjectId, RequestId, TenantId, Version};
 use talon_transport::frame::{FrameHeader, MsgType, HEADER_LEN};
 use talon_transport::{
     decode_error_payload, encode_cached_block_put_header, encode_cached_request, encode_delete,
-    encode_put_header, encode_request, CachedBlockPutRequest, CachedRangeRequest, DataPlaneError,
-    DeleteRequest, Flags, PutRequest, RangeRequest, MAX_CONTROL_PAYLOAD_LEN,
+    encode_put_header, encode_request, encode_tenant_request, CachedBlockPutRequest,
+    CachedRangeRequest, DataPlaneError, DeleteRequest, Flags, PutRequest, RangeRequest,
+    TenantScopedRange, MAX_CONTROL_PAYLOAD_LEN,
 };
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -100,6 +101,9 @@ impl WorkerError {
 pub struct WorkerClient {
     addr: String,
     pool: Arc<ConnectionPool>,
+    /// Tenant every fetch from this client is attributed to. `Unattributed`
+    /// unless set with [`with_tenant`](Self::with_tenant).
+    tenant: TenantId,
 }
 
 impl WorkerClient {
@@ -117,12 +121,44 @@ impl WorkerClient {
         Self {
             addr: addr.into(),
             pool,
+            tenant: TenantId::Unattributed,
         }
     }
 
     /// The worker address this client talks to.
     pub fn addr(&self) -> &str {
         &self.addr
+    }
+
+    /// Attribute every fetch from this client to `tenant` for per-tenant QoS.
+    ///
+    /// A named tenant is sent as a `GetRangeTenant` frame; the default
+    /// (`Unattributed`) sends an ordinary `GetRange`. Send a named tenant only
+    /// to workers known to understand the type — an older worker fails the
+    /// request closed rather than misreading it.
+    pub fn with_tenant(mut self, tenant: TenantId) -> Self {
+        self.tenant = tenant;
+        self
+    }
+
+    /// Encode a range request, as a tenant-scoped frame when this client is
+    /// bound to a named tenant, else as a plain `GetRange`.
+    fn encode_range_request(
+        &self,
+        request_id: u32,
+        request: RangeRequest,
+    ) -> Result<Vec<u8>, talon_transport::DataError> {
+        if self.tenant.is_unattributed() {
+            encode_request(request_id, &request)
+        } else {
+            encode_tenant_request(
+                request_id,
+                &TenantScopedRange {
+                    tenant: self.tenant.clone(),
+                    request,
+                },
+            )
+        }
     }
 
     /// Fetch `[offset, offset+len)` of `object` from the worker.
@@ -151,7 +187,7 @@ impl WorkerClient {
         // Allocate a correlation id and put it on the wire, so the worker's
         // logs for this fetch can be joined with the client's (#304).
         let req_id = RequestId::next();
-        let out = encode_request(req_id.0, &req)?;
+        let out = self.encode_range_request(req_id.0, req)?;
         // Try a pooled connection first; if it was reused and fails with an I/O
         // error (the peer may have closed it while idle), retry once on a fresh
         // dial so a stale pooled socket never turns a healthy peer into a
@@ -204,7 +240,7 @@ impl WorkerClient {
             len: dst.len() as u64,
         };
         let request_id = RequestId::next();
-        let output = encode_request(request_id.0, &request)?;
+        let output = self.encode_range_request(request_id.0, request)?;
         match self.exchange_into(&output, dst).await {
             Ok(n) => Ok(n),
             Err((true, err)) if err.is_transport_failure() => {
@@ -804,8 +840,8 @@ mod tests {
     use std::time::Duration;
     use talon_core::Backend;
     use talon_transport::{
-        decode_cached_block_put_header, decode_cached_request, decode_request, encode_error,
-        response_header_ok,
+        decode_cached_block_put_header, decode_cached_request, decode_request,
+        decode_tenant_request, encode_error, response_header_ok,
     };
     use tokio::net::TcpListener;
 
@@ -940,6 +976,55 @@ mod tests {
             ids[0], ids[1],
             "each request needs a distinct id to be correlatable"
         );
+    }
+
+    #[tokio::test]
+    async fn tenant_client_sends_a_tenant_scoped_frame() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let seen: Arc<std::sync::Mutex<Option<TenantId>>> = Arc::new(std::sync::Mutex::new(None));
+        let recorded = Arc::clone(&seen);
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut hdr = [0u8; HEADER_LEN];
+            sock.read_exact(&mut hdr).await.unwrap();
+            let header = FrameHeader::decode(&hdr).unwrap();
+            assert_eq!(header.msg_type, MsgType::GetRangeTenant);
+            let mut body = vec![0u8; header.length as usize];
+            sock.read_exact(&mut body).await.unwrap();
+            let mut full = hdr.to_vec();
+            full.extend_from_slice(&body);
+            let (_h, scoped) = decode_tenant_request(&full).unwrap();
+            *recorded.lock().unwrap() = Some(scoped.tenant);
+            // Reply with the requested bytes so the client fetch succeeds; the
+            // reply is an ordinary GetRange frame.
+            let mut out = response_header_ok(header.request_id, scoped.request.len as u32).to_vec();
+            out.resize(out.len() + scoped.request.len as usize, 0);
+            sock.write_all(&out).await.unwrap();
+            sock.flush().await.unwrap();
+        });
+
+        let client = WorkerClient::new(addr).with_tenant(TenantId::named("acme"));
+        let bytes = client.fetch_range(&object(), 0, 16).await.unwrap();
+        assert_eq!(bytes.len(), 16);
+        assert_eq!(seen.lock().unwrap().take(), Some(TenantId::named("acme")));
+    }
+
+    #[tokio::test]
+    async fn default_client_sends_a_plain_getrange() {
+        // Without a tenant the client sends an ordinary GetRange, which the
+        // GetRange-only mock worker decodes successfully (backward compatible).
+        let addr = mock_worker(|req| {
+            let mut out = response_header_ok(0, req.len as u32).to_vec();
+            out.resize(out.len() + req.len as usize, 0);
+            out
+        })
+        .await;
+        let bytes = WorkerClient::new(addr)
+            .fetch_range(&object(), 0, 8)
+            .await
+            .unwrap();
+        assert_eq!(bytes.len(), 8);
     }
 
     #[tokio::test]

--- a/crates/talon-core/src/config.rs
+++ b/crates/talon-core/src/config.rs
@@ -23,7 +23,8 @@ use std::path::PathBuf;
 
 use crate::status::MAX_STATUS_FIELD_BYTES;
 use crate::{
-    ControlTlsConfig, ControlTlsConfigPatch, Error, NamespacePolicy, ObjectNamespace, Result,
+    ControlTlsConfig, ControlTlsConfigPatch, Error, NamespacePolicy, ObjectNamespace,
+    RateLimitPolicy, Result,
 };
 
 /// A configuration patch: a set of optionally-present overrides.
@@ -100,7 +101,7 @@ pub struct ConfigVar {
 }
 
 /// Fully-resolved worker configuration.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WorkerConfig {
     /// Address the worker's RPC service binds to.
     pub listen: String,
@@ -216,6 +217,10 @@ pub struct WorkerConfig {
     /// `data_plane_rings = 1` with `TALON_WORKER_FORCE_TOKIO_DATA_PLANE=1` to
     /// pin the legacy path explicitly.
     pub data_plane_rings: usize,
+    /// Static per-tenant rate-limit policy. Disabled unless a `[rate_limits]`
+    /// table sets `enabled = true`. This is the local, single-worker stage of
+    /// the eventual-global-tenant-rate-limits design.
+    pub rate_limits: RateLimitPolicy,
 }
 
 /// Read the Azure SAS token from the environment (`TALON_WORKER_AZURE_SAS`).
@@ -291,6 +296,7 @@ impl Default for WorkerConfig {
             s3_path_style: None,
             gcs_endpoint: None,
             data_plane_rings: 0,
+            rate_limits: RateLimitPolicy::default(),
         }
     }
 }
@@ -370,6 +376,8 @@ pub struct WorkerConfigPatch {
     pub gcs_endpoint: Option<String>,
     /// Override for [`WorkerConfig::data_plane_rings`].
     pub data_plane_rings: Option<usize>,
+    /// Optional `[rate_limits]` table: the per-tenant rate-limit policy.
+    pub rate_limits: Option<RateLimitPolicy>,
 }
 
 impl Patch for WorkerConfigPatch {
@@ -419,6 +427,7 @@ impl Patch for WorkerConfigPatch {
             s3_path_style: self.s3_path_style.or(base.s3_path_style),
             gcs_endpoint: self.gcs_endpoint.or(base.gcs_endpoint),
             data_plane_rings: self.data_plane_rings.or(base.data_plane_rings),
+            rate_limits: self.rate_limits.or(base.rate_limits),
         }
     }
 }
@@ -921,6 +930,8 @@ impl WorkerConfigPatch {
             backend_min_throughput_bytes: get(worker_env::BACKEND_MIN_THROUGHPUT_BYTES)
                 .map(|v| parse_u64(v, worker_env::BACKEND_MIN_THROUGHPUT_BYTES))
                 .transpose()?,
+            // The [rate_limits] table is file-only; env does not override it.
+            rate_limits: None,
         })
     }
 }
@@ -999,6 +1010,7 @@ impl WorkerConfig {
                 .backend_min_throughput_bytes
                 .or(d.backend_min_throughput_bytes),
             data_plane_rings: merged.data_plane_rings.unwrap_or(d.data_plane_rings),
+            rate_limits: merged.rate_limits.unwrap_or(d.rate_limits),
         };
         cfg.validate()?;
         Ok(cfg)
@@ -1040,6 +1052,9 @@ impl WorkerConfig {
         if self.cluster_id.is_empty() {
             return Err(Error::Other("cluster_id must not be empty".into()));
         }
+        self.rate_limits
+            .validate()
+            .map_err(|e| Error::Other(format!("invalid [rate_limits]: {e}")))?;
         if self.node_id.as_ref().is_some_and(String::is_empty) {
             return Err(Error::Other("node_id must not be empty when set".into()));
         }

--- a/crates/talon-core/src/lib.rs
+++ b/crates/talon-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod metrics;
 pub mod namespace_policy;
 pub mod node;
 pub mod placement;
+pub mod rate_limit;
 pub mod status;
 pub mod store;
 pub mod tenant;
@@ -34,6 +35,7 @@ pub use metrics::{Counter, Gauge, Histogram, Metrics};
 pub use namespace_policy::{NamespacePolicy, ObjectNamespace};
 pub use node::{NodeId, NodeInfo, NodeRole};
 pub use placement::{cache_membership_epoch, rank_cache_workers, CachePlacementTable};
+pub use rate_limit::{Gcra, RateDecision, RateLimit, RateLimitError, RateMetric};
 pub use status::{
     NodeHealth, NodeMetricsSnapshot, NodeStatus, NodeStatusError, MAX_NODE_STATUS_BYTES,
     MAX_STATUS_FIELD_BYTES, MAX_STATUS_LABELS, MAX_STATUS_LABEL_KEY_BYTES,

--- a/crates/talon-core/src/lib.rs
+++ b/crates/talon-core/src/lib.rs
@@ -35,7 +35,9 @@ pub use metrics::{Counter, Gauge, Histogram, Metrics};
 pub use namespace_policy::{NamespacePolicy, ObjectNamespace};
 pub use node::{NodeId, NodeInfo, NodeRole};
 pub use placement::{cache_membership_epoch, rank_cache_workers, CachePlacementTable};
-pub use rate_limit::{Gcra, RateDecision, RateLimit, RateLimitError, RateMetric};
+pub use rate_limit::{
+    Gcra, MetricLimits, RateDecision, RateLimit, RateLimitError, RateLimitPolicy, RateMetric,
+};
 pub use status::{
     NodeHealth, NodeMetricsSnapshot, NodeStatus, NodeStatusError, MAX_NODE_STATUS_BYTES,
     MAX_STATUS_FIELD_BYTES, MAX_STATUS_LABELS, MAX_STATUS_LABEL_KEY_BYTES,

--- a/crates/talon-core/src/lib.rs
+++ b/crates/talon-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod node;
 pub mod placement;
 pub mod status;
 pub mod store;
+pub mod tenant;
 pub mod trace;
 
 pub use backend::{BackendStore, ListPage, ListedObject, ObjectStat};
@@ -39,4 +40,5 @@ pub use status::{
     MAX_STATUS_LABEL_VALUE_BYTES, NODE_STATUS_SCHEMA_VERSION, NODE_ZONE_LABEL,
 };
 pub use store::{BlockHandle, ObjectStore};
+pub use tenant::{TenantId, TenantIdError, MAX_TENANT_ID_BYTES};
 pub use trace::{init_tracing, RequestId};

--- a/crates/talon-core/src/rate_limit.rs
+++ b/crates/talon-core/src/rate_limit.rs
@@ -206,8 +206,11 @@ const NANOS_PER_SEC: u64 = 1_000_000_000;
 pub struct Gcra {
     /// Theoretical arrival time, in nanoseconds from the caller's clock origin.
     tat_nanos: AtomicU64,
-    /// Emission interval: nanoseconds of TAT advance per unit of cost.
-    interval_nanos: u64,
+    /// Sustained ceiling in units per second. The per-cost TAT advance is
+    /// `cost * 1e9 / rate` with the multiply applied first, so rates above
+    /// 1e9 units/s keep full precision — a pre-divided per-unit interval would
+    /// round down to 0ns and silently cap every rate at 1e9 units/s.
+    rate: u64,
     /// Tolerance: how far ahead of "now" the TAT may sit — `burst_ratio`
     /// seconds, i.e. `rate * burst_ratio` units of credit.
     tolerance_nanos: u64,
@@ -216,20 +219,17 @@ pub struct Gcra {
 impl Gcra {
     /// Build a fresh, empty cell for the given limit.
     pub fn new(limit: RateLimit) -> Self {
-        // Nanoseconds of credit per unit. Clamped to at least 1ns so a single
-        // unit always advances the TAT and an admitted cost is never a no-op.
-        let interval_nanos = NANOS_PER_SEC
-            .checked_div(limit.rate)
-            .unwrap_or(NANOS_PER_SEC)
-            .max(1);
-        // The burst window is `burst_ratio` seconds of accumulation, which works
-        // out to `rate * burst_ratio` units. Clamp to at least one emission
-        // interval so a single unit is always admittable, even for a tiny ratio.
+        // A zero rate makes the per-cost increment ill-defined. `RateLimit::new`
+        // forbids it, but the fields are public, so clamp defensively.
+        let rate = limit.rate.max(1);
+        // The burst window is `burst_ratio` seconds of accumulation, i.e.
+        // `rate * burst_ratio` units of credit. A single charge is always
+        // admittable from an idle cell regardless of this value (see the
+        // per-charge ceiling in `charge_at`), so no interval floor is needed.
         let tolerance_nanos = ((limit.burst_ratio.max(0.0)) * NANOS_PER_SEC as f64) as u64;
-        let tolerance_nanos = tolerance_nanos.max(interval_nanos);
         Self {
             tat_nanos: AtomicU64::new(0),
-            interval_nanos,
+            rate,
             tolerance_nanos,
         }
     }
@@ -237,22 +237,32 @@ impl Gcra {
     /// Charge `cost` units against the cell at monotonic time `now_nanos`.
     ///
     /// A zero cost is always admitted without touching the cell. On success the
-    /// TAT advances by `cost` emission intervals; on throttle the cell is left
+    /// TAT advances by `cost / rate` seconds; on throttle the cell is left
     /// unchanged and the returned delay is when the same cost would next fit.
     pub fn charge_at(&self, cost: u64, now_nanos: u64) -> RateDecision {
         if cost == 0 {
             return RateDecision::Admitted;
         }
-        // Total TAT advance for this cost, saturating rather than wrapping for
-        // pathological (huge cost, tiny rate) combinations.
-        let increment = (cost as u128 * self.interval_nanos as u128).min(u64::MAX as u128) as u64;
+        // Total TAT advance for this cost: `cost / rate` seconds, in nanos.
+        // Multiply before dividing so rates above 1e9 units/s stay exact (a
+        // pre-divided per-unit interval rounds to 0ns and caps the rate), and
+        // saturate rather than wrap for pathological (huge cost, tiny rate).
+        let increment =
+            (cost as u128 * NANOS_PER_SEC as u128 / self.rate as u128).min(u64::MAX as u128) as u64;
+        // The ceiling for THIS charge is at least its own increment, so a single
+        // request larger than the configured burst is still admittable from an
+        // idle cell instead of being rejected forever with a retry_after that
+        // could never come true. Such a request is admitted only once the cell
+        // has drained to "now", then advances the TAT by the full increment,
+        // pacing the tenant for the oversized cost. For the common
+        // `increment <= tolerance` case the ceiling is exactly the burst.
+        let ceiling = self.tolerance_nanos.max(increment);
         loop {
             let tat = self.tat_nanos.load(Ordering::Relaxed);
             let base = tat.max(now_nanos);
             let new_tat = base.saturating_add(increment);
-            // Backlog after admitting = new_tat - now. Admit while it fits the
-            // burst tolerance.
-            if new_tat.saturating_sub(now_nanos) <= self.tolerance_nanos {
+            // Backlog after admitting = new_tat - now. Admit while it fits.
+            if new_tat.saturating_sub(now_nanos) <= ceiling {
                 match self.tat_nanos.compare_exchange_weak(
                     tat,
                     new_tat,
@@ -264,10 +274,8 @@ impl Gcra {
                     Err(_) => continue,
                 }
             }
-            // Earliest time the cost fits: when backlog drains to the tolerance.
-            let retry = new_tat
-                .saturating_sub(self.tolerance_nanos)
-                .saturating_sub(now_nanos);
+            // Earliest time the cost fits: when the backlog drains to `ceiling`.
+            let retry = new_tat.saturating_sub(ceiling).saturating_sub(now_nanos);
             return RateDecision::Throttled {
                 retry_after: Duration::from_nanos(retry),
             };
@@ -393,5 +401,47 @@ mod tests {
         assert_eq!(cell.charge_at(0, 0), RateDecision::Admitted);
         // The one unit of burst is still available afterwards.
         assert!(cell.charge_at(1, 0).is_admitted());
+    }
+
+    #[test]
+    fn oversized_cost_admits_from_idle_then_paces_with_truthful_retry() {
+        // Regression: a single cost larger than the burst capacity used to be
+        // rejected forever, and the returned retry_after never came true —
+        // retrying at `now + retry_after` was throttled identically because the
+        // cell had not advanced. At rate 10, burst_ratio 1.0 the burst is 10
+        // units; charge 25 (2.5x the burst).
+        let cell = Gcra::new(limit(10, 1.0));
+        // Admitted from an idle cell despite exceeding the 10-unit burst...
+        assert!(cell.charge_at(25, 0).is_admitted());
+        // ...the next identical charge is paced, not permanently stuck.
+        let retry = match cell.charge_at(25, 0) {
+            RateDecision::Throttled { retry_after } => retry_after,
+            other => panic!("expected throttle, got {other:?}"),
+        };
+        // 25 units at 10 units/s = 2.5s of backlog to drain.
+        assert_eq!(retry, Duration::from_millis(2500));
+        // Waiting exactly that long and retrying succeeds — the retry is real.
+        assert!(cell.charge_at(25, retry.as_nanos() as u64).is_admitted());
+    }
+
+    #[test]
+    fn rate_above_one_billion_is_not_capped_at_1e9() {
+        // Regression: `interval = 1e9 / rate` floored to 0 (clamped to 1ns) for
+        // rates above 1e9 units/s, capping every such rate at 1e9. At 2e9
+        // units/s with burst_ratio 1.0 the burst is a full 2e9 units, which the
+        // capped implementation could not admit within one second.
+        let cell = Gcra::new(limit(2_000_000_000, 1.0));
+        // A full second's worth (2e9 units) fits the burst — impossible if the
+        // rate were silently capped at 1e9.
+        assert!(cell.charge_at(2_000_000_000, 0).is_admitted());
+        // The next second's worth is paced by exactly one second.
+        match cell.charge_at(2_000_000_000, 0) {
+            RateDecision::Throttled { retry_after } => {
+                assert_eq!(retry_after, Duration::from_secs(1));
+            }
+            other => panic!("expected throttle, got {other:?}"),
+        }
+        // ...and admitted once that second has elapsed.
+        assert!(cell.charge_at(2_000_000_000, NANOS_PER_SEC).is_admitted());
     }
 }

--- a/crates/talon-core/src/rate_limit.rs
+++ b/crates/talon-core/src/rate_limit.rs
@@ -1,0 +1,272 @@
+//! Per-tenant rate-limit primitives shared by every enforcement tier.
+//!
+//! This module holds the tier-agnostic building blocks — the metrics a policy
+//! is expressed over, a single metric's `(rate, burst)` limit, and a lock-free
+//! GCRA cell that admits or throttles one stream of requests. Where the limit is
+//! *enforced* (the object-store gateway for authenticated tenants, the worker
+//! for direct clients) is a property of the caller, not of these primitives.
+//!
+//! The cell is a Generic Cell Rate Algorithm meter: its entire state is one
+//! "theoretical arrival time" (TAT) timestamp held in a single [`AtomicU64`], so
+//! concurrent callers admit or throttle with a single compare-and-swap and never
+//! serialize on a lock. That property is what lets the data-plane rings (and the
+//! gateway's request tasks) charge a shared per-tenant limit without contention.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// A rate-limited traffic dimension for one tenant.
+///
+/// Costs are expressed in the metric's natural unit: one request for
+/// [`RateMetric::ReadIops`], one byte for the byte metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RateMetric {
+    /// Client read requests admitted (cost is one request).
+    ReadIops,
+    /// Bytes sent from the serving tier to the client (cost is bytes).
+    ClientEgressBytes,
+    /// Bytes fetched from the object-store origin on a cache miss (cost is bytes).
+    OriginReadBytes,
+}
+
+impl RateMetric {
+    /// Every metric, in a stable order for iteration and per-metric tables.
+    pub const ALL: [RateMetric; 3] = [
+        RateMetric::ReadIops,
+        RateMetric::ClientEgressBytes,
+        RateMetric::OriginReadBytes,
+    ];
+
+    /// Stable, low-cardinality label for telemetry and configuration keys.
+    pub const fn label(self) -> &'static str {
+        match self {
+            RateMetric::ReadIops => "read_iops",
+            RateMetric::ClientEgressBytes => "client_egress_bytes",
+            RateMetric::OriginReadBytes => "origin_read_bytes",
+        }
+    }
+}
+
+impl std::fmt::Display for RateMetric {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// A single metric's sustained rate and burst allowance.
+///
+/// `rate` is the long-run ceiling in units per second; `burst` is the largest
+/// instantaneous backlog, in the same units, admitted before pacing kicks in.
+/// Both must be non-zero — an absent limit is modelled by the caller as "no
+/// [`RateLimit`] configured for this metric", not by a zero here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RateLimit {
+    /// Sustained ceiling in units per second.
+    pub rate: u64,
+    /// Maximum burst, in units, admitted ahead of the sustained rate.
+    pub burst: u64,
+}
+
+impl RateLimit {
+    /// Construct a limit, returning an error for a non-positive rate or burst.
+    pub fn new(rate: u64, burst: u64) -> Result<Self, RateLimitError> {
+        if rate == 0 {
+            return Err(RateLimitError::ZeroRate);
+        }
+        if burst == 0 {
+            return Err(RateLimitError::ZeroBurst);
+        }
+        Ok(Self { rate, burst })
+    }
+}
+
+/// Why a [`RateLimit`] is invalid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum RateLimitError {
+    /// The sustained rate was zero; use "no limit configured" instead.
+    #[error("rate limit rate must be non-zero")]
+    ZeroRate,
+    /// The burst allowance was zero; a limit must admit at least one unit.
+    #[error("rate limit burst must be non-zero")]
+    ZeroBurst,
+}
+
+/// The outcome of charging a [`Gcra`] cell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RateDecision {
+    /// The request is admitted and the cell has been advanced.
+    Admitted,
+    /// The request would exceed the limit; retry after this delay. The cell is
+    /// unchanged, so a caller that waits and retries is charged exactly once.
+    Throttled {
+        /// How long until enough capacity exists to admit the same cost.
+        retry_after: Duration,
+    },
+}
+
+impl RateDecision {
+    /// Whether the request was admitted.
+    pub fn is_admitted(self) -> bool {
+        matches!(self, RateDecision::Admitted)
+    }
+}
+
+const NANOS_PER_SEC: u64 = 1_000_000_000;
+
+/// A lock-free GCRA rate-limit cell for one `(tenant, metric)`.
+///
+/// The cell admits a burst of up to `burst` units instantaneously and then
+/// paces admissions at `rate` units per second. All state is one atomic TAT, so
+/// charging is a single compare-and-swap; time is supplied by the caller (as
+/// monotonic nanoseconds from a fixed origin) so the algorithm is deterministic
+/// and testable.
+#[derive(Debug)]
+pub struct Gcra {
+    /// Theoretical arrival time, in nanoseconds from the caller's clock origin.
+    tat_nanos: AtomicU64,
+    /// Emission interval: nanoseconds of TAT advance per unit of cost.
+    interval_nanos: u64,
+    /// Tolerance: how far ahead of "now" the TAT may sit (i.e. `burst` units).
+    tolerance_nanos: u64,
+}
+
+impl Gcra {
+    /// Build a fresh, empty cell for the given limit.
+    pub fn new(limit: RateLimit) -> Self {
+        // Nanoseconds of credit per unit, and the burst window in those units.
+        // Both are clamped to at least 1ns so a single unit always advances the
+        // TAT and an admitted cost is never a no-op.
+        let interval_nanos = (NANOS_PER_SEC / limit.rate).max(1);
+        let tolerance_nanos =
+            (limit.burst as u128 * interval_nanos as u128).min(u64::MAX as u128) as u64;
+        Self {
+            tat_nanos: AtomicU64::new(0),
+            interval_nanos,
+            tolerance_nanos,
+        }
+    }
+
+    /// Charge `cost` units against the cell at monotonic time `now_nanos`.
+    ///
+    /// A zero cost is always admitted without touching the cell. On success the
+    /// TAT advances by `cost` emission intervals; on throttle the cell is left
+    /// unchanged and the returned delay is when the same cost would next fit.
+    pub fn charge_at(&self, cost: u64, now_nanos: u64) -> RateDecision {
+        if cost == 0 {
+            return RateDecision::Admitted;
+        }
+        // Total TAT advance for this cost, saturating rather than wrapping for
+        // pathological (huge cost, tiny rate) combinations.
+        let increment = (cost as u128 * self.interval_nanos as u128).min(u64::MAX as u128) as u64;
+        loop {
+            let tat = self.tat_nanos.load(Ordering::Relaxed);
+            let base = tat.max(now_nanos);
+            let new_tat = base.saturating_add(increment);
+            // Backlog after admitting = new_tat - now. Admit while it fits the
+            // burst tolerance.
+            if new_tat.saturating_sub(now_nanos) <= self.tolerance_nanos {
+                match self.tat_nanos.compare_exchange_weak(
+                    tat,
+                    new_tat,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => return RateDecision::Admitted,
+                    // Lost the race; another charge advanced the TAT. Retry.
+                    Err(_) => continue,
+                }
+            }
+            // Earliest time the cost fits: when backlog drains to the tolerance.
+            let retry = new_tat
+                .saturating_sub(self.tolerance_nanos)
+                .saturating_sub(now_nanos);
+            return RateDecision::Throttled {
+                retry_after: Duration::from_nanos(retry),
+            };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metric_labels_are_stable_and_unique() {
+        let labels: Vec<_> = RateMetric::ALL.iter().map(|m| m.label()).collect();
+        assert_eq!(
+            labels,
+            ["read_iops", "client_egress_bytes", "origin_read_bytes"]
+        );
+        assert_eq!(RateMetric::ReadIops.to_string(), "read_iops");
+    }
+
+    #[test]
+    fn rate_limit_rejects_zero() {
+        assert_eq!(RateLimit::new(0, 1), Err(RateLimitError::ZeroRate));
+        assert_eq!(RateLimit::new(1, 0), Err(RateLimitError::ZeroBurst));
+        assert!(RateLimit::new(100, 10).is_ok());
+    }
+
+    #[test]
+    fn admits_a_full_burst_then_throttles() {
+        // 100 units/sec, burst 10: ten immediate admits at t=0, eleventh paces.
+        let cell = Gcra::new(RateLimit::new(100, 10).unwrap());
+        for _ in 0..10 {
+            assert_eq!(cell.charge_at(1, 0), RateDecision::Admitted);
+        }
+        match cell.charge_at(1, 0) {
+            RateDecision::Throttled { retry_after } => {
+                // One emission interval = 1/100 s = 10ms.
+                assert_eq!(retry_after, Duration::from_millis(10));
+            }
+            other => panic!("expected throttle, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn refills_at_the_configured_rate() {
+        let cell = Gcra::new(RateLimit::new(100, 10).unwrap());
+        for _ in 0..10 {
+            assert!(cell.charge_at(1, 0).is_admitted());
+        }
+        // Still throttled just before one interval elapses...
+        assert!(!cell.charge_at(1, 9_999_999).is_admitted());
+        // ...and admitted once a full 10ms interval has passed.
+        assert!(cell.charge_at(1, 10_000_000).is_admitted());
+    }
+
+    #[test]
+    fn cost_scales_with_units_for_byte_metrics() {
+        // 1000 bytes/sec, burst 1000 bytes: one 1000-byte admit drains the burst.
+        let cell = Gcra::new(RateLimit::new(1000, 1000).unwrap());
+        assert!(cell.charge_at(1000, 0).is_admitted());
+        assert!(!cell.charge_at(1, 0).is_admitted());
+        // After 1s, the whole burst has refilled.
+        assert!(cell.charge_at(1000, NANOS_PER_SEC).is_admitted());
+    }
+
+    #[test]
+    fn zero_cost_never_throttles_or_advances() {
+        let cell = Gcra::new(RateLimit::new(1, 1).unwrap());
+        assert_eq!(cell.charge_at(0, 0), RateDecision::Admitted);
+        // The one unit of burst is still available afterwards.
+        assert!(cell.charge_at(1, 0).is_admitted());
+    }
+
+    #[test]
+    fn throttle_delay_grows_with_backlog() {
+        // burst 1 so the cell paces immediately; a 5-unit cost needs ~5 intervals.
+        let cell = Gcra::new(RateLimit::new(100, 1).unwrap());
+        assert!(cell.charge_at(1, 0).is_admitted());
+        match cell.charge_at(5, 0) {
+            RateDecision::Throttled { retry_after } => {
+                // Need 5 more units of credit beyond the 1-unit tolerance.
+                assert_eq!(retry_after, Duration::from_millis(50));
+            }
+            other => panic!("expected throttle, got {other:?}"),
+        }
+    }
+}

--- a/crates/talon-core/src/rate_limit.rs
+++ b/crates/talon-core/src/rate_limit.rs
@@ -1,33 +1,39 @@
 //! Per-tenant rate-limit primitives shared by every enforcement tier.
 //!
 //! This module holds the tier-agnostic building blocks — the metrics a policy
-//! is expressed over, a single metric's `(rate, burst)` limit, and a lock-free
-//! GCRA cell that admits or throttles one stream of requests. Where the limit is
-//! *enforced* (the object-store gateway for authenticated tenants, the worker
-//! for direct clients) is a property of the caller, not of these primitives.
+//! is expressed over, a single metric's `(rate, burst_ratio)` limit, and a
+//! lock-free GCRA cell that admits or throttles one stream of requests. Where
+//! the limit is *enforced* (the worker for direct clients, the object-store
+//! gateway for its own traffic) is a property of the caller, not of these
+//! primitives.
 //!
 //! The cell is a Generic Cell Rate Algorithm meter: its entire state is one
 //! "theoretical arrival time" (TAT) timestamp held in a single [`AtomicU64`], so
 //! concurrent callers admit or throttle with a single compare-and-swap and never
-//! serialize on a lock. That property is what lets the data-plane rings (and the
-//! gateway's request tasks) charge a shared per-tenant limit without contention.
+//! serialize on a lock. That property is what lets the data-plane rings charge a
+//! shared per-tenant limit without contention.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
+use crate::TenantId;
+
 /// A rate-limited traffic dimension for one tenant.
 ///
 /// Costs are expressed in the metric's natural unit: one request for
-/// [`RateMetric::ReadIops`], one byte for the byte metrics.
+/// [`RateMetric::ReadIops`], one byte for the byte-rate metrics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum RateMetric {
-    /// Client read requests admitted (cost is one request).
+    /// Client read requests admitted per second (cost is one request).
     ReadIops,
-    /// Bytes sent from the serving tier to the client (cost is bytes).
-    ClientEgressBytes,
-    /// Bytes fetched from the object-store origin on a cache miss (cost is bytes).
+    /// Bytes per second served to the client — the read throughput / egress
+    /// bandwidth (cost is bytes).
+    ReadThroughput,
+    /// Bytes per second fetched from the object-store origin on a cache miss
+    /// (cost is bytes).
     OriginReadBytes,
 }
 
@@ -35,7 +41,7 @@ impl RateMetric {
     /// Every metric, in a stable order for iteration and per-metric tables.
     pub const ALL: [RateMetric; 3] = [
         RateMetric::ReadIops,
-        RateMetric::ClientEgressBytes,
+        RateMetric::ReadThroughput,
         RateMetric::OriginReadBytes,
     ];
 
@@ -43,7 +49,7 @@ impl RateMetric {
     pub const fn label(self) -> &'static str {
         match self {
             RateMetric::ReadIops => "read_iops",
-            RateMetric::ClientEgressBytes => "client_egress_bytes",
+            RateMetric::ReadThroughput => "read_throughput",
             RateMetric::OriginReadBytes => "origin_read_bytes",
         }
     }
@@ -55,42 +61,116 @@ impl std::fmt::Display for RateMetric {
     }
 }
 
-/// A single metric's sustained rate and burst allowance.
+/// The default burst window, in seconds, when a limit does not set its own.
 ///
-/// `rate` is the long-run ceiling in units per second; `burst` is the largest
-/// instantaneous backlog, in the same units, admitted before pacing kicks in.
-/// Both must be non-zero — an absent limit is modelled by the caller as "no
-/// [`RateLimit`] configured for this metric", not by a zero here.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// A ratio of 1.0 lets a tenant burst up to one second's worth of its sustained
+/// rate before pacing takes over.
+pub const DEFAULT_BURST_RATIO: f64 = 1.0;
+
+fn default_burst_ratio() -> f64 {
+    DEFAULT_BURST_RATIO
+}
+
+/// A single metric's sustained rate and relative burst allowance.
+///
+/// `rate` is the long-run ceiling in units per second. `burst_ratio` sizes the
+/// burst *relative* to that rate: the largest instantaneous backlog admitted
+/// before pacing is `rate * burst_ratio` units, i.e. `burst_ratio` seconds of
+/// accumulation. It defaults to [`DEFAULT_BURST_RATIO`], so a config may set
+/// only `rate`.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RateLimit {
     /// Sustained ceiling in units per second.
     pub rate: u64,
-    /// Maximum burst, in units, admitted ahead of the sustained rate.
-    pub burst: u64,
+    /// Burst window in seconds: burst size is `rate * burst_ratio` units.
+    #[serde(default = "default_burst_ratio")]
+    pub burst_ratio: f64,
 }
 
 impl RateLimit {
-    /// Construct a limit, returning an error for a non-positive rate or burst.
-    pub fn new(rate: u64, burst: u64) -> Result<Self, RateLimitError> {
+    /// Construct a limit, returning an error for a non-positive rate or an
+    /// invalid burst ratio (non-finite or not strictly positive).
+    pub fn new(rate: u64, burst_ratio: f64) -> Result<Self, RateLimitError> {
         if rate == 0 {
             return Err(RateLimitError::ZeroRate);
         }
-        if burst == 0 {
-            return Err(RateLimitError::ZeroBurst);
+        if !burst_ratio.is_finite() || burst_ratio <= 0.0 {
+            return Err(RateLimitError::InvalidBurstRatio(burst_ratio));
         }
-        Ok(Self { rate, burst })
+        Ok(Self { rate, burst_ratio })
     }
 }
 
 /// Why a [`RateLimit`] is invalid.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, Copy, PartialEq, thiserror::Error)]
 pub enum RateLimitError {
     /// The sustained rate was zero; use "no limit configured" instead.
     #[error("rate limit rate must be non-zero")]
     ZeroRate,
-    /// The burst allowance was zero; a limit must admit at least one unit.
-    #[error("rate limit burst must be non-zero")]
-    ZeroBurst,
+    /// The burst ratio was not a finite, strictly-positive number.
+    #[error("rate limit burst_ratio must be finite and positive, got {0}")]
+    InvalidBurstRatio(f64),
+}
+
+/// The per-metric limits applied to one tenant. A `None` leaves that metric
+/// unlimited. Deserialized from a config table such as
+/// `read_iops = { rate = 1000, burst_ratio = 2.0 }`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct MetricLimits {
+    /// Admitted client read requests per second.
+    pub read_iops: Option<RateLimit>,
+    /// Read throughput (bytes per second served to the client).
+    pub read_throughput: Option<RateLimit>,
+}
+
+impl MetricLimits {
+    /// Whether any metric is limited.
+    pub fn is_empty(&self) -> bool {
+        self.read_iops.is_none() && self.read_throughput.is_none()
+    }
+
+    /// Validate every configured limit.
+    pub fn validate(&self) -> Result<(), RateLimitError> {
+        for limit in [self.read_iops, self.read_throughput].into_iter().flatten() {
+            RateLimit::new(limit.rate, limit.burst_ratio)?;
+        }
+        Ok(())
+    }
+}
+
+/// A static per-worker rate-limit policy: one default applied to every tenant
+/// plus optional per-tenant overrides, keyed by tenant name.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct RateLimitPolicy {
+    /// When false the limiter admits everything (the feature is off).
+    pub enabled: bool,
+    /// Limits applied to a tenant with no explicit override.
+    pub default: MetricLimits,
+    /// Per-tenant overrides, keyed by [`TenantId`] name.
+    pub overrides: HashMap<String, MetricLimits>,
+}
+
+impl RateLimitPolicy {
+    /// The limits that apply to `tenant`: its override if present, else the
+    /// default. The unattributed tenant always uses the default.
+    pub fn limits_for(&self, tenant: &TenantId) -> MetricLimits {
+        tenant
+            .name()
+            .and_then(|name| self.overrides.get(name).copied())
+            .unwrap_or(self.default)
+    }
+
+    /// Validate every limit in the policy.
+    pub fn validate(&self) -> Result<(), RateLimitError> {
+        self.default.validate()?;
+        for limits in self.overrides.values() {
+            limits.validate()?;
+        }
+        Ok(())
+    }
 }
 
 /// The outcome of charging a [`Gcra`] cell.
@@ -117,30 +197,36 @@ const NANOS_PER_SEC: u64 = 1_000_000_000;
 
 /// A lock-free GCRA rate-limit cell for one `(tenant, metric)`.
 ///
-/// The cell admits a burst of up to `burst` units instantaneously and then
-/// paces admissions at `rate` units per second. All state is one atomic TAT, so
-/// charging is a single compare-and-swap; time is supplied by the caller (as
-/// monotonic nanoseconds from a fixed origin) so the algorithm is deterministic
-/// and testable.
+/// The cell admits a burst of up to `rate * burst_ratio` units instantaneously
+/// and then paces admissions at `rate` units per second. All state is one atomic
+/// TAT, so charging is a single compare-and-swap; time is supplied by the caller
+/// (as monotonic nanoseconds from a fixed origin) so the algorithm is
+/// deterministic and testable.
 #[derive(Debug)]
 pub struct Gcra {
     /// Theoretical arrival time, in nanoseconds from the caller's clock origin.
     tat_nanos: AtomicU64,
     /// Emission interval: nanoseconds of TAT advance per unit of cost.
     interval_nanos: u64,
-    /// Tolerance: how far ahead of "now" the TAT may sit (i.e. `burst` units).
+    /// Tolerance: how far ahead of "now" the TAT may sit — `burst_ratio`
+    /// seconds, i.e. `rate * burst_ratio` units of credit.
     tolerance_nanos: u64,
 }
 
 impl Gcra {
     /// Build a fresh, empty cell for the given limit.
     pub fn new(limit: RateLimit) -> Self {
-        // Nanoseconds of credit per unit, and the burst window in those units.
-        // Both are clamped to at least 1ns so a single unit always advances the
-        // TAT and an admitted cost is never a no-op.
-        let interval_nanos = (NANOS_PER_SEC / limit.rate).max(1);
-        let tolerance_nanos =
-            (limit.burst as u128 * interval_nanos as u128).min(u64::MAX as u128) as u64;
+        // Nanoseconds of credit per unit. Clamped to at least 1ns so a single
+        // unit always advances the TAT and an admitted cost is never a no-op.
+        let interval_nanos = NANOS_PER_SEC
+            .checked_div(limit.rate)
+            .unwrap_or(NANOS_PER_SEC)
+            .max(1);
+        // The burst window is `burst_ratio` seconds of accumulation, which works
+        // out to `rate * burst_ratio` units. Clamp to at least one emission
+        // interval so a single unit is always admittable, even for a tiny ratio.
+        let tolerance_nanos = ((limit.burst_ratio.max(0.0)) * NANOS_PER_SEC as f64) as u64;
+        let tolerance_nanos = tolerance_nanos.max(interval_nanos);
         Self {
             tat_nanos: AtomicU64::new(0),
             interval_nanos,
@@ -193,34 +279,77 @@ impl Gcra {
 mod tests {
     use super::*;
 
+    fn limit(rate: u64, burst_ratio: f64) -> RateLimit {
+        RateLimit::new(rate, burst_ratio).unwrap()
+    }
+
     #[test]
     fn metric_labels_are_stable_and_unique() {
         let labels: Vec<_> = RateMetric::ALL.iter().map(|m| m.label()).collect();
         assert_eq!(
             labels,
-            ["read_iops", "client_egress_bytes", "origin_read_bytes"]
+            ["read_iops", "read_throughput", "origin_read_bytes"]
         );
-        assert_eq!(RateMetric::ReadIops.to_string(), "read_iops");
+        assert_eq!(RateMetric::ReadThroughput.to_string(), "read_throughput");
     }
 
     #[test]
-    fn rate_limit_rejects_zero() {
-        assert_eq!(RateLimit::new(0, 1), Err(RateLimitError::ZeroRate));
-        assert_eq!(RateLimit::new(1, 0), Err(RateLimitError::ZeroBurst));
-        assert!(RateLimit::new(100, 10).is_ok());
+    fn rate_limit_rejects_invalid_values() {
+        assert_eq!(RateLimit::new(0, 1.0), Err(RateLimitError::ZeroRate));
+        assert!(matches!(
+            RateLimit::new(1, 0.0),
+            Err(RateLimitError::InvalidBurstRatio(_))
+        ));
+        assert!(matches!(
+            RateLimit::new(1, f64::NAN),
+            Err(RateLimitError::InvalidBurstRatio(_))
+        ));
+        assert!(RateLimit::new(100, 2.0).is_ok());
+    }
+
+    #[test]
+    fn burst_ratio_defaults_when_absent_in_config() {
+        let limit: RateLimit = toml::from_str("rate = 1000").unwrap();
+        assert_eq!(limit.rate, 1000);
+        assert_eq!(limit.burst_ratio, DEFAULT_BURST_RATIO);
+    }
+
+    #[test]
+    fn policy_deserializes_from_a_config_table() {
+        let toml = r#"
+            enabled = true
+            [default]
+            read_iops = { rate = 1000, burst_ratio = 2.0 }
+            [overrides.acme]
+            read_throughput = { rate = 1048576 }
+        "#;
+        let policy: RateLimitPolicy = toml::from_str(toml).unwrap();
+        assert!(policy.enabled);
+        assert_eq!(policy.default.read_iops, Some(limit(1000, 2.0)));
+        // A named override wins over the default for that tenant, and its
+        // throughput limit uses the default burst ratio.
+        let acme = policy.limits_for(&TenantId::named("acme"));
+        assert_eq!(
+            acme.read_throughput,
+            Some(limit(1_048_576, DEFAULT_BURST_RATIO))
+        );
+        assert_eq!(acme.read_iops, None);
+        // Any other tenant falls back to the default.
+        assert_eq!(policy.limits_for(&TenantId::named("other")), policy.default);
+        policy.validate().unwrap();
     }
 
     #[test]
     fn admits_a_full_burst_then_throttles() {
-        // 100 units/sec, burst 10: ten immediate admits at t=0, eleventh paces.
-        let cell = Gcra::new(RateLimit::new(100, 10).unwrap());
+        // 10 units/sec, burst_ratio 1.0 => 1s window => 10 units of burst.
+        let cell = Gcra::new(limit(10, 1.0));
         for _ in 0..10 {
             assert_eq!(cell.charge_at(1, 0), RateDecision::Admitted);
         }
         match cell.charge_at(1, 0) {
             RateDecision::Throttled { retry_after } => {
-                // One emission interval = 1/100 s = 10ms.
-                assert_eq!(retry_after, Duration::from_millis(10));
+                // One emission interval = 1/10 s = 100ms.
+                assert_eq!(retry_after, Duration::from_millis(100));
             }
             other => panic!("expected throttle, got {other:?}"),
         }
@@ -228,45 +357,41 @@ mod tests {
 
     #[test]
     fn refills_at_the_configured_rate() {
-        let cell = Gcra::new(RateLimit::new(100, 10).unwrap());
+        let cell = Gcra::new(limit(10, 1.0));
         for _ in 0..10 {
             assert!(cell.charge_at(1, 0).is_admitted());
         }
-        // Still throttled just before one interval elapses...
-        assert!(!cell.charge_at(1, 9_999_999).is_admitted());
-        // ...and admitted once a full 10ms interval has passed.
-        assert!(cell.charge_at(1, 10_000_000).is_admitted());
+        // Still throttled just before one interval (100ms) elapses...
+        assert!(!cell.charge_at(1, 99_999_999).is_admitted());
+        // ...and admitted once a full 100ms interval has passed.
+        assert!(cell.charge_at(1, 100_000_000).is_admitted());
+    }
+
+    #[test]
+    fn burst_ratio_scales_the_burst_window() {
+        // burst_ratio 2.0 at 10/sec => 20 units of burst before pacing.
+        let cell = Gcra::new(limit(10, 2.0));
+        for _ in 0..20 {
+            assert!(cell.charge_at(1, 0).is_admitted());
+        }
+        assert!(!cell.charge_at(1, 0).is_admitted());
     }
 
     #[test]
     fn cost_scales_with_units_for_byte_metrics() {
-        // 1000 bytes/sec, burst 1000 bytes: one 1000-byte admit drains the burst.
-        let cell = Gcra::new(RateLimit::new(1000, 1000).unwrap());
+        // 1000 bytes/sec, burst_ratio 1.0 => 1000 bytes of burst.
+        let cell = Gcra::new(limit(1000, 1.0));
         assert!(cell.charge_at(1000, 0).is_admitted());
         assert!(!cell.charge_at(1, 0).is_admitted());
-        // After 1s, the whole burst has refilled.
+        // After 1s the whole burst has refilled.
         assert!(cell.charge_at(1000, NANOS_PER_SEC).is_admitted());
     }
 
     #[test]
     fn zero_cost_never_throttles_or_advances() {
-        let cell = Gcra::new(RateLimit::new(1, 1).unwrap());
+        let cell = Gcra::new(limit(1, 1.0));
         assert_eq!(cell.charge_at(0, 0), RateDecision::Admitted);
         // The one unit of burst is still available afterwards.
         assert!(cell.charge_at(1, 0).is_admitted());
-    }
-
-    #[test]
-    fn throttle_delay_grows_with_backlog() {
-        // burst 1 so the cell paces immediately; a 5-unit cost needs ~5 intervals.
-        let cell = Gcra::new(RateLimit::new(100, 1).unwrap());
-        assert!(cell.charge_at(1, 0).is_admitted());
-        match cell.charge_at(5, 0) {
-            RateDecision::Throttled { retry_after } => {
-                // Need 5 more units of credit beyond the 1-unit tolerance.
-                assert_eq!(retry_after, Duration::from_millis(50));
-            }
-            other => panic!("expected throttle, got {other:?}"),
-        }
     }
 }

--- a/crates/talon-core/src/tenant.rs
+++ b/crates/talon-core/src/tenant.rs
@@ -1,41 +1,44 @@
 //! Tenant identity for per-tenant quality-of-service.
 //!
-//! A *tenant* is the authenticated resource owner a request is attributed to
-//! when the cluster enforces per-tenant rate limits (and, later, cache quotas).
-//! Tenant identity originates at the object-store gateway, which resolves it
-//! from the request credential — the provider account established during
-//! authentication — and is propagated to workers on the data plane. Enforcement
-//! therefore keys on a non-forgeable identity derived from the authenticated
-//! request rather than on a client-supplied claim.
+//! A *tenant* is the resource owner a request is attributed to when the cluster
+//! enforces per-tenant rate limits (and, later, cache quotas). Tenant identity
+//! reaches the enforcing tier in one of two ways:
 //!
-//! Clients that connect directly to a worker and bypass the gateway — the FUSE
-//! mount and the native clients — present no credential. Their traffic is
-//! attributed to the reserved [`TenantId::Unattributed`] tenant so that it is
-//! still counted and bounded rather than silently escaping per-tenant policy.
+//! - on the **direct data plane**, the native SDK (and FUSE) declares the tenant
+//!   on each request, and the worker enforces against it;
+//! - at the **object-store gateway**, the tenant is resolved from the
+//!   authenticated principal (the provider account) and carried to the worker
+//!   the same way.
+//!
+//! The direct path is not authenticated, so a declared tenant is trusted for
+//! fairness, not treated as a security boundary. Requests that declare no tenant
+//! — a client that has not been taught to, or the FUSE mount — are attributed to
+//! the reserved [`TenantId::Unattributed`] tenant so that their traffic is still
+//! counted and bounded rather than silently escaping per-tenant policy.
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-/// Maximum length, in bytes, of a tenant account identifier.
+/// Maximum length, in bytes, of a tenant name.
 ///
-/// Tenant ids are derived from a gateway-authenticated provider account and
-/// then travel through control-plane messages, serve as map keys on the hot
-/// path, and appear in bounded telemetry. A fixed ceiling keeps every one of
-/// those uses bounded regardless of the credential's contents.
+/// Tenant ids are client- or gateway-supplied and then travel through
+/// data-plane requests, serve as map keys on the hot path, and appear in bounded
+/// telemetry. A fixed ceiling keeps every one of those uses bounded regardless
+/// of the caller.
 pub const MAX_TENANT_ID_BYTES: usize = 256;
 
-/// The authenticated resource owner a request is attributed to for QoS.
+/// The resource owner a request is attributed to for QoS.
 ///
 /// See the [module documentation](self) for how identity is established and why
 /// the unattributed tenant exists. `TenantId` is `Hash + Eq`, so it is used
-/// directly as a map key; two authenticated tenants are equal exactly when they
-/// name the same provider account.
+/// directly as a map key; two named tenants are equal exactly when they share a
+/// name.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TenantId {
-    /// An authenticated tenant, named by its gateway provider account.
-    Principal(String),
-    /// Traffic that arrived without an authenticated tenant — a direct client
-    /// that bypassed the gateway.
+    /// A named tenant, declared by the SDK on the direct path or resolved from
+    /// the authenticated principal at the gateway.
+    Named(String),
+    /// Traffic that declared no tenant.
     Unattributed,
 }
 
@@ -44,15 +47,15 @@ impl TenantId {
     /// the management API, and (allow-listed) telemetry.
     pub const UNATTRIBUTED_LABEL: &'static str = "unattributed";
 
-    /// Construct a tenant from an authenticated provider account.
+    /// Construct a named tenant.
     ///
-    /// The account is taken verbatim; call [`TenantId::validate`] at the trust
+    /// The name is taken verbatim; call [`TenantId::validate`] at the trust
     /// boundary to reject an empty or over-long value.
-    pub fn principal(account: impl Into<String>) -> Self {
-        Self::Principal(account.into())
+    pub fn named(name: impl Into<String>) -> Self {
+        Self::Named(name.into())
     }
 
-    /// The reserved tenant for traffic with no authenticated identity.
+    /// The reserved tenant for traffic that declared no identity.
     pub const fn unattributed() -> Self {
         Self::Unattributed
     }
@@ -62,31 +65,30 @@ impl TenantId {
         matches!(self, Self::Unattributed)
     }
 
-    /// The provider account backing an authenticated tenant, or `None` for the
-    /// unattributed tenant.
+    /// The name of a named tenant, or `None` for the unattributed tenant.
     ///
     /// Prefer matching on the tenant, or using it directly as a map key, over
-    /// flattening it to a string: two distinct tenants never share an account,
-    /// and the unattributed tenant deliberately has none.
-    pub fn account(&self) -> Option<&str> {
+    /// flattening it to a string: two distinct tenants never share a name, and
+    /// the unattributed tenant deliberately has none.
+    pub fn name(&self) -> Option<&str> {
         match self {
-            Self::Principal(account) => Some(account),
+            Self::Named(name) => Some(name),
             Self::Unattributed => None,
         }
     }
 
     /// Validate a tenant established at a trust boundary.
     ///
-    /// An authenticated tenant must carry a non-empty account no longer than
+    /// A named tenant must carry a non-empty name no longer than
     /// [`MAX_TENANT_ID_BYTES`]. The unattributed tenant is always valid.
     pub fn validate(&self) -> Result<(), TenantIdError> {
         match self {
             Self::Unattributed => Ok(()),
-            Self::Principal(account) if account.is_empty() => Err(TenantIdError::Empty),
-            Self::Principal(account) if account.len() > MAX_TENANT_ID_BYTES => {
-                Err(TenantIdError::TooLong(account.len()))
+            Self::Named(name) if name.is_empty() => Err(TenantIdError::Empty),
+            Self::Named(name) if name.len() > MAX_TENANT_ID_BYTES => {
+                Err(TenantIdError::TooLong(name.len()))
             }
-            Self::Principal(_) => Ok(()),
+            Self::Named(_) => Ok(()),
         }
     }
 }
@@ -94,7 +96,7 @@ impl TenantId {
 impl fmt::Display for TenantId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Principal(account) => f.write_str(account),
+            Self::Named(name) => f.write_str(name),
             Self::Unattributed => f.write_str(Self::UNATTRIBUTED_LABEL),
         }
     }
@@ -103,11 +105,11 @@ impl fmt::Display for TenantId {
 /// Why a tenant identifier is rejected at a trust boundary.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum TenantIdError {
-    /// An authenticated tenant carried an empty account.
-    #[error("tenant account is empty")]
+    /// A named tenant carried an empty name.
+    #[error("tenant name is empty")]
     Empty,
-    /// An authenticated tenant account exceeded the maximum tenant id length.
-    #[error("tenant account of {0} bytes exceeds the maximum tenant id length")]
+    /// A named tenant exceeded the maximum tenant id length.
+    #[error("tenant name of {0} bytes exceeds the maximum tenant id length")]
     TooLong(usize),
 }
 
@@ -116,29 +118,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn principal_carries_its_account() {
-        let tenant = TenantId::principal("acme");
-        assert_eq!(tenant.account(), Some("acme"));
+    fn named_carries_its_name() {
+        let tenant = TenantId::named("acme");
+        assert_eq!(tenant.name(), Some("acme"));
         assert!(!tenant.is_unattributed());
         assert_eq!(tenant.to_string(), "acme");
     }
 
     #[test]
-    fn unattributed_has_no_account() {
+    fn unattributed_has_no_name() {
         let tenant = TenantId::unattributed();
-        assert_eq!(tenant.account(), None);
+        assert_eq!(tenant.name(), None);
         assert!(tenant.is_unattributed());
         assert_eq!(tenant.to_string(), "unattributed");
     }
 
     #[test]
-    fn equality_is_by_account_and_never_conflates_unattributed() {
-        assert_eq!(TenantId::principal("a"), TenantId::principal("a"));
-        assert_ne!(TenantId::principal("a"), TenantId::principal("b"));
-        assert_ne!(TenantId::principal("a"), TenantId::Unattributed);
+    fn equality_is_by_name_and_never_conflates_unattributed() {
+        assert_eq!(TenantId::named("a"), TenantId::named("a"));
+        assert_ne!(TenantId::named("a"), TenantId::named("b"));
+        assert_ne!(TenantId::named("a"), TenantId::Unattributed);
         // A tenant literally named like the unattributed label is still a
-        // distinct authenticated tenant, not the reserved one.
-        let lookalike = TenantId::principal(TenantId::UNATTRIBUTED_LABEL);
+        // distinct named tenant, not the reserved one.
+        let lookalike = TenantId::named(TenantId::UNATTRIBUTED_LABEL);
         assert_ne!(lookalike, TenantId::Unattributed);
         assert!(!lookalike.is_unattributed());
     }
@@ -147,35 +149,32 @@ mod tests {
     fn usable_as_a_map_key() {
         use std::collections::HashMap;
         let mut counts: HashMap<TenantId, u64> = HashMap::new();
-        *counts.entry(TenantId::principal("a")).or_default() += 1;
-        *counts.entry(TenantId::principal("a")).or_default() += 1;
+        *counts.entry(TenantId::named("a")).or_default() += 1;
+        *counts.entry(TenantId::named("a")).or_default() += 1;
         *counts.entry(TenantId::unattributed()).or_default() += 1;
-        assert_eq!(counts[&TenantId::principal("a")], 2);
+        assert_eq!(counts[&TenantId::named("a")], 2);
         assert_eq!(counts[&TenantId::unattributed()], 1);
     }
 
     #[test]
-    fn validate_bounds_authenticated_accounts() {
+    fn validate_bounds_named_tenants() {
         assert_eq!(TenantId::unattributed().validate(), Ok(()));
-        assert_eq!(TenantId::principal("acme").validate(), Ok(()));
-        assert_eq!(
-            TenantId::principal("").validate(),
-            Err(TenantIdError::Empty)
-        );
+        assert_eq!(TenantId::named("acme").validate(), Ok(()));
+        assert_eq!(TenantId::named("").validate(), Err(TenantIdError::Empty));
         let overlong = "x".repeat(MAX_TENANT_ID_BYTES + 1);
         assert_eq!(
-            TenantId::principal(overlong).validate(),
+            TenantId::named(overlong).validate(),
             Err(TenantIdError::TooLong(MAX_TENANT_ID_BYTES + 1))
         );
         assert_eq!(
-            TenantId::principal("y".repeat(MAX_TENANT_ID_BYTES)).validate(),
+            TenantId::named("y".repeat(MAX_TENANT_ID_BYTES)).validate(),
             Ok(())
         );
     }
 
     #[test]
     fn serde_round_trips_both_variants() {
-        for tenant in [TenantId::principal("acme"), TenantId::unattributed()] {
+        for tenant in [TenantId::named("acme"), TenantId::unattributed()] {
             let encoded = serde_json::to_string(&tenant).unwrap();
             let decoded: TenantId = serde_json::from_str(&encoded).unwrap();
             assert_eq!(decoded, tenant);

--- a/crates/talon-core/src/tenant.rs
+++ b/crates/talon-core/src/tenant.rs
@@ -1,0 +1,184 @@
+//! Tenant identity for per-tenant quality-of-service.
+//!
+//! A *tenant* is the authenticated resource owner a request is attributed to
+//! when the cluster enforces per-tenant rate limits (and, later, cache quotas).
+//! Tenant identity originates at the object-store gateway, which resolves it
+//! from the request credential — the provider account established during
+//! authentication — and is propagated to workers on the data plane. Enforcement
+//! therefore keys on a non-forgeable identity derived from the authenticated
+//! request rather than on a client-supplied claim.
+//!
+//! Clients that connect directly to a worker and bypass the gateway — the FUSE
+//! mount and the native clients — present no credential. Their traffic is
+//! attributed to the reserved [`TenantId::Unattributed`] tenant so that it is
+//! still counted and bounded rather than silently escaping per-tenant policy.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Maximum length, in bytes, of a tenant account identifier.
+///
+/// Tenant ids are derived from a gateway-authenticated provider account and
+/// then travel through control-plane messages, serve as map keys on the hot
+/// path, and appear in bounded telemetry. A fixed ceiling keeps every one of
+/// those uses bounded regardless of the credential's contents.
+pub const MAX_TENANT_ID_BYTES: usize = 256;
+
+/// The authenticated resource owner a request is attributed to for QoS.
+///
+/// See the [module documentation](self) for how identity is established and why
+/// the unattributed tenant exists. `TenantId` is `Hash + Eq`, so it is used
+/// directly as a map key; two authenticated tenants are equal exactly when they
+/// name the same provider account.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TenantId {
+    /// An authenticated tenant, named by its gateway provider account.
+    Principal(String),
+    /// Traffic that arrived without an authenticated tenant — a direct client
+    /// that bypassed the gateway.
+    Unattributed,
+}
+
+impl TenantId {
+    /// Human-readable label for the [`TenantId::Unattributed`] tenant in logs,
+    /// the management API, and (allow-listed) telemetry.
+    pub const UNATTRIBUTED_LABEL: &'static str = "unattributed";
+
+    /// Construct a tenant from an authenticated provider account.
+    ///
+    /// The account is taken verbatim; call [`TenantId::validate`] at the trust
+    /// boundary to reject an empty or over-long value.
+    pub fn principal(account: impl Into<String>) -> Self {
+        Self::Principal(account.into())
+    }
+
+    /// The reserved tenant for traffic with no authenticated identity.
+    pub const fn unattributed() -> Self {
+        Self::Unattributed
+    }
+
+    /// Whether this is the reserved [`TenantId::Unattributed`] tenant.
+    pub fn is_unattributed(&self) -> bool {
+        matches!(self, Self::Unattributed)
+    }
+
+    /// The provider account backing an authenticated tenant, or `None` for the
+    /// unattributed tenant.
+    ///
+    /// Prefer matching on the tenant, or using it directly as a map key, over
+    /// flattening it to a string: two distinct tenants never share an account,
+    /// and the unattributed tenant deliberately has none.
+    pub fn account(&self) -> Option<&str> {
+        match self {
+            Self::Principal(account) => Some(account),
+            Self::Unattributed => None,
+        }
+    }
+
+    /// Validate a tenant established at a trust boundary.
+    ///
+    /// An authenticated tenant must carry a non-empty account no longer than
+    /// [`MAX_TENANT_ID_BYTES`]. The unattributed tenant is always valid.
+    pub fn validate(&self) -> Result<(), TenantIdError> {
+        match self {
+            Self::Unattributed => Ok(()),
+            Self::Principal(account) if account.is_empty() => Err(TenantIdError::Empty),
+            Self::Principal(account) if account.len() > MAX_TENANT_ID_BYTES => {
+                Err(TenantIdError::TooLong(account.len()))
+            }
+            Self::Principal(_) => Ok(()),
+        }
+    }
+}
+
+impl fmt::Display for TenantId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Principal(account) => f.write_str(account),
+            Self::Unattributed => f.write_str(Self::UNATTRIBUTED_LABEL),
+        }
+    }
+}
+
+/// Why a tenant identifier is rejected at a trust boundary.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TenantIdError {
+    /// An authenticated tenant carried an empty account.
+    #[error("tenant account is empty")]
+    Empty,
+    /// An authenticated tenant account exceeded the maximum tenant id length.
+    #[error("tenant account of {0} bytes exceeds the maximum tenant id length")]
+    TooLong(usize),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn principal_carries_its_account() {
+        let tenant = TenantId::principal("acme");
+        assert_eq!(tenant.account(), Some("acme"));
+        assert!(!tenant.is_unattributed());
+        assert_eq!(tenant.to_string(), "acme");
+    }
+
+    #[test]
+    fn unattributed_has_no_account() {
+        let tenant = TenantId::unattributed();
+        assert_eq!(tenant.account(), None);
+        assert!(tenant.is_unattributed());
+        assert_eq!(tenant.to_string(), "unattributed");
+    }
+
+    #[test]
+    fn equality_is_by_account_and_never_conflates_unattributed() {
+        assert_eq!(TenantId::principal("a"), TenantId::principal("a"));
+        assert_ne!(TenantId::principal("a"), TenantId::principal("b"));
+        assert_ne!(TenantId::principal("a"), TenantId::Unattributed);
+        // A tenant literally named like the unattributed label is still a
+        // distinct authenticated tenant, not the reserved one.
+        let lookalike = TenantId::principal(TenantId::UNATTRIBUTED_LABEL);
+        assert_ne!(lookalike, TenantId::Unattributed);
+        assert!(!lookalike.is_unattributed());
+    }
+
+    #[test]
+    fn usable_as_a_map_key() {
+        use std::collections::HashMap;
+        let mut counts: HashMap<TenantId, u64> = HashMap::new();
+        *counts.entry(TenantId::principal("a")).or_default() += 1;
+        *counts.entry(TenantId::principal("a")).or_default() += 1;
+        *counts.entry(TenantId::unattributed()).or_default() += 1;
+        assert_eq!(counts[&TenantId::principal("a")], 2);
+        assert_eq!(counts[&TenantId::unattributed()], 1);
+    }
+
+    #[test]
+    fn validate_bounds_authenticated_accounts() {
+        assert_eq!(TenantId::unattributed().validate(), Ok(()));
+        assert_eq!(TenantId::principal("acme").validate(), Ok(()));
+        assert_eq!(
+            TenantId::principal("").validate(),
+            Err(TenantIdError::Empty)
+        );
+        let overlong = "x".repeat(MAX_TENANT_ID_BYTES + 1);
+        assert_eq!(
+            TenantId::principal(overlong).validate(),
+            Err(TenantIdError::TooLong(MAX_TENANT_ID_BYTES + 1))
+        );
+        assert_eq!(
+            TenantId::principal("y".repeat(MAX_TENANT_ID_BYTES)).validate(),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn serde_round_trips_both_variants() {
+        for tenant in [TenantId::principal("acme"), TenantId::unattributed()] {
+            let encoded = serde_json::to_string(&tenant).unwrap();
+            let decoded: TenantId = serde_json::from_str(&encoded).unwrap();
+            assert_eq!(decoded, tenant);
+        }
+    }
+}

--- a/crates/talon-gateway/src/azure.rs
+++ b/crates/talon-gateway/src/azure.rs
@@ -1569,6 +1569,14 @@ fn cache_error(error: CacheReadError) -> AzureRequestError {
             indeterminate_commit: false,
         },
         CacheReadError::Origin(message) => AzureRequestError::origin_unavailable(message),
+        CacheReadError::RateLimited(message) => AzureRequestError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            code: "ServerBusy",
+            message,
+            failure: FailureReason::RateLimited,
+            content_range: None,
+            indeterminate_commit: false,
+        },
         CacheReadError::Protocol(message)
         | CacheReadError::Internal(message)
         | CacheReadError::Unknown(message) => AzureRequestError::internal(message),

--- a/crates/talon-gateway/src/model.rs
+++ b/crates/talon-gateway/src/model.rs
@@ -168,6 +168,8 @@ pub enum FailureReason {
     Internal,
     /// The operation is not in the advertised compatibility matrix.
     Unsupported,
+    /// The tenant exceeded its rate limit and was throttled.
+    RateLimited,
 }
 
 impl FailureReason {
@@ -183,6 +185,7 @@ impl FailureReason {
             Self::Origin => "origin",
             Self::Internal => "internal",
             Self::Unsupported => "unsupported",
+            Self::RateLimited => "rate_limited",
         }
     }
 }

--- a/crates/talon-gateway/src/s3.rs
+++ b/crates/talon-gateway/src/s3.rs
@@ -1752,6 +1752,14 @@ fn cache_error(error: CacheReadError) -> S3RequestError {
             indeterminate_commit: false,
         },
         CacheReadError::Origin(message) => S3RequestError::origin_unavailable(message),
+        CacheReadError::RateLimited(message) => S3RequestError {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            code: "SlowDown",
+            message,
+            failure: FailureReason::RateLimited,
+            content_range: None,
+            indeterminate_commit: false,
+        },
         CacheReadError::Protocol(message)
         | CacheReadError::Internal(message)
         | CacheReadError::Unknown(message) => S3RequestError::internal(message),

--- a/crates/talon-transport/src/data.rs
+++ b/crates/talon-transport/src/data.rs
@@ -12,7 +12,7 @@
 //! module only handles the request encode/decode and the response header shape.
 
 use serde::{Deserialize, Serialize};
-use talon_core::{BlockId, ObjectId, Version};
+use talon_core::{BlockId, ObjectId, TenantId, Version};
 
 use crate::frame::{Flags, FrameError, FrameHeader, MsgType, HEADER_LEN};
 
@@ -73,6 +73,19 @@ pub struct RangeRequest {
     pub offset: u64,
     /// Number of bytes to read.
     pub len: u64,
+}
+
+/// A [`RangeRequest`] annotated with the tenant it is attributed to.
+///
+/// Sent as a [`MsgType::GetRangeTenant`] frame so per-tenant QoS on the direct
+/// data plane keys on a client-declared tenant. The reply is an ordinary
+/// `GetRange` frame, identical to a plain request's.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TenantScopedRange {
+    /// The tenant this request is attributed to.
+    pub tenant: TenantId,
+    /// The underlying range request.
+    pub request: RangeRequest,
 }
 
 /// A cache-only range probe carrying the exact versioned cache identity.
@@ -181,6 +194,44 @@ pub fn decode_request(buf: &[u8]) -> Result<(FrameHeader, RangeRequest), DataErr
     }
     let req: RangeRequest = bincode::deserialize(body)?;
     Ok((header, req))
+}
+
+/// Encode a tenant-attributed range request as a [`MsgType::GetRangeTenant`]
+/// frame (`header || bincode(TenantScopedRange)`).
+///
+/// The reply is an ordinary `GetRange` frame, so a caller reads it back exactly
+/// as it reads a plain [`encode_request`] reply. A worker that predates
+/// per-tenant QoS rejects the distinct message type (fail-closed) rather than
+/// misreading the tenant prefix as part of the request, so this must be sent
+/// only to workers known to understand it.
+pub fn encode_tenant_request(
+    request_id: u32,
+    scoped: &TenantScopedRange,
+) -> Result<Vec<u8>, DataError> {
+    let body = bincode::serialize(scoped)?;
+    let header = FrameHeader::new(MsgType::GetRangeTenant, request_id, body.len() as u32);
+    let mut buf = Vec::with_capacity(HEADER_LEN + body.len());
+    buf.extend_from_slice(&header.encode());
+    buf.extend_from_slice(&body);
+    Ok(buf)
+}
+
+/// Decode a [`MsgType::GetRangeTenant`] frame into its header and scoped request.
+pub fn decode_tenant_request(buf: &[u8]) -> Result<(FrameHeader, TenantScopedRange), DataError> {
+    let header = FrameHeader::decode(buf)?;
+    if header.msg_type != MsgType::GetRangeTenant {
+        return Err(DataError::NotGetRange(header.msg_type));
+    }
+    let declared = header.length as usize;
+    let body = &buf[HEADER_LEN..];
+    if body.len() != declared {
+        return Err(DataError::LengthMismatch {
+            declared,
+            actual: body.len(),
+        });
+    }
+    let scoped = bincode::deserialize(body)?;
+    Ok((header, scoped))
 }
 
 /// Encode a cache-only range probe. Older workers reject its distinct message
@@ -435,6 +486,48 @@ mod tests {
         assert!(matches!(
             decode_request(&buf),
             Err(DataError::LengthMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn tenant_request_round_trips() {
+        let scoped = TenantScopedRange {
+            tenant: TenantId::named("acme"),
+            request: req(),
+        };
+        let buf = encode_tenant_request(5, &scoped).unwrap();
+        let header = FrameHeader::decode(&buf).unwrap();
+        assert_eq!(header.msg_type, MsgType::GetRangeTenant);
+        let (decoded_header, back) = decode_tenant_request(&buf).unwrap();
+        assert_eq!(decoded_header.request_id, 5);
+        assert_eq!(back, scoped);
+        assert_eq!(back.tenant, TenantId::named("acme"));
+    }
+
+    #[test]
+    fn unattributed_tenant_request_round_trips() {
+        let scoped = TenantScopedRange {
+            tenant: TenantId::unattributed(),
+            request: req(),
+        };
+        let buf = encode_tenant_request(1, &scoped).unwrap();
+        let (_header, back) = decode_tenant_request(&buf).unwrap();
+        assert_eq!(back.tenant, TenantId::unattributed());
+        assert_eq!(back.request, req());
+    }
+
+    #[test]
+    fn tenant_frame_is_not_misread_by_the_plain_range_decoder() {
+        // Fail-closed: the distinct message type means an older GetRange decoder
+        // rejects the frame rather than reading the tenant prefix as a request.
+        let scoped = TenantScopedRange {
+            tenant: TenantId::named("acme"),
+            request: req(),
+        };
+        let buf = encode_tenant_request(5, &scoped).unwrap();
+        assert!(matches!(
+            decode_request(&buf),
+            Err(DataError::NotGetRange(MsgType::GetRangeTenant))
         ));
     }
 

--- a/crates/talon-transport/src/data.rs
+++ b/crates/talon-transport/src/data.rs
@@ -104,6 +104,21 @@ pub struct CachedRangeRequest {
     pub len: u64,
 }
 
+/// A [`CachedRangeRequest`] annotated with the tenant it is attributed to.
+///
+/// Sent as a [`MsgType::GetCachedRangeTenant`] frame so resident-only reads on
+/// the direct data plane are still metered per tenant, closing the gap where a
+/// tenant could otherwise escape its limits whenever the version was resident.
+/// The reply is an ordinary `GetRange` frame, identical to a plain cached
+/// request's.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TenantScopedCachedRange {
+    /// The tenant this request is attributed to.
+    pub tenant: TenantId,
+    /// The underlying cache-only range request.
+    pub request: CachedRangeRequest,
+}
+
 /// A client→worker request to write a whole object (write-through, #226).
 ///
 /// This is the framed **header**; the raw object bytes (`body_len` of them)
@@ -267,6 +282,46 @@ pub fn decode_cached_request(buf: &[u8]) -> Result<(FrameHeader, CachedRangeRequ
     }
     let req = bincode::deserialize(body)?;
     Ok((header, req))
+}
+
+/// Encode a tenant-attributed cache-only range probe as a
+/// [`MsgType::GetCachedRangeTenant`] frame (`header || bincode(...)`).
+///
+/// Like [`encode_cached_request`] the reply is an ordinary `GetRange` frame, and
+/// like [`encode_tenant_request`] an older worker rejects this distinct message
+/// type (fail-closed) rather than misreading the tenant prefix, so it must be
+/// sent only to workers known to understand it.
+pub fn encode_cached_tenant_request(
+    request_id: u32,
+    scoped: &TenantScopedCachedRange,
+) -> Result<Vec<u8>, DataError> {
+    let body = bincode::serialize(scoped)?;
+    let header = FrameHeader::new(MsgType::GetCachedRangeTenant, request_id, body.len() as u32);
+    let mut buf = Vec::with_capacity(HEADER_LEN + body.len());
+    buf.extend_from_slice(&header.encode());
+    buf.extend_from_slice(&body);
+    Ok(buf)
+}
+
+/// Decode a [`MsgType::GetCachedRangeTenant`] frame into its header and scoped
+/// cache-only request.
+pub fn decode_cached_tenant_request(
+    buf: &[u8],
+) -> Result<(FrameHeader, TenantScopedCachedRange), DataError> {
+    let header = FrameHeader::decode(buf)?;
+    if header.msg_type != MsgType::GetCachedRangeTenant {
+        return Err(DataError::NotGetRange(header.msg_type));
+    }
+    let declared = header.length as usize;
+    let body = &buf[HEADER_LEN..];
+    if body.len() != declared {
+        return Err(DataError::LengthMismatch {
+            declared,
+            actual: body.len(),
+        });
+    }
+    let scoped = bincode::deserialize(body)?;
+    Ok((header, scoped))
 }
 
 /// Encode a [`PutRequest`] header into `header || bincode(req)`.
@@ -470,6 +525,46 @@ mod tests {
         assert_eq!(header.msg_type, MsgType::GetCachedRange);
         assert_eq!(header.request_id, 12);
         assert_eq!(decoded, request);
+    }
+
+    fn cached_req() -> CachedRangeRequest {
+        CachedRangeRequest {
+            object: req().object,
+            version: Version::new("etag-v9"),
+            offset: 5,
+            len: 9,
+        }
+    }
+
+    #[test]
+    fn cached_tenant_request_round_trips() {
+        let scoped = TenantScopedCachedRange {
+            tenant: TenantId::named("acme"),
+            request: cached_req(),
+        };
+        let buf = encode_cached_tenant_request(7, &scoped).unwrap();
+        let header = FrameHeader::decode(&buf).unwrap();
+        assert_eq!(header.msg_type, MsgType::GetCachedRangeTenant);
+        let (decoded_header, back) = decode_cached_tenant_request(&buf).unwrap();
+        assert_eq!(decoded_header.request_id, 7);
+        assert_eq!(back, scoped);
+        assert_eq!(back.tenant, TenantId::named("acme"));
+    }
+
+    #[test]
+    fn cached_tenant_frame_is_not_misread_by_the_plain_cached_decoder() {
+        // Fail-closed: the distinct message type means an older cache-only
+        // decoder rejects the frame rather than reading the tenant prefix as a
+        // CachedRangeRequest.
+        let scoped = TenantScopedCachedRange {
+            tenant: TenantId::named("acme"),
+            request: cached_req(),
+        };
+        let buf = encode_cached_tenant_request(1, &scoped).unwrap();
+        assert!(matches!(
+            decode_cached_request(&buf),
+            Err(DataError::NotGetRange(MsgType::GetCachedRangeTenant))
+        ));
     }
 
     #[test]

--- a/crates/talon-transport/src/data.rs
+++ b/crates/talon-transport/src/data.rs
@@ -39,6 +39,9 @@ pub enum DataErrorCode {
     Origin,
     /// The worker encountered an internal or protocol failure.
     Internal,
+    /// The tenant exceeded its configured rate limit; the caller should back off
+    /// and retry. Added last so existing discriminants are unchanged.
+    RateLimited,
 }
 
 /// A decoded data-plane error, including legacy string-only replies.

--- a/crates/talon-transport/src/frame.rs
+++ b/crates/talon-transport/src/frame.rs
@@ -64,6 +64,12 @@ pub enum MsgType {
     /// Admit one complete, versioned block into the worker cache without
     /// accessing the configured backend.
     AdmitCachedBlock = 7,
+    /// A sub-range fetch that declares the tenant it is attributed to, for
+    /// per-tenant QoS (a bincode
+    /// [`TenantScopedRange`](crate::data::TenantScopedRange) header). The reply
+    /// is an ordinary `GetRange` frame; an older worker rejects this distinct
+    /// type rather than misreading the tenant prefix as part of the request.
+    GetRangeTenant = 8,
 }
 
 impl MsgType {
@@ -78,6 +84,7 @@ impl MsgType {
             5 => MsgType::Delete,
             6 => MsgType::GetCachedRange,
             7 => MsgType::AdmitCachedBlock,
+            8 => MsgType::GetRangeTenant,
             other => return Err(FrameError::UnknownMsgType(other)),
         })
     }
@@ -220,6 +227,7 @@ mod tests {
             MsgType::Delete,
             MsgType::GetCachedRange,
             MsgType::AdmitCachedBlock,
+            MsgType::GetRangeTenant,
         ]
         .into_iter()
         .enumerate()

--- a/crates/talon-transport/src/frame.rs
+++ b/crates/talon-transport/src/frame.rs
@@ -70,6 +70,14 @@ pub enum MsgType {
     /// is an ordinary `GetRange` frame; an older worker rejects this distinct
     /// type rather than misreading the tenant prefix as part of the request.
     GetRangeTenant = 8,
+    /// A cache-only versioned range fetch that declares the tenant it is
+    /// attributed to (a bincode
+    /// [`TenantScopedCachedRange`](crate::data::TenantScopedCachedRange) header),
+    /// so resident-only reads are still metered per tenant. Like
+    /// `GetCachedRange` it must never access the worker backend, and like
+    /// `GetRangeTenant` an older worker rejects this distinct type rather than
+    /// misreading the tenant prefix.
+    GetCachedRangeTenant = 9,
 }
 
 impl MsgType {
@@ -85,6 +93,7 @@ impl MsgType {
             6 => MsgType::GetCachedRange,
             7 => MsgType::AdmitCachedBlock,
             8 => MsgType::GetRangeTenant,
+            9 => MsgType::GetCachedRangeTenant,
             other => return Err(FrameError::UnknownMsgType(other)),
         })
     }
@@ -228,6 +237,7 @@ mod tests {
             MsgType::GetCachedRange,
             MsgType::AdmitCachedBlock,
             MsgType::GetRangeTenant,
+            MsgType::GetCachedRangeTenant,
         ]
         .into_iter()
         .enumerate()

--- a/crates/talon-transport/src/lib.rs
+++ b/crates/talon-transport/src/lib.rs
@@ -28,8 +28,8 @@ pub use data::{
     encode_cached_block_put_header, encode_cached_request, encode_cached_tenant_request,
     encode_delete, encode_error, encode_put_header, encode_request, encode_tenant_request,
     encode_typed_error, response_header_ok, CachedBlockPutRequest, CachedRangeRequest, DataError,
-    DataErrorCode, DataPlaneError, DeleteRequest, PutRequest, RangeRequest, TenantScopedCachedRange,
-    TenantScopedRange,
+    DataErrorCode, DataPlaneError, DeleteRequest, PutRequest, RangeRequest,
+    TenantScopedCachedRange, TenantScopedRange,
 };
 pub use frame::{Flags, FrameError, FrameHeader, MsgType, HEADER_LEN, MAGIC, PROTOCOL_VERSION};
 pub use limits::{

--- a/crates/talon-transport/src/lib.rs
+++ b/crates/talon-transport/src/lib.rs
@@ -24,10 +24,11 @@ pub use codec::{
 };
 pub use data::{
     decode_cached_block_put_header, decode_cached_request, decode_delete, decode_error_payload,
-    decode_put_header, decode_request, encode_cached_block_put_header, encode_cached_request,
-    encode_delete, encode_error, encode_put_header, encode_request, encode_typed_error,
-    response_header_ok, CachedBlockPutRequest, CachedRangeRequest, DataError, DataErrorCode,
-    DataPlaneError, DeleteRequest, PutRequest, RangeRequest,
+    decode_put_header, decode_request, decode_tenant_request, encode_cached_block_put_header,
+    encode_cached_request, encode_delete, encode_error, encode_put_header, encode_request,
+    encode_tenant_request, encode_typed_error, response_header_ok, CachedBlockPutRequest,
+    CachedRangeRequest, DataError, DataErrorCode, DataPlaneError, DeleteRequest, PutRequest,
+    RangeRequest, TenantScopedRange,
 };
 pub use frame::{Flags, FrameError, FrameHeader, MsgType, HEADER_LEN, MAGIC, PROTOCOL_VERSION};
 pub use limits::{

--- a/crates/talon-transport/src/lib.rs
+++ b/crates/talon-transport/src/lib.rs
@@ -23,12 +23,13 @@ pub use codec::{
     CONTROL_SCHEMA_VERSION, MIN_CONTROL_SCHEMA_VERSION,
 };
 pub use data::{
-    decode_cached_block_put_header, decode_cached_request, decode_delete, decode_error_payload,
-    decode_put_header, decode_request, decode_tenant_request, encode_cached_block_put_header,
-    encode_cached_request, encode_delete, encode_error, encode_put_header, encode_request,
-    encode_tenant_request, encode_typed_error, response_header_ok, CachedBlockPutRequest,
-    CachedRangeRequest, DataError, DataErrorCode, DataPlaneError, DeleteRequest, PutRequest,
-    RangeRequest, TenantScopedRange,
+    decode_cached_block_put_header, decode_cached_request, decode_cached_tenant_request,
+    decode_delete, decode_error_payload, decode_put_header, decode_request, decode_tenant_request,
+    encode_cached_block_put_header, encode_cached_request, encode_cached_tenant_request,
+    encode_delete, encode_error, encode_put_header, encode_request, encode_tenant_request,
+    encode_typed_error, response_header_ok, CachedBlockPutRequest, CachedRangeRequest, DataError,
+    DataErrorCode, DataPlaneError, DeleteRequest, PutRequest, RangeRequest, TenantScopedCachedRange,
+    TenantScopedRange,
 };
 pub use frame::{Flags, FrameError, FrameHeader, MsgType, HEADER_LEN, MAGIC, PROTOCOL_VERSION};
 pub use limits::{

--- a/crates/talon-transport/src/limits.rs
+++ b/crates/talon-transport/src/limits.rs
@@ -48,9 +48,11 @@ pub fn max_payload_for(msg_type: MsgType) -> u32 {
     match msg_type {
         MsgType::Control => MAX_CONTROL_PAYLOAD_LEN,
         MsgType::Ping => MAX_PING_PAYLOAD_LEN,
-        MsgType::Put | MsgType::Delete | MsgType::GetCachedRange | MsgType::AdmitCachedBlock => {
-            MAX_CONTROL_PAYLOAD_LEN
-        }
+        MsgType::Put
+        | MsgType::Delete
+        | MsgType::GetCachedRange
+        | MsgType::AdmitCachedBlock
+        | MsgType::GetRangeTenant => MAX_CONTROL_PAYLOAD_LEN,
         MsgType::Get | MsgType::GetRange => MAX_PAYLOAD_LEN,
     }
 }

--- a/crates/talon-transport/src/limits.rs
+++ b/crates/talon-transport/src/limits.rs
@@ -52,7 +52,8 @@ pub fn max_payload_for(msg_type: MsgType) -> u32 {
         | MsgType::Delete
         | MsgType::GetCachedRange
         | MsgType::AdmitCachedBlock
-        | MsgType::GetRangeTenant => MAX_CONTROL_PAYLOAD_LEN,
+        | MsgType::GetRangeTenant
+        | MsgType::GetCachedRangeTenant => MAX_CONTROL_PAYLOAD_LEN,
         MsgType::Get | MsgType::GetRange => MAX_PAYLOAD_LEN,
     }
 }

--- a/crates/talon-worker/Cargo.toml
+++ b/crates/talon-worker/Cargo.toml
@@ -65,5 +65,9 @@ tokio = { workspace = true, features = ["test-util"] }
 name = "dataplane_benches"
 harness = false
 
+[[bench]]
+name = "rate_limit_benches"
+harness = false
+
 [build-dependencies]
 prost-build.workspace = true

--- a/crates/talon-worker/benches/rate_limit_benches.rs
+++ b/crates/talon-worker/benches/rate_limit_benches.rs
@@ -1,0 +1,114 @@
+//! Microbenchmarks for the per-tenant rate limiter's hot-path overhead.
+//!
+//! [`TenantRateLimiter::admit`] runs on the data plane once per read, so its
+//! cost is pure overhead on every request. These measure that overhead —
+//! disabled vs enabled, one metric vs two, one tenant vs many — and the
+//! same-tenant contention behaviour, since the design's claim is that the
+//! io_uring rings never serialize on a global QoS lock (the limiter is one
+//! lock-free GCRA cell per `(tenant, metric)`, so concurrent admits are a single
+//! atomic CAS, and worst-case contention is a CAS retry, never a blocked thread).
+//!
+//! To isolate the admitted-path cost from the (cheaper) throttle path, the
+//! enabled limiters use an enormous burst so they always admit; the throttle
+//! path does strictly less work (an atomic load and compare, no successful CAS).
+//!
+//! Run: `cargo bench -p talon-worker --bench rate_limit_benches`.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use talon_core::{MetricLimits, RateLimit, RateLimitPolicy, TenantId};
+use talon_worker::TenantRateLimiter;
+
+fn main() {
+    divan::main();
+}
+
+/// A representative response size charged against read_throughput.
+const READ_BYTES: u64 = 64 * 1024;
+
+/// A limiter whose burst is so large it always admits, so a bench measures the
+/// admitted path (map lookup + GCRA CAS per configured metric).
+fn always_admits(iops: bool, throughput: bool) -> TenantRateLimiter {
+    // A huge burst_ratio saturates the GCRA tolerance, so no charge ever throttles.
+    let limit = RateLimit::new(1_000_000, 1.0e15).unwrap();
+    TenantRateLimiter::new(RateLimitPolicy {
+        enabled: true,
+        default: MetricLimits {
+            read_iops: iops.then_some(limit),
+            read_throughput: throughput.then_some(limit),
+        },
+        overrides: HashMap::new(),
+    })
+}
+
+/// Baseline: a disabled limiter returns immediately after the enabled check.
+#[divan::bench]
+fn admit_disabled(bencher: divan::Bencher) {
+    let limiter = TenantRateLimiter::disabled();
+    let tenant = TenantId::named("t");
+    bencher.bench(|| limiter.admit(divan::black_box(&tenant), divan::black_box(READ_BYTES)));
+}
+
+/// Enabled with only a read_iops limit: one warm map lookup + one GCRA charge.
+#[divan::bench]
+fn admit_iops_only(bencher: divan::Bencher) {
+    let limiter = always_admits(true, false);
+    let tenant = TenantId::named("t");
+    let _ = limiter.admit(&tenant, READ_BYTES); // warm the tenant entry
+    bencher.bench(|| limiter.admit(divan::black_box(&tenant), divan::black_box(READ_BYTES)));
+}
+
+/// The full hot path: both read_iops and read_throughput limited (two charges).
+#[divan::bench]
+fn admit_iops_and_throughput(bencher: divan::Bencher) {
+    let limiter = always_admits(true, true);
+    let tenant = TenantId::named("t");
+    let _ = limiter.admit(&tenant, READ_BYTES);
+    bencher.bench(|| limiter.admit(divan::black_box(&tenant), divan::black_box(READ_BYTES)));
+}
+
+/// Steady-state cost when the map holds many tenants and requests rotate over
+/// them (measures lookup + cache behaviour, not first-insert).
+#[divan::bench(args = [64, 1024])]
+fn admit_across_tenants(bencher: divan::Bencher, tenants: usize) {
+    let limiter = always_admits(true, true);
+    let ids: Vec<TenantId> = (0..tenants)
+        .map(|i| TenantId::named(format!("tenant-{i}")))
+        .collect();
+    for id in &ids {
+        let _ = limiter.admit(id, READ_BYTES); // warm every entry
+    }
+    let cursor = AtomicUsize::new(0);
+    bencher.bench(|| {
+        let idx = cursor.fetch_add(1, Ordering::Relaxed) % ids.len();
+        limiter.admit(divan::black_box(&ids[idx]), divan::black_box(READ_BYTES))
+    });
+}
+
+/// Contention: every thread hammers ONE tenant, so all admits contend on a
+/// single GCRA atomic. Lock-free — the worst case is a CAS retry, never a
+/// blocked thread — so this shows how the single-atomic cell degrades under
+/// concurrency rather than whether it serializes.
+#[divan::bench(threads = [1, 4, 8, 16])]
+fn admit_same_tenant_contended(bencher: divan::Bencher) {
+    let limiter = always_admits(true, true);
+    let tenant = TenantId::named("hot");
+    let _ = limiter.admit(&tenant, READ_BYTES);
+    bencher.bench(|| limiter.admit(divan::black_box(&tenant), divan::black_box(READ_BYTES)));
+}
+
+/// Contention control: each thread uses a distinct tenant (a thread-local id),
+/// so admits touch independent atoms and should scale without cross-thread
+/// interference — the counterpoint to the single-tenant contention above.
+#[divan::bench(threads = [1, 4, 8, 16])]
+fn admit_distinct_tenants_scaled(bencher: divan::Bencher) {
+    thread_local! {
+        static TENANT: TenantId =
+            TenantId::named(format!("t-{:?}", std::thread::current().id()));
+    }
+    let limiter = always_admits(true, true);
+    bencher.bench(|| {
+        TENANT.with(|t| limiter.admit(divan::black_box(t), divan::black_box(READ_BYTES)))
+    });
+}

--- a/crates/talon-worker/src/lib.rs
+++ b/crates/talon-worker/src/lib.rs
@@ -17,6 +17,7 @@ pub mod memory_store;
 pub mod miss;
 pub mod observability;
 pub mod paged_store;
+pub mod rate_limit;
 pub mod runtime;
 pub mod sendfile;
 pub mod splice;
@@ -39,6 +40,7 @@ pub use memory_store::{MemoryInsert, MemoryPageKey, MemoryStore};
 pub use miss::{touched_pages, Admission, InFlightGuard, InFlightLoads, LoadKey};
 pub use observability::{serve_admin, WorkerMetrics, WorkerObservability, WorkerReadiness};
 pub use paged_store::PagedBlockStore;
+pub use rate_limit::{TenantRateLimiter, Throttled};
 pub use runtime::{ServeOutcome, WorkerRuntime};
 pub use sendfile::{
     send_file_range, send_header_and_file_range, send_header_and_file_ranges, DEFAULT_CHUNK,

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -42,8 +42,8 @@ use talon_worker::mapping_guard::MappingGuard;
 use talon_worker::tokio_conn::{handle_conn, read_control};
 use talon_worker::uring_conn;
 use talon_worker::{
-    serve_admin, BlockIndex, InFlightLoads, PagedBlockStore, WholeBlockStore, WorkerObservability,
-    WorkerRuntime,
+    serve_admin, BlockIndex, InFlightLoads, PagedBlockStore, TenantRateLimiter, WholeBlockStore,
+    WorkerObservability, WorkerRuntime,
 };
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -193,6 +193,8 @@ impl Args {
             s3_access_key_id: None,
             s3_path_style: None,
             gcs_endpoint: None,
+            // The [rate_limits] table is file-only; the CLI leaves it unset.
+            rate_limits: None,
         }
     }
 }
@@ -592,7 +594,11 @@ async fn main() -> anyhow::Result<()> {
         observability.metrics().clone(),
     )
     .with_backend_kind(configured_backend)
-    .with_paged_miss_run_concurrency(cfg.paged_miss_run_concurrency);
+    .with_paged_miss_run_concurrency(cfg.paged_miss_run_concurrency)
+    .with_rate_limiter(Arc::new(TenantRateLimiter::new(cfg.rate_limits.clone())));
+    if cfg.rate_limits.enabled {
+        tracing::info!("worker per-tenant rate limiting enabled");
+    }
     if let Some(paged) = paged {
         runtime = runtime.with_paged_store(paged);
     }

--- a/crates/talon-worker/src/observability.rs
+++ b/crates/talon-worker/src/observability.rs
@@ -16,7 +16,7 @@ use axum::{Json, Router};
 use talon_core::metrics::labels;
 use talon_core::{
     Counter, Gauge, Histogram, Metrics, NodeHealth, NodeInfo, NodeMetricsSnapshot, NodeStatus,
-    NODE_STATUS_SCHEMA_VERSION,
+    RateMetric, NODE_STATUS_SCHEMA_VERSION,
 };
 use tokio::net::TcpListener;
 
@@ -323,6 +323,22 @@ impl WorkerMetrics {
         self.requests_total.inc();
         self.request_errors_total.inc();
         self.request_duration_seconds.observe(elapsed.as_secs_f64());
+    }
+
+    /// Record a request rejected by per-tenant rate limiting.
+    ///
+    /// Labelled only by the exceeded metric, never by tenant, to keep the series
+    /// bounded; per-tenant drill-down is a management-API concern. A throttle is
+    /// a distinct outcome from success or error, so it does not touch the
+    /// request success/error counters.
+    pub fn record_rate_limited(&self, metric: RateMetric) {
+        self.registry
+            .counter(
+                "talon_worker_rate_limited_total",
+                "Requests rejected by per-tenant rate limiting, by exceeded metric.",
+                labels(&[("metric", metric.label())]),
+            )
+            .inc();
     }
 
     /// Record a whole-block cache hit.

--- a/crates/talon-worker/src/rate_limit.rs
+++ b/crates/talon-worker/src/rate_limit.rs
@@ -349,8 +349,12 @@ mod tests {
         // Each must be capped at its own rate — a greedy tenant never borrows
         // another's budget, and a small tenant is not dragged up by a large one.
         let mut policy = iops_policy(1000, 1.0); // "a" falls back to this default
-        policy.overrides.insert("vip".to_string(), iops_override(5000, 1.0));
-        policy.overrides.insert("tiny".to_string(), iops_override(100, 1.0));
+        policy
+            .overrides
+            .insert("vip".to_string(), iops_override(5000, 1.0));
+        policy
+            .overrides
+            .insert("tiny".to_string(), iops_override(100, 1.0));
         let limiter = TenantRateLimiter::new(policy);
 
         // (tenant, configured rate/s).
@@ -397,7 +401,9 @@ mod tests {
         // confirms each tenant is throttled near its own rate — nowhere near the
         // millions of calls each thread actually offers.
         let mut policy = iops_policy(2000, 1.0);
-        policy.overrides.insert("vip".to_string(), iops_override(8000, 1.0));
+        policy
+            .overrides
+            .insert("vip".to_string(), iops_override(8000, 1.0));
         let limiter = std::sync::Arc::new(TenantRateLimiter::new(policy));
 
         let window = Duration::from_millis(300);

--- a/crates/talon-worker/src/rate_limit.rs
+++ b/crates/talon-worker/src/rate_limit.rs
@@ -13,7 +13,7 @@
 //! into the cache-miss path).
 
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
 use talon_core::{Gcra, MetricLimits, RateDecision, RateLimitPolicy, RateMetric, TenantId};
@@ -31,6 +31,27 @@ impl TenantCells {
             read_iops: limits.read_iops.map(Gcra::new),
             read_throughput: limits.read_throughput.map(Gcra::new),
         }
+    }
+
+    /// Charge one read of `read_bytes` against this tenant's cells.
+    fn charge(&self, read_bytes: u64, now_nanos: u64) -> Result<(), Throttled> {
+        if let Some(cell) = &self.read_iops {
+            if let RateDecision::Throttled { retry_after } = cell.charge_at(1, now_nanos) {
+                return Err(Throttled {
+                    metric: RateMetric::ReadIops,
+                    retry_after,
+                });
+            }
+        }
+        if let Some(cell) = &self.read_throughput {
+            if let RateDecision::Throttled { retry_after } = cell.charge_at(read_bytes, now_nanos) {
+                return Err(Throttled {
+                    metric: RateMetric::ReadThroughput,
+                    retry_after,
+                });
+            }
+        }
+        Ok(())
     }
 }
 
@@ -51,7 +72,7 @@ pub struct TenantRateLimiter {
     origin: Instant,
     /// Lazily-created per-tenant cells. A read lock covers the common warm
     /// lookup; the write lock is taken only the first time a tenant is seen.
-    cells: RwLock<HashMap<TenantId, Arc<TenantCells>>>,
+    cells: RwLock<HashMap<TenantId, TenantCells>>,
 }
 
 impl TenantRateLimiter {
@@ -77,6 +98,10 @@ impl TenantRateLimiter {
     /// Charge one read request expected to return `read_bytes` bytes against
     /// `tenant`, returning [`Throttled`] if it would exceed a configured limit.
     pub fn admit(&self, tenant: &TenantId, read_bytes: u64) -> Result<(), Throttled> {
+        // Skip the clock read entirely when the feature is off.
+        if !self.policy.enabled {
+            return Ok(());
+        }
         self.admit_at(tenant, read_bytes, self.now_nanos())
     }
 
@@ -94,38 +119,18 @@ impl TenantRateLimiter {
         if !self.policy.enabled {
             return Ok(());
         }
-        let cells = self.cells_for(tenant);
-        if let Some(cell) = &cells.read_iops {
-            if let RateDecision::Throttled { retry_after } = cell.charge_at(1, now_nanos) {
-                return Err(Throttled {
-                    metric: RateMetric::ReadIops,
-                    retry_after,
-                });
-            }
-        }
-        if let Some(cell) = &cells.read_throughput {
-            if let RateDecision::Throttled { retry_after } = cell.charge_at(read_bytes, now_nanos) {
-                return Err(Throttled {
-                    metric: RateMetric::ReadThroughput,
-                    retry_after,
-                });
-            }
-        }
-        Ok(())
-    }
-
-    fn cells_for(&self, tenant: &TenantId) -> Arc<TenantCells> {
+        // Fast path: a warm tenant is charged in place under a shared read lock,
+        // so admits for different tenants never block each other and the
+        // same-tenant case is a single atomic CAS with no allocation or clone.
         if let Some(cells) = self.cells.read().unwrap().get(tenant) {
-            return Arc::clone(cells);
+            return cells.charge(read_bytes, now_nanos);
         }
-        let mut cells = self.cells.write().unwrap();
-        // Re-check: another task may have inserted between the two locks.
-        if let Some(existing) = cells.get(tenant) {
-            return Arc::clone(existing);
-        }
-        let created = Arc::new(TenantCells::from_limits(&self.policy.limits_for(tenant)));
-        cells.insert(tenant.clone(), Arc::clone(&created));
-        created
+        // Slow path (first time this tenant is seen): insert, then charge. The
+        // brief write lock is paid once per tenant, not per request.
+        let mut map = self.cells.write().unwrap();
+        map.entry(tenant.clone())
+            .or_insert_with(|| TenantCells::from_limits(&self.policy.limits_for(tenant)))
+            .charge(read_bytes, now_nanos)
     }
 
     fn now_nanos(&self) -> u64 {
@@ -229,5 +234,35 @@ mod tests {
         // ...the next byte is throttled on throughput, not iops.
         let throttled = limiter.admit_at(&tenant, 1, 0).unwrap_err();
         assert_eq!(throttled.metric, RateMetric::ReadThroughput);
+    }
+
+    #[test]
+    fn caps_the_sustained_rate_under_overload() {
+        // Capability: at read_iops rate 1000/s (burst 1000), offer 10x the rate
+        // across a simulated second and confirm the admitted count is the burst
+        // plus one second of the sustained rate (~2000), not the 10_000 offered.
+        let limiter = TenantRateLimiter::new(iops_policy(1000, 1.0));
+        let tenant = TenantId::named("a");
+        let offered = 10_000u64;
+        let mut admitted = 0u64;
+        // 1000 steps of 1ms across ~1s; 10 requests offered per step.
+        for step in 0..1000u64 {
+            let now = step * 1_000_000; // ns
+            for _ in 0..10 {
+                if limiter.admit_at(&tenant, 0, now).is_ok() {
+                    admitted += 1;
+                }
+            }
+        }
+        // The rate is capped far below the offered load...
+        assert!(
+            admitted < offered / 2,
+            "admitted {admitted} of {offered} offered"
+        );
+        // ...and close to burst (1000) + one second of rate (1000) = ~2000.
+        assert!(
+            (1800..=2200).contains(&admitted),
+            "admitted {admitted}, expected ~2000 (burst + 1s of rate)"
+        );
     }
 }

--- a/crates/talon-worker/src/rate_limit.rs
+++ b/crates/talon-worker/src/rate_limit.rs
@@ -64,24 +64,67 @@ pub struct Throttled {
     pub retry_after: Duration,
 }
 
+/// The maximum number of distinct tenants that get their own dedicated GCRA
+/// cells on one worker.
+///
+/// The direct data plane is unauthenticated, so a client can declare
+/// arbitrarily many distinct tenant names; without a ceiling the cell map would
+/// grow without bound — a memory-exhaustion vector. Tenants first seen beyond
+/// this cap share a single overflow cell governed by the default limit, so
+/// memory stays bounded while the (almost certainly abusive or misconfigured)
+/// excess is still paced. Configured overrides are pre-created and never lost to
+/// the cap.
+const MAX_TENANT_CELLS: usize = 4096;
+
 /// Worker-global, `Arc`-shared per-tenant limiter.
 #[derive(Debug)]
 pub struct TenantRateLimiter {
     policy: RateLimitPolicy,
     /// Monotonic clock origin; GCRA cells advance in nanoseconds from here.
     origin: Instant,
-    /// Lazily-created per-tenant cells. A read lock covers the common warm
-    /// lookup; the write lock is taken only the first time a tenant is seen.
+    /// Per-tenant cells: created eagerly for configured overrides and lazily for
+    /// default-governed tenants. A read lock covers the common warm lookup; the
+    /// write lock is taken only the first time a default-governed tenant is
+    /// seen. Bounded at `max_cells` entries (see [`MAX_TENANT_CELLS`]).
     cells: RwLock<HashMap<TenantId, TenantCells>>,
+    /// Shared fallback cell for tenants first seen after the cap is reached,
+    /// governed by the default limit. `None` when the default limits nothing
+    /// (then default-governed tenants are admitted without a cell at all).
+    overflow: Option<TenantCells>,
+    /// Ceiling on the number of distinct tenant cells (see [`MAX_TENANT_CELLS`]).
+    max_cells: usize,
 }
 
 impl TenantRateLimiter {
     /// Build a limiter from a static local policy.
     pub fn new(policy: RateLimitPolicy) -> Self {
+        Self::with_max_cells(policy, MAX_TENANT_CELLS)
+    }
+
+    /// Build a limiter with an explicit cardinality cap (see
+    /// [`MAX_TENANT_CELLS`]); [`new`](Self::new) uses the default.
+    ///
+    /// Overrides are pre-created so each is honored regardless of arrival order
+    /// and never lost to the cap, and a shared overflow cell is prepared when
+    /// the default limits anything.
+    fn with_max_cells(policy: RateLimitPolicy, max_cells: usize) -> Self {
+        let mut cells = HashMap::new();
+        for (name, limits) in &policy.overrides {
+            if !limits.is_empty() {
+                cells.insert(
+                    TenantId::named(name.clone()),
+                    TenantCells::from_limits(limits),
+                );
+            }
+        }
+        let overflow =
+            (!policy.default.is_empty()).then(|| TenantCells::from_limits(&policy.default));
         Self {
             policy,
             origin: Instant::now(),
-            cells: RwLock::new(HashMap::new()),
+            cells: RwLock::new(cells),
+            overflow,
+            max_cells,
         }
     }
 
@@ -119,18 +162,43 @@ impl TenantRateLimiter {
         if !self.policy.enabled {
             return Ok(());
         }
-        // Fast path: a warm tenant is charged in place under a shared read lock,
+        // Fast path: a warm tenant (an override or a previously-seen
+        // default-governed tenant) is charged in place under a shared read lock,
         // so admits for different tenants never block each other and the
         // same-tenant case is a single atomic CAS with no allocation or clone.
         if let Some(cells) = self.cells.read().unwrap().get(tenant) {
             return cells.charge(read_bytes, now_nanos);
         }
-        // Slow path (first time this tenant is seen): insert, then charge. The
-        // brief write lock is paid once per tenant, not per request.
+        // Unseen tenant. If nothing limits it, admit without allocating a cell;
+        // this also keeps an empty default from ever growing the map.
+        let limits = self.policy.limits_for(tenant);
+        if limits.is_empty() {
+            return Ok(());
+        }
+        // Otherwise give it a dedicated cell — unless the cardinality cap is
+        // reached, in which case fall back to the shared overflow cell so the
+        // unauthenticated map cannot grow without bound.
         let mut map = self.cells.write().unwrap();
-        map.entry(tenant.clone())
-            .or_insert_with(|| TenantCells::from_limits(&self.policy.limits_for(tenant)))
-            .charge(read_bytes, now_nanos)
+        // Re-check under the write lock: another thread may have inserted.
+        if let Some(cells) = map.get(tenant) {
+            return cells.charge(read_bytes, now_nanos);
+        }
+        if map.len() < self.max_cells {
+            return map
+                .entry(tenant.clone())
+                .or_insert_with(|| TenantCells::from_limits(&limits))
+                .charge(read_bytes, now_nanos);
+        }
+        drop(map);
+        match &self.overflow {
+            Some(overflow) => overflow.charge(read_bytes, now_nanos),
+            None => Ok(()),
+        }
+    }
+
+    #[cfg(test)]
+    fn cell_count(&self) -> usize {
+        self.cells.read().unwrap().len()
     }
 
     fn now_nanos(&self) -> u64 {
@@ -264,5 +332,69 @@ mod tests {
             (1800..=2200).contains(&admitted),
             "admitted {admitted}, expected ~2000 (burst + 1s of rate)"
         );
+    }
+
+    #[test]
+    fn empty_limits_admit_without_allocating_a_cell() {
+        // Enabled, but nothing configured (empty default, no overrides): every
+        // tenant is admitted and no cell is ever created, so distinct tenant
+        // names cannot grow worker memory.
+        let limiter = TenantRateLimiter::new(RateLimitPolicy {
+            enabled: true,
+            default: MetricLimits::default(),
+            overrides: HashMap::new(),
+        });
+        for i in 0..1000 {
+            assert!(limiter
+                .admit_at(&TenantId::named(format!("t{i}")), 0, 0)
+                .is_ok());
+        }
+        assert_eq!(limiter.cell_count(), 0);
+    }
+
+    #[test]
+    fn bounds_cardinality_and_overflows_to_a_shared_cell() {
+        // A non-empty default with a tiny cap: only `max_cells` distinct tenants
+        // get their own cell; further tenants share the overflow cell, so the
+        // unauthenticated map cannot grow past the cap.
+        let limiter = TenantRateLimiter::with_max_cells(iops_policy(1, 1.0), 2);
+        // Two distinct tenants each get a dedicated cell (fresh burst each).
+        assert!(limiter.admit_at(&TenantId::named("t0"), 0, 0).is_ok());
+        assert!(limiter.admit_at(&TenantId::named("t1"), 0, 0).is_ok());
+        assert_eq!(limiter.cell_count(), 2);
+        // A third distinct tenant does not grow the map — it shares the overflow
+        // cell, and is admitted on the overflow cell's own fresh burst...
+        assert!(limiter.admit_at(&TenantId::named("t2"), 0, 0).is_ok());
+        assert_eq!(limiter.cell_count(), 2);
+        // ...while a fourth overflow tenant is throttled, because it shares that
+        // now-drained overflow cell (rate 1) rather than getting its own burst.
+        assert!(limiter.admit_at(&TenantId::named("t3"), 0, 0).is_err());
+        assert_eq!(limiter.cell_count(), 2);
+    }
+
+    #[test]
+    fn overrides_are_pre_created_and_exempt_from_the_cap() {
+        // With the cap already reached by dynamic tenants, a configured override
+        // is still honored (it was pre-created), not shunted to the overflow.
+        let mut policy = iops_policy(1, 1.0);
+        policy.overrides.insert(
+            "vip".to_string(),
+            MetricLimits {
+                read_iops: Some(talon_core::RateLimit::new(10, 1.0).unwrap()),
+                read_throughput: None,
+            },
+        );
+        // Cap of 1, already consumed by the pre-created override cell.
+        let limiter = TenantRateLimiter::with_max_cells(policy, 1);
+        assert_eq!(limiter.cell_count(), 1);
+        // A dynamic default tenant is already over the cap, so it shares the
+        // overflow cell rather than getting its own (the map does not grow)...
+        assert!(limiter.admit_at(&TenantId::named("t0"), 0, 0).is_ok());
+        assert_eq!(limiter.cell_count(), 1);
+        // ...while the override keeps its full rate-10 burst on its own cell.
+        for _ in 0..10 {
+            assert!(limiter.admit_at(&TenantId::named("vip"), 0, 0).is_ok());
+        }
+        assert!(limiter.admit_at(&TenantId::named("vip"), 0, 0).is_err());
     }
 }

--- a/crates/talon-worker/src/rate_limit.rs
+++ b/crates/talon-worker/src/rate_limit.rs
@@ -1,0 +1,233 @@
+//! Worker-side per-tenant rate limiting.
+//!
+//! A [`TenantRateLimiter`] enforces a static, per-worker local policy: for each
+//! tenant it holds one lock-free GCRA cell per limited metric and admits or
+//! throttles a request with a single atomic op, so the io_uring rings never
+//! serialize on a global QoS lock — only same-tenant requests briefly touch the
+//! same cell.
+//!
+//! This is the local, single-worker stage of the eventual global design: limits
+//! are per worker and per process, sized so the fleet aggregate stays bounded.
+//! Cross-worker owners and snapshot propagation are a later stage, as is
+//! enforcing [`RateMetric::OriginReadBytes`] (which needs the tenant threaded
+//! into the cache-miss path).
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+use talon_core::{Gcra, MetricLimits, RateDecision, RateLimitPolicy, RateMetric, TenantId};
+
+/// One tenant's GCRA cells, one per limited metric.
+#[derive(Debug)]
+struct TenantCells {
+    read_iops: Option<Gcra>,
+    read_throughput: Option<Gcra>,
+}
+
+impl TenantCells {
+    fn from_limits(limits: &MetricLimits) -> Self {
+        Self {
+            read_iops: limits.read_iops.map(Gcra::new),
+            read_throughput: limits.read_throughput.map(Gcra::new),
+        }
+    }
+}
+
+/// A rejected admission: which metric was exceeded and when to retry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Throttled {
+    /// The metric whose limit the request would exceed.
+    pub metric: RateMetric,
+    /// How long the caller should wait before retrying the same request.
+    pub retry_after: Duration,
+}
+
+/// Worker-global, `Arc`-shared per-tenant limiter.
+#[derive(Debug)]
+pub struct TenantRateLimiter {
+    policy: RateLimitPolicy,
+    /// Monotonic clock origin; GCRA cells advance in nanoseconds from here.
+    origin: Instant,
+    /// Lazily-created per-tenant cells. A read lock covers the common warm
+    /// lookup; the write lock is taken only the first time a tenant is seen.
+    cells: RwLock<HashMap<TenantId, Arc<TenantCells>>>,
+}
+
+impl TenantRateLimiter {
+    /// Build a limiter from a static local policy.
+    pub fn new(policy: RateLimitPolicy) -> Self {
+        Self {
+            policy,
+            origin: Instant::now(),
+            cells: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// A limiter that admits every request (the feature disabled).
+    pub fn disabled() -> Self {
+        Self::new(RateLimitPolicy::default())
+    }
+
+    /// Whether the limiter enforces anything.
+    pub fn is_enabled(&self) -> bool {
+        self.policy.enabled
+    }
+
+    /// Charge one read request expected to return `read_bytes` bytes against
+    /// `tenant`, returning [`Throttled`] if it would exceed a configured limit.
+    pub fn admit(&self, tenant: &TenantId, read_bytes: u64) -> Result<(), Throttled> {
+        self.admit_at(tenant, read_bytes, self.now_nanos())
+    }
+
+    /// Time-injected core of [`admit`](Self::admit).
+    ///
+    /// read_iops is charged before read_throughput; a request rejected on
+    /// throughput has already consumed its one read-iops credit, which only
+    /// makes the limiter more conservative under overload.
+    fn admit_at(
+        &self,
+        tenant: &TenantId,
+        read_bytes: u64,
+        now_nanos: u64,
+    ) -> Result<(), Throttled> {
+        if !self.policy.enabled {
+            return Ok(());
+        }
+        let cells = self.cells_for(tenant);
+        if let Some(cell) = &cells.read_iops {
+            if let RateDecision::Throttled { retry_after } = cell.charge_at(1, now_nanos) {
+                return Err(Throttled {
+                    metric: RateMetric::ReadIops,
+                    retry_after,
+                });
+            }
+        }
+        if let Some(cell) = &cells.read_throughput {
+            if let RateDecision::Throttled { retry_after } = cell.charge_at(read_bytes, now_nanos) {
+                return Err(Throttled {
+                    metric: RateMetric::ReadThroughput,
+                    retry_after,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn cells_for(&self, tenant: &TenantId) -> Arc<TenantCells> {
+        if let Some(cells) = self.cells.read().unwrap().get(tenant) {
+            return Arc::clone(cells);
+        }
+        let mut cells = self.cells.write().unwrap();
+        // Re-check: another task may have inserted between the two locks.
+        if let Some(existing) = cells.get(tenant) {
+            return Arc::clone(existing);
+        }
+        let created = Arc::new(TenantCells::from_limits(&self.policy.limits_for(tenant)));
+        cells.insert(tenant.clone(), Arc::clone(&created));
+        created
+    }
+
+    fn now_nanos(&self) -> u64 {
+        Instant::now()
+            .saturating_duration_since(self.origin)
+            .as_nanos()
+            .min(u64::MAX as u128) as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use talon_core::RateLimit;
+
+    fn iops_policy(rate: u64, burst_ratio: f64) -> RateLimitPolicy {
+        RateLimitPolicy {
+            enabled: true,
+            default: MetricLimits {
+                read_iops: Some(RateLimit::new(rate, burst_ratio).unwrap()),
+                read_throughput: None,
+            },
+            overrides: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn disabled_admits_everything() {
+        let limiter = TenantRateLimiter::disabled();
+        for _ in 0..1000 {
+            assert!(limiter.admit(&TenantId::named("a"), u64::MAX).is_ok());
+        }
+    }
+
+    #[test]
+    fn read_iops_admits_a_burst_then_throttles() {
+        // rate 10, burst_ratio 1.0 => 10 units of burst.
+        let limiter = TenantRateLimiter::new(iops_policy(10, 1.0));
+        let tenant = TenantId::named("a");
+        for _ in 0..10 {
+            assert!(limiter.admit_at(&tenant, 0, 0).is_ok());
+        }
+        let throttled = limiter.admit_at(&tenant, 0, 0).unwrap_err();
+        assert_eq!(throttled.metric, RateMetric::ReadIops);
+        assert_eq!(throttled.retry_after, Duration::from_millis(100));
+    }
+
+    #[test]
+    fn tenants_are_limited_independently() {
+        // rate 1, burst_ratio 1.0 => one request then pacing.
+        let limiter = TenantRateLimiter::new(iops_policy(1, 1.0));
+        assert!(limiter.admit_at(&TenantId::named("a"), 0, 0).is_ok());
+        // A different tenant has its own fresh burst.
+        assert!(limiter.admit_at(&TenantId::named("b"), 0, 0).is_ok());
+        // ...but the first tenant is now paced.
+        assert!(limiter.admit_at(&TenantId::named("a"), 0, 0).is_err());
+    }
+
+    #[test]
+    fn unattributed_uses_the_default_limit() {
+        let limiter = TenantRateLimiter::new(iops_policy(1, 1.0));
+        assert!(limiter.admit_at(&TenantId::unattributed(), 0, 0).is_ok());
+        assert!(limiter.admit_at(&TenantId::unattributed(), 0, 0).is_err());
+    }
+
+    #[test]
+    fn overrides_take_precedence_over_the_default() {
+        let mut policy = iops_policy(1, 1.0);
+        policy.overrides.insert(
+            "vip".to_string(),
+            MetricLimits {
+                read_iops: Some(RateLimit::new(10, 1.0).unwrap()),
+                read_throughput: None,
+            },
+        );
+        let limiter = TenantRateLimiter::new(policy);
+        // The default tenant is paced after one request...
+        assert!(limiter.admit_at(&TenantId::named("a"), 0, 0).is_ok());
+        assert!(limiter.admit_at(&TenantId::named("a"), 0, 0).is_err());
+        // ...while the override grants a larger burst.
+        for _ in 0..10 {
+            assert!(limiter.admit_at(&TenantId::named("vip"), 0, 0).is_ok());
+        }
+        assert!(limiter.admit_at(&TenantId::named("vip"), 0, 0).is_err());
+    }
+
+    #[test]
+    fn throughput_limit_throttles_on_bytes() {
+        let policy = RateLimitPolicy {
+            enabled: true,
+            default: MetricLimits {
+                read_iops: None,
+                read_throughput: Some(RateLimit::new(1_000_000, 1.0).unwrap()),
+            },
+            overrides: HashMap::new(),
+        };
+        let limiter = TenantRateLimiter::new(policy);
+        let tenant = TenantId::named("a");
+        // One request draining the whole burst is admitted...
+        assert!(limiter.admit_at(&tenant, 1_000_000, 0).is_ok());
+        // ...the next byte is throttled on throughput, not iops.
+        let throttled = limiter.admit_at(&tenant, 1, 0).unwrap_err();
+        assert_eq!(throttled.metric, RateMetric::ReadThroughput);
+    }
+}

--- a/crates/talon-worker/src/rate_limit.rs
+++ b/crates/talon-worker/src/rate_limit.rs
@@ -334,6 +334,127 @@ mod tests {
         );
     }
 
+    // Build an iops-only override for a single tenant tier.
+    fn iops_override(rate: u64, burst_ratio: f64) -> MetricLimits {
+        MetricLimits {
+            read_iops: Some(RateLimit::new(rate, burst_ratio).unwrap()),
+            read_throughput: None,
+        }
+    }
+
+    #[test]
+    fn caps_each_tenant_independently_under_concurrent_overload() {
+        // Multi-tenant capability: three tenants with *different* read_iops
+        // limits all offer far more than their share at every simulated instant.
+        // Each must be capped at its own rate — a greedy tenant never borrows
+        // another's budget, and a small tenant is not dragged up by a large one.
+        let mut policy = iops_policy(1000, 1.0); // "a" falls back to this default
+        policy.overrides.insert("vip".to_string(), iops_override(5000, 1.0));
+        policy.overrides.insert("tiny".to_string(), iops_override(100, 1.0));
+        let limiter = TenantRateLimiter::new(policy);
+
+        // (tenant, configured rate/s).
+        let tenants = [
+            (TenantId::named("a"), 1000u64),
+            (TenantId::named("vip"), 5000),
+            (TenantId::named("tiny"), 100),
+        ];
+        let mut admitted = [0u64; 3];
+        // 1000 steps of 1ms across ~1s. At every step *each* tenant offers 20
+        // requests (>> even vip's per-ms share), so all three are overloaded at
+        // the same instants — the interleaving models simultaneous callers.
+        let offered_per_tenant = 1000u64 * 20;
+        for step in 0..1000u64 {
+            let now = step * 1_000_000; // ns
+            for (i, (tenant, _)) in tenants.iter().enumerate() {
+                for _ in 0..20 {
+                    if limiter.admit_at(tenant, 0, now).is_ok() {
+                        admitted[i] += 1;
+                    }
+                }
+            }
+        }
+
+        for (i, (tenant, rate)) in tenants.iter().enumerate() {
+            // Each tenant is capped near burst (1x rate) + one second of its own
+            // rate (1x rate) = ~2x rate, independent of the others.
+            let expected = 2 * rate;
+            let (lo, hi) = (expected * 9 / 10, expected * 11 / 10);
+            assert!(
+                (lo..=hi).contains(&admitted[i]),
+                "tenant {tenant} admitted {} of {offered_per_tenant} offered, \
+                 expected ~{expected} ({lo}..={hi})",
+                admitted[i],
+            );
+        }
+    }
+
+    #[test]
+    fn isolates_tenant_rates_under_real_thread_contention() {
+        // Same guarantee, but under genuine concurrency: one OS thread per
+        // tenant hammers the *shared* limiter with its own id for a fixed
+        // window. This exercises the lock-free cells under contention and
+        // confirms each tenant is throttled near its own rate — nowhere near the
+        // millions of calls each thread actually offers.
+        let mut policy = iops_policy(2000, 1.0);
+        policy.overrides.insert("vip".to_string(), iops_override(8000, 1.0));
+        let limiter = std::sync::Arc::new(TenantRateLimiter::new(policy));
+
+        let window = Duration::from_millis(300);
+        let tenants = [("a", 2000u64), ("vip", 8000u64)];
+        let handles: Vec<_> = tenants
+            .iter()
+            .map(|&(name, rate)| {
+                let limiter = std::sync::Arc::clone(&limiter);
+                let tenant = TenantId::named(name);
+                std::thread::spawn(move || {
+                    let start = Instant::now();
+                    let mut admitted = 0u64;
+                    // Tight batches so the offered rate dwarfs the limit; count
+                    // only what the limiter lets through.
+                    while start.elapsed() < window {
+                        for _ in 0..64 {
+                            if limiter.admit(&tenant, 0).is_ok() {
+                                admitted += 1;
+                            }
+                        }
+                    }
+                    (rate, admitted, start.elapsed())
+                })
+            })
+            .collect();
+
+        let mut results = Vec::new();
+        for h in handles {
+            results.push(h.join().unwrap());
+        }
+
+        for &(rate, admitted, elapsed) in &results {
+            // Expected ~ burst (1x rate) + rate * elapsed. Loose absolute bounds
+            // absorb scheduler jitter while still proving the cap holds: raw
+            // throughput over 300ms is in the millions, so [0.5x, 3x] rate can
+            // only be reached by real limiting.
+            let secs = elapsed.as_secs_f64();
+            let expected = rate as f64 * (1.0 + secs);
+            let (lo, hi) = ((rate / 2), (rate * 3));
+            assert!(
+                admitted >= lo && admitted <= hi,
+                "rate {rate}: admitted {admitted}, expected ~{expected:.0} \
+                 ({lo}..={hi}) over {secs:.3}s",
+            );
+        }
+
+        // Isolation is also visible in the ratio: both tiers ran the same
+        // window, so the 8000 tenant admits ~4x the 2000 tenant (burst and rate
+        // both scale with the tier), never the same amount.
+        let a = results.iter().find(|r| r.0 == 2000).unwrap().1;
+        let vip = results.iter().find(|r| r.0 == 8000).unwrap().1;
+        assert!(
+            vip > a * 2,
+            "vip (8000/s) admitted {vip} should far exceed a (2000/s) {a}",
+        );
+    }
+
     #[test]
     fn empty_limits_admit_without_allocating_a_cell() {
         // Enabled, but nothing configured (empty default, no overrides): every

--- a/crates/talon-worker/src/runtime.rs
+++ b/crates/talon-worker/src/runtime.rs
@@ -18,7 +18,7 @@ use talon_transport::{codec, ControlMessage, ObjectEntry, MAX_CONTROL_PAYLOAD_LE
 use crate::data_error::CacheMiss;
 use crate::{
     miss::touched_pages, BlockIndex, CacheUnit, InFlightLoads, LoadKey, Lru, MemoryInsert,
-    MemoryStore, PagedBlockStore, Presence, WholeBlockStore, WorkerMetrics,
+    MemoryStore, PagedBlockStore, Presence, TenantRateLimiter, WholeBlockStore, WorkerMetrics,
 };
 
 /// Default lifetime of a cached resolved object version.
@@ -106,6 +106,8 @@ pub struct WorkerRuntime {
     /// a backend `HEAD` per request (issue #163).
     version_cache: Mutex<HashMap<ObjectId, CachedVersion>>,
     version_ttl: Duration,
+    /// Worker-global per-tenant rate limiter; disabled unless configured.
+    rate_limiter: Arc<TenantRateLimiter>,
 }
 
 impl WorkerRuntime {
@@ -180,6 +182,7 @@ impl WorkerRuntime {
             paged_miss_run_concurrency: DEFAULT_PAGED_MISS_RUN_CONCURRENCY,
             version_cache: Mutex::new(HashMap::new()),
             version_ttl: DEFAULT_VERSION_TTL,
+            rate_limiter: Arc::new(TenantRateLimiter::disabled()),
         }
     }
 
@@ -202,6 +205,18 @@ impl WorkerRuntime {
     pub fn with_paged_miss_run_concurrency(mut self, concurrency: usize) -> Self {
         self.paged_miss_run_concurrency = concurrency.max(1);
         self
+    }
+
+    /// Attach a per-tenant rate limiter. Without this the runtime admits every
+    /// request (the limiter is disabled).
+    pub fn with_rate_limiter(mut self, limiter: Arc<TenantRateLimiter>) -> Self {
+        self.rate_limiter = limiter;
+        self
+    }
+
+    /// The worker's per-tenant rate limiter.
+    pub fn rate_limiter(&self) -> &TenantRateLimiter {
+        &self.rate_limiter
     }
 
     /// The paged L2 page size, or `None` when paged mode is off.

--- a/crates/talon-worker/src/tokio_conn.rs
+++ b/crates/talon-worker/src/tokio_conn.rs
@@ -51,6 +51,25 @@ fn decode_range_with_tenant(
     }
 }
 
+/// Decode a `GetCachedRange` or `GetCachedRangeTenant` frame into its cache-only
+/// request and the tenant it declared (`Unattributed` for a plain
+/// `GetCachedRange`).
+fn decode_cached_range_with_tenant(
+    header: &FrameHeader,
+    payload: &[u8],
+) -> Result<(FrameHeader, data::CachedRangeRequest, TenantId), talon_transport::DataError> {
+    let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
+    full.extend_from_slice(&header.encode());
+    full.extend_from_slice(payload);
+    if header.msg_type == MsgType::GetCachedRangeTenant {
+        let (frame, scoped) = data::decode_cached_tenant_request(&full)?;
+        Ok((frame, scoped.request, scoped.tenant))
+    } else {
+        let (frame, req) = data::decode_cached_request(&full)?;
+        Ok((frame, req, TenantId::Unattributed))
+    }
+}
+
 /// Serve data-plane range and cache-only probe requests until EOF.
 pub async fn handle_conn(
     mut stream: TcpStream,
@@ -134,7 +153,9 @@ pub async fn handle_conn(
             .await?;
             continue;
         }
-        if header.msg_type == MsgType::GetCachedRange {
+        if header.msg_type == MsgType::GetCachedRange
+            || header.msg_type == MsgType::GetCachedRangeTenant
+        {
             handle_cached_range(
                 &mut stream,
                 &header,
@@ -413,10 +434,7 @@ async fn handle_cached_range(
     observability: &WorkerObservability,
     request_started: Instant,
 ) -> std::io::Result<()> {
-    let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
-    full.extend_from_slice(&header.encode());
-    full.extend_from_slice(payload);
-    let (decoded, request) = match data::decode_cached_request(&full) {
+    let (decoded, request, tenant) = match decode_cached_range_with_tenant(header, payload) {
         Ok(value) => value,
         Err(error) => {
             let reply = data::encode_typed_error(
@@ -432,6 +450,19 @@ async fn handle_cached_range(
             return Ok(());
         }
     };
+    if let Err(error) = tenant.validate() {
+        let reply = data::encode_typed_error(
+            decoded.request_id,
+            DataErrorCode::InvalidRequest,
+            format!("invalid tenant: {error}"),
+        );
+        stream.write_all(&reply).await?;
+        stream.flush().await?;
+        observability
+            .metrics()
+            .record_request_error(request_started.elapsed());
+        return Ok(());
+    }
     if !observability.is_ready() {
         let reply = data::encode_typed_error(
             decoded.request_id,
@@ -456,6 +487,26 @@ async fn handle_cached_range(
         observability
             .metrics()
             .record_request_error(request_started.elapsed());
+        return Ok(());
+    }
+    // Meter the cache-only read too, so a resident-version read cannot escape
+    // the tenant's read_iops / read_throughput limits (a plain GetCachedRange
+    // carries no tenant and is charged to Unattributed under the default).
+    if let Err(throttled) = worker.rate_limiter().admit(&tenant, request.len) {
+        let reply = data::encode_typed_error(
+            decoded.request_id,
+            DataErrorCode::RateLimited,
+            format!(
+                "tenant rate limit exceeded on {}; retry after {} ms",
+                throttled.metric.label(),
+                throttled.retry_after.as_millis()
+            ),
+        );
+        stream.write_all(&reply).await?;
+        stream.flush().await?;
+        observability
+            .metrics()
+            .record_rate_limited(throttled.metric);
         return Ok(());
     }
     match worker.serve_cached(&request).await {

--- a/crates/talon-worker/src/tokio_conn.rs
+++ b/crates/talon-worker/src/tokio_conn.rs
@@ -23,7 +23,7 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use talon_core::RequestId;
+use talon_core::{RequestId, TenantId};
 use talon_transport::data;
 use talon_transport::frame::{MsgType, HEADER_LEN};
 use talon_transport::{codec, ControlMessage, DataErrorCode, FrameHeader};
@@ -32,6 +32,24 @@ use tokio::net::TcpStream;
 
 use crate::data_error::encode_runtime_error;
 use crate::{send_file_range, ServeOutcome, WorkerObservability, WorkerRuntime, DEFAULT_CHUNK};
+
+/// Decode a `GetRange` or `GetRangeTenant` frame into its request and the tenant
+/// it declared (`Unattributed` for a plain `GetRange`).
+fn decode_range_with_tenant(
+    header: &FrameHeader,
+    payload: &[u8],
+) -> Result<(FrameHeader, data::RangeRequest, TenantId), talon_transport::DataError> {
+    let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
+    full.extend_from_slice(&header.encode());
+    full.extend_from_slice(payload);
+    if header.msg_type == MsgType::GetRangeTenant {
+        let (frame, scoped) = data::decode_tenant_request(&full)?;
+        Ok((frame, scoped.request, scoped.tenant))
+    } else {
+        let (frame, req) = data::decode_request(&full)?;
+        Ok((frame, req, TenantId::Unattributed))
+    }
+}
 
 /// Serve data-plane range and cache-only probe requests until EOF.
 pub async fn handle_conn(
@@ -132,7 +150,7 @@ pub async fn handle_conn(
         // Type check BEFORE any per-request work; a data listener only serves
         // GetRange (plus the Put/Delete/Control handled above); other frames are
         // capped tightly by read_frame.
-        if header.msg_type != MsgType::GetRange {
+        if header.msg_type != MsgType::GetRange && header.msg_type != MsgType::GetRangeTenant {
             let err = data::encode_typed_error(
                 header.request_id,
                 DataErrorCode::InvalidRequest,
@@ -146,10 +164,7 @@ pub async fn handle_conn(
             continue;
         }
 
-        let mut full = Vec::with_capacity(HEADER_LEN + payload.len());
-        full.extend_from_slice(&header.encode());
-        full.extend_from_slice(&payload);
-        let (h, req) = match data::decode_request(&full) {
+        let (h, req, tenant) = match decode_range_with_tenant(&header, &payload) {
             Ok(v) => v,
             Err(e) => {
                 let err = data::encode_typed_error(
@@ -191,6 +206,24 @@ pub async fn handle_conn(
             observability
                 .metrics()
                 .record_request_error(request_started.elapsed());
+            continue;
+        }
+
+        if let Err(throttled) = worker.rate_limiter().admit(&tenant, req.len) {
+            let err = data::encode_typed_error(
+                h.request_id,
+                DataErrorCode::RateLimited,
+                format!(
+                    "tenant rate limit exceeded on {}; retry after {} ms",
+                    throttled.metric.label(),
+                    throttled.retry_after.as_millis()
+                ),
+            );
+            stream.write_all(&err).await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_rate_limited(throttled.metric);
             continue;
         }
 

--- a/crates/talon-worker/src/tokio_conn.rs
+++ b/crates/talon-worker/src/tokio_conn.rs
@@ -181,6 +181,23 @@ pub async fn handle_conn(
             }
         };
 
+        // The declared tenant is attacker-controlled on the unauthenticated data
+        // plane; reject an empty or over-long name before it is used as a cell
+        // key or telemetry label. `Unattributed` always validates.
+        if let Err(e) = tenant.validate() {
+            let err = data::encode_typed_error(
+                h.request_id,
+                DataErrorCode::InvalidRequest,
+                format!("invalid tenant: {e}"),
+            );
+            stream.write_all(&err).await?;
+            stream.flush().await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+            continue;
+        }
+
         if !observability.is_ready() {
             let err = data::encode_typed_error(
                 h.request_id,

--- a/crates/talon-worker/src/uring_conn.rs
+++ b/crates/talon-worker/src/uring_conn.rs
@@ -196,6 +196,22 @@ pub async fn handle_conn(
             }
         };
 
+        // The declared tenant is attacker-controlled on the unauthenticated data
+        // plane; reject an empty or over-long name before it is used as a cell
+        // key or telemetry label. `Unattributed` always validates.
+        if let Err(e) = tenant.validate() {
+            let err = data::encode_typed_error(
+                h.request_id,
+                DataErrorCode::InvalidRequest,
+                format!("invalid tenant: {e}"),
+            );
+            write_all(&mut stream, err).await?;
+            observability
+                .metrics()
+                .record_request_error(request_started.elapsed());
+            continue;
+        }
+
         if !observability.is_ready() {
             let err = data::encode_typed_error(
                 h.request_id,

--- a/crates/talon-worker/src/uring_conn.rs
+++ b/crates/talon-worker/src/uring_conn.rs
@@ -151,7 +151,7 @@ pub async fn handle_conn(
                 .await?;
                 continue;
             }
-            MsgType::GetCachedRange => {
+            MsgType::GetCachedRange | MsgType::GetCachedRangeTenant => {
                 handle_cached_range(
                     &mut stream,
                     &header,
@@ -337,6 +337,23 @@ fn decode_range_with_tenant(
     }
 }
 
+/// Decode a `GetCachedRange` or `GetCachedRangeTenant` frame into its cache-only
+/// request and the tenant it declared (`Unattributed` for a plain
+/// `GetCachedRange`).
+fn decode_cached_range_with_tenant(
+    header: &FrameHeader,
+    payload: &[u8],
+) -> Result<(FrameHeader, data::CachedRangeRequest, TenantId), talon_transport::DataError> {
+    let buf = rejoin(header, payload);
+    if header.msg_type == MsgType::GetCachedRangeTenant {
+        let (frame, scoped) = data::decode_cached_tenant_request(&buf)?;
+        Ok((frame, scoped.request, scoped.tenant))
+    } else {
+        let (frame, req) = data::decode_cached_request(&buf)?;
+        Ok((frame, req, TenantId::Unattributed))
+    }
+}
+
 async fn handle_cached_block_admission(
     stream: &mut TcpStream,
     reader: &mut BufferedFrameReader,
@@ -416,7 +433,7 @@ async fn handle_cached_range(
     observability: &WorkerObservability,
     request_started: Instant,
 ) -> std::io::Result<()> {
-    let (decoded, request) = match data::decode_cached_request(&rejoin(header, payload)) {
+    let (decoded, request, tenant) = match decode_cached_range_with_tenant(header, payload) {
         Ok(value) => value,
         Err(error) => {
             let reply = data::encode_typed_error(
@@ -431,6 +448,18 @@ async fn handle_cached_range(
             return Ok(());
         }
     };
+    if let Err(error) = tenant.validate() {
+        let reply = data::encode_typed_error(
+            decoded.request_id,
+            DataErrorCode::InvalidRequest,
+            format!("invalid tenant: {error}"),
+        );
+        write_all(stream, reply).await?;
+        observability
+            .metrics()
+            .record_request_error(request_started.elapsed());
+        return Ok(());
+    }
     if !observability.is_ready() {
         let reply = data::encode_typed_error(
             decoded.request_id,
@@ -453,6 +482,25 @@ async fn handle_cached_range(
         observability
             .metrics()
             .record_request_error(request_started.elapsed());
+        return Ok(());
+    }
+    // Meter the cache-only read too, so a resident-version read cannot escape
+    // the tenant's read_iops / read_throughput limits (a plain GetCachedRange
+    // carries no tenant and is charged to Unattributed under the default).
+    if let Err(throttled) = worker.rate_limiter().admit(&tenant, request.len) {
+        let reply = data::encode_typed_error(
+            decoded.request_id,
+            DataErrorCode::RateLimited,
+            format!(
+                "tenant rate limit exceeded on {}; retry after {} ms",
+                throttled.metric.label(),
+                throttled.retry_after.as_millis()
+            ),
+        );
+        write_all(stream, reply).await?;
+        observability
+            .metrics()
+            .record_rate_limited(throttled.metric);
         return Ok(());
     }
     match worker.serve_cached(&request).await {

--- a/crates/talon-worker/src/uring_conn.rs
+++ b/crates/talon-worker/src/uring_conn.rs
@@ -57,7 +57,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use monoio::net::TcpStream;
-use talon_core::{BlockHandle, RequestId};
+use talon_core::{BlockHandle, RequestId, TenantId};
 use talon_transport::data;
 use talon_transport::frame::{FrameHeader, MsgType, HEADER_LEN};
 use talon_transport::uring::{write_all, write_all_buf, BufferedFrameReader};
@@ -163,7 +163,7 @@ pub async fn handle_conn(
                 .await?;
                 continue;
             }
-            MsgType::GetRange => {}
+            MsgType::GetRange | MsgType::GetRangeTenant => {}
             // A data listener serves only GetRange/Put/Delete; anything else is
             // rejected before any per-request work.
             _ => {
@@ -180,7 +180,7 @@ pub async fn handle_conn(
             }
         }
 
-        let (h, req) = match data::decode_request(&rejoin(&header, &payload)) {
+        let (h, req, tenant) = match decode_range_with_tenant(&header, &payload) {
             Ok(v) => v,
             Err(e) => {
                 let err = data::encode_typed_error(
@@ -219,6 +219,23 @@ pub async fn handle_conn(
             observability
                 .metrics()
                 .record_request_error(request_started.elapsed());
+            continue;
+        }
+
+        if let Err(throttled) = worker.rate_limiter().admit(&tenant, req.len) {
+            let err = data::encode_typed_error(
+                h.request_id,
+                DataErrorCode::RateLimited,
+                format!(
+                    "tenant rate limit exceeded on {}; retry after {} ms",
+                    throttled.metric.label(),
+                    throttled.retry_after.as_millis()
+                ),
+            );
+            write_all(&mut stream, err).await?;
+            observability
+                .metrics()
+                .record_rate_limited(throttled.metric);
             continue;
         }
 
@@ -285,6 +302,22 @@ pub async fn handle_conn(
                     .record_request_error(request_started.elapsed());
             }
         }
+    }
+}
+
+/// Decode a `GetRange` or `GetRangeTenant` frame into its request and the tenant
+/// it declared (`Unattributed` for a plain `GetRange`).
+fn decode_range_with_tenant(
+    header: &FrameHeader,
+    payload: &[u8],
+) -> Result<(FrameHeader, data::RangeRequest, TenantId), talon_transport::DataError> {
+    let buf = rejoin(header, payload);
+    if header.msg_type == MsgType::GetRangeTenant {
+        let (frame, scoped) = data::decode_tenant_request(&buf)?;
+        Ok((frame, scoped.request, scoped.tenant))
+    } else {
+        let (frame, req) = data::decode_request(&buf)?;
+        Ok((frame, req, TenantId::Unattributed))
     }
 }
 


### PR DESCRIPTION
## Summary

Worker-side per-tenant rate limiting for the **SDK-direct data plane**: when a
client declares a tenant, the worker admits or throttles the read against a
static per-tenant policy. Supersedes #550 (opened from a different fork; same
feature, now with the requested `read_throughput` / `burst_ratio` config shape).

## What it does

- **Tenant identity** (`talon-core`): `TenantId::Named` (SDK-declared) /
  `Unattributed` (undeclared, e.g. FUSE). The direct path is unauthenticated, so
  a declared tenant is trusted for fairness, not as a security boundary.
- **Wire** (`talon-transport`): new `MsgType::GetRangeTenant` carrying a
  `TenantScopedRange`; the reply is an ordinary `GetRange` frame. **Fail-closed
  on older workers** (a distinct opcode, like `GetCachedRange`), and conformance
  vectors are unchanged so the other-language clients are unaffected.
- **Policy** (`[rate_limits]` table): `enabled`, a `default` `MetricLimits`, and
  per-tenant `overrides`. Each metric is `RateLimit { rate, burst_ratio }` where
  the burst is `rate * burst_ratio`. Metrics: `read_iops` (req/s) and
  `read_throughput` (bytes/s served to the client). `origin_read_bytes` is a
  defined metric for a later stage.
- **Enforcement** (`talon-worker`): a lock-free `TenantRateLimiter` (one GCRA
  cell per `(tenant, metric)`, single-atomic TAT, `Arc`-shared across io_uring
  rings). Admission before serve in **both** the io_uring and Tokio handlers;
  charges `read_iops` + `read_throughput`. A throttle returns
  `DataErrorCode::RateLimited`.
- **Client** (`talon-cache-client`): `WorkerClient::with_tenant` sends
  `GetRangeTenant`; `RateLimited` maps to a **non-origin-fallback**
  `CacheReadError` (a throttle can't be evaded via origin bypass).
- **Gateway**: `RateLimited` → S3 `503 SlowDown` / Azure `503 ServerBusy`.
- **Telemetry**: bounded `talon_worker_rate_limited_total{metric}`; no raw
  tenant labels (per-tenant drill-down is a management-API concern).

## Config example

```toml
[rate_limits]
enabled = true
[rate_limits.default]
read_iops = { rate = 5000, burst_ratio = 2.0 }
read_throughput = { rate = 1073741824 }        # 1 GiB/s; burst_ratio defaults to 1.0
[rate_limits.overrides.acme]
read_iops = { rate = 20000, burst_ratio = 2.0 }
```

## Testing

`cargo test` green: `talon-core` (71) and `talon-worker` (253). Unit coverage:
GCRA burst/refill/burst-ratio, limiter admission (per-tenant, overrides,
throughput), `[rate_limits]` TOML parse, and `WorkerClient` tenant-scoped vs
plain-`GetRange` send.

## Deliberate follow-ups (noted in code)

- `origin_read_bytes` **enforcement** (needs the tenant threaded into the
  cache-miss path).
- Per-SDK tenant knobs (BlockReader / `talon-client` CLI / C / Python / Java).
- A socket-level worker end-to-end throttle test.
- Later stages: coordinator policy distribution → consistent-hash owner/peer
  layer → Tier-2 monitoring (`docs/explanation/tenant-traffic-observability.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)