### PR TITLE
fix(worker): support the data plane/build on macOS

### DIFF
--- a/crates/talon-worker/src/lib.rs
+++ b/crates/talon-worker/src/lib.rs
@@ -20,10 +20,13 @@ pub mod paged_store;
 pub mod rate_limit;
 pub mod runtime;
 pub mod sendfile;
+#[cfg(target_os = "linux")]
 pub mod splice;
 pub mod staging;
 pub mod tokio_conn;
+#[cfg(target_os = "linux")]
 pub mod uring_conn;
+#[cfg(target_os = "linux")]
 pub mod uring_serve;
 pub mod wal;
 pub mod wal_checkpoint;
@@ -45,6 +48,7 @@ pub use runtime::{ServeOutcome, WorkerRuntime};
 pub use sendfile::{
     send_file_range, send_header_and_file_range, send_header_and_file_ranges, DEFAULT_CHUNK,
 };
+#[cfg(target_os = "linux")]
 pub use splice::{ingest_put, splice_to_file};
 pub use staging::{Checksum, Stager};
 pub use write_cache::{FlushItem, WriteCache};

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -40,6 +40,7 @@ use talon_transport::control_tls::ControlTlsChannel;
 use talon_transport::{codec, ControlMessage};
 use talon_worker::mapping_guard::MappingGuard;
 use talon_worker::tokio_conn::{handle_conn, read_control};
