### PR TITLE
build: bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## What

Pin `h2` to `0.4.16`, which patches **RUSTSEC-2026-0258** (a remotely-triggerable DoS in `h2` 0.4.15). `h2` is a transitive dependency reached through the gateway's hyper/axum stack.

## Why

The `dependency-advisories` CI gate currently fails on this advisory across all branches (it is a newly-published advisory on an existing transitive dep, not introduced by any feature work). This unblocks CI independently of any in-flight feature PR.

## Scope

Lockfile-only, and deliberately **h2-only**: just the `h2` version + checksum change. A plain `cargo update -p h2` also dragged `socket2` and `windows-sys` *down* (MSRV resolver fallback churn); those were reverted so this PR does not alter the rest of the dependency graph. `cargo tree -p h2 --locked` confirms the lockfile stays consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)