### PR TITLE
feat(c-sdk): optional version/size fast-path and concurrent block reads

### DIFF
--- a/clients/c/examples/async_read.c
+++ b/clients/c/examples/async_read.c
@@ -47,12 +47,15 @@ int main(void) {
     pthread_cond_init(&ctx->cond, NULL);
 
     uint64_t request_id = 0;
+    /* version = NULL, object_size = NULL → the SDK resolves both with a stat. */
     int status = talon_read_async(
         client,
         "s3://bucket/path/object.bin",
         0,
         ctx->buffer,
         4096,
+        NULL,
+        NULL,
         on_read,
         ctx,
         &request_id);

--- a/clients/c/include/talon.h
+++ b/clients/c/include/talon.h
@@ -67,6 +67,21 @@ void talon_client_free(talon_client *client);
  * [dst, dst + dst_len) is exclusively owned by the SDK until the callback runs:
  * callers must not read, write, free, or reuse overlapping storage for another
  * operation during that interval. A zero-length read may pass NULL for dst.
+ *
+ * version and object_size are each optional and independently nullable; NULL
+ * means the caller does not have that value. The read skips the StatObject round
+ * trip only when BOTH are non-NULL, using the caller-supplied version and size
+ * (the caller owns keeping them current for the object generation being read).
+ * If either is NULL the SDK resolves both with a StatObject first and any lone
+ * value supplied is ignored, since a read cannot skip the stat without both.
+ *
+ * When used, *object_size is the object's total byte length and bounds the read
+ * at EOF (a POSIX short read): a value smaller than offset + dst_len yields a
+ * short read, 0 denotes a genuinely empty object (an unambiguous zero-byte
+ * read), and a value larger than the object surfaces as a read error rather than
+ * fabricated bytes. A caller with no valid size passes NULL.
+ *
+ * Blocks spanned by the read are fetched concurrently.
  */
 int talon_read_async(
     talon_client *client,
@@ -74,6 +89,8 @@ int talon_read_async(
     uint64_t offset,
     uint8_t *dst,
     size_t dst_len,
+    const char *version,
+    const uint64_t *object_size,
     talon_callback callback,
     void *user_data,
     uint64_t *request_id_out);

--- a/clients/c/src/lib.rs
+++ b/clients/c/src/lib.rs
@@ -13,8 +13,7 @@ use std::ptr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use talon_cache_client::block_reader::FileView;
-use talon_cache_client::{BlockReader, CoordinatorClient, PlacementCache};
+use talon_cache_client::{plan_read, BlockReader, CoordinatorClient, PlacementCache};
 use talon_core::{ObjectId, Version};
 
 const DEFAULT_BLOCK_SIZE: u32 = 256 << 20;
@@ -260,6 +259,23 @@ pub unsafe extern "C" fn talon_client_free(client: *mut TalonClient) {
 }
 
 /// Submit an async read.
+///
+/// `version` and `object_size` are each optional and independently nullable;
+/// NULL means "the caller does not have this value". The read takes the fast
+/// path that skips the `StatObject` round trip **only when both are non-NULL** —
+/// then it reads under the caller-supplied version and size, and the caller owns
+/// keeping them current for the object generation being read. If either is NULL
+/// the SDK resolves both with a `StatObject` first (the historical behavior) and
+/// any lone value that was supplied is ignored, since a stat is authoritative
+/// for both and a read cannot skip it without both halves.
+///
+/// When taken, `*object_size` is the object's total byte length and bounds the
+/// read at EOF (a POSIX short read): a value smaller than `offset + dst_len`
+/// yields a short read, `0` denotes a genuinely empty object (an unambiguous
+/// zero-byte read), and a value larger than the object surfaces as a read error
+/// rather than fabricated bytes. A caller that has no valid size passes NULL.
+///
+/// Blocks spanned by the read are fetched concurrently.
 #[no_mangle]
 pub unsafe extern "C" fn talon_read_async(
     client: *mut TalonClient,
@@ -267,6 +283,8 @@ pub unsafe extern "C" fn talon_read_async(
     offset: u64,
     dst: *mut u8,
     dst_len: usize,
+    version: *const c_char,
+    object_size: *const u64,
     callback: Option<TalonCallback>,
     user_data: *mut c_void,
     request_id_out: *mut u64,
@@ -291,6 +309,18 @@ pub unsafe extern "C" fn talon_read_async(
 
         let uri = c_string(uri, "uri")?;
         let object = parse_uri(&uri)?;
+        // A read skips StatObject only when the caller supplies both halves of
+        // the object's identity; a NULL in either means "resolve it".
+        let known_version = if version.is_null() {
+            None
+        } else {
+            Some(c_string(version, "version")?)
+        };
+        let known_size = if object_size.is_null() {
+            None
+        } else {
+            Some(unsafe { *object_size })
+        };
         let request_id = inner.next_request_id.fetch_add(1, Ordering::Relaxed);
         unsafe {
             *request_id_out = request_id;
@@ -311,22 +341,26 @@ pub unsafe extern "C" fn talon_read_async(
                 if read_buffer.len == 0 {
                     return Ok(0);
                 }
-                let stat = coordinator
-                    .stat_object(&object)
-                    .await
-                    .map_err(|error| error.to_string())?;
-                let version = Version::new(stat.version.as_str());
-                let file = FileView {
-                    object: &object,
-                    block_size,
-                    version: &version,
-                    size: stat.size,
+                let (version, size) = match (known_version, known_size) {
+                    (Some(version), Some(size)) => (Version::new(version.as_str()), size),
+                    _ => {
+                        let stat = coordinator
+                            .stat_object(&object)
+                            .await
+                            .map_err(|error| error.to_string())?;
+                        (Version::new(stat.version.as_str()), stat.size)
+                    }
                 };
                 let dst = unsafe { read_buffer.into_mut_slice() };
-                reader
-                    .read_into(&file, offset, dst, now_ms())
-                    .await
-                    .map_err(|error| error.to_string())
+                let plan = plan_read(
+                    &object,
+                    offset,
+                    dst.len() as u64,
+                    block_size,
+                    &version,
+                    size,
+                );
+                fetch_blocks_concurrent(reader, plan, dst, now_ms()).await
             }
             .await;
             dispatch_result(
@@ -338,6 +372,60 @@ pub unsafe extern "C" fn talon_read_async(
         });
         Ok(())
     })
+}
+
+/// Fetch every segment of `plan` concurrently into `dst`, rather than walking
+/// the blocks in series.
+///
+/// [`plan_read`] partitions the requested range into disjoint per-block segments
+/// (already clamped at EOF); each segment is handed an exclusive sub-slice of
+/// `dst`, and every block is fetched in parallel on the runtime. The segments
+/// cover `[0, planned_len)` in order and every task is joined before this future
+/// resolves; the caller owns `dst` until the callback runs (the header
+/// contract), so lending each task a disjoint `'static` sub-slice is sound.
+async fn fetch_blocks_concurrent(
+    reader: BlockReader,
+    plan: Vec<talon_cache_client::BlockSegment>,
+    dst: &'static mut [u8],
+    now_ms: u64,
+) -> Result<usize, String> {
+    if plan.is_empty() {
+        return Ok(0);
+    }
+
+    let mut tasks = tokio::task::JoinSet::new();
+    let mut rest = dst;
+    for segment in plan {
+        let want = segment.len as usize;
+        let (chunk, tail) = split_static_prefix(rest, want);
+        rest = tail;
+        let reader = reader.clone();
+        tasks.spawn(async move {
+            reader
+                .read_block_into(&segment.block, segment.offset_in_block, chunk, now_ms)
+                .await
+                .map_err(|error| error.to_string())
+                .map(|read| (read, want))
+        });
+    }
+
+    let mut written = 0usize;
+    while let Some(joined) = tasks.join_next().await {
+        let (read, want) = joined.map_err(|error| format!("block read task failed: {error}"))??;
+        if read != want {
+            return Err(format!(
+                "worker returned {read} of {want} requested bytes; the object may have changed"
+            ));
+        }
+        written += read;
+    }
+    Ok(written)
+}
+
+/// Split a `'static` buffer into an owned `'static` prefix of `n` bytes and the
+/// `'static` remainder, so each concurrent block fetch can own its slice.
+fn split_static_prefix(buf: &'static mut [u8], n: usize) -> (&'static mut [u8], &'static mut [u8]) {
+    buf.split_at_mut(n)
 }
 
 /// Submit an async stat.
@@ -775,6 +863,15 @@ mod tests {
     }
 
     async fn mock_coordinator(worker_addr: String) -> String {
+        mock_coordinator_counting(worker_addr, Arc::new(AtomicUsize::new(0))).await
+    }
+
+    /// Like [`mock_coordinator`], but records how many `StatObject` control
+    /// messages it served, so a test can prove the version fast path skips them.
+    async fn mock_coordinator_counting(
+        worker_addr: String,
+        stat_calls: Arc<AtomicUsize>,
+    ) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap().to_string();
         tokio::spawn(async move {
@@ -784,6 +881,7 @@ mod tests {
                     Err(_) => return,
                 };
                 let worker_addr = worker_addr.clone();
+                let stat_calls = Arc::clone(&stat_calls);
                 tokio::spawn(async move {
                     let mut hdr = [0u8; HEADER_LEN];
                     if sock.read_exact(&mut hdr).await.is_err() {
@@ -796,10 +894,13 @@ mod tests {
                     full.extend_from_slice(&body);
                     let (_header, msg) = talon_transport::decode(&full).unwrap();
                     let reply = match msg {
-                        ControlMessage::StatObject { .. } => ControlMessage::ObjectStat {
-                            size: 8192,
-                            version: "test-version".into(),
-                        },
+                        ControlMessage::StatObject { .. } => {
+                            stat_calls.fetch_add(1, Ordering::SeqCst);
+                            ControlMessage::ObjectStat {
+                                size: 8192,
+                                version: "test-version".into(),
+                            }
+                        }
                         ControlMessage::MembershipQuery {} => ControlMessage::MembershipList {
                             nodes: vec![NodeInfo {
                                 id: NodeId::new("worker-a"),
@@ -854,6 +955,24 @@ mod tests {
         (client, coordinator)
     }
 
+    /// Build a client with a caller-chosen block size whose coordinator counts
+    /// the `StatObject` calls it serves.
+    async fn new_client_counting(block_size: u32) -> (*mut TalonClient, Arc<AtomicUsize>) {
+        let worker = mock_worker().await;
+        let stat_calls = Arc::new(AtomicUsize::new(0));
+        let coordinator = mock_coordinator_counting(worker, Arc::clone(&stat_calls)).await;
+        let coordinator_c = cstring(&coordinator);
+        let options = TalonClientOptions {
+            block_size,
+            callback_executor: ptr::null(),
+        };
+        let mut client = ptr::null_mut();
+        let status = unsafe { talon_client_new(coordinator_c.as_ptr(), &options, &mut client) };
+        assert_eq!(status, STATUS_OK);
+        assert!(!client.is_null());
+        (client, stat_calls)
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn client_create_and_free_with_default_options() {
         let (client, _coordinator) = new_client().await;
@@ -895,6 +1014,8 @@ mod tests {
                 100,
                 dst.as_mut_ptr(),
                 dst.len(),
+                ptr::null(),
+                ptr::null(),
                 Some(capture_callback),
                 state.user_data(),
                 &mut request_id,
@@ -929,6 +1050,8 @@ mod tests {
                 100,
                 ptr::null_mut(),
                 0,
+                ptr::null(),
+                ptr::null(),
                 Some(capture_callback),
                 state.user_data(),
                 &mut request_id,
@@ -941,6 +1064,205 @@ mod tests {
         assert_eq!(snapshot.request_id, request_id);
         assert_eq!(snapshot.bytes_written, 0);
         assert!(snapshot.error.is_none());
+
+        unsafe {
+            talon_client_free(client);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn read_with_version_skips_stat() {
+        let (client, stat_calls) = new_client_counting(0).await;
+        let state = CallbackState::new();
+        let uri = cstring("s3://bucket/object.bin");
+        let version = cstring("caller-known-version");
+        let object_size: u64 = 8192;
+        let mut dst = vec![0u8; 4096];
+        let mut request_id = 0u64;
+
+        let status = unsafe {
+            talon_read_async(
+                client,
+                uri.as_ptr(),
+                100,
+                dst.as_mut_ptr(),
+                dst.len(),
+                version.as_ptr(),
+                &object_size,
+                Some(capture_callback),
+                state.user_data(),
+                &mut request_id,
+            )
+        };
+        assert_eq!(status, STATUS_OK);
+        let snapshot = state.wait();
+        assert_eq!(snapshot.status, STATUS_OK);
+        assert_eq!(snapshot.bytes_written, dst.len());
+        let expected: Vec<u8> = (0..dst.len()).map(|j| ((100 + j) % 251) as u8).collect();
+        assert_eq!(dst, expected);
+        assert_eq!(
+            stat_calls.load(Ordering::SeqCst),
+            0,
+            "a caller-supplied version and size must skip the StatObject round trip"
+        );
+        assert!(snapshot.error.is_none());
+
+        unsafe {
+            talon_client_free(client);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn read_without_version_calls_stat() {
+        let (client, stat_calls) = new_client_counting(0).await;
+        let state = CallbackState::new();
+        let uri = cstring("s3://bucket/object.bin");
+        let mut dst = vec![0u8; 4096];
+        let mut request_id = 0u64;
+
+        let status = unsafe {
+            talon_read_async(
+                client,
+                uri.as_ptr(),
+                100,
+                dst.as_mut_ptr(),
+                dst.len(),
+                ptr::null(),
+                ptr::null(),
+                Some(capture_callback),
+                state.user_data(),
+                &mut request_id,
+            )
+        };
+        assert_eq!(status, STATUS_OK);
+        let snapshot = state.wait();
+        assert_eq!(snapshot.status, STATUS_OK);
+        assert_eq!(
+            stat_calls.load(Ordering::SeqCst),
+            1,
+            "a NULL version must resolve metadata with StatObject"
+        );
+
+        unsafe {
+            talon_client_free(client);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn version_without_size_falls_back_to_stat() {
+        // A caller that knows the version but has no valid size passes a NULL
+        // object_size; the read must resolve both via StatObject, not guess.
+        let (client, stat_calls) = new_client_counting(0).await;
+        let state = CallbackState::new();
+        let uri = cstring("s3://bucket/object.bin");
+        let version = cstring("caller-known-version");
+        let mut dst = vec![0u8; 4096];
+        let mut request_id = 0u64;
+
+        let status = unsafe {
+            talon_read_async(
+                client,
+                uri.as_ptr(),
+                100,
+                dst.as_mut_ptr(),
+                dst.len(),
+                version.as_ptr(),
+                ptr::null(),
+                Some(capture_callback),
+                state.user_data(),
+                &mut request_id,
+            )
+        };
+        assert_eq!(status, STATUS_OK);
+        let snapshot = state.wait();
+        assert_eq!(snapshot.status, STATUS_OK);
+        assert_eq!(snapshot.bytes_written, dst.len());
+        assert_eq!(
+            stat_calls.load(Ordering::SeqCst),
+            1,
+            "a NULL size must resolve metadata with StatObject even when a version is given"
+        );
+
+        unsafe {
+            talon_client_free(client);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn empty_object_fast_path_reads_zero_without_stat() {
+        // object_size pointing at 0 is a genuinely empty object, distinct from a
+        // NULL "unknown": the read returns zero bytes and still skips the stat.
+        let (client, stat_calls) = new_client_counting(0).await;
+        let state = CallbackState::new();
+        let uri = cstring("s3://bucket/object.bin");
+        let version = cstring("caller-known-version");
+        let object_size: u64 = 0;
+        let mut dst = vec![0u8; 128];
+        let mut request_id = 0u64;
+
+        let status = unsafe {
+            talon_read_async(
+                client,
+                uri.as_ptr(),
+                0,
+                dst.as_mut_ptr(),
+                dst.len(),
+                version.as_ptr(),
+                &object_size,
+                Some(capture_callback),
+                state.user_data(),
+                &mut request_id,
+            )
+        };
+        assert_eq!(status, STATUS_OK);
+        let snapshot = state.wait();
+        assert_eq!(snapshot.status, STATUS_OK);
+        assert_eq!(snapshot.bytes_written, 0);
+        assert_eq!(
+            stat_calls.load(Ordering::SeqCst),
+            0,
+            "a size of 0 is an empty object, not a reason to stat"
+        );
+
+        unsafe {
+            talon_client_free(client);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn multi_block_read_reassembles_concurrent_blocks() {
+        // A 1 KiB block size makes a 4 KiB read span five blocks, so the
+        // concurrent fetches must land in the right disjoint sub-slices.
+        let (client, _stat_calls) = new_client_counting(1024).await;
+        let state = CallbackState::new();
+        let uri = cstring("s3://bucket/object.bin");
+        let version = cstring("caller-known-version");
+        let object_size: u64 = 1 << 20;
+        let mut dst = vec![0u8; 4096];
+        let mut request_id = 0u64;
+
+        let status = unsafe {
+            talon_read_async(
+                client,
+                uri.as_ptr(),
+                100,
+                dst.as_mut_ptr(),
+                dst.len(),
+                version.as_ptr(),
+                &object_size,
+                Some(capture_callback),
+                state.user_data(),
+                &mut request_id,
+            )
+        };
+        assert_eq!(status, STATUS_OK);
+        let snapshot = state.wait();
+        assert_eq!(snapshot.status, STATUS_OK, "error: {:?}", snapshot.error);
+        assert_eq!(snapshot.bytes_written, dst.len());
+        // The mock worker fills each byte with (absolute_offset % 251), so a
+        // correct reassembly reproduces that sequence across every block.
+        let expected: Vec<u8> = (0..dst.len()).map(|j| ((100 + j) % 251) as u8).collect();
+        assert_eq!(dst, expected);
 
         unsafe {
             talon_client_free(client);
@@ -1040,6 +1362,8 @@ mod tests {
                 0,
                 ptr::null_mut(),
                 0,
+                ptr::null(),
+                ptr::null(),
                 Some(capture_callback),
                 ptr::null_mut(),
                 &mut request_id,

--- a/clients/c/tests/c_api_smoke.c
+++ b/clients/c/tests/c_api_smoke.c
@@ -50,7 +50,7 @@ int talon_c_api_smoke_test(void) {
         return 4;
     }
 
-    if (talon_read_async(client, "s3://bucket/object", 0, NULL, 1,
+    if (talon_read_async(client, "s3://bucket/object", 0, NULL, 1, NULL, NULL,
                          capture_zero_length_read, NULL, &request_id) !=
         TALON_STATUS_INVALID_ARGUMENT) {
         talon_client_free(client);
@@ -64,7 +64,7 @@ int talon_c_api_smoke_test(void) {
 
     atomic_store_explicit(&callback_done, 0, memory_order_relaxed);
     atomic_store_explicit(&callback_ok, 0, memory_order_relaxed);
-    if (talon_read_async(client, "s3://bucket/object", 0, NULL, 0,
+    if (talon_read_async(client, "s3://bucket/object", 0, NULL, 0, NULL, NULL,
                          capture_zero_length_read, NULL, &request_id) != TALON_STATUS_OK ||
         request_id != 1) {
         talon_client_free(client);

--- a/test/sdk/c/minio_e2e.c
+++ b/test/sdk/c/minio_e2e.c
@@ -95,8 +95,13 @@ static int check_bytes(const uint8_t *got, size_t got_len, uint64_t start,
     return same;
 }
 
+/*
+ * A NULL version or object_size takes the stat-then-read path; passing both
+ * takes the fast path that skips StatObject.
+ */
 static int do_read(talon_client *client, const char *uri, uint64_t offset,
-                   size_t len, op_context *ctx, const char *name) {
+                   size_t len, const char *version, const uint64_t *object_size,
+                   op_context *ctx, const char *name) {
     memset(ctx, 0, sizeof(*ctx));
     ctx->buffer_len = len;
     /* Zero-length reads may pass NULL for dst (talon.h). */
@@ -109,8 +114,8 @@ static int do_read(talon_client *client, const char *uri, uint64_t offset,
     }
 
     uint64_t request_id = 0;
-    int rc = talon_read_async(client, uri, offset, ctx->buffer, len, on_result, ctx,
-                              &request_id);
+    int rc = talon_read_async(client, uri, offset, ctx->buffer, len, version,
+                              object_size, on_result, ctx, &request_id);
     if (rc != TALON_STATUS_OK) {
         fprintf(stderr, "  FAIL %s: submit failed: %s\n", name, talon_last_error());
         pthread_cond_destroy(&ctx->cond);
@@ -166,8 +171,8 @@ static int do_bad_uri(talon_client *client, op_context *ctx) {
     pthread_cond_init(&ctx->cond, NULL);
     uint8_t byte;
     uint64_t request_id = 0;
-    int rc = talon_read_async(client, "ftp://bucket/key", 0, &byte, 1, on_result, ctx,
-                              &request_id);
+    int rc = talon_read_async(client, "ftp://bucket/key", 0, &byte, 1, NULL, 0,
+                              on_result, ctx, &request_id);
     int ok = rc != TALON_STATUS_OK;
     if (!ok) {
         fprintf(stderr, "  FAIL bad-uri: submit unexpectedly succeeded\n");
@@ -204,27 +209,36 @@ int main(int argc, char **argv) {
     ok = do_stat(client, uri, &ctx);
     printf("  %s stat returns size and version\n", ok ? "ok" : "FAIL");
     ok ? passed++ : failed++;
+    /* Reuse the version + size from the stat above for the fast-path read. */
+    char stat_version[64];
+    snprintf(stat_version, sizeof(stat_version), "%s", ctx.version);
+    uint64_t stat_size = ctx.object_size;
 
-    ok = do_read(client, uri, 0, 4096, &ctx, "reads exact bytes at offset 0");
+    ok = do_read(client, uri, 0, 4096, NULL, NULL, &ctx, "reads exact bytes at offset 0");
     printf("  %s reads exact bytes at offset 0\n", ok ? "ok" : "FAIL");
     ok ? passed++ : failed++;
 
-    ok = do_read(client, uri, 1000, 8192, &ctx, "reads exact bytes at offset 1000");
+    ok = do_read(client, uri, 1000, 8192, NULL, NULL, &ctx, "reads exact bytes at offset 1000");
     printf("  %s reads exact bytes at offset 1000\n", ok ? "ok" : "FAIL");
     ok ? passed++ : failed++;
 
-    ok = do_read(client, uri, 0, (size_t)(block_size + (4u << 20)), &ctx,
+    ok = do_read(client, uri, 0, (size_t)(block_size + (4u << 20)), NULL, NULL, &ctx,
                  "reassembles a range spanning block boundaries");
     printf("  %s reassembles a range spanning block boundaries\n", ok ? "ok" : "FAIL");
     ok ? passed++ : failed++;
 
-    ok = do_read(client, uri, block_size - 2048, 4096, &ctx,
+    ok = do_read(client, uri, block_size - 2048, 4096, NULL, NULL, &ctx,
                  "reads across exactly one block edge");
     printf("  %s reads across exactly one block edge\n", ok ? "ok" : "FAIL");
     ok ? passed++ : failed++;
 
-    ok = do_read(client, uri, 0, 0, &ctx, "zero-length read returns empty");
+    ok = do_read(client, uri, 0, 0, NULL, NULL, &ctx, "zero-length read returns empty");
     printf("  %s zero-length read returns empty\n", ok ? "ok" : "FAIL");
+    ok ? passed++ : failed++;
+
+    ok = do_read(client, uri, 1000, (size_t)(block_size + (4u << 20)), stat_version,
+                 &stat_size, &ctx, "fast-path read with a caller-supplied version");
+    printf("  %s fast-path read with a caller-supplied version\n", ok ? "ok" : "FAIL");
     ok ? passed++ : failed++;
 
     ok = do_bad_uri(client, &ctx);


### PR DESCRIPTION
## What

Two changes to the C SDK read path (`talon_read_async`), aimed at removing avoidable overhead when the caller already knows an object's identity.

### 1. Optional caller-supplied version + size (skip `StatObject`)

`talon_read_async` gains two new, independently-nullable parameters:

```c
int talon_read_async(
    talon_client *client, const char *uri, uint64_t offset,
    uint8_t *dst, size_t dst_len,
    const char *version,          /* NULL = unknown */
    const uint64_t *object_size,  /* NULL = unknown */
    talon_callback callback, void *user_data, uint64_t *request_id_out);
```

- **Both non-NULL** → fast path: the read uses the caller's version + size and **skips the `StatObject` control round trip** entirely. The caller owns keeping them current for the object generation being read.
- **Either NULL** → the SDK resolves both with a `StatObject` first (the historical behavior); a lone supplied value is ignored, since a read cannot skip the stat without both halves.

`object_size` is a pointer specifically so *"no valid size"* (`NULL`) is distinct from *"a genuinely empty object"* (`*object_size == 0`, an unambiguous zero-byte read). EOF semantics are preserved: a size smaller than `offset + dst_len` yields a POSIX short read, and a size larger than the object surfaces as a read error rather than fabricated bytes.

### 2. Concurrent block fetches

A read spanning multiple blocks previously fetched them in a serial `await` loop. It now fans the per-block fetches out concurrently (a `JoinSet` over disjoint `'static` sub-slices of the caller buffer), so a large read no longer pays one worker RTT per block in series.

## Note

This is a **breaking change to the C ABI** of `talon_read_async` (two new parameters). Existing callers that want the previous behavior pass `NULL, NULL`. The in-repo header, smoke test, example, and MinIO e2e are all updated; the e2e adds a fast-path case that reuses the version + size from its stat.

## Testing

- `cargo test -p talon-c`: 13 unit tests pass, including new coverage for the fast path skipping the stat, version-without-size falling back to the stat, the empty-object (`size == 0`) fast path, and concurrent multi-block reassembly.
- `cargo clippy -p talon-c --all-targets` clean; `cargo fmt` clean.
- All C sources compile under `-std=c11 -Wall -Wextra -Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)