+#[cfg(target_os = "linux")]
 use talon_worker::uring_conn;
 use talon_worker::{
     serve_admin, BlockIndex, InFlightLoads, PagedBlockStore, TenantRateLimiter, WholeBlockStore,
@@ -59,6 +60,7 @@ const MAX_DATA_PLANE_CONNECTIONS: usize = 1024;
 /// Blocking helper threads per io_uring ring, for the zero-copy `sendfile`
 /// path. Kept small because every ring has its own pool and the rings are
 /// pinned: a large pool per ring would oversubscribe the cores they sit on.
+#[cfg(target_os = "linux")]
 const URING_BLOCKING_THREADS_PER_RING: usize = 4;
 
 /// Bridges the backend retry decorator to the worker's metrics registry.
@@ -658,7 +660,10 @@ async fn main() -> anyhow::Result<()> {
     let force_tokio = std::env::var(FORCE_TOKIO_ENV)
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
+    #[cfg(target_os = "linux")]
     let uring_available = talon_worker::uring_serve::io_uring_available();
+    #[cfg(not(target_os = "linux"))]
+    let uring_available = false;
     if force_tokio {
         tracing::info!("{FORCE_TOKIO_ENV} is set; serving the data plane on the Tokio path");
     } else if !uring_available {
@@ -667,6 +672,7 @@ async fn main() -> anyhow::Result<()> {
              data plane. Performance will be lower under high connection counts."
         );
     }
+    #[cfg(target_os = "linux")]
     if !force_tokio && uring_available {
         let rings = talon_worker::uring_serve::resolve_ring_count(cfg.data_plane_rings);
         tracing::info!(

--- a/crates/talon-worker/src/sendfile.rs
+++ b/crates/talon-worker/src/sendfile.rs
@@ -9,7 +9,7 @@
 //! - handles short writes (a partial `sendfile` return advances the offset and
 //!   retries) and `EINTR`.
 //!
-//! `sendfile` is Linux-specific and blocking; per DESIGN.md it runs in the
+//! `sendfile` is platform-specific and blocking; per DESIGN.md it runs in the
 //! worker's blocking helper pool, never on the io_uring control ring. The
 //! caller writes the response frame header first, then calls
 //! [`send_file_range`] to stream the payload.
@@ -26,6 +26,7 @@ pub const DEFAULT_CHUNK: usize = 1 << 20;
 /// Returns the total number of bytes sent (== `len` on success). Handles short
 /// writes and `EINTR`; any other error is returned. `chunk` bounds a single
 /// syscall's transfer (use [`DEFAULT_CHUNK`]).
+#[cfg(target_os = "linux")]
 pub fn send_file_range(
     sock: &impl AsRawFd,
     file: &impl AsRawFd,
@@ -64,6 +65,61 @@ pub fn send_file_range(
     Ok(sent_total)
 }
 
+/// macOS `sendfile(2)` takes the input file first and reports bytes written
+/// through an in/out length pointer, including bytes written before an error.
+#[cfg(target_os = "macos")]
+pub fn send_file_range(
+    sock: &impl AsRawFd,
+    file: &impl AsRawFd,
+    offset: u64,
+    len: u64,
+    chunk: usize,
+) -> io::Result<u64> {
+    let out_fd: RawFd = sock.as_raw_fd();
+    let in_fd: RawFd = file.as_raw_fd();
+    let chunk = chunk.max(1);
+
+    let mut off = offset as libc::off_t;
+    let mut remaining = len;
+    let mut sent_total = 0u64;
+
+    while remaining > 0 {
+        let mut sent = remaining.min(chunk as u64) as libc::off_t;
+        // SAFETY: valid fds; `sent` is a valid in/out pointer. macOS writes
+        // the number of transferred bytes to it even when the call returns an
+        // error after a partial transfer.
+        let rc = unsafe { libc::sendfile(in_fd, out_fd, off, &mut sent, std::ptr::null_mut(), 0) };
+        if sent > 0 {
+            let sent = sent as u64;
+            sent_total += sent;
+            remaining -= sent;
+            off += sent as libc::off_t;
+        }
+        if rc == 0 {
+            if sent == 0 {
+                // EOF before we expected it: the file is shorter than requested.
+                break;
+            }
+            continue;
+        }
+
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::EINTR) {
+            continue;
+        }
+        return Err(err);
+    }
+    Ok(sent_total)
+}
+
+#[cfg(target_os = "linux")]
+const HEADER_SEND_FLAGS: libc::c_int = libc::MSG_MORE | libc::MSG_NOSIGNAL;
+
+// Darwin has no MSG_MORE. MSG_NOSIGNAL still prevents a closed peer from
+// terminating the worker while the following sendfile call supplies payload.
+#[cfg(target_os = "macos")]
+const HEADER_SEND_FLAGS: libc::c_int = libc::MSG_NOSIGNAL;
+
 /// Send `header` and then `[offset, offset + len)` of `file` to `sock` in a
 /// single blocking step.
 ///
@@ -73,9 +129,9 @@ pub fn send_file_range(
 /// per-request cost on the serve path, since the payload copy itself is
 /// already zero-copy.
 ///
-/// The header goes out with `MSG_MORE` so the kernel holds it back and
-/// coalesces it with the first `sendfile` chunk into one TCP segment instead
-/// of emitting a tiny header-only packet.
+/// On Linux the header goes out with `MSG_MORE` so the kernel can coalesce it
+/// with the first `sendfile` chunk. macOS has no `MSG_MORE`, so it uses only
+/// `MSG_NOSIGNAL` and preserves correctness without that optimization.
 ///
 /// Returns the number of *payload* bytes sent (header bytes are not counted),
 /// so the caller can apply the same short-send check as [`send_file_range`].
@@ -97,7 +153,7 @@ pub fn send_header_and_file_range(
                 out_fd,
                 header[written..].as_ptr() as *const libc::c_void,
                 header.len() - written,
-                libc::MSG_MORE | libc::MSG_NOSIGNAL,
+                HEADER_SEND_FLAGS,
             )
         };
         if n < 0 {
@@ -116,8 +172,8 @@ pub fn send_header_and_file_range(
         written += n as usize;
     }
 
-    // `MSG_MORE` leaves the header corked; the sendfile below uncorks it by
-    // filling the segment. A zero-length payload would strand it, so flush.
+    // On Linux, `MSG_MORE` leaves the header corked and a zero-length payload
+    // would strand it. On macOS the header is already sent; this is harmless.
     if len == 0 {
         // SAFETY: valid fd; a zero-length send with no MSG_MORE flushes.
         unsafe { libc::send(out_fd, [].as_ptr(), 0, libc::MSG_NOSIGNAL) };
@@ -136,10 +192,9 @@ pub fn send_header_and_file_range(
 /// `sendfile` per segment keeps the whole read zero-copy instead of falling
 /// back to reading each page into a buffer and concatenating.
 ///
-/// The header goes out corked with `MSG_MORE`, so the kernel coalesces it with
-/// the first page's bytes instead of emitting a header-only packet. Successive
-/// `sendfile` calls append into the same socket buffer, so adjacent pages fill
-/// full segments rather than one packet per page.
+/// Linux corks the header with `MSG_MORE`, so the kernel can coalesce it with
+/// the first page's bytes. macOS sends the header with `MSG_NOSIGNAL` only;
+/// successive `sendfile` calls still preserve the same byte order.
 ///
 /// Returns the number of *payload* bytes sent (header bytes are not counted).
 /// A short return means some segment hit EOF early; the caller must treat that
@@ -160,7 +215,7 @@ pub fn send_header_and_file_ranges<F: AsRawFd>(
                 out_fd,
                 header[written..].as_ptr() as *const libc::c_void,
                 header.len() - written,
-                libc::MSG_MORE | libc::MSG_NOSIGNAL,
+                HEADER_SEND_FLAGS,
             )
         };
         if n < 0 {
@@ -181,8 +236,9 @@ pub fn send_header_and_file_ranges<F: AsRawFd>(
 
     let total: u64 = segments.iter().map(|(_, _, len)| *len).sum();
     if total == 0 {
-        // `MSG_MORE` left the header corked and no payload will uncork it.
-        // SAFETY: valid fd; a zero-length send with no MSG_MORE flushes.
+        // Linux needs a send without MSG_MORE to flush its corked header; on
+        // macOS this zero-length send is harmless.
+        // SAFETY: valid fd.
         unsafe { libc::send(out_fd, [].as_ptr(), 0, libc::MSG_NOSIGNAL) };
         return Ok(0);
     }


### PR DESCRIPTION

<!--
Thanks for contributing to Talon! Keep PRs small and single-purpose.
Please fill out each section. Delete any that genuinely don't apply.
-->

## Summary

The worker data plane was still tied to Linux-only APIs such as io_uring, splice, the Linux sendfile signature, and MSG_MORE, which prevented it from building and running on macOS. Add a native macOS path while keeping the existing optimized Linux behavior unchanged.

Gate the io_uring and splice modules, imports, and configuration behind Linux-only compilation. On macOS, report io_uring as unavailable and naturally fall back to the portable Tokio data plane.

Implement the Darwin sendfile calling convention and correctly track partial transfers, offsets, and interrupted calls. Use platform-specific header flags so Linux can keep coalescing headers with MSG_MORE, while macOS sends headers safely with MSG_NOSIGNAL for both single-range and multi-range responses.

## Related issues

nope

## Type of change

- [x] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [ ] Docs / tests / tooling

## Design alignment

<!--
Which DESIGN.md area does this touch? Reference the section(s).
If this diverges from or amends the design, explain why.
-->

## Changes

<!-- Bullet the notable changes, grouped by crate if it helps. -->

-

## Test plan

<!-- How did you verify this? Commands and results. -->

- [ ] `just ci` passes locally (fmt + clippy + test)
- [ ] Workspace compiles (`cargo build --workspace`)
- [ ] Added/updated tests for new behavior

## Performance impact

<!--
Did this touch a hot path (keys, placement, block/page index, data plane)?
If so, paste the `just bench-check` verdict table. If a regression is
intentional, note it and confirm the baseline was refreshed and committed.
-->

- [ ] Not performance-sensitive, OR
- [ ] `just bench-check` run; results below (baseline refreshed if the change is intentional)

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`<type>(<scope>): <description>`) — it becomes the squash-merge commit subject and is checked by CI
- [ ] Public items are documented; no broken intra-doc links
- [ ] No new dependencies without discussion
- [ ] Rebased on the latest `main`
