### PR TITLE
feat(clients): add a shared Rust SDK and slim down C/Python adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,11 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo build --workspace --all-targets --all-features --locked
+        # talon-python's extension-module feature deliberately avoids linking
+        # libpython, so its Rust test executable is built in the Python job.
+        run: cargo build --workspace --exclude talon-python --all-targets --all-features --locked
       - name: Test
-        run: cargo test --workspace --all-features --locked
+        run: cargo test --workspace --exclude talon-python --all-features --locked
 
   fuse-mount:
     name: fuse mount e2e
@@ -502,6 +504,9 @@ jobs:
           # client's generated code; both binaries below need it.
           sudo apt-get update && sudo apt-get install -y protobuf-compiler
           python -m pip install --upgrade maturin pytest
+      - name: Test the Rust-side Python bindings
+        # Rust tests need libpython, so do not enable extension-module here.
+        run: cargo test -p talon-python --locked
       - name: Build the release binaries the tests drive
         run: |
           cargo build --release --locked \

--- a/.github/workflows/minio-sdk-e2e.yml
+++ b/.github/workflows/minio-sdk-e2e.yml
@@ -17,6 +17,7 @@ on:
       - "deploy/docker/**"
       - "deploy/helm/talon/**"
       - "clients/python/**"
+      - "clients/rust/**"
       - "clients/java/**"
       - "clients/c/**"
       - "crates/talon-client/**"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2583,8 +2583,8 @@ name = "talon-c"
 version = "0.1.0"
 dependencies = [
  "cc",
- "talon-cache-client",
  "talon-core",
+ "talon-rust-client",
  "talon-transport",
  "tokio",
 ]
@@ -2745,9 +2745,19 @@ name = "talon-python"
 version = "0.1.0"
 dependencies = [
  "pyo3",
+ "talon-rust-client",
+ "tokio",
+]
+
+[[package]]
+name = "talon-rust-client"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "talon-cache-client",
  "talon-core",
- "talon-fuse",
  "talon-transport",
+ "thiserror 2.0.19",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/talon-backend",
     "crates/talon-client",
     "clients/c",
+    "clients/rust",
     "clients/python",
     "crates/talon-observability",
     "crates/talon-metadata",
@@ -26,6 +27,7 @@ rust-version = "1.80"
 [workspace.dependencies]
 talon-core = { path = "crates/talon-core" }
 talon-cache-client = { path = "crates/talon-cache-client" }
+talon-rust-client = { path = "clients/rust" }
 talon-transport = { path = "crates/talon-transport" }
 talon-metadata = { path = "crates/talon-metadata" }
 

--- a/clients/c/Cargo.toml
+++ b/clients/c/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 talon-core.workspace = true
-talon-cache-client.workspace = true
+talon-rust-client.workspace = true
 talon-transport.workspace = true
 tokio.workspace = true
 

--- a/clients/c/src/lib.rs
+++ b/clients/c/src/lib.rs
@@ -13,12 +13,12 @@ use std::ptr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use talon_cache_client::{plan_read, BlockReader, CoordinatorClient, PlacementCache};
-use talon_core::{ObjectId, Version};
+use talon_rust_client::{
+    parse_uri as parse_rust_uri, Client as RustClient, Error as RustError, ObjectId,
+    ObjectStat as RustObjectStat, UriError,
+};
 
 const DEFAULT_BLOCK_SIZE: u32 = 256 << 20;
-const PLACEMENT_TTL_MS: u64 = 30_000;
-const REPLICAS_K: u8 = 1;
 
 const STATUS_OK: c_int = 0;
 const STATUS_INVALID_ARGUMENT: c_int = 1;
