### PR TITLE
fix(worker): bound io_uring admission before accept

### DIFF
--- a/crates/talon-transport/src/limits.rs
+++ b/crates/talon-transport/src/limits.rs
@@ -144,6 +144,14 @@ impl ConnectionLimit {
         }
     }
 
+    /// Acquire a permit immediately, or return `None` when the limit is reached.
+    ///
+    /// Callers that wait after `None` can report saturation without racing a
+    /// separate available-permit check.
+    pub fn try_acquire(&self) -> Option<OwnedSemaphorePermit> {
+        Arc::clone(&self.semaphore).try_acquire_owned().ok()
+    }
+
     /// Acquire a permit, waiting if the limit is currently reached. The permit
     /// is released when dropped (i.e. when the connection ends).
     pub async fn acquire(&self) -> OwnedSemaphorePermit {
@@ -224,10 +232,12 @@ mod tests {
     async fn connection_limit_bounds_permits() {
         let limit = ConnectionLimit::new(2);
         assert_eq!(limit.available(), 2);
-        let _p1 = limit.acquire().await;
+        let _p1 = limit.try_acquire().unwrap();
         let _p2 = limit.acquire().await;
         assert_eq!(limit.available(), 0);
+        assert!(limit.try_acquire().is_none());
         drop(_p1);
         assert_eq!(limit.available(), 1);
+        assert!(limit.try_acquire().is_some());
     }
 }

--- a/crates/talon-worker/benches/dataplane_benches.rs
+++ b/crates/talon-worker/benches/dataplane_benches.rs
@@ -227,10 +227,11 @@ fn spawn_uring_server(
     let addr = probe.local_addr().unwrap().to_string();
     drop(probe);
 
-    let h = talon_worker::uring_conn::RingConnHandler::new(runtime, observability, 128);
+    let admission = talon_worker::ConnectionAdmission::new(128, observability.metrics().clone());
+    let h = talon_worker::uring_conn::RingConnHandler::new(runtime, observability);
     let serve_addr = addr.clone();
     std::thread::spawn(move || {
-        let _ = talon_worker::uring_serve::serve(serve_addr, 1, 4, h, handle);
+        let _ = talon_worker::uring_serve::serve(serve_addr, 1, 4, admission, h, handle);
     });
 
     // Wait for the ring to bind before the harness starts timing.

--- a/crates/talon-worker/src/bin/loadgen.rs
+++ b/crates/talon-worker/src/bin/loadgen.rs
@@ -10,9 +10,10 @@
 //! about the regime a cache fleet actually runs in.
 //!
 //! This binary opens N connections, drives closed-loop range requests on each
-//! for a fixed duration, and reports the **latency distribution** plus
-//! server-side CPU and RSS. It is a manual tool for a known machine, not a CI
-//! gate: shared runners are too noisy for absolute-time comparisons.
+//! for a fixed duration, and reports TCP-connected versus actually served
+//! connections, the **latency distribution**, and server-side CPU, FD, and RSS
+//! usage. It is a manual tool for a known machine, not a CI gate: shared runners
+//! are too noisy for absolute-time comparisons.
 //!
 //! # Usage
 //!
@@ -68,7 +69,7 @@ struct Args {
     /// Container or bucket the object lives in.
     #[arg(long, default_value = "c")]
     container: String,
-    /// Worker PID to sample CPU and RSS from. Skipped when unset.
+    /// Worker PID to sample CPU, open FDs, and RSS from. Skipped when unset.
     #[arg(long)]
     server_pid: Option<u32>,
     /// Emit JSON Lines instead of a table, for scripted comparison.
@@ -88,9 +89,19 @@ struct Args {
     depth: usize,
 }
 
+/// Per-run connection progress shared by client tasks.
+#[derive(Default)]
+struct RunProgress {
+    connected: AtomicU64,
+    served: AtomicU64,
+    errors: AtomicU64,
+}
+
 /// One connection count's result.
 struct Run {
     conns: usize,
+    connected_conns: u64,
+    served_conns: u64,
     rps: f64,
     p50: f64,
     p90: f64,
@@ -99,6 +110,7 @@ struct Run {
     max: f64,
     samples: usize,
     cpu_percent: Option<f64>,
+    server_fds: Option<usize>,
     rss_kb: Option<u64>,
 }
 
@@ -125,6 +137,10 @@ fn proc_rss_kb(pid: u32) -> Option<u64> {
         .and_then(|v| v.parse().ok())
 }
 
+fn proc_fd_count(pid: u32) -> Option<usize> {
+    Some(std::fs::read_dir(format!("/proc/{pid}/fd")).ok()?.count())
+}
+
 /// Drive one connection closed-loop until `stop`, returning post-warmup
 /// latencies in nanoseconds.
 #[allow(clippy::too_many_arguments)]
@@ -134,7 +150,7 @@ async fn drive_one(
     range: u64,
     warmup: Duration,
     stop: Arc<AtomicBool>,
-    errors: Arc<AtomicU64>,
+    progress: Arc<RunProgress>,
     offset_seed: u64,
     depth: usize,
 ) -> Vec<u64> {
@@ -145,16 +161,19 @@ async fn drive_one(
             range,
             warmup,
             stop,
-            errors,
+            progress,
             offset_seed,
             depth,
         )
         .await;
     }
     let mut sock = match TcpStream::connect(&addr).await {
-        Ok(s) => s,
+        Ok(s) => {
+            progress.connected.fetch_add(1, Ordering::Relaxed);
+            s
+        }
         Err(_) => {
-            errors.fetch_add(1, Ordering::Relaxed);
+            progress.errors.fetch_add(1, Ordering::Relaxed);
             return Vec::new();
         }
     };
@@ -167,6 +186,7 @@ async fn drive_one(
     let mut offset = (offset_seed * range) % (16 << 20);
     let started = Instant::now();
     let mut recording = false;
+    let mut served = false;
 
     while !stop.load(Ordering::Relaxed) {
         if !recording && started.elapsed() >= warmup {
@@ -184,29 +204,42 @@ async fn drive_one(
 
         let t0 = Instant::now();
         if sock.write_all(&encoded).await.is_err() {
-            errors.fetch_add(1, Ordering::Relaxed);
+            progress.errors.fetch_add(1, Ordering::Relaxed);
             break;
         }
         if sock.read_exact(&mut header_buf).await.is_err() {
-            errors.fetch_add(1, Ordering::Relaxed);
+            progress.errors.fetch_add(1, Ordering::Relaxed);
             break;
         }
         let Ok(header) = FrameHeader::decode(&header_buf) else {
-            errors.fetch_add(1, Ordering::Relaxed);
+            progress.errors.fetch_add(1, Ordering::Relaxed);
             break;
         };
+        if header.request_id != 0 {
+            if progress.errors.fetch_add(1, Ordering::Relaxed) == 0 {
+                eprintln!(
+                    "reply for unknown request_id {}: expected 0",
+                    header.request_id
+                );
+            }
+            break;
+        }
         let len = header.length as usize;
         if len > body.len() {
             body.resize(len, 0);
         }
         if len > 0 && sock.read_exact(&mut body[..len]).await.is_err() {
-            errors.fetch_add(1, Ordering::Relaxed);
+            progress.errors.fetch_add(1, Ordering::Relaxed);
             break;
+        }
+        if !served {
+            progress.served.fetch_add(1, Ordering::Relaxed);
+            served = true;
         }
         // An ERROR-flagged response is a served request but not a served read;
         // count it so a misconfigured run cannot look like a fast one.
         if header.flags.contains(talon_transport::Flags::ERROR) {
-            if errors.fetch_add(1, Ordering::Relaxed) == 0 {
+            if progress.errors.fetch_add(1, Ordering::Relaxed) == 0 {
                 // Surface the first error verbatim: a misconfigured run is far
                 // more likely than a server bug, and the message says which.
                 eprintln!(
@@ -243,14 +276,17 @@ async fn drive_one_pipelined(
     range: u64,
     warmup: Duration,
     stop: Arc<AtomicBool>,
-    errors: Arc<AtomicU64>,
+    progress: Arc<RunProgress>,
     offset_seed: u64,
     depth: usize,
 ) -> Vec<u64> {
     let sock = match TcpStream::connect(&addr).await {
-        Ok(s) => s,
+        Ok(s) => {
+            progress.connected.fetch_add(1, Ordering::Relaxed);
+            s
+        }
         Err(_) => {
-            errors.fetch_add(1, Ordering::Relaxed);
+            progress.errors.fetch_add(1, Ordering::Relaxed);
             return Vec::new();
         }
     };
@@ -268,7 +304,7 @@ async fn drive_one_pipelined(
     let done = Arc::new(AtomicBool::new(false));
     let writer_stop = Arc::clone(&stop);
     let writer_done = Arc::clone(&done);
-    let writer_errors = Arc::clone(&errors);
+    let writer_progress = Arc::clone(&progress);
     let writer = tokio::spawn(async move {
         let mut offset = (offset_seed * range) % (16 << 20);
         let mut next_id: u32 = 1;
@@ -299,7 +335,7 @@ async fn drive_one_pipelined(
                 break;
             }
             if wr.write_all(&encoded).await.is_err() {
-                writer_errors.fetch_add(1, Ordering::Relaxed);
+                writer_progress.errors.fetch_add(1, Ordering::Relaxed);
                 break;
             }
             window += 1;
@@ -313,6 +349,7 @@ async fn drive_one_pipelined(
     let mut header_buf = [0u8; HEADER_LEN];
     let started = Instant::now();
     let mut recording = false;
+    let mut served = false;
     // Sent-but-unanswered requests, keyed by the id echoed in the reply header.
     let mut pending: HashMap<u32, Instant> = HashMap::with_capacity(depth * 2);
 
@@ -338,11 +375,11 @@ async fn drive_one_pipelined(
             pending.insert(id, t0);
         }
         if rd.read_exact(&mut header_buf).await.is_err() {
-            errors.fetch_add(1, Ordering::Relaxed);
+            progress.errors.fetch_add(1, Ordering::Relaxed);
             break;
         }
         let Ok(header) = FrameHeader::decode(&header_buf) else {
-            errors.fetch_add(1, Ordering::Relaxed);
+            progress.errors.fetch_add(1, Ordering::Relaxed);
             break;
         };
         let len = header.length as usize;
@@ -350,7 +387,7 @@ async fn drive_one_pipelined(
             body.resize(len, 0);
         }
         if len > 0 && rd.read_exact(&mut body[..len]).await.is_err() {
-            errors.fetch_add(1, Ordering::Relaxed);
+            progress.errors.fetch_add(1, Ordering::Relaxed);
             break;
         }
         // Out-of-order replies are expected from a multiplexing worker. The id
@@ -371,7 +408,7 @@ async fn drive_one_pipelined(
             }
         };
         let Some(t0) = t0 else {
-            if errors.fetch_add(1, Ordering::Relaxed) == 0 {
+            if progress.errors.fetch_add(1, Ordering::Relaxed) == 0 {
                 eprintln!(
                     "reply for unknown request_id {}: never sent on this connection",
                     header.request_id
@@ -379,18 +416,12 @@ async fn drive_one_pipelined(
             }
             break;
         };
-        if header.flags.contains(talon_transport::Flags::ERROR) {
-            if errors.fetch_add(1, Ordering::Relaxed) == 0 {
-                eprintln!(
-                    "first error response: {}",
-                    String::from_utf8_lossy(&body[..len])
-                );
-            }
-        } else if recording {
-            latencies.push(t0.elapsed().as_nanos() as u64);
+        if !served {
+            progress.served.fetch_add(1, Ordering::Relaxed);
+            served = true;
         }
         if header.flags.contains(talon_transport::Flags::ERROR) {
-            if errors.fetch_add(1, Ordering::Relaxed) == 0 {
+            if progress.errors.fetch_add(1, Ordering::Relaxed) == 0 {
                 eprintln!(
                     "first error response: {}",
                     String::from_utf8_lossy(&body[..len])
@@ -416,7 +447,7 @@ async fn drive_one_pipelined(
 async fn run_one(args: &Args, conns: usize) -> Run {
     let object = ObjectId::new(args.backend, &args.container, &args.object);
     let stop = Arc::new(AtomicBool::new(false));
-    let errors = Arc::new(AtomicU64::new(0));
+    let progress = Arc::new(RunProgress::default());
     let warmup = Duration::from_secs(args.warmup);
 
     let mut tasks = Vec::with_capacity(conns);
@@ -427,7 +458,7 @@ async fn run_one(args: &Args, conns: usize) -> Run {
             args.range,
             warmup,
             Arc::clone(&stop),
-            Arc::clone(&errors),
+            Arc::clone(&progress),
             i as u64,
             args.depth.max(1),
         )));
@@ -441,7 +472,12 @@ async fn run_one(args: &Args, conns: usize) -> Run {
     tokio::time::sleep(Duration::from_secs(args.seconds)).await;
     let measured = measure_start.elapsed();
     let cpu_after = args.server_pid.and_then(proc_cpu_jiffies);
+    let server_fds = args.server_pid.and_then(proc_fd_count);
     let rss_kb = args.server_pid.and_then(proc_rss_kb);
+    // Snapshot admission before stopping clients. Connections released while the
+    // tasks drain must not make an over-capacity run look fully served.
+    let connected_conns = progress.connected.load(Ordering::Relaxed);
+    let served_conns = progress.served.load(Ordering::Relaxed);
     stop.store(true, Ordering::Relaxed);
 
     let mut all: Vec<u64> = Vec::new();
@@ -467,13 +503,15 @@ async fn run_one(args: &Args, conns: usize) -> Run {
         _ => None,
     };
 
-    let errs = errors.load(Ordering::Relaxed);
+    let errs = progress.errors.load(Ordering::Relaxed);
     if errs > 0 {
         eprintln!("warning: {errs} errored requests at {conns} connections");
     }
 
     Run {
         conns,
+        connected_conns,
+        served_conns,
         rps: all.len() as f64 / measured.as_secs_f64(),
         p50: pct(0.50),
         p90: pct(0.90),
@@ -482,6 +520,7 @@ async fn run_one(args: &Args, conns: usize) -> Run {
         max: all.last().copied().unwrap_or(0) as f64 / 1000.0,
         samples: all.len(),
         cpu_percent,
+        server_fds,
         rss_kb,
     }
 }
@@ -495,18 +534,31 @@ async fn main() -> anyhow::Result<()> {
             args.addr, args.range, args.seconds, args.warmup
         );
         println!(
-            "{:>6} {:>12} {:>9} {:>9} {:>9} {:>9} {:>10} {:>7} {:>8}",
-            "conns", "rps", "p50 us", "p90 us", "p99 us", "p999 us", "max us", "cpu %", "rss MB"
+            "{:>6} {:>9} {:>8} {:>12} {:>9} {:>9} {:>9} {:>9} {:>10} {:>7} {:>7} {:>8}",
+            "conns",
+            "connected",
+            "served",
+            "rps",
+            "p50 us",
+            "p90 us",
+            "p99 us",
+            "p999 us",
+            "max us",
+            "cpu %",
+            "fds",
+            "rss MB"
         );
-        println!("{}", "-".repeat(90));
+        println!("{}", "-".repeat(112));
     }
 
     for &conns in &args.conns {
         let run = run_one(&args, conns).await;
         if args.json {
             println!(
-                r#"{{"conns":{},"rps":{:.0},"p50_us":{:.1},"p90_us":{:.1},"p99_us":{:.1},"p999_us":{:.1},"max_us":{:.1},"samples":{},"cpu_percent":{},"rss_kb":{}}}"#,
+                r#"{{"conns":{},"connected_conns":{},"served_conns":{},"rps":{:.0},"p50_us":{:.1},"p90_us":{:.1},"p99_us":{:.1},"p999_us":{:.1},"max_us":{:.1},"samples":{},"cpu_percent":{},"server_fds":{},"rss_kb":{}}}"#,
                 run.conns,
+                run.connected_conns,
+                run.served_conns,
                 run.rps,
                 run.p50,
                 run.p90,
@@ -517,14 +569,19 @@ async fn main() -> anyhow::Result<()> {
                 run.cpu_percent
                     .map(|c| format!("{c:.1}"))
                     .unwrap_or_else(|| "null".into()),
+                run.server_fds
+                    .map(|fds| fds.to_string())
+                    .unwrap_or_else(|| "null".into()),
                 run.rss_kb
                     .map(|r| r.to_string())
                     .unwrap_or_else(|| "null".into()),
             );
         } else {
             println!(
-                "{:>6} {:>12.0} {:>9.1} {:>9.1} {:>9.1} {:>9.1} {:>10.1} {:>7} {:>8}",
+                "{:>6} {:>9} {:>8} {:>12.0} {:>9.1} {:>9.1} {:>9.1} {:>9.1} {:>10.1} {:>7} {:>7} {:>8}",
                 run.conns,
+                run.connected_conns,
+                run.served_conns,
                 run.rps,
                 run.p50,
                 run.p90,
@@ -533,6 +590,9 @@ async fn main() -> anyhow::Result<()> {
                 run.max,
                 run.cpu_percent
                     .map(|c| format!("{c:.0}"))
+                    .unwrap_or_else(|| "-".into()),
+                run.server_fds
+                    .map(|fds| fds.to_string())
                     .unwrap_or_else(|| "-".into()),
                 run.rss_kb
                     .map(|r| format!("{:.1}", r as f64 / 1024.0))

--- a/crates/talon-worker/src/connection_admission.rs
+++ b/crates/talon-worker/src/connection_admission.rs
@@ -1,0 +1,103 @@
+//! Worker-global data-plane connection admission.
+//!
+//! Both server implementations acquire from this budget **before** accepting a
+//! socket. When the budget is full, the accept loop waits and excess peers stay
+//! in the kernel listen backlog: the worker does not reject them, accept their
+//! file descriptors, or spawn parked per-connection tasks. Because there is one
+//! accept loop per listener, waiting inside the worker is bounded by the number
+//! of listeners.
+
+use talon_transport::ConnectionLimit;
+use tokio::sync::OwnedSemaphorePermit;
+
+use crate::WorkerMetrics;
+
+/// A cloneable worker-global connection budget with admission observability.
+#[derive(Clone)]
+pub struct ConnectionAdmission {
+    limit: ConnectionLimit,
+    metrics: WorkerMetrics,
+}
+
+impl ConnectionAdmission {
+    /// Create one admission budget and publish its configured capacity.
+    pub fn new(capacity: usize, metrics: WorkerMetrics) -> Self {
+        let limit = ConnectionLimit::new(capacity);
+        metrics.set_connection_capacity(capacity.max(1));
+        Self { limit, metrics }
+    }
+
+    /// Acquire capacity before accepting a socket.
+    ///
+    /// Saturation is recorded at the failed immediate acquisition, before this
+    /// future waits. The returned RAII permit must be held until the accepted
+    /// connection task exits.
+    pub async fn acquire(&self) -> OwnedSemaphorePermit {
+        if let Some(permit) = self.limit.try_acquire() {
+            return permit;
+        }
+        self.metrics.record_connection_admission_saturation();
+        self.limit.acquire().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn cancelled_permit_holder_releases_capacity() {
+        let metrics = WorkerMetrics::new(0);
+        let admission = ConnectionAdmission::new(1, metrics);
+        let permit = admission.acquire().await;
+        let holder = tokio::spawn(async move {
+            let _permit = permit;
+            std::future::pending::<()>().await;
+        });
+        tokio::task::yield_now().await;
+        holder.abort();
+        holder.await.unwrap_err();
+
+        let replacement = tokio::time::timeout(Duration::from_secs(1), admission.acquire())
+            .await
+            .expect("cancelling a connection task must release its permit");
+        drop(replacement);
+    }
+
+    #[tokio::test]
+    async fn clones_share_capacity_and_cancelled_waiters_do_not_leak() {
+        let metrics = WorkerMetrics::new(0);
+        let admission = ConnectionAdmission::new(1, metrics.clone());
+        let permit = admission.acquire().await;
+
+        let waiting_admission = admission.clone();
+        let waiter = tokio::spawn(async move { waiting_admission.acquire().await });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if metrics
+                    .render()
+                    .contains("talon_worker_connection_admission_saturated_total 1")
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("blocked clone should report saturation");
+
+        waiter.abort();
+        waiter.await.unwrap_err();
+        drop(permit);
+
+        let replacement = tokio::time::timeout(Duration::from_secs(1), admission.acquire())
+            .await
+            .expect("cancelled waiter must not retain capacity");
+        drop(replacement);
+        let rendered = metrics.render();
+        assert!(rendered.contains("talon_worker_connection_capacity 1"));
+        assert!(rendered.contains("talon_worker_connection_admission_saturated_total 1"));
+    }
+}

--- a/crates/talon-worker/src/lib.rs
+++ b/crates/talon-worker/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod block_store;
 pub mod capacity;
+pub mod connection_admission;
 mod data_error;
 pub mod eviction;
 mod fd_cache;
@@ -35,6 +36,7 @@ pub mod write_cache;
 
 pub use block_store::WholeBlockStore;
 pub use capacity::{CacheDirConfig, CacheDirs};
+pub use connection_admission::ConnectionAdmission;
 pub use eviction::{CacheUnit, Lru};
 pub use flusher::{FlushOutcome, FlushPolicy, FlushStats, Flusher};
 pub use index::{BlockIndex, Presence};

--- a/crates/talon-worker/src/main.rs
+++ b/crates/talon-worker/src/main.rs
@@ -43,8 +43,8 @@ use talon_worker::tokio_conn::{handle_conn, read_control};
 #[cfg(target_os = "linux")]
 use talon_worker::uring_conn;
 use talon_worker::{
-    serve_admin, BlockIndex, InFlightLoads, PagedBlockStore, TenantRateLimiter, WholeBlockStore,
-    WorkerObservability, WorkerRuntime,
+    serve_admin, BlockIndex, ConnectionAdmission, InFlightLoads, PagedBlockStore,
+    TenantRateLimiter, WholeBlockStore, WorkerObservability, WorkerRuntime,
 };
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -52,9 +52,9 @@ use tokio::net::{TcpListener, TcpStream};
 const CONTROL_OPERATION_TIMEOUT: Duration = Duration::from_secs(3);
 const CONTROL_TLS_RELOAD_INTERVAL: Duration = Duration::from_secs(5);
 
-/// Upper bound on concurrent data-plane connections. Beyond this, new peers wait
-/// for an in-flight connection to finish rather than each spawning an unbounded
-/// task that could pin a payload buffer (issue #111).
+/// Worker-global budget for accepted data-plane connections. Both server paths
+/// acquire before `accept`, so excess peers remain in the kernel backlog instead
+/// of consuming a worker FD or task (issues #111 and #568).
 const MAX_DATA_PLANE_CONNECTIONS: usize = 1024;
 
 /// Blocking helper threads per io_uring ring, for the zero-copy `sendfile`
@@ -672,6 +672,8 @@ async fn main() -> anyhow::Result<()> {
              data plane. Performance will be lower under high connection counts."
         );
     }
+    let connection_admission =
+        ConnectionAdmission::new(MAX_DATA_PLANE_CONNECTIONS, observability.metrics().clone());
     #[cfg(target_os = "linux")]
     if !force_tokio && uring_available {
         let rings = talon_worker::uring_serve::resolve_ring_count(cfg.data_plane_rings);
@@ -684,21 +686,18 @@ async fn main() -> anyhow::Result<()> {
         // Tokio worker threads it is handing out — so drive it on a dedicated
         // thread and park this task on the join.
         let addr = cfg.listen.clone();
-        // RingConnHandler is cloned for every ring, and those clones share one
-        // semaphore. Pass the worker-wide budget unchanged: dividing it by the
-        // ring count would accidentally turn the global 1024-connection cap into
-        // a 1024/rings cap for the entire worker (#111).
-        let handler = uring_conn::RingConnHandler::new(
-            Arc::clone(&worker),
-            Arc::clone(&observability),
-            MAX_DATA_PLANE_CONNECTIONS,
-        );
+        // Every SO_REUSEPORT listener shares this worker-global budget. `serve`
+        // acquires it before accept, matching the Tokio fallback and ensuring the
+        // 1024 cap covers accepted socket FDs and their tasks (#568).
+        let handler =
+            uring_conn::RingConnHandler::new(Arc::clone(&worker), Arc::clone(&observability));
         let tokio_handle = tokio::runtime::Handle::current();
         let joined = tokio::task::spawn_blocking(move || {
             talon_worker::uring_serve::serve(
                 addr,
                 rings,
                 URING_BLOCKING_THREADS_PER_RING,
+                connection_admission,
                 handler,
                 tokio_handle,
             )
@@ -709,11 +708,10 @@ async fn main() -> anyhow::Result<()> {
 
     let listener = TcpListener::bind(&cfg.listen).await?;
     tracing::info!(listen = %cfg.listen, "worker serving data plane");
-    // Bound concurrent connections so a flood of idle peers cannot exhaust
-    // memory/FDs (issue #111).
-    let conn_limit = talon_transport::ConnectionLimit::new(MAX_DATA_PLANE_CONNECTIONS);
     loop {
-        let permit = conn_limit.acquire().await;
+        // Wait before accept just like each io_uring listener; overload remains
+        // in the kernel backlog and cannot allocate an accepted FD or task.
+        let permit = connection_admission.acquire().await;
         let (stream, peer) = listener.accept().await?;
         let worker = Arc::clone(&worker);
         let observability = Arc::clone(&observability);

--- a/crates/talon-worker/src/observability.rs
+++ b/crates/talon-worker/src/observability.rs
@@ -28,6 +28,7 @@ pub struct WorkerMetrics {
     registry: Metrics,
     configured_capacity_bytes: u64,
     active_connection_count: Arc<AtomicU64>,
+    connection_admission_saturated_total: Counter,
     requests_total: Counter,
     request_errors_total: Counter,
     bytes_served_total: Counter,
@@ -52,6 +53,7 @@ pub struct WorkerMetrics {
     heartbeat_failure_total: Counter,
     request_duration_seconds: Histogram,
     backend_fetch_duration_seconds: Histogram,
+    connection_capacity: Gauge,
     active_connections: Gauge,
     inflight_loads: Gauge,
     block_count: Gauge,
@@ -93,6 +95,11 @@ impl WorkerMetrics {
             )
             .set(1.0);
         let active_connection_count = Arc::new(AtomicU64::new(0));
+        let connection_admission_saturated_total = registry.counter(
+            "talon_worker_connection_admission_saturated_total",
+            "Accept-loop waits caused by the worker-global data-plane connection budget being full.",
+            BTreeMap::new(),
+        );
         let requests_total = registry.counter(
             "talon_worker_requests_total",
             "Data-plane requests completed by the worker.",
@@ -213,9 +220,14 @@ impl WorkerMetrics {
             "Origin backend range fetch latency in seconds.",
             backend_labels,
         );
+        let connection_capacity = registry.gauge(
+            "talon_worker_connection_capacity",
+            "Configured worker-global data-plane connection capacity.",
+            BTreeMap::new(),
+        );
         let active_connections = registry.gauge(
             "talon_worker_active_connections",
-            "Data-plane connections currently open.",
+            "Accepted data-plane connections currently being served.",
             BTreeMap::new(),
         );
         let inflight_loads = registry.gauge(
@@ -274,6 +286,7 @@ impl WorkerMetrics {
             registry,
             configured_capacity_bytes,
             active_connection_count,
+            connection_admission_saturated_total,
             requests_total,
             request_errors_total,
             bytes_served_total,
@@ -298,6 +311,7 @@ impl WorkerMetrics {
             heartbeat_failure_total,
             request_duration_seconds,
             backend_fetch_duration_seconds,
+            connection_capacity,
             active_connections,
             inflight_loads,
             block_count,
@@ -475,6 +489,16 @@ impl WorkerMetrics {
     /// Record a completed cache eviction.
     pub fn record_eviction(&self) {
         self.evictions_total.inc();
+    }
+
+    /// Publish the worker-global data-plane connection capacity.
+    pub fn set_connection_capacity(&self, capacity: usize) {
+        self.connection_capacity.set(capacity as f64);
+    }
+
+    /// Record an accept loop waiting for connection capacity.
+    pub fn record_connection_admission_saturation(&self) {
+        self.connection_admission_saturated_total.inc();
     }
 
     /// Increment active connections until the returned guard is dropped.
@@ -880,6 +904,17 @@ mod tests {
             )
             .unwrap(),
         )
+    }
+
+    #[test]
+    fn connection_admission_metrics_report_capacity_and_saturation() {
+        let metrics = WorkerMetrics::new(4096);
+        metrics.set_connection_capacity(1024);
+        metrics.record_connection_admission_saturation();
+
+        let rendered = metrics.render();
+        assert!(rendered.contains("talon_worker_connection_capacity 1024"));
+        assert!(rendered.contains("talon_worker_connection_admission_saturated_total 1"));
     }
 
     #[test]

--- a/crates/talon-worker/src/uring_conn.rs
+++ b/crates/talon-worker/src/uring_conn.rs
@@ -841,40 +841,26 @@ async fn handle_delete(
 }
 
 /// Adapts [`handle_conn`] to the ring runtime's [`crate::uring_serve::RingHandler`]
-/// trait.
-///
-/// Carries the shared worker state and enforces the same worker-wide connection
-/// cap as the Tokio path (#111). [`RingConnHandler`] is cloned once per ring, and
-/// every clone shares the same semaphore, so callers must pass the global budget
-/// unchanged.
+/// trait. Connection admission belongs to the server accept loop; this handler
+/// owns only protocol state.
 #[derive(Clone)]
 pub struct RingConnHandler {
     worker: Arc<WorkerRuntime>,
     observability: Arc<WorkerObservability>,
-    limit: Arc<tokio::sync::Semaphore>,
 }
 
 impl RingConnHandler {
-    /// Build a handler admitting at most `max_connections` concurrent
-    /// connections across all rings that share its clones.
-    pub fn new(
-        worker: Arc<WorkerRuntime>,
-        observability: Arc<WorkerObservability>,
-        global_max_connections: usize,
-    ) -> Self {
+    /// Build a protocol handler for an already-admitted connection.
+    pub fn new(worker: Arc<WorkerRuntime>, observability: Arc<WorkerObservability>) -> Self {
         Self {
             worker,
             observability,
-            limit: Arc::new(tokio::sync::Semaphore::new(global_max_connections)),
         }
     }
 }
 
 impl crate::uring_serve::RingHandler for RingConnHandler {
     async fn handle(&self, stream: TcpStream) -> anyhow::Result<()> {
-        // Acquire before serving and hold for the connection's lifetime, so a
-        // flood of idle peers cannot exhaust memory or file descriptors.
-        let _permit = self.limit.clone().acquire_owned().await?;
         handle_conn(
             stream,
             Arc::clone(&self.worker),
@@ -1419,38 +1405,8 @@ mod tests {
         std::fs::remove_dir_all(root).ok();
     }
 
-    /// `serve` clones one handler per io_uring ring. The semaphore deliberately
-    /// remains worker-wide across those clones, so main must pass the global
-    /// connection budget rather than dividing it by the number of rings.
-    #[test]
-    fn ring_handler_clones_share_one_global_connection_budget() {
-        let root = tmp_root("ring-global-limit");
-        let tokio_rt = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
-            .enable_all()
-            .build()
-            .unwrap();
-        let (worker, obs) = {
-            let _guard = tokio_rt.enter();
-            build(&root, Arc::new(RampBackend), 16)
-        };
-
-        let handler = RingConnHandler::new(worker, obs, 3);
-        let clone = handler.clone();
-        assert!(Arc::ptr_eq(&handler.limit, &clone.limit));
-
-        let permits: Vec<_> = (0..3)
-            .map(|_| handler.limit.clone().try_acquire_owned().unwrap())
-            .collect();
-        assert!(clone.limit.clone().try_acquire_owned().is_err());
-
-        drop(permits);
-        assert!(clone.limit.clone().try_acquire_owned().is_ok());
-        std::fs::remove_dir_all(root).ok();
-    }
-
-    /// The RingConnHandler admits up to its cap and serves real traffic through
-    /// the ring runtime — the wiring main.rs uses.
+    /// The RingConnHandler serves real traffic through the ring runtime — the
+    /// wiring main.rs uses.
     #[test]
     fn ring_handler_serves_through_the_ring_runtime() {
         use crate::uring_serve::serve;
@@ -1470,11 +1426,12 @@ mod tests {
         let addr = probe.local_addr().unwrap().to_string();
         drop(probe);
 
-        let handler = RingConnHandler::new(worker, obs, 8);
+        let admission = crate::ConnectionAdmission::new(8, obs.metrics().clone());
+        let handler = RingConnHandler::new(worker, obs);
         let handle = tokio_rt.handle().clone();
         let serve_addr = addr.clone();
         std::thread::spawn(move || {
-            let _ = serve(serve_addr, 2, 2, handler, handle);
+            let _ = serve(serve_addr, 2, 2, admission, handler, handle);
         });
 
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);

--- a/crates/talon-worker/src/uring_serve.rs
+++ b/crates/talon-worker/src/uring_serve.rs
@@ -29,6 +29,8 @@
 
 use std::sync::Arc;
 
+use crate::ConnectionAdmission;
+
 /// The CPUs this process is actually allowed to run on, in ascending order.
 ///
 /// Reads the thread's affinity mask rather than assuming CPUs are numbered
@@ -125,6 +127,11 @@ pub trait RingHandler: Clone + 'static {
 ///    for `sendfile`,
 /// 3. binds `addr` with `SO_REUSEPORT` and accepts forever.
 ///
+/// Every ring shares `admission`. A ring acquires capacity before `accept`, so
+/// excess peers remain in that listener's kernel backlog without an accepted FD
+/// or Monoio task. The permit moves into the connection task and is released on
+/// every completion, error, or runtime-cancellation path.
+///
 /// `handler` is cloned per ring; share state through an `Arc` inside it.
 ///
 /// # Tokio coexistence
@@ -150,6 +157,7 @@ pub fn serve<H>(
     addr: String,
     rings: usize,
     blocking_threads: usize,
+    admission: ConnectionAdmission,
     handler: H,
     tokio_handle: tokio::runtime::Handle,
 ) -> anyhow::Result<()>
@@ -173,6 +181,7 @@ where
 
     for ring_id in 0..rings {
         let addr = addr.clone();
+        let admission = admission.clone();
         let handler = handler.clone();
         let ready = Arc::clone(&ready);
         let tokio_handle = tokio_handle.clone();
@@ -242,6 +251,10 @@ where
                         tracing::info!(ring = ring_id, %addr, "data-plane ring listening");
 
                         loop {
+                            // Match the Tokio data plane's overload policy: wait
+                            // for worker-global capacity before accepting, leaving
+                            // excess peers in this ring's kernel backlog.
+                            let permit = admission.acquire().await;
                             let (stream, peer) = match listener.accept().await {
                                 Ok(v) => v,
                                 Err(e) => {
@@ -252,6 +265,9 @@ where
                             let _ = stream.set_nodelay(true);
                             let handler = handler.clone();
                             monoio::spawn(async move {
+                                // The permit covers the accepted FD and task for
+                                // their complete lifetime.
+                                let _permit = permit;
                                 if let Err(e) = handler.handle(stream).await {
                                     tracing::debug!(?peer, error = %e, "connection ended");
                                 }
@@ -279,6 +295,10 @@ mod tests {
     use std::collections::HashSet;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Mutex;
+
+    fn admission(capacity: usize) -> ConnectionAdmission {
+        ConnectionAdmission::new(capacity, crate::WorkerMetrics::new(0))
+    }
 
     /// The default configuration must select the io_uring data plane, and it
     /// must be usable on any host CI runs on — the fallback exists precisely so
@@ -459,7 +479,14 @@ mod tests {
         let serve_addr = addr.clone();
         std::thread::spawn(move || {
             let rt = tokio::runtime::Runtime::new().unwrap();
-            let _ = serve(serve_addr, 4, 2, handler, rt.handle().clone());
+            let _ = serve(
+                serve_addr,
+                4,
+                2,
+                admission(128),
+                handler,
+                rt.handle().clone(),
+            );
         });
 
         // Wait for at least one ring to bind.
@@ -504,7 +531,14 @@ mod tests {
         let serve_addr = addr.clone();
         std::thread::spawn(move || {
             let rt = tokio::runtime::Runtime::new().unwrap();
-            let _ = serve(serve_addr, 2, 1, handler, rt.handle().clone());
+            let _ = serve(
+                serve_addr,
+                2,
+                1,
+                admission(128),
+                handler,
+                rt.handle().clone(),
+            );
         });
 
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
@@ -521,5 +555,185 @@ mod tests {
         }
         // One shared counter, incremented from whichever ring served.
         await_count(&served, 10);
+    }
+
+    /// Resources held by one synthetic connection handler.
+    struct HandlerResourceGuard {
+        active: Arc<AtomicUsize>,
+        resident_bytes: Arc<AtomicUsize>,
+        bytes: usize,
+    }
+
+    impl Drop for HandlerResourceGuard {
+        fn drop(&mut self) {
+            self.active.fetch_sub(1, Ordering::Relaxed);
+            self.resident_bytes.fetch_sub(self.bytes, Ordering::Relaxed);
+        }
+    }
+
+    /// An idle handler with deterministic per-task residency. Every admitted
+    /// connection blocks on one byte, then returns an error to exercise permit
+    /// release on the error path.
+    #[derive(Clone)]
+    struct IdleHandler {
+        started: Arc<AtomicUsize>,
+        active: Arc<AtomicUsize>,
+        peak: Arc<AtomicUsize>,
+        resident_bytes: Arc<AtomicUsize>,
+        bytes_per_connection: usize,
+    }
+
+    impl RingHandler for IdleHandler {
+        async fn handle(&self, mut stream: monoio::net::TcpStream) -> anyhow::Result<()> {
+            let active = self.active.fetch_add(1, Ordering::Relaxed) + 1;
+            self.peak.fetch_max(active, Ordering::Relaxed);
+            self.started.fetch_add(1, Ordering::Relaxed);
+            self.resident_bytes
+                .fetch_add(self.bytes_per_connection, Ordering::Relaxed);
+            let _guard = HandlerResourceGuard {
+                active: Arc::clone(&self.active),
+                resident_bytes: Arc::clone(&self.resident_bytes),
+                bytes: self.bytes_per_connection,
+            };
+            let allocation = vec![0xa5; self.bytes_per_connection];
+            let (result, _) = stream.read_exact(vec![0u8; 1]).await;
+            std::hint::black_box(&allocation);
+            result?;
+            anyhow::bail!("synthetic handler error")
+        }
+    }
+
+    /// Count established sockets owned by this process whose local port is the
+    /// server port. Correlating `/proc/net/tcp` inodes with `/proc/self/fd`
+    /// excludes client-side sockets in this test and connections still queued in
+    /// the kernel backlog.
+    fn accepted_server_fds(port: u16) -> usize {
+        let socket_inodes: HashSet<String> = std::fs::read_dir("/proc/self/fd")
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter_map(|entry| std::fs::read_link(entry.path()).ok())
+            .filter_map(|target| {
+                let target = target.to_string_lossy();
+                target
+                    .strip_prefix("socket:[")
+                    .and_then(|value| value.strip_suffix(']'))
+                    .map(str::to_owned)
+            })
+            .collect();
+        let expected_port = format!("{port:04X}");
+        std::fs::read_to_string("/proc/net/tcp")
+            .unwrap()
+            .lines()
+            .skip(1)
+            .filter(|line| {
+                let fields: Vec<_> = line.split_whitespace().collect();
+                fields.get(1).is_some_and(|local| {
+                    local
+                        .rsplit_once(':')
+                        .is_some_and(|(_, local_port)| local_port == expected_port)
+                }) && fields.get(3) == Some(&"01")
+                    && fields
+                        .get(9)
+                        .is_some_and(|inode| socket_inodes.contains(*inode))
+            })
+            .count()
+    }
+
+    fn await_zero(counter: &AtomicUsize) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while counter.load(Ordering::Relaxed) != 0 {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "counter remained at {}",
+                counter.load(Ordering::Relaxed)
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
+    /// Admission happens before both accept and spawn. Excess idle clients stay
+    /// in the kernel backlog, so accepted FDs, handler tasks, and handler-owned
+    /// resident memory all remain bounded by one budget shared across rings.
+    #[test]
+    fn global_admission_bounds_accepts_tasks_and_residency() {
+        const CAPACITY: usize = 2;
+        const CLIENTS: usize = 32;
+        const BYTES_PER_CONNECTION: usize = 256 * 1024;
+
+        let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let socket_addr = probe.local_addr().unwrap();
+        let addr = socket_addr.to_string();
+        drop(probe);
+
+        let started = Arc::new(AtomicUsize::new(0));
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let resident_bytes = Arc::new(AtomicUsize::new(0));
+        let handler = IdleHandler {
+            started: Arc::clone(&started),
+            active: Arc::clone(&active),
+            peak: Arc::clone(&peak),
+            resident_bytes: Arc::clone(&resident_bytes),
+            bytes_per_connection: BYTES_PER_CONNECTION,
+        };
+        let metrics = crate::WorkerMetrics::new(0);
+        let connection_admission = ConnectionAdmission::new(CAPACITY, metrics.clone());
+        let serve_addr = addr.clone();
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            let _ = serve(
+                serve_addr,
+                2,
+                1,
+                connection_admission,
+                handler,
+                rt.handle().clone(),
+            );
+        });
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let first = loop {
+            match std::net::TcpStream::connect(&addr) {
+                Ok(stream) => break stream,
+                Err(_) => {
+                    assert!(std::time::Instant::now() < deadline, "rings never bound");
+                    std::thread::sleep(std::time::Duration::from_millis(25));
+                }
+            }
+        };
+        let mut clients = Vec::with_capacity(CLIENTS);
+        clients.push(first);
+        for _ in 1..CLIENTS {
+            clients.push(std::net::TcpStream::connect(&addr).unwrap());
+        }
+
+        await_count(&started, CAPACITY);
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        assert_eq!(started.load(Ordering::Relaxed), CAPACITY);
+        assert_eq!(active.load(Ordering::Relaxed), CAPACITY);
+        assert_eq!(peak.load(Ordering::Relaxed), CAPACITY);
+        assert_eq!(
+            resident_bytes.load(Ordering::Relaxed),
+            CAPACITY * BYTES_PER_CONNECTION
+        );
+        assert_eq!(accepted_server_fds(socket_addr.port()), CAPACITY);
+        let saturation = metrics
+            .render()
+            .lines()
+            .find(|line| line.starts_with("talon_worker_connection_admission_saturated_total "))
+            .and_then(|line| line.split_whitespace().nth(1))
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap();
+        assert!(saturation > 0);
+
+        // Every error completion releases its permit, allowing all queued peers
+        // to enter without ever exceeding the peak.
+        for client in &mut clients {
+            std::io::Write::write_all(client, b"x").unwrap();
+        }
+        await_count(&started, CLIENTS);
+        await_zero(&active);
+        assert_eq!(peak.load(Ordering::Relaxed), CAPACITY);
+        assert_eq!(resident_bytes.load(Ordering::Relaxed), 0);
     }
 }


### PR DESCRIPTION
## Summary

Make both the Tokio and io_uring data-plane accept loops acquire one worker-global connection permit before accepting a socket. When the 1024-connection budget is saturated, excess peers remain in the kernel listen backlog instead of allocating accepted worker FDs and parked connection tasks.

This is a follow-up to #567. It does not change the wire protocol, persistent state, or configuration interface.

## Related issues

Follow-up to #567.
Related to #111 and #568.

## Type of change

- [x] Bug fix
- [ ] New feature / functionality
- [ ] Refactor (no behavior change)
- [ ] Performance
- [ ] Docs / tests / tooling

## Design alignment

This touches DESIGN.md: Runtime & I/O model / Layer 1 — control & protocol scheduling, where accept and connection management belong. It preserves the documented thread-per-core io_uring default and Tokio fallback while aligning their admission semantics.

## Changes

- Add a cloneable worker-global ConnectionAdmission budget backed by talon-transport ConnectionLimit.
- Acquire capacity before accept in both Tokio and io_uring paths, and hold the RAII permit for the full accepted-connection lifetime.
- Share one 1024-connection budget across all SO_REUSEPORT io_uring listeners.
- Export talon_worker_connection_capacity and talon_worker_connection_admission_saturated_total metrics.
- Add permit cancellation/release coverage and a real multi-ring overload regression that bounds accepted FDs, handler tasks, and handler-owned residency.
- Extend loadgen output with TCP-connected versus served connections and server FD reporting.

## Test plan

- [ ] just ci passes locally (fmt + clippy + test)
- [ ] Workspace compiles (cargo build --workspace)
- [x] Added/updated tests for new behavior

Verified locally:

- cargo fmt --all -- --check — PASS
- cargo test -p talon-worker --lib --locked connection_admission — PASS, 3 tests
- cargo test -p talon-worker --lib --locked global_admission_bounds_accepts_tasks_and_residency -- --nocapture — PASS, 1 test
- cargo test -p talon-worker --lib --locked — PASS, 263 tests

## Performance impact

- [ ] Not performance-sensitive, OR
- [ ] just bench-check run; results below (baseline refreshed if the change is intentional)

No benchmark was run. This changes the data-plane accept boundary, so it is not marked as performance-insensitive. The overload regression directly verifies the intended resource bound; no benchmark result is claimed.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (type(scope): description) — it becomes the squash-merge commit subject and is checked by CI
- [x] Public items are documented; no broken intra-doc links
- [x] No new dependencies without discussion
- [x] Rebased on the latest main