### PR TITLE
fix(worker): restore the global io_uring connection limit

### DIFF
--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -684,14 +684,14 @@ async fn main() -> anyhow::Result<()> {
         // Tokio worker threads it is handing out — so drive it on a dedicated
         // thread and park this task on the join.
         let addr = cfg.listen.clone();
-        // The cap is per ring, so divide the global budget across them; the
-        // total admitted stays MAX_DATA_PLANE_CONNECTIONS regardless of how many
-        // rings are configured (#111).
-        let per_ring_connections = MAX_DATA_PLANE_CONNECTIONS.div_ceil(rings).max(1);
+        // RingConnHandler is cloned for every ring, and those clones share one
+        // semaphore. Pass the worker-wide budget unchanged: dividing it by the
+        // ring count would accidentally turn the global 1024-connection cap into
+        // a 1024/rings cap for the entire worker (#111).
         let handler = uring_conn::RingConnHandler::new(
             Arc::clone(&worker),
             Arc::clone(&observability),
-            per_ring_connections,
+            MAX_DATA_PLANE_CONNECTIONS,
         );
         let tokio_handle = tokio::runtime::Handle::current();
         let joined = tokio::task::spawn_blocking(move || {

--- a/crates/talon-worker/src/uring_conn.rs
+++ b/crates/talon-worker/src/uring_conn.rs
@@ -843,10 +843,10 @@ async fn handle_delete(
 /// Adapts [`handle_conn`] to the ring runtime's [`crate::uring_serve::RingHandler`]
 /// trait.
 ///
-/// Carries the shared worker state and enforces the same connection cap as the
-/// Tokio path (#111). The cap is **per ring**, not global: each ring owns an
-/// independent semaphore, so N rings admit `N * max_connections` in total.
-/// Callers should divide the global budget by the ring count.
+/// Carries the shared worker state and enforces the same worker-wide connection
+/// cap as the Tokio path (#111). [`RingConnHandler`] is cloned once per ring, and
+/// every clone shares the same semaphore, so callers must pass the global budget
+/// unchanged.
 #[derive(Clone)]
 pub struct RingConnHandler {
     worker: Arc<WorkerRuntime>,
@@ -856,16 +856,16 @@ pub struct RingConnHandler {
 
 impl RingConnHandler {
     /// Build a handler admitting at most `max_connections` concurrent
-    /// connections on the ring that owns it.
+    /// connections across all rings that share its clones.
     pub fn new(
         worker: Arc<WorkerRuntime>,
         observability: Arc<WorkerObservability>,
-        max_connections: usize,
+        global_max_connections: usize,
     ) -> Self {
         Self {
             worker,
             observability,
-            limit: Arc::new(tokio::sync::Semaphore::new(max_connections)),
+            limit: Arc::new(tokio::sync::Semaphore::new(global_max_connections)),
         }
     }
 }
@@ -1416,6 +1416,36 @@ mod tests {
             drop(c);
             assert!(served.await.is_ok());
         });
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    /// `serve` clones one handler per io_uring ring. The semaphore deliberately
+    /// remains worker-wide across those clones, so main must pass the global
+    /// connection budget rather than dividing it by the number of rings.
+    #[test]
+    fn ring_handler_clones_share_one_global_connection_budget() {
+        let root = tmp_root("ring-global-limit");
+        let tokio_rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+        let (worker, obs) = {
+            let _guard = tokio_rt.enter();
+            build(&root, Arc::new(RampBackend), 16)
+        };
+
+        let handler = RingConnHandler::new(worker, obs, 3);
+        let clone = handler.clone();
+        assert!(Arc::ptr_eq(&handler.limit, &clone.limit));
+
+        let permits: Vec<_> = (0..3)
+            .map(|_| handler.limit.clone().try_acquire_owned().unwrap())
+            .collect();
+        assert!(clone.limit.clone().try_acquire_owned().is_err());
+
+        drop(permits);
+        assert!(clone.limit.clone().try_acquire_owned().is_ok());
         std::fs::remove_dir_all(root).ok();
     }
 


### PR DESCRIPTION
## Problem

The io_uring worker computes ceil(1024 / rings) and passes that value to RingConnHandler as if every ring owned an independent connection semaphore. In reality, serve clones one RingConnHandler for all rings, and its Arc<Semaphore> is shared by every clone.

On a 64-ring worker this reduces the intended worker-wide limit from 1024 concurrent connections to 16 for the entire io_uring data plane. Higher client concurrency therefore queues behind roughly 16 active connections, especially visible when request latency increases.

## Fix

- Pass MAX_DATA_PLANE_CONNECTIONS to the shared RingConnHandler unchanged.
- Document that the semaphore is worker-wide across all ring clones.
- Add a regression test proving clones consume one shared global budget.

The Tokio data plane, wire protocol, and configuration surface are unchanged.

## Validation

- cargo fmt --all --check
- cargo test -p talon-worker --lib --locked (260 passed)
- cargo test -p talon-worker ring_handler_serves_through_the_ring_runtime --locked
- cargo clippy -p talon-worker --lib --bin talon-worker --locked -- -D warnings
- cargo rustdoc -p talon-worker --lib --locked -- -D warnings