@@ -67,9 +67,7 @@ pub struct TalonClient {
 
 struct ClientInner {
     runtime: Arc<tokio::runtime::Runtime>,
-    coordinator: CoordinatorClient,
-    reader: BlockReader,
-    block_size: u32,
+    client: Arc<RustClient>,
     dispatcher: Arc<CallbackDispatcher>,
     next_request_id: AtomicU64,
 }
@@ -224,15 +222,12 @@ pub unsafe extern "C" fn talon_client_new(
             .enable_all()
             .build()
             .map_err(|error| (STATUS_RUNTIME_ERROR, error.to_string()))?;
-        let coordinator = CoordinatorClient::new(coordinator_addr);
-        let cache = Arc::new(PlacementCache::new(PLACEMENT_TTL_MS));
-        let reader = BlockReader::new(coordinator.clone(), cache, REPLICAS_K);
+        let rust_client = RustClient::new(coordinator_addr, block_size)
+            .map_err(|error| (STATUS_INVALID_ARGUMENT, error.to_string()))?;
         let client = Box::new(TalonClient {
             inner: Arc::new(ClientInner {
                 runtime: Arc::new(runtime),
-                coordinator,
-                reader,
-                block_size,
+                client: Arc::new(rust_client),
                 dispatcher: Arc::new(dispatcher),
                 next_request_id: AtomicU64::new(1),
             }),
@@ -332,35 +327,22 @@ pub unsafe extern "C" fn talon_read_async(
         };
         let user_data = UserData(user_data);
         let runtime = Arc::clone(&inner.runtime);
-        let coordinator = inner.coordinator.clone();
-        let reader = inner.reader.clone();
+        let client = Arc::clone(&inner.client);
         let dispatcher = Arc::clone(&inner.dispatcher);
-        let block_size = inner.block_size;
+        let known_stat = match (known_version, known_size) {
+            (Some(version), Some(size)) => Some(RustObjectStat { size, version }),
+            _ => None,
+        };
         runtime.spawn(async move {
             let result = async {
                 if read_buffer.len == 0 {
                     return Ok(0);
                 }
-                let (version, size) = match (known_version, known_size) {
-                    (Some(version), Some(size)) => (Version::new(version.as_str()), size),
-                    _ => {
-                        let stat = coordinator
-                            .stat_object(&object)
-                            .await
-                            .map_err(|error| error.to_string())?;
-                        (Version::new(stat.version.as_str()), stat.size)
-                    }
-                };
                 let dst = unsafe { read_buffer.into_mut_slice() };
-                let plan = plan_read(
-                    &object,
-                    offset,
-                    dst.len() as u64,
-                    block_size,
-                    &version,
-                    size,
-                );
-                fetch_blocks_concurrent(reader, plan, dst, now_ms()).await
+                client
+                    .read_into(&object, offset, dst, known_stat.as_ref())
+                    .await
+                    .map_err(|error| error.to_string())
             }
             .await;
             dispatch_result(
@@ -372,60 +354,6 @@ pub unsafe extern "C" fn talon_read_async(
         });
         Ok(())
     })
-}
-
-/// Fetch every segment of `plan` concurrently into `dst`, rather than walking
-/// the blocks in series.
-///
-/// [`plan_read`] partitions the requested range into disjoint per-block segments
-/// (already clamped at EOF); each segment is handed an exclusive sub-slice of
-/// `dst`, and every block is fetched in parallel on the runtime. The segments
-/// cover `[0, planned_len)` in order and every task is joined before this future
-/// resolves; the caller owns `dst` until the callback runs (the header
-/// contract), so lending each task a disjoint `'static` sub-slice is sound.
-async fn fetch_blocks_concurrent(
-    reader: BlockReader,
-    plan: Vec<talon_cache_client::BlockSegment>,
-    dst: &'static mut [u8],
-    now_ms: u64,
-) -> Result<usize, String> {
-    if plan.is_empty() {
-        return Ok(0);
-    }
-
-    let mut tasks = tokio::task::JoinSet::new();
-    let mut rest = dst;
-    for segment in plan {
-        let want = segment.len as usize;
-        let (chunk, tail) = split_static_prefix(rest, want);
-        rest = tail;
-        let reader = reader.clone();
-        tasks.spawn(async move {
-            reader
-                .read_block_into(&segment.block, segment.offset_in_block, chunk, now_ms)
-                .await
-                .map_err(|error| error.to_string())
-                .map(|read| (read, want))
-        });
-    }
-
-    let mut written = 0usize;
-    while let Some(joined) = tasks.join_next().await {
-        let (read, want) = joined.map_err(|error| format!("block read task failed: {error}"))??;
-        if read != want {
-            return Err(format!(
-                "worker returned {read} of {want} requested bytes; the object may have changed"
-            ));
-        }
-        written += read;
-    }
-    Ok(written)
-}
-
-/// Split a `'static` buffer into an owned `'static` prefix of `n` bytes and the
-/// `'static` remainder, so each concurrent block fetch can own its slice.
-fn split_static_prefix(buf: &'static mut [u8], n: usize) -> (&'static mut [u8], &'static mut [u8]) {
-    buf.split_at_mut(n)
 }
 
 /// Submit an async stat.
@@ -458,11 +386,11 @@ pub unsafe extern "C" fn talon_stat_async(
 
         let user_data = UserData(user_data);
         let runtime = Arc::clone(&inner.runtime);
-        let coordinator = inner.coordinator.clone();
+        let client = Arc::clone(&inner.client);
         let dispatcher = Arc::clone(&inner.dispatcher);
         runtime.spawn(async move {
-            let result = coordinator
-                .stat_object(&object)
+            let result = client
+                .stat(&object)
                 .await
                 .map_err(|error| error.to_string());
             dispatch_result(
@@ -573,10 +501,7 @@ impl TalonResult {
         }
     }
 
-    fn stat(
-        request_id: u64,
-        result: Result<talon_cache_client::coordinator_client::ObjectStat, String>,
-    ) -> Self {
+    fn stat(request_id: u64, result: Result<RustObjectStat, String>) -> Self {
         match result {
             Ok(stat) => Self {
                 operation: OPERATION_STAT,
@@ -642,44 +567,18 @@ fn c_string(ptr: *const c_char, name: &str) -> Result<String, (c_int, String)> {
 }
 
 fn parse_uri(uri: &str) -> Result<ObjectId, (c_int, String)> {
-    let (scheme, rest) = uri.split_once("://").ok_or_else(|| {
-        (
-            STATUS_INVALID_ARGUMENT,
-            format!("expected a scheme://bucket/key URI, got {uri:?} (schemes: s3, gcs, az)"),
-        )
-    })?;
-    let backend = scheme.parse().map_err(|_| {
-        (
-            STATUS_INVALID_ARGUMENT,
-            format!("unknown backend scheme {scheme:?}"),
-        )
-    })?;
-    let (bucket, key) = rest.split_once('/').ok_or_else(|| {
-        (
-            STATUS_INVALID_ARGUMENT,
-            format!("URI is missing an object key: {uri:?}"),
-        )
-    })?;
-    if bucket.is_empty() {
-        return Err((
-            STATUS_INVALID_ARGUMENT,
-            format!("URI has an empty bucket: {uri:?}"),
-        ));
-    }
-    if key.is_empty() {
-        return Err((
-            STATUS_INVALID_ARGUMENT,
-            format!("URI has an empty object key: {uri:?}"),
-        ));
-    }
-    Ok(ObjectId::new(backend, bucket, key))
-}
-
-fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
+    parse_rust_uri(uri).map_err(|error| {
+        let message = match error {
+            RustError::InvalidUri(UriError::UnknownScheme { scheme }) => {
+                format!("unknown backend scheme {scheme:?}")
+            }
+            RustError::InvalidUri(UriError::MissingKey { uri, .. }) => {
+                format!("URI is missing an object key: {uri:?}")
+            }
+            error => error.to_string(),
+        };
+        (STATUS_INVALID_ARGUMENT, message)
+    })
 }
 
 fn ffi_status<F>(f: F) -> c_int
@@ -1345,6 +1244,45 @@ mod tests {
         let snapshot = state.wait();
         assert_eq!(snapshot.status, STATUS_OK);
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        unsafe {
+            talon_client_free(client);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn invalid_uri_messages_preserve_the_c_contract() {
+        let (client, _) = new_client().await;
+        for (uri, expected) in [
+            ("ftp://bucket/key", "unknown backend scheme \"ftp\""),
+            (
+                "az://bucket",
+                "URI is missing an object key: \"az://bucket\"",
+            ),
+        ] {
+            let uri = cstring(uri);
+            let mut request_id = 0;
+            let status = unsafe {
+                talon_read_async(
+                    client,
+                    uri.as_ptr(),
+                    0,
+                    ptr::null_mut(),
+                    0,
+                    ptr::null(),
+                    ptr::null(),
+                    Some(capture_callback),
+                    ptr::null_mut(),
+                    &mut request_id,
+                )
+            };
+
+            assert_eq!(status, STATUS_INVALID_ARGUMENT);
+            let message = unsafe { CStr::from_ptr(talon_last_error()) }
+                .to_string_lossy()
+                .into_owned();
+            assert_eq!(message, expected);
+        }
 
         unsafe {
             talon_client_free(client);

--- a/clients/python/Cargo.toml
+++ b/clients/python/Cargo.toml
@@ -19,12 +19,7 @@ crate-type = ["cdylib", "rlib"]
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
-talon-core.workspace = true
-talon-transport.workspace = true
-# The read path (block splitting, placement cache, replica fallback, pooling)
-# already exists here and is exercised by the FUSE client. Default features
-# exclude `fuser`, so no FUSE dependency reaches the Python extension.
-talon-fuse = { path = "../../crates/talon-fuse" }
+talon-rust-client.workspace = true
 # `extension-module` tells pyo3 not to link libpython, which is correct for a
 # wheel but breaks `cargo test` (the test harness needs a Python to link
 # against). It is therefore opt-in via the `extension-module` feature, which

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -1,12 +1,7 @@
 //! Python bindings for the Talon client (#312).
 //!
-//! Binds the Rust read path rather than reimplementing it. Block splitting,
-//! placement caching, replica fallback, and connection pooling already exist in
-//! `talon-fuse` and are exercised by the FUSE client; duplicating them in
-//! Python would duplicate their bugs too.
-//!
-//! `talon-fuse`'s default features exclude `fuser`, so no FUSE or libfuse
-//! dependency reaches the extension module.
+//! Adapts the native Rust client rather than reimplementing URI parsing, stat
+//! fallback, range planning, placement, or block reads in the binding.
 //!
 //! # Threading
 //!
@@ -26,55 +21,33 @@ use std::sync::Arc;
 use pyo3::exceptions::{PyIOError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
-use talon_core::{ObjectId, Version};
-use talon_fuse::block_reader::FileView;
-use talon_fuse::{BlockReader, CoordinatorClient, PlacementCache};
+use talon_rust_client::{
+    parse_uri, Client as RustClient, Error as RustError, ObjectStat as RustObjectStat,
+};
 
-/// Placement entries older than this are re-resolved. Matches the FUSE client's
-/// default so both see the same staleness window.
-const PLACEMENT_TTL_MS: u64 = 30_000;
-/// Replicas to request per placement lookup. RF=1 in v1.
-const REPLICAS_K: u8 = 1;
-
-/// Milliseconds since the epoch, for placement-cache expiry.
-fn now_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
-}
-
-/// Map a client-side failure to a Python exception, preserving the worker's own
-/// message. Flattening these to a generic error would hide the distinction
-/// between "object does not exist" and "every replica is down".
+/// Runtime construction failures are infrastructure errors.
 fn io_err<E: std::fmt::Display>(e: E) -> PyErr {
     PyIOError::new_err(e.to_string())
 }
 
-/// Parse a `scheme://bucket/key` URI into an [`ObjectId`].
-///
-/// The schemes match the namespaces the FUSE mount exposes (`s3`, `gcs`, `az`),
-/// so a path used with one client addresses the same object in the other.
-///
-/// Returns a plain `String` error rather than a `PyErr` so the parsing rules can
-/// be tested without an initialised interpreter; [`parse_uri`] wraps it.
-fn parse_uri_inner(uri: &str) -> Result<ObjectId, String> {
-    let (scheme, rest) = uri.split_once("://").ok_or_else(|| {
-        format!("expected a scheme://bucket/key URI, got {uri:?} (schemes: s3, gcs, az)")
-    })?;
-    let backend = scheme
-        .parse()
-        .map_err(|_| format!("unknown backend scheme {scheme:?}; expected s3, gcs, or az"))?;
-    let (bucket, key) = rest.split_once('/').ok_or_else(|| {
-        format!("URI is missing an object key: {uri:?} (expected {scheme}://bucket/key)")
-    })?;
-    if bucket.is_empty() {
-        return Err(format!("URI has an empty bucket: {uri:?}"));
+/// Preserve the SDK's input-versus-I/O error distinction at the Python boundary.
+fn client_err(error: RustError) -> PyErr {
+    let message = error.to_string();
+    match error {
+        RustError::InvalidUri(_) | RustError::InvalidArgument(_) => PyValueError::new_err(message),
+        RustError::Coordinator(_) | RustError::Block(_) => PyIOError::new_err(message),
     }
-    if key.is_empty() {
-        return Err(format!("URI has an empty object key: {uri:?}"));
+}
+
+fn complete_known_stat(
+    known_version: Option<String>,
+    known_size: Option<u64>,
+    resolved: RustObjectStat,
+) -> RustObjectStat {
+    RustObjectStat {
+        size: known_size.unwrap_or(resolved.size),
+        version: known_version.unwrap_or(resolved.version),
     }
-    Ok(ObjectId::new(backend, bucket, key))
 }
 
 /// An object's size and source version.
@@ -119,9 +92,7 @@ impl ObjectEntry {
 #[pyclass(module = "talon")]
 pub struct Client {
     runtime: Arc<tokio::runtime::Runtime>,
-    coordinator: CoordinatorClient,
-    reader: BlockReader,
-    block_size: u32,
+    client: Arc<RustClient>,
 }
 
 #[pymethods]
@@ -141,14 +112,11 @@ impl Client {
             .enable_all()
             .build()
             .map_err(io_err)?;
-        let coordinator_client = CoordinatorClient::new(coordinator);
-        let cache = Arc::new(PlacementCache::new(PLACEMENT_TTL_MS));
-        let reader = BlockReader::new(coordinator_client.clone(), cache, REPLICAS_K);
+        let client = RustClient::new(coordinator, block_size)
+            .map_err(|error| PyValueError::new_err(error.to_string()))?;
         Ok(Self {
             runtime: Arc::new(runtime),
-            coordinator: coordinator_client,
-            reader,
-            block_size,
+            client: Arc::new(client),
         })
     }
 
@@ -175,66 +143,43 @@ impl Client {
         version: Option<&str>,
         size: Option<u64>,
     ) -> PyResult<Bound<'py, PyBytes>> {
-        let object = parse_uri_inner(uri).map_err(PyValueError::new_err)?;
-        let known_version = version.map(Version::new);
+        let object = parse_uri(uri).map_err(|error| PyValueError::new_err(error.to_string()))?;
+        let known_version = version.map(str::to_owned);
         let runtime = Arc::clone(&self.runtime);
-        let reader = self.reader.clone();
-        let coordinator = self.coordinator.clone();
-        let block_size = self.block_size;
+        let client = Arc::clone(&self.client);
 
         // Release the GIL: this is network I/O, and holding it would serialise
         // every reader thread in the process on one request.
         let bytes = py.allow_threads(move || {
             runtime.block_on(async move {
-                // One stat covers both, so only issue it when something is
-                // actually missing.
-                let (version, file_size) = match (known_version, size) {
-                    (Some(v), Some(s)) => (v, s),
-                    (known, known_size) => {
-                        let stat = coordinator
-                            .stat_object(&object)
-                            .await
-                            .map_err(|e| e.to_string())?;
-                        (
-                            known.unwrap_or_else(|| Version::new(stat.version.as_str())),
-                            known_size.unwrap_or(stat.size),
-                        )
+                let known_stat = match (known_version, size) {
+                    (Some(version), Some(size)) => Some(RustObjectStat { size, version }),
+                    (None, None) => None,
+                    (known_version, known_size) => {
+                        let stat = client.stat(&object).await?;
+                        Some(complete_known_stat(known_version, known_size, stat))
                     }
                 };
-                let len = length.unwrap_or_else(|| file_size.saturating_sub(offset));
-                let file = FileView {
-                    object: &object,
-                    block_size,
-                    version: &version,
-                    size: file_size,
-                };
-                reader
-                    .read(&file, offset, len, now_ms())
+                client
+                    .read(&object, offset, length, known_stat.as_ref())
                     .await
-                    .map_err(|e| e.to_string())
             })
         });
-        let bytes = bytes.map_err(PyIOError::new_err)?;
+        let bytes = bytes.map_err(client_err)?;
         Ok(PyBytes::new_bound(py, &bytes))
     }
 
     /// Return an object's size and version.
     fn stat(&self, py: Python<'_>, uri: &str) -> PyResult<ObjectStat> {
-        let object = parse_uri_inner(uri).map_err(PyValueError::new_err)?;
+        let object = parse_uri(uri).map_err(|error| PyValueError::new_err(error.to_string()))?;
         let runtime = Arc::clone(&self.runtime);
-        let coordinator = self.coordinator.clone();
-        let stat = py.allow_threads(move || {
-            runtime.block_on(async move {
-                coordinator
-                    .stat_object(&object)
-                    .await
-                    .map_err(|e| e.to_string())
-            })
-        });
-        let stat = stat.map_err(PyIOError::new_err)?;
+        let client = Arc::clone(&self.client);
+        let stat =
+            py.allow_threads(move || runtime.block_on(async move { client.stat(&object).await }));
+        let stat = stat.map_err(client_err)?;
         Ok(ObjectStat {
             size: stat.size,
-            version: stat.version.as_str().to_string(),
+            version: stat.version,
         })
     }
 
@@ -250,17 +195,11 @@ impl Client {
     /// instead of returning an incomplete list; use a narrower prefix.
     fn list(&self, py: Python<'_>, prefix: &str) -> PyResult<Vec<ObjectEntry>> {
         let runtime = Arc::clone(&self.runtime);
-        let coordinator = self.coordinator.clone();
+        let client = Arc::clone(&self.client);
         let prefix = prefix.to_string();
-        let entries = py.allow_threads(move || {
-            runtime.block_on(async move {
-                coordinator
-                    .list_objects(&prefix)
-                    .await
-                    .map_err(|e| e.to_string())
-            })
-        });
-        let entries = entries.map_err(PyIOError::new_err)?;
+        let entries =
+            py.allow_threads(move || runtime.block_on(async move { client.list(&prefix).await }));
+        let entries = entries.map_err(client_err)?;
         Ok(entries
             .into_iter()
             .map(|e| ObjectEntry {
@@ -273,14 +212,14 @@ impl Client {
     /// The coordinator address this client is connected to.
     #[getter]
     fn coordinator(&self) -> &str {
-        self.reader.coordinator_addr()
+        self.client.coordinator_addr()
     }
 
     fn __repr__(&self) -> String {
         format!(
             "Client(coordinator={:?}, block_size={})",
-            self.reader.coordinator_addr(),
-            self.block_size
+            self.client.coordinator_addr(),
+            self.client.block_size()
         )
     }
 
@@ -314,44 +253,57 @@ fn talon(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use talon_core::Backend;
 
     #[test]
-    fn parse_uri_accepts_each_backend_scheme() {
-        for (uri, backend) in [
-            ("s3://bucket/key", Backend::S3),
-            ("gcs://bucket/key", Backend::Gcs),
-            ("az://container/key", Backend::Azure),
-        ] {
-            let id = parse_uri_inner(uri).expect("valid uri");
-            assert_eq!(id.backend, backend);
-            assert_eq!(id.object_path, "key");
-        }
+    fn completing_partial_stat_preserves_caller_version() {
+        let completed = complete_known_stat(
+            Some("caller-version".into()),
+            None,
+            RustObjectStat {
+                size: 4096,
+                version: "coordinator-version".into(),
+            },
+        );
+
+        assert_eq!(completed.size, 4096);
+        assert_eq!(completed.version, "caller-version");
     }
 
     #[test]
-    fn parse_uri_keeps_nested_keys_intact() {
-        let id = parse_uri_inner("az://container/a/b/c.parquet").expect("valid uri");
-        assert_eq!(id.bucket, "container");
-        assert_eq!(id.object_path, "a/b/c.parquet");
+    fn invalid_read_argument_raises_value_error() {
+        pyo3::prepare_freethreaded_python();
+        let client = Client::new("unused", 1).unwrap();
+        let oversized = (isize::MAX as u64).saturating_add(1);
+
+        Python::with_gil(|py| {
+            let error = match client.read(
+                py,
+                "s3://bucket/key",
+                0,
+                Some(oversized),
+                Some("version"),
+                Some(oversized),
+            ) {
+                Ok(_) => panic!("oversized read must fail"),
+                Err(error) => error,
+            };
+
+            assert!(error.is_instance_of::<PyValueError>(py));
+        });
     }
 
-    /// Malformed URIs must name what is wrong; a bare "invalid input" sends the
-    /// caller to the debugger for something the message could have answered.
     #[test]
-    fn parse_uri_rejects_malformed_input_with_a_useful_message() {
-        for (uri, expected) in [
-            ("bucket/key", "scheme://bucket/key"),
-            ("ftp://bucket/key", "unknown backend scheme"),
-            ("az://bucket", "missing an object key"),
-            ("az:///key", "empty bucket"),
-            ("az://bucket/", "empty object key"),
-        ] {
-            let msg = parse_uri_inner(uri).expect_err("should reject");
-            assert!(
-                msg.contains(expected),
-                "error for {uri:?} should mention {expected:?}, got {msg:?}"
-            );
-        }
+    fn coordinator_failure_raises_io_error() {
+        pyo3::prepare_freethreaded_python();
+        let client = Client::new("127.0.0.1:0", 1).unwrap();
+
+        Python::with_gil(|py| {
+            let error = match client.stat(py, "s3://bucket/key") {
+                Ok(_) => panic!("stat without a coordinator must fail"),
+                Err(error) => error,
+            };
+
+            assert!(error.is_instance_of::<PyIOError>(py));
+        });
     }
 }

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -112,8 +112,12 @@ def test_stat_returns_size_and_version(client):
     assert info.size > 0
 
 
-def test_read_returns_exact_bytes(client):
+def test_read_with_only_version_preserves_supplied_version(client):
     assert client.read(URI, version=VERSION, offset=0, length=4096) == ramp(0, 4096)
+
+
+def test_read_with_only_size_preserves_supplied_size(client):
+    assert client.read(URI, size=1024, offset=0, length=4096) == ramp(0, 1024)
 
 
 def test_read_at_offset(client):

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "talon-rust-client"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Native async Rust client for the Talon distributed object-store cache"
+publish = false
+
+[dependencies]
+talon-core.workspace = true
+talon-cache-client.workspace = true
+talon-transport.workspace = true
+futures.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tokio.workspace = true

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -1,0 +1,713 @@
+use std::sync::Arc;
+
+use crate::{Error, ObjectEntry, ObjectId, ObjectStat, UriError, Version};
+use futures::stream::{FuturesUnordered, StreamExt};
+use talon_cache_client::{plan_read, BlockReader, CoordinatorClient, PlacementCache};
+
+const PLACEMENT_TTL_MS: u64 = 30_000;
+const REPLICAS_K: u8 = 1;
+
+/// A reusable, runtime-owning-neutral Talon client.
+#[derive(Clone)]
+pub struct Client {
+    coordinator: CoordinatorClient,
+    reader: BlockReader,
+    block_size: u32,
+}
+
+impl Client {
+    /// Construct a client without creating or selecting a Tokio runtime.
+    pub fn new(coordinator: impl Into<String>, block_size: u32) -> Result<Self, Error> {
+        if block_size == 0 {
+            return Err(Error::InvalidArgument("block_size must be non-zero".into()));
+        }
+        let coordinator = CoordinatorClient::new(coordinator);
+        let cache = Arc::new(PlacementCache::new(PLACEMENT_TTL_MS));
+        let reader = BlockReader::new(coordinator.clone(), cache, REPLICAS_K);
+        Ok(Self {
+            coordinator,
+            reader,
+            block_size,
+        })
+    }
+
+    /// Address of the coordinator used by this client.
+    pub fn coordinator_addr(&self) -> &str {
+        self.coordinator.addr()
+    }
+
+    /// Logical block size used for range planning.
+    pub fn block_size(&self) -> u32 {
+        self.block_size
+    }
+
+    /// Return an object's current size and source version.
+    pub async fn stat(&self, object: &ObjectId) -> Result<ObjectStat, Error> {
+        Ok(self.coordinator.stat_object(object).await?)
+    }
+
+    /// List objects below a mount-relative prefix.
+    pub async fn list(&self, prefix: &str) -> Result<Vec<ObjectEntry>, Error> {
+        Ok(self.coordinator.list_objects(prefix).await?)
+    }
+
+    /// Read an object range into a newly allocated buffer.
+    pub async fn read(
+        &self,
+        object: &ObjectId,
+        offset: u64,
+        length: Option<u64>,
+        known_stat: Option<&ObjectStat>,
+    ) -> Result<Vec<u8>, Error> {
+        if length == Some(0) {
+            return Ok(Vec::new());
+        }
+        let stat = match known_stat {
+            Some(stat) => stat.clone(),
+            None => self.stat(object).await?,
+        };
+        let requested = length.unwrap_or_else(|| stat.size.saturating_sub(offset));
+        let planned = requested.min(stat.size.saturating_sub(offset));
+        let planned = usize::try_from(planned).map_err(|_| {
+            Error::InvalidArgument("planned read length does not fit in usize".into())
+        })?;
+        // Byte-vector allocations cannot exceed isize::MAX even when usize is wider.
+        if planned > isize::MAX as usize {
+            return Err(Error::InvalidArgument(
+                "planned read length exceeds Vec capacity".into(),
+            ));
+        }
+        if planned == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut bytes = vec![0_u8; planned];
+        let written = self
+            .read_into_resolved(object, offset, &mut bytes, &stat)
+            .await?;
+        bytes.truncate(written);
+        Ok(bytes)
+    }
+
+    /// Read an object range into a caller-owned buffer.
+    pub async fn read_into(
+        &self,
+        object: &ObjectId,
+        offset: u64,
+        dst: &mut [u8],
+        known_stat: Option<&ObjectStat>,
+    ) -> Result<usize, Error> {
+        if dst.is_empty() {
+            return Ok(0);
+        }
+        let stat = match known_stat {
+            Some(stat) => stat.clone(),
+            None => self.stat(object).await?,
+        };
+        self.read_into_resolved(object, offset, dst, &stat).await
+    }
+
+    async fn read_into_resolved(
+        &self,
+        object: &ObjectId,
+        offset: u64,
+        dst: &mut [u8],
+        stat: &ObjectStat,
+    ) -> Result<usize, Error> {
+        let requested = u64::try_from(dst.len())
+            .map_err(|_| Error::InvalidArgument("destination length does not fit in u64".into()))?;
+        let version = Version::new(stat.version.as_str());
+        let plan = plan_read(
+            object,
+            offset,
+            requested,
+            self.block_size,
+            &version,
+            stat.size,
+        );
+        let planned_len: usize = plan.iter().map(|segment| segment.len as usize).sum();
+        if planned_len == 0 {
+            return Ok(0);
+        }
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_millis() as u64)
+            .unwrap_or(0);
+        let mut pending = FuturesUnordered::new();
+        let mut rest = &mut dst[..planned_len];
+        for segment in plan {
+            let (chunk, tail) = rest.split_at_mut(segment.len as usize);
+            rest = tail;
+            let reader = &self.reader;
+            pending.push(async move {
+                reader
+                    .read_block_into(&segment.block, segment.offset_in_block, chunk, now_ms)
+                    .await
+                    .map_err(Error::from)
+            });
+        }
+
+        let mut written = 0;
+        while let Some(result) = pending.next().await {
+            written += result?;
+        }
+        Ok(written)
+    }
+}
+
+/// Parse a `scheme://bucket/key` URI into an object id.
+pub fn parse_uri(uri: &str) -> Result<ObjectId, Error> {
+    let (scheme, rest) = uri
+        .split_once("://")
+        .ok_or_else(|| UriError::MissingScheme {
+            uri: uri.to_string(),
+        })?;
+    let backend = scheme.parse().map_err(|_| UriError::UnknownScheme {
+        scheme: scheme.to_string(),
+    })?;
+    let (bucket, key) = rest.split_once('/').ok_or_else(|| UriError::MissingKey {
+        uri: uri.to_string(),
+        scheme: scheme.to_string(),
+    })?;
+    if bucket.is_empty() {
+        return Err(UriError::EmptyBucket {
+            uri: uri.to_string(),
+        }
+        .into());
+    }
+    if key.is_empty() {
+        return Err(UriError::EmptyKey {
+            uri: uri.to_string(),
+        }
+        .into());
+    }
+    Ok(ObjectId::new(backend, bucket, key))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use talon_core::{Backend, NodeId, NodeInfo, NodeRole};
+    use talon_transport::frame::{FrameHeader, HEADER_LEN};
+    use talon_transport::{
+        decode_request, encode_typed_error, response_header_ok, ControlMessage, DataErrorCode,
+        RangeRequest,
+    };
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::sync::Notify;
+
+    async fn mock_coordinator() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    let mut header_bytes = [0_u8; HEADER_LEN];
+                    socket.read_exact(&mut header_bytes).await.unwrap();
+                    let header = FrameHeader::decode(&header_bytes).unwrap();
+                    let mut payload = vec![0_u8; header.length as usize];
+                    socket.read_exact(&mut payload).await.unwrap();
+                    let mut frame = header_bytes.to_vec();
+                    frame.extend_from_slice(&payload);
+                    let (_, request) = talon_transport::decode(&frame).unwrap();
+                    let response = match request {
+                        ControlMessage::StatObject { .. } => ControlMessage::ObjectStat {
+                            size: 8192,
+                            version: "test-version".into(),
+                        },
+                        ControlMessage::ListObjects { prefix } => {
+                            assert_eq!(prefix, "s3/bucket/data");
+                            ControlMessage::ObjectList {
+                                entries: vec![ObjectEntry {
+                                    path: "s3/bucket/data/a.parquet".into(),
+                                    size: 17,
+                                }],
+                            }
+                        }
+                        other => panic!("unexpected request: {other:?}"),
+                    };
+                    socket
+                        .write_all(&talon_transport::encode(0, &response).unwrap())
+                        .await
+                        .unwrap();
+                });
+            }
+        });
+        addr
+    }
+
+    async fn mock_worker() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    let mut header_bytes = [0_u8; HEADER_LEN];
+                    if socket.read_exact(&mut header_bytes).await.is_err() {
+                        return;
+                    }
+                    let header = FrameHeader::decode(&header_bytes).unwrap();
+                    let mut payload = vec![0_u8; header.length as usize];
+                    socket.read_exact(&mut payload).await.unwrap();
+                    let mut frame = header_bytes.to_vec();
+                    frame.extend_from_slice(&payload);
+                    let (_, request): (_, RangeRequest) = decode_request(&frame).unwrap();
+                    let bytes: Vec<u8> = (0..request.len)
+                        .map(|index| ((request.offset + index) % 251) as u8)
+                        .collect();
+                    let mut response = response_header_ok(0, bytes.len() as u32).to_vec();
+                    response.extend_from_slice(&bytes);
+                    socket.write_all(&response).await.unwrap();
+                });
+            }
+        });
+        addr
+    }
+
+    async fn mock_short_worker() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                tokio::spawn(async move {
+                    let mut header_bytes = [0_u8; HEADER_LEN];
+                    if socket.read_exact(&mut header_bytes).await.is_err() {
+                        return;
+                    }
+                    let header = FrameHeader::decode(&header_bytes).unwrap();
+                    let mut payload = vec![0_u8; header.length as usize];
+                    socket.read_exact(&mut payload).await.unwrap();
+                    let mut frame = header_bytes.to_vec();
+                    frame.extend_from_slice(&payload);
+                    let (_, request): (_, RangeRequest) = decode_request(&frame).unwrap();
+                    let short_len = request.len.saturating_sub(1) as usize;
+                    let mut response = response_header_ok(0, short_len as u32).to_vec();
+                    response.extend_from_slice(&vec![0_u8; short_len]);
+                    socket.write_all(&response).await.unwrap();
+                });
+            }
+        });
+        addr
+    }
+
+    async fn mock_delayed_worker(
+        second_block_started: Arc<Notify>,
+        release_first_block: Arc<Notify>,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                let second_block_started = Arc::clone(&second_block_started);
+                let release_first_block = Arc::clone(&release_first_block);
+                tokio::spawn(async move {
+                    let mut header_bytes = [0_u8; HEADER_LEN];
+                    if socket.read_exact(&mut header_bytes).await.is_err() {
+                        return;
+                    }
+                    let header = FrameHeader::decode(&header_bytes).unwrap();
+                    let mut payload = vec![0_u8; header.length as usize];
+                    socket.read_exact(&mut payload).await.unwrap();
+                    let mut frame = header_bytes.to_vec();
+                    frame.extend_from_slice(&payload);
+                    let (_, request): (_, RangeRequest) = decode_request(&frame).unwrap();
+                    if request.offset < 8 {
+                        release_first_block.notified().await;
+                    } else {
+                        second_block_started.notify_one();
+                    }
+                    let bytes: Vec<u8> = (0..request.len)
+                        .map(|index| ((request.offset + index) % 251) as u8)
+                        .collect();
+                    let mut response = response_header_ok(0, bytes.len() as u32).to_vec();
+                    response.extend_from_slice(&bytes);
+                    socket.write_all(&response).await.unwrap();
+                });
+            }
+        });
+        addr
+    }
+
+    async fn mock_failure_worker(
+        stalled_block_started: Arc<Notify>,
+        stalled_block_disconnected: Arc<Notify>,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                let stalled_block_started = Arc::clone(&stalled_block_started);
+                let stalled_block_disconnected = Arc::clone(&stalled_block_disconnected);
+                tokio::spawn(async move {
+                    let mut header_bytes = [0_u8; HEADER_LEN];
+                    if socket.read_exact(&mut header_bytes).await.is_err() {
+                        return;
+                    }
+                    let header = FrameHeader::decode(&header_bytes).unwrap();
+                    let mut payload = vec![0_u8; header.length as usize];
+                    socket.read_exact(&mut payload).await.unwrap();
+                    let mut frame = header_bytes.to_vec();
+                    frame.extend_from_slice(&payload);
+                    let (_, request): (_, RangeRequest) = decode_request(&frame).unwrap();
+                    if request.offset < 8 {
+                        stalled_block_started.notify_one();
+                        let mut byte = [0_u8; 1];
+                        if socket.read(&mut byte).await.unwrap() == 0 {
+                            stalled_block_disconnected.notify_one();
+                        }
+                    } else {
+                        stalled_block_started.notified().await;
+                        socket
+                            .write_all(&encode_typed_error(
+                                0,
+                                DataErrorCode::InvalidRequest,
+                                "injected block failure",
+                            ))
+                            .await
+                            .unwrap();
+                    }
+                });
+            }
+        });
+        addr
+    }
+
+    async fn mock_read_coordinator(
+        worker_addr: String,
+        size: u64,
+        stat_calls: Arc<AtomicUsize>,
+    ) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    return;
+                };
+                let worker_addr = worker_addr.clone();
+                let stat_calls = Arc::clone(&stat_calls);
+                tokio::spawn(async move {
+                    let mut header_bytes = [0_u8; HEADER_LEN];
+                    if socket.read_exact(&mut header_bytes).await.is_err() {
+                        return;
+                    }
+                    let header = FrameHeader::decode(&header_bytes).unwrap();
+                    let mut payload = vec![0_u8; header.length as usize];
+                    socket.read_exact(&mut payload).await.unwrap();
+                    let mut frame = header_bytes.to_vec();
+                    frame.extend_from_slice(&payload);
+                    let (_, request) = talon_transport::decode(&frame).unwrap();
+                    let response = match request {
+                        ControlMessage::StatObject { .. } => {
+                            stat_calls.fetch_add(1, Ordering::SeqCst);
+                            ControlMessage::ObjectStat {
+                                size,
+                                version: "test-version".into(),
+                            }
+                        }
+                        ControlMessage::MembershipQuery {} => ControlMessage::MembershipList {
+                            nodes: vec![NodeInfo {
+                                id: NodeId::new("worker-a"),
+                                address: worker_addr,
+                                role: NodeRole::Worker,
+                            }],
+                        },
+                        ControlMessage::MembershipQueryV2 {} => ControlMessage::MembershipListV2 {
+                            nodes: vec![talon_transport::ZonedNodeInfo {
+                                info: NodeInfo {
+                                    id: NodeId::new("worker-a"),
+                                    address: worker_addr,
+                                    role: NodeRole::Worker,
+                                },
+                                zone: None,
+                            }],
+                        },
+                        other => panic!("unexpected request: {other:?}"),
+                    };
+                    socket
+                        .write_all(&talon_transport::encode(0, &response).unwrap())
+                        .await
+                        .unwrap();
+                });
+            }
+        });
+        addr
+    }
+
+    async fn read_client(size: u64) -> (Client, Arc<AtomicUsize>) {
+        let worker = mock_worker().await;
+        let stat_calls = Arc::new(AtomicUsize::new(0));
+        let coordinator = mock_read_coordinator(worker, size, Arc::clone(&stat_calls)).await;
+        (Client::new(coordinator, 8).unwrap(), stat_calls)
+    }
+
+    #[test]
+    fn parses_supported_object_uris() {
+        for (uri, backend) in [
+            ("s3://bucket/key", Backend::S3),
+            ("gcs://bucket/key", Backend::Gcs),
+            ("az://container/a/b.parquet", Backend::Azure),
+        ] {
+            let object = parse_uri(uri).unwrap();
+            assert_eq!(object.backend, backend);
+        }
+    }
+
+    #[test]
+    fn parse_uri_keeps_nested_keys_intact() {
+        let object = parse_uri("az://container/a/b/c.parquet").unwrap();
+
+        assert_eq!(object.bucket, "container");
+        assert_eq!(object.object_path, "a/b/c.parquet");
+    }
+
+    #[test]
+    fn parse_uri_rejects_malformed_input_with_a_useful_message() {
+        for (uri, expected) in [
+            ("bucket/key", "scheme://bucket/key"),
+            ("ftp://bucket/key", "unknown backend scheme"),
+            ("az://bucket", "missing an object key"),
+            ("az:///key", "empty bucket"),
+            ("az://bucket/", "empty object key"),
+        ] {
+            let message = parse_uri(uri).unwrap_err().to_string();
+            assert!(
+                message.contains(expected),
+                "error for {uri:?} should mention {expected:?}, got {message:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_zero_block_size() {
+        let error = Client::new("127.0.0.1:7000", 0)
+            .err()
+            .expect("zero block size must fail");
+        assert!(matches!(error, Error::InvalidArgument(_)));
+    }
+
+    #[tokio::test]
+    async fn stat_returns_coordinator_metadata() {
+        let client = Client::new(mock_coordinator().await, 1024).unwrap();
+
+        let stat = client
+            .stat(&parse_uri("s3://bucket/key").unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(stat.size, 8192);
+        assert_eq!(stat.version, "test-version");
+    }
+
+    #[tokio::test]
+    async fn list_returns_existing_object_entries() {
+        let client = Client::new(mock_coordinator().await, 1024).unwrap();
+
+        let entries = client.list("s3/bucket/data").await.unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].path, "s3/bucket/data/a.parquet");
+        assert_eq!(entries[0].size, 17);
+    }
+
+    #[tokio::test]
+    async fn known_stat_skips_coordinator_stat() {
+        let (client, stat_calls) = read_client(16).await;
+        let object = parse_uri("s3://bucket/key").unwrap();
+        let stat = ObjectStat {
+            size: 16,
+            version: "test-version".into(),
+        };
+
+        let bytes = client.read(&object, 2, Some(6), Some(&stat)).await.unwrap();
+
+        assert_eq!(bytes, vec![2, 3, 4, 5, 6, 7]);
+        assert_eq!(stat_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn missing_stat_is_resolved_once() {
+        let (client, stat_calls) = read_client(16).await;
+        let object = parse_uri("s3://bucket/key").unwrap();
+
+        let bytes = client.read(&object, 0, Some(4), None).await.unwrap();
+
+        assert_eq!(bytes, vec![0, 1, 2, 3]);
+        assert_eq!(stat_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn read_to_end_uses_resolved_size() {
+        let (client, _) = read_client(10).await;
+        let object = parse_uri("s3://bucket/key").unwrap();
+
+        let bytes = client.read(&object, 4, None, None).await.unwrap();
+
+        assert_eq!(bytes, vec![4, 5, 6, 7, 8, 9]);
+    }
+
+    #[tokio::test]
+    async fn allocating_read_rejects_length_above_vec_capacity() {
+        let client = Client::new("127.0.0.1:1", 8).unwrap();
+        let object = parse_uri("s3://bucket/key").unwrap();
+        let too_large = isize::MAX as u64 + 1;
+        let stat = ObjectStat {
+            size: too_large,
+            version: "test-version".into(),
+        };
+
+        let error = client
+            .read(&object, 0, Some(too_large), Some(&stat))
+            .await
+            .expect_err("lengths above Vec capacity must be rejected");
+
+        assert!(matches!(error, Error::InvalidArgument(_)));
+    }
+
+    #[tokio::test]
+    async fn read_into_crossing_eof_returns_short_count() {
+        let (client, _) = read_client(10).await;
+        let object = parse_uri("s3://bucket/key").unwrap();
+        let stat = ObjectStat {
+            size: 10,
+            version: "test-version".into(),
+        };
+        let mut dst = [0_u8; 8];
+
+        let written = client
+            .read_into(&object, 6, &mut dst, Some(&stat))
+            .await
+            .unwrap();
+
+        assert_eq!(written, 4);
+        assert_eq!(&dst[..written], &[6, 7, 8, 9]);
+    }
+
+    #[tokio::test]
+    async fn empty_reads_do_not_stat_or_fetch() {
+        let (client, stat_calls) = read_client(16).await;
+        let object = parse_uri("s3://bucket/key").unwrap();
+        let mut dst = [];
+
+        assert!(client
+            .read(&object, 0, Some(0), None)
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            client.read_into(&object, 0, &mut dst, None).await.unwrap(),
+            0
+        );
+        assert_eq!(stat_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn multi_block_read_is_concurrent_and_keeps_byte_order() {
+        let second_block_started = Arc::new(Notify::new());
+        let release_first_block = Arc::new(Notify::new());
+        let worker = mock_delayed_worker(
+            Arc::clone(&second_block_started),
+            Arc::clone(&release_first_block),
+        )
+        .await;
+        let stat_calls = Arc::new(AtomicUsize::new(0));
+        let coordinator = mock_read_coordinator(worker, 16, stat_calls).await;
+        let client = Client::new(coordinator, 8).unwrap();
+        let object = parse_uri("s3://bucket/key").unwrap();
+        let stat = ObjectStat {
+            size: 16,
+            version: "test-version".into(),
+        };
+        let read = tokio::spawn(async move { client.read(&object, 6, Some(8), Some(&stat)).await });
+
+        let overlapped =
+            tokio::time::timeout(Duration::from_millis(250), second_block_started.notified())
+                .await
+                .is_ok();
+        release_first_block.notify_one();
+        let bytes = tokio::time::timeout(Duration::from_secs(2), read)
+            .await
+            .expect("read did not finish")
+            .unwrap()
+            .unwrap();
+
+        assert!(
+            overlapped,
+            "second block did not start while first was pending"
+        );
+        assert_eq!(bytes, vec![6, 7, 8, 9, 10, 11, 12, 13]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn block_failure_drops_the_other_unfinished_read() {
+        let stalled_block_started = Arc::new(Notify::new());
+        let stalled_block_disconnected = Arc::new(Notify::new());
+        let worker = mock_failure_worker(
+            Arc::clone(&stalled_block_started),
+            Arc::clone(&stalled_block_disconnected),
+        )
+        .await;
+        let stat_calls = Arc::new(AtomicUsize::new(0));
+        let coordinator = mock_read_coordinator(worker, 16, stat_calls).await;
+        let client = Client::new(coordinator, 8).unwrap();
+        let object = parse_uri("s3://bucket/key").unwrap();
+        let stat = ObjectStat {
+            size: 16,
+            version: "test-version".into(),
+        };
+        let mut dst = [0_u8; 16];
+
+        let error = client
+            .read_into(&object, 0, &mut dst, Some(&stat))
+            .await
+            .expect_err("one failed block must fail the whole read");
+
+        assert!(matches!(error, Error::Block(_)));
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            stalled_block_disconnected.notified(),
+        )
+        .await
+        .expect("unfinished block connection was not cancelled");
+    }
+
+    #[tokio::test]
+    async fn short_worker_reply_fails_the_whole_read() {
+        let worker = mock_short_worker().await;
+        let stat_calls = Arc::new(AtomicUsize::new(0));
+        let coordinator = mock_read_coordinator(worker, 8, stat_calls).await;
+        let client = Client::new(coordinator, 8).unwrap();
+        let object = parse_uri("s3://bucket/key").unwrap();
+        let stat = ObjectStat {
+            size: 8,
+            version: "test-version".into(),
+        };
+        let mut dst = [0_u8; 8];
+
+        let error = client
+            .read_into(&object, 0, &mut dst, Some(&stat))
+            .await
+            .expect_err("short worker reply must fail the whole read");
+
+        assert!(matches!(error, Error::Block(_)));
+    }
+}

--- a/clients/rust/src/error.rs
+++ b/clients/rust/src/error.rs
@@ -1,0 +1,29 @@
+use talon_cache_client::{BlockReadError, CoordinatorError};
+
+/// Structured failures from parsing an object URI.
+#[derive(Debug, thiserror::Error)]
+pub enum UriError {
+    #[error("expected a scheme://bucket/key URI, got {uri:?} (schemes: s3, gcs, az)")]
+    MissingScheme { uri: String },
+    #[error("unknown backend scheme {scheme:?}; expected s3, gcs, or az")]
+    UnknownScheme { scheme: String },
+    #[error("URI is missing an object key: {uri:?} (expected {scheme}://bucket/key)")]
+    MissingKey { uri: String, scheme: String },
+    #[error("URI has an empty bucket: {uri:?}")]
+    EmptyBucket { uri: String },
+    #[error("URI has an empty object key: {uri:?}")]
+    EmptyKey { uri: String },
+}
+
+/// Errors returned by the native Rust client.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    InvalidUri(#[from] UriError),
+    #[error("{0}")]
+    InvalidArgument(String),
+    #[error(transparent)]
+    Coordinator(#[from] CoordinatorError),
+    #[error(transparent)]
+    Block(#[from] BlockReadError),
+}

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -1,0 +1,10 @@
+//! Native async client for reading objects through a Talon cache cluster.
+
+mod client;
+mod error;
+
+pub use client::{parse_uri, Client};
+pub use error::{Error, UriError};
+pub use talon_cache_client::ObjectStat;
+pub use talon_core::{ObjectId, Version};
+pub use talon_transport::ObjectEntry;


### PR DESCRIPTION
<!--
Thanks for contributing to Talon! Keep PRs small and single-purpose.
Please fill out each section. Delete any that genuinely don't apply.
-->

## Summary

We needed a first-class native Rust client so the C and Python SDKs would no longer maintain separate copies of URI parsing, metadata lookup, range planning, EOF handling, and multi-block read orchestration. The new clients/rust package provides async stat, list, read, and read-into APIs while leaving Tokio runtime ownership to each caller.

The shared client builds on the existing talon-cache-client primitives and adds structured URI errors, optional known object metadata, allocating and caller-buffer reads, EOF clamping, and concurrent block fetching within the parent Future. Its public surface stays small through lib.rs, while the implementation and error definitions live in focused modules.

The C adapter now keeps only its C ABI responsibilities, including runtime ownership, raw-buffer lifetime, request IDs, result conversion, and callback dispatch. The Python adapter similarly keeps PyO3, GIL, runtime, and Python type conversion concerns while delegating object operations to the Rust SDK and removing its dependency on talon-fuse. Existing C error text and Python partial version/size behavior remain compatible.
## Related issues
nope

## Type of change

- [ ] Bug fix
- [x] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [ ] Docs / tests / tooling

## Design alignment

<!--
Which DESIGN.md area does this touch? Reference the section(s).
If this diverges from or amends the design, explain why.
-->

## Changes

<!-- Bullet the notable changes, grouped by crate if it helps. -->

-

## Test plan

<!-- How did you verify this? Commands and results. -->

- [ ] `just ci` passes locally (fmt + clippy + test)
- [ ] Workspace compiles (`cargo build --workspace`)
- [ ] Added/updated tests for new behavior

## Performance impact

<!--
Did this touch a hot path (keys, placement, block/page index, data plane)?
If so, paste the `just bench-check` verdict table. If a regression is
intentional, note it and confirm the baseline was refreshed and committed.
-->

- [ ] Not performance-sensitive, OR
- [ ] `just bench-check` run; results below (baseline refreshed if the change is intentional)

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`<type>(<scope>): <description>`) — it becomes the squash-merge commit subject and is checked by CI
- [ ] Public items are documented; no broken intra-doc links
- [ ] No new dependencies without discussion
- [ ] Rebased on the latest `main`
