### PR TITLE
feat(clients): make idle connection limits configurable

### DIFF
--- a/clients/c/examples/async_read.c
+++ b/clients/c/examples/async_read.c
@@ -34,6 +34,7 @@ static void on_read(talon_result *result, void *user_data) {
 int main(void) {
     talon_client_options options;
     talon_client_options_init(&options);
+    options.max_idle_per_addr = 32;
 
     talon_client *client = NULL;
     if (talon_client_new("127.0.0.1:7000", &options, &client) != TALON_STATUS_OK) {

--- a/clients/c/include/talon.h
+++ b/clients/c/include/talon.h
@@ -44,6 +44,9 @@ typedef struct talon_callback_executor {
 typedef struct talon_client_options {
     uint32_t block_size;
     const talon_callback_executor *callback_executor;
+    /* Maximum idle connections per peer in each pool. Zero uses the default 8.
+     * This does not limit active connections. */
+    uint32_t max_idle_per_addr;
 } talon_client_options;
 
 void talon_client_options_init(talon_client_options *options);

--- a/clients/c/src/lib.rs
+++ b/clients/c/src/lib.rs
@@ -14,11 +14,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use talon_rust_client::{
-    parse_uri as parse_rust_uri, Client as RustClient, Error as RustError, ObjectId,
+    parse_uri as parse_rust_uri, Client as RustClient, ClientBuilder, Error as RustError, ObjectId,
     ObjectStat as RustObjectStat, UriError,
 };
 
 const DEFAULT_BLOCK_SIZE: u32 = 256 << 20;
+const DEFAULT_MAX_IDLE_PER_ADDR: u32 = 8;
 
 const STATUS_OK: c_int = 0;
 const STATUS_INVALID_ARGUMENT: c_int = 1;
@@ -58,6 +59,9 @@ pub struct TalonClientOptions {
     /// Optional caller-owned callback executor. Without one, callbacks run on
     /// the Tokio runtime thread that completed the operation.
     pub callback_executor: *const TalonCallbackExecutor,
+    /// Maximum idle connections per peer in each pool. Zero uses the default 8.
+    /// Does not limit active connections.
+    pub max_idle_per_addr: u32,
 }
 
 /// Opaque client handle.
@@ -171,6 +175,7 @@ pub unsafe extern "C" fn talon_client_options_init(options: *mut TalonClientOpti
             TalonClientOptions {
                 block_size: DEFAULT_BLOCK_SIZE,
                 callback_executor: ptr::null(),
+                max_idle_per_addr: DEFAULT_MAX_IDLE_PER_ADDR,
             },
         );
     }
@@ -196,6 +201,7 @@ pub unsafe extern "C" fn talon_client_new(
             TalonClientOptions {
                 block_size: DEFAULT_BLOCK_SIZE,
                 callback_executor: ptr::null(),
+                max_idle_per_addr: DEFAULT_MAX_IDLE_PER_ADDR,
             }
         } else {
             unsafe { *options }
@@ -204,6 +210,11 @@ pub unsafe extern "C" fn talon_client_new(
             DEFAULT_BLOCK_SIZE
         } else {
             options.block_size
+        };
+        let max_idle_per_addr = if options.max_idle_per_addr == 0 {
+            DEFAULT_MAX_IDLE_PER_ADDR
+        } else {
+            options.max_idle_per_addr
         };
         let dispatcher = if options.callback_executor.is_null() {
             CallbackDispatcher::Inline
@@ -222,7 +233,11 @@ pub unsafe extern "C" fn talon_client_new(
             .enable_all()
             .build()
             .map_err(|error| (STATUS_RUNTIME_ERROR, error.to_string()))?;
-        let rust_client = RustClient::new(coordinator_addr, block_size)
+        let rust_client = ClientBuilder::default()
+            .with_coordinator(coordinator_addr)
+            .with_block_size(block_size)
+            .with_max_idle_per_addr(max_idle_per_addr as usize)
+            .build()
             .map_err(|error| (STATUS_INVALID_ARGUMENT, error.to_string()))?;
         let client = Box::new(TalonClient {
             inner: Arc::new(ClientInner {
@@ -843,6 +858,7 @@ mod tests {
         let mut options = TalonClientOptions {
             block_size: 0,
             callback_executor: ptr::null(),
+            max_idle_per_addr: 0,
         };
         unsafe {
             talon_client_options_init(&mut options);
@@ -864,6 +880,7 @@ mod tests {
         let options = TalonClientOptions {
             block_size,
             callback_executor: ptr::null(),
+            max_idle_per_addr: 0,
         };
         let mut client = ptr::null_mut();
         let status = unsafe { talon_client_new(coordinator_c.as_ptr(), &options, &mut client) };
@@ -1223,6 +1240,7 @@ mod tests {
         let options = TalonClientOptions {
             block_size: DEFAULT_BLOCK_SIZE,
             callback_executor: &executor,
+            max_idle_per_addr: 0,
         };
         let mut client = ptr::null_mut();
         let status = unsafe { talon_client_new(coordinator_c.as_ptr(), &options, &mut client) };

--- a/clients/c/tests/c_api_smoke.c
+++ b/clients/c/tests/c_api_smoke.c
@@ -33,7 +33,8 @@ int talon_c_api_smoke_test(void) {
     const char *last_error;
 
     talon_client_options_init(&options);
-    if (options.block_size != (256u << 20) || options.callback_executor != NULL) {
+    if (options.block_size != (256u << 20) || options.callback_executor != NULL ||
+        options.max_idle_per_addr != 8) {
         return 1;
     }
 
@@ -45,6 +46,7 @@ int talon_c_api_smoke_test(void) {
         return 3;
     }
 
+    options.max_idle_per_addr = 32;
     if (talon_client_new("127.0.0.1:1", &options, &client) != TALON_STATUS_OK ||
         client == NULL) {
         return 4;

--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -6,12 +6,24 @@ JVM build, with no per-platform artifact, no `System.loadLibrary`, and no JNI
 crash surface.
 
 ```java
-try (TalonClient client = TalonClient.connect("coordinator-host:7000", 8 << 20)) {
+try (TalonClient client = TalonClient.connect("coordinator-host:7000", 8 << 20, 32)) {
     byte[] data = client.read("az://container/dataset.parquet",
                               "0x8DABCDEF",   // object version (ETag)
                               0, 1 << 20);
 }
 ```
+
+`maxIdlePerAddr` defaults to **8** when omitted and must be positive. It limits idle TCP
+connections retained per address, independently in the coordinator and worker
+pools; concurrent requests may open more connections. Idle connections expire
+after 30 seconds and are discarded on checkout. Failed exchanges close their
+connections; a reused connection that disconnects is retried once on a fresh
+connection. `close()` closes idle connections and prevents in-flight connections
+from returning to the pools.
+
+The existing `TalonClient.connect(coordinator, blockSize)` and
+`TalonClient.connect(coordinator)` calls use the default idle limit. The default
+block size is 256 MiB and must match the workers' configuration.
 
 URIs use the same namespaces as the FUSE mount — `s3://`, `gcs://`, `az://` —
 so a path addresses the same object through either client.
@@ -30,8 +42,8 @@ silently breaking a deployment.
 JAVA_HOME=/path/to/jdk scripts/java_client_e2e.sh
 ```
 
-That runs both suites: the vectors, and an end-to-end read against a live
-cluster.
+That runs the vectors and local TCP pool checks, followed by an end-to-end read
+against a live cluster.
 
 ## Current scope
 

--- a/clients/java/src/main/java/io/milvus/talon/TalonClient.java
+++ b/clients/java/src/main/java/io/milvus/talon/TalonClient.java
@@ -2,11 +2,13 @@ package io.milvus.talon;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -27,9 +29,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * <h2>Thread safety</h2>
  *
- * Instances are safe for concurrent use. Each call opens its own connection
- * rather than sharing one, so a slow read cannot block an unrelated one; the
- * placement cache is shared and synchronised.
+ * Instances are safe for concurrent use. Each call exclusively checks out a
+ * connection, so a slow read cannot block an unrelated one. Idle connections
+ * are reused; their limit does not constrain concurrent requests.
  *
  * <h2>Example</h2>
  *
@@ -51,27 +53,48 @@ public final class TalonClient implements AutoCloseable {
 
     private final String coordinator;
     private final int blockSize;
+    private final ConnectionPool coordinatorPool;
+    private final ConnectionPool workerPool;
     private final AtomicInteger requestIds = new AtomicInteger(1);
     private final Map<BlockId, CachedPlacement> placementCache = new HashMap<>();
     private final Object membershipLock = new Object();
     private CachedMembership membership;
 
-    private TalonClient(String coordinator, int blockSize) {
+    private TalonClient(String coordinator, int blockSize, int maxIdlePerAddr) {
         this.coordinator = coordinator;
         this.blockSize = blockSize;
+        this.coordinatorPool = new ConnectionPool(maxIdlePerAddr);
+        this.workerPool = new ConnectionPool(maxIdlePerAddr);
     }
 
     /**
-     * Connect to a coordinator.
+     * Connect to a coordinator with a configurable idle connection limit.
+     *
+     * @param blockSize must match the workers' configured block size
+     * @param maxIdlePerAddr positive maximum idle connections per address in each
+     *     coordinator/worker pool; does not limit concurrent requests
+     */
+    public static TalonClient connect(String coordinator, int blockSize, int maxIdlePerAddr) {
+        if (coordinator == null || coordinator.isBlank()) {
+            throw new IllegalArgumentException("coordinator is required");
+        }
+        if (blockSize <= 0) {
+            throw new IllegalArgumentException("blockSize must be positive, got " + blockSize);
+        }
+        if (maxIdlePerAddr <= 0) {
+            throw new IllegalArgumentException("maxIdlePerAddr must be positive, got " + maxIdlePerAddr);
+        }
+        return new TalonClient(coordinator, blockSize, maxIdlePerAddr);
+    }
+
+    /**
+     * Connect to a coordinator, retaining up to 8 idle connections per address.
      *
      * @param blockSize must match the workers' configured block size; placement
      *     is per block, so a mismatch addresses blocks that do not exist
      */
     public static TalonClient connect(String coordinator, int blockSize) {
-        if (blockSize <= 0) {
-            throw new IllegalArgumentException("blockSize must be positive, got " + blockSize);
-        }
-        return new TalonClient(coordinator, blockSize);
+        return connect(coordinator, blockSize, 8);
     }
 
     /** Connect using the worker default block size of 256 MiB. */
@@ -137,12 +160,13 @@ public final class TalonClient implements AutoCloseable {
     /** As {@link #stat(String)}, with a parsed object id. */
     public ObjectStat stat(ObjectId object) throws IOException {
         int id = requestIds.getAndIncrement();
-        Messages.Response resp = controlRoundTrip(Messages.statObject(id, object));
-        if (resp.tag == Messages.TAG_OBJECT_STAT) {
-            long size = resp.body.u64();
-            return new ObjectStat(size, resp.body.string());
-        }
-        throw unexpected("StatObject", resp);
+        return controlRoundTrip(Messages.statObject(id, object), resp -> {
+            if (resp.tag == Messages.TAG_OBJECT_STAT) {
+                long size = resp.body.u64();
+                return new ObjectStat(size, resp.body.string());
+            }
+            throw unexpected("StatObject", resp);
+        });
     }
 
     /**
@@ -159,20 +183,23 @@ public final class TalonClient implements AutoCloseable {
      */
     public List<ObjectEntry> list(String prefix) throws IOException {
         int id = requestIds.getAndIncrement();
-        Messages.Response resp = controlRoundTrip(Messages.listObjects(id, prefix));
-        if (resp.tag == Messages.TAG_OBJECT_LIST) {
-            int n = resp.body.seqLen();
-            List<ObjectEntry> entries = new ArrayList<>(n);
-            for (int i = 0; i < n; i++) {
-                entries.add(new ObjectEntry(resp.body.string(), resp.body.u64()));
+        return controlRoundTrip(Messages.listObjects(id, prefix), resp -> {
+            if (resp.tag == Messages.TAG_OBJECT_LIST) {
+                int n = resp.body.seqLen();
+                List<ObjectEntry> entries = new ArrayList<>(n);
+                for (int i = 0; i < n; i++) {
+                    entries.add(new ObjectEntry(resp.body.string(), resp.body.u64()));
+                }
+                return entries;
             }
-            return entries;
-        }
-        throw unexpected("ListObjects", resp);
+            throw unexpected("ListObjects", resp);
+        });
     }
 
     @Override
     public void close() {
+        coordinatorPool.close();
+        workerPool.close();
         synchronized (placementCache) {
             placementCache.clear();
         }
@@ -326,11 +353,12 @@ public final class TalonClient implements AutoCloseable {
             List<NodeInfo> nodes;
             try {
                 int id = requestIds.getAndIncrement();
-                Messages.Response resp = controlRoundTrip(Messages.membershipQuery(id));
-                if (resp.tag != Messages.TAG_MEMBERSHIP_LIST) {
-                    throw unexpected("MembershipQuery", resp);
-                }
-                nodes = Messages.readMembershipList(resp.body);
+                nodes = controlRoundTrip(Messages.membershipQuery(id), resp -> {
+                    if (resp.tag != Messages.TAG_MEMBERSHIP_LIST) {
+                        throw unexpected("MembershipQuery", resp);
+                    }
+                    return Messages.readMembershipList(resp.body);
+                });
             } catch (IOException refreshFailure) {
                 if (membership != null) {
                     return membership;
@@ -371,8 +399,9 @@ public final class TalonClient implements AutoCloseable {
 
     // --- transport ---------------------------------------------------------
 
-    private Messages.Response controlRoundTrip(byte[] request) throws IOException {
-        try (Socket socket = dial(coordinator)) {
+    private <T> T controlRoundTrip(byte[] request, IoFunction<Messages.Response, T> decode)
+            throws IOException {
+        return coordinatorPool.exchange(coordinator, socket -> {
             OutputStream out = socket.getOutputStream();
             out.write(request);
             out.flush();
@@ -383,8 +412,8 @@ public final class TalonClient implements AutoCloseable {
                 throw new IOException(
                         "coordinator returned an error: " + new String(payload, java.nio.charset.StandardCharsets.UTF_8));
             }
-            return Messages.decodeBody(payload);
-        }
+            return decode.apply(Messages.decodeBody(payload));
+        });
     }
 
     private byte[] fetchRange(String workerAddress, Segment seg) throws IOException {
@@ -397,7 +426,7 @@ public final class TalonClient implements AutoCloseable {
         byte[] body = w.toBytes();
         byte[] header = new Frame(Frame.MsgType.GET_RANGE, 0, id, body.length).encode();
 
-        try (Socket socket = dial(workerAddress)) {
+        return workerPool.exchange(workerAddress, socket -> {
             OutputStream out = socket.getOutputStream();
             out.write(header);
             out.write(body);
@@ -412,10 +441,110 @@ public final class TalonClient implements AutoCloseable {
                                 + new String(payload, java.nio.charset.StandardCharsets.UTF_8));
             }
             return payload;
+        });
+    }
+
+    @FunctionalInterface
+    private interface IoFunction<T, R> {
+        R apply(T input) throws IOException;
+    }
+
+    /** Exclusive checkout; only successfully decoded exchanges return to the pool. */
+    private static final class ConnectionPool {
+        private static final long IDLE_TTL_NANOS = 30_000_000_000L;
+        private record Idle(Socket socket, long returnedAt) {}
+
+        private final Map<String, List<Idle>> idle = new HashMap<>();
+        private final int maxIdlePerAddr;
+        private boolean closed;
+
+        ConnectionPool(int maxIdlePerAddr) {
+            this.maxIdlePerAddr = maxIdlePerAddr;
+        }
+
+        <T> T exchange(String address, IoFunction<Socket, T> request) throws IOException {
+            Socket socket = takeIdle(address);
+            boolean reused = socket != null;
+            for (;;) {
+                if (socket == null) {
+                    ensureOpen();
+                    // Dial and all request I/O run outside the pool lock.
+                    socket = dial(address);
+                }
+                boolean completed = false;
+                try {
+                    T result = request.apply(socket);
+                    release(address, socket);
+                    completed = true;
+                    return result;
+                } catch (EOFException | SocketException disconnected) {
+                    if (!reused) {
+                        throw disconnected;
+                    }
+                    // The peer may close an idle socket. Retry once, bypassing the pool.
+                    reused = false;
+                } finally {
+                    if (!completed) {
+                        closeSocket(socket);
+                    }
+                }
+                socket = null;
+            }
+        }
+
+        private synchronized void ensureOpen() throws IOException {
+            if (closed) {
+                throw new IOException("Talon client is closed");
+            }
+        }
+
+        private synchronized Socket takeIdle(String address) throws IOException {
+            ensureOpen();
+            List<Idle> bucket = idle.get(address);
+            while (bucket != null && !bucket.isEmpty()) {
+                Idle entry = bucket.remove(bucket.size() - 1);
+                if (bucket.isEmpty()) {
+                    idle.remove(address);
+                }
+                if (System.nanoTime() - entry.returnedAt() < IDLE_TTL_NANOS) {
+                    return entry.socket();
+                }
+                closeSocket(entry.socket());
+            }
+            return null;
+        }
+
+        private synchronized void release(String address, Socket socket) {
+            if (!closed) {
+                List<Idle> bucket = idle.computeIfAbsent(address, ignored -> new ArrayList<>());
+                if (bucket.size() < maxIdlePerAddr) {
+                    bucket.add(new Idle(socket, System.nanoTime()));
+                    return;
+                }
+            }
+            closeSocket(socket);
+        }
+
+        synchronized void close() {
+            closed = true;
+            for (List<Idle> bucket : idle.values()) {
+                for (Idle entry : bucket) {
+                    closeSocket(entry.socket());
+                }
+            }
+            idle.clear();
         }
     }
 
-    private Socket dial(String hostPort) throws IOException {
+    private static void closeSocket(Socket socket) {
+        try {
+            socket.close();
+        } catch (IOException ignored) {
+            // Cleanup must not hide the original exchange failure.
+        }
+    }
+
+    private static Socket dial(String hostPort) throws IOException {
         int colon = hostPort.lastIndexOf(':');
         if (colon < 0) {
             throw new IOException("address is missing a port: " + hostPort);
@@ -423,10 +552,15 @@ public final class TalonClient implements AutoCloseable {
         String host = hostPort.substring(0, colon);
         int port = Integer.parseInt(hostPort.substring(colon + 1));
         Socket socket = new Socket();
-        socket.connect(new InetSocketAddress(host, port), CONNECT_TIMEOUT_MS);
-        socket.setSoTimeout(READ_TIMEOUT_MS);
-        socket.setTcpNoDelay(true);
-        return socket;
+        try {
+            socket.connect(new InetSocketAddress(host, port), CONNECT_TIMEOUT_MS);
+            socket.setSoTimeout(READ_TIMEOUT_MS);
+            socket.setTcpNoDelay(true);
+            return socket;
+        } catch (IOException | RuntimeException failure) {
+            closeSocket(socket);
+            throw failure;
+        }
     }
 
     private static Frame readHeader(InputStream in) throws IOException {

--- a/clients/java/src/test/java/io/milvus/talon/ConformanceTest.java
+++ b/clients/java/src/test/java/io/milvus/talon/ConformanceTest.java
@@ -1,6 +1,9 @@
 package io.milvus.talon;
 
 import java.io.IOException;
+import java.io.DataInputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -10,6 +13,14 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Validates this client's codec against the conformance vectors.
@@ -49,6 +60,7 @@ public final class ConformanceTest {
         statObjectEncodesIdentically(byName);
         listObjectsEncodesEmptyPrefix(byName);
         errorResponseIsFlaggedAndCarriesAMessage(byName);
+        connectionPooling();
 
         System.out.println();
         if (failures.isEmpty()) {
@@ -232,6 +244,169 @@ public final class ConformanceTest {
 
     // --- harness -----------------------------------------------------------
 
+    private static void connectionPooling() {
+        check("connect rejects non-positive idle limits", () -> {
+            for (int limit : new int[] {0, -1}) {
+                try {
+                    TalonClient.connect("localhost:1", 1024, limit);
+                    throw new AssertionError("accepted idle limit " + limit);
+                } catch (IllegalArgumentException expected) {
+                    // Invalid configuration fails before any I/O.
+                }
+            }
+        });
+        check("custom idle limit, stale retry, and malformed response discard", () -> {
+            try (PoolPeer peer = new PoolPeer();
+                    TalonClient client = TalonClient.connect(peer.address(), 1024, 2)) {
+                poolWave(client, peer, 10, false);
+                poolWave(client, peer, 10, false);
+                assertEquals(19, peer.accepts.get(), "two idle worker connections reused");
+                for (Socket socket : peer.sockets) {
+                    socket.close();
+                }
+                assertEquals("v1", client.stat("s3://bucket/key").version(), "fresh retry response");
+                assertEquals(20, peer.accepts.get(), "closed pooled connection retried once fresh");
+                peer.malformedStat = true;
+                try {
+                    client.stat("s3://bucket/key");
+                    throw new AssertionError("malformed stat accepted");
+                } catch (ProtocolException expected) {
+                    // A complete frame with an invalid body must also be discarded.
+                }
+                peer.malformedStat = false;
+                client.stat("s3://bucket/key");
+                assertEquals(21, peer.accepts.get(), "malformed connection was discarded");
+            }
+        });
+        check("default idle limit is 8; concurrent reads reuse both pools", () -> {
+            try (PoolPeer peer = new PoolPeer();
+                    TalonClient client = TalonClient.connect(peer.address(), 1024)) {
+                poolWave(client, peer, 10, false);
+                client.stat("s3://bucket/key");
+                client.stat("s3://bucket/key");
+                assertEquals(11, peer.accepts.get(), "ten worker connections and one control");
+                poolWave(client, peer, 10, false);
+                assertEquals(13, peer.accepts.get(), "eight idle worker connections reused");
+                poolWave(client, peer, 1, true);
+                long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+                while (!peer.sockets.isEmpty() && System.nanoTime() < deadline) {
+                    Thread.sleep(5);
+                }
+                assertTrue(peer.sockets.isEmpty(), "close releases idle and in-flight connections");
+                try {
+                    client.stat("s3://bucket/key");
+                    throw new AssertionError("closed client accepted a request");
+                } catch (IOException expected) {
+                    // A closed pool cannot dial or accept an in-flight return.
+                }
+            }
+        });
+    }
+
+    private static void poolWave(TalonClient client, PoolPeer peer, int count, boolean close)
+            throws Exception {
+        peer.arrived = new CountDownLatch(count);
+        peer.release = new CountDownLatch(1);
+        ExecutorService readers = Executors.newFixedThreadPool(count);
+        try {
+            List<Future<byte[]>> results = new ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                results.add(readers.submit(() -> client.read("s3://bucket/key", "v1", 0, 1)));
+            }
+            assertTrue(peer.arrived.await(5, TimeUnit.SECONDS), "idle limit must not limit concurrency");
+            if (close) {
+                client.close();
+            }
+            peer.release.countDown();
+            for (Future<byte[]> result : results) {
+                assertBytes(new byte[] {42}, result.get(5, TimeUnit.SECONDS));
+            }
+        } finally {
+            peer.release.countDown();
+            readers.shutdownNow();
+        }
+    }
+
+    /** A real TCP peer serving just the frames needed by the pool checks. */
+    private static final class PoolPeer implements java.io.Closeable {
+        final ServerSocket listener = new ServerSocket(0, 50, java.net.InetAddress.getLoopbackAddress());
+        final Set<Socket> sockets = ConcurrentHashMap.newKeySet();
+        final AtomicInteger accepts = new AtomicInteger();
+        final ExecutorService threads = Executors.newCachedThreadPool();
+        volatile CountDownLatch arrived = new CountDownLatch(0);
+        volatile CountDownLatch release = new CountDownLatch(0);
+        volatile boolean malformedStat;
+
+        PoolPeer() throws IOException {
+            threads.submit(() -> {
+                try {
+                    while (!listener.isClosed()) {
+                        Socket socket = listener.accept();
+                        sockets.add(socket);
+                        accepts.incrementAndGet();
+                        threads.submit(() -> serve(socket));
+                    }
+                } catch (IOException expectedOnClose) {
+                    // Closing the fixture stops accept().
+                }
+            });
+        }
+
+        String address() {
+            return "localhost:" + listener.getLocalPort();
+        }
+
+        void serve(Socket socket) {
+            try (socket) {
+                DataInputStream in = new DataInputStream(socket.getInputStream());
+                while (true) {
+                    byte[] header = new byte[Frame.HEADER_LEN];
+                    in.readFully(header);
+                    Frame request = Frame.decode(header);
+                    byte[] body = new byte[request.length()];
+                    in.readFully(body);
+                    byte[] response;
+                    if (request.type() == Frame.MsgType.GET_RANGE) {
+                        arrived.countDown();
+                        if (!release.await(5, TimeUnit.SECONDS)) {
+                            throw new IOException("test response gate timed out");
+                        }
+                        response = new byte[] {42};
+                    } else if (Messages.decodeBody(body).tag == Messages.TAG_MEMBERSHIP_QUERY) {
+                        response = new Bincode.Writer().u16(1).variant(Messages.TAG_MEMBERSHIP_LIST)
+                                .u64(1).string("worker").string(address()).variant(Messages.ROLE_WORKER)
+                                .toBytes();
+                    } else {
+                        Bincode.Writer w = new Bincode.Writer().u16(2).variant(Messages.TAG_OBJECT_STAT);
+                        if (!malformedStat) {
+                            w.u64(1).string("v1");
+                        }
+                        response = w.toBytes();
+                    }
+                    socket.getOutputStream().write(new Frame(request.type(), 0,
+                            request.requestId(), response.length).encode());
+                    socket.getOutputStream().write(response);
+                    socket.getOutputStream().flush();
+                }
+            } catch (IOException expectedOnClose) {
+                // EOF/reset is expected when the client discards or closes a connection.
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+            } finally {
+                sockets.remove(socket);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            listener.close();
+            for (Socket socket : sockets) {
+                socket.close();
+            }
+            threads.shutdownNow();
+        }
+    }
+
     private static Messages.Response body(byte[] framed) {
         Frame header = Frame.decode(framed);
         byte[] payload = Arrays.copyOfRange(framed, Frame.HEADER_LEN, framed.length);
@@ -240,7 +415,7 @@ public final class ConformanceTest {
     }
 
     private interface Check {
-        void run();
+        void run() throws Exception;
     }
 
     private static void check(String name, Check c) {

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -14,7 +14,7 @@ a cluster it cannot host.
 ```python
 import talon
 
-with talon.Client("coordinator-host:7000") as client:
+with talon.Client("coordinator-host:7000", max_idle_per_addr=32) as client:
     info = client.stat("az://container/datasets/train.parquet")
     print(info.size, info.version)
 
@@ -31,6 +31,10 @@ so a path addresses the same object through either client.
 
 Blocking calls release the GIL, so threaded loaders are limited by the network
 rather than serialised on the interpreter.
+
+`max_idle_per_addr` defaults to 8 and must be positive. It controls idle
+connections retained per peer address in each coordinator/worker pool, not
+the number of concurrent requests. The idle timeout remains 30 seconds.
 
 **Read-only in this release.** Writes go through the FUSE mount or the Rust
 client; `put`/`delete` are tracked separately.

--- a/clients/python/src/lib.rs
+++ b/clients/python/src/lib.rs
@@ -22,7 +22,8 @@ use pyo3::exceptions::{PyIOError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use talon_rust_client::{
-    parse_uri, Client as RustClient, Error as RustError, ObjectStat as RustObjectStat,
+    parse_uri, Client as RustClient, ClientBuilder, Error as RustError,
+    ObjectStat as RustObjectStat,
 };
 
 /// Runtime construction failures are infrastructure errors.
@@ -102,18 +103,21 @@ impl Client {
     /// `block_size` must match the workers' configured block size; placement is
     /// computed per block, so a mismatch addresses the wrong blocks. It
     /// defaults to the worker default of 256 MiB.
+    /// `max_idle_per_addr` is the positive idle connection limit per peer in
+    /// both coordinator and worker pools; it does not limit active connections.
     #[new]
-    #[pyo3(signature = (coordinator, *, block_size = 256 << 20))]
-    fn new(coordinator: &str, block_size: u32) -> PyResult<Self> {
-        if block_size == 0 {
-            return Err(PyValueError::new_err("block_size must be non-zero"));
-        }
+    #[pyo3(signature = (coordinator, *, block_size = 256 << 20, max_idle_per_addr = 8))]
+    fn new(coordinator: &str, block_size: u32, max_idle_per_addr: usize) -> PyResult<Self> {
+        let client = ClientBuilder::default()
+            .with_coordinator(coordinator)
+            .with_block_size(block_size)
+            .with_max_idle_per_addr(max_idle_per_addr)
+            .build()
+            .map_err(|error| PyValueError::new_err(error.to_string()))?;
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .map_err(io_err)?;
-        let client = RustClient::new(coordinator, block_size)
-            .map_err(|error| PyValueError::new_err(error.to_string()))?;
         Ok(Self {
             runtime: Arc::new(runtime),
             client: Arc::new(client),
@@ -255,6 +259,27 @@ mod tests {
     use super::*;
 
     #[test]
+    fn constructor_accepts_pool_limit_keyword_and_rejects_zero() {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let client_type = py.get_type_bound::<Client>();
+            client_type.call1(("127.0.0.1:7000",)).unwrap();
+            let kwargs = pyo3::types::PyDict::new_bound(py);
+            for limit in [1, 32] {
+                kwargs.set_item("max_idle_per_addr", limit).unwrap();
+                client_type
+                    .call(("127.0.0.1:7000",), Some(&kwargs))
+                    .unwrap();
+            }
+            kwargs.set_item("max_idle_per_addr", 0).unwrap();
+            let error = client_type
+                .call(("127.0.0.1:7000",), Some(&kwargs))
+                .unwrap_err();
+            assert!(error.is_instance_of::<PyValueError>(py));
+        });
+    }
+
+    #[test]
     fn completing_partial_stat_preserves_caller_version() {
         let completed = complete_known_stat(
             Some("caller-version".into()),
@@ -272,7 +297,7 @@ mod tests {
     #[test]
     fn invalid_read_argument_raises_value_error() {
         pyo3::prepare_freethreaded_python();
-        let client = Client::new("unused", 1).unwrap();
+        let client = Client::new("unused", 1, 8).unwrap();
         let oversized = (isize::MAX as u64).saturating_add(1);
 
         Python::with_gil(|py| {
@@ -295,7 +320,7 @@ mod tests {
     #[test]
     fn coordinator_failure_raises_io_error() {
         pyo3::prepare_freethreaded_python();
-        let client = Client::new("127.0.0.1:0", 1).unwrap();
+        let client = Client::new("127.0.0.1:0", 1, 8).unwrap();
 
         Python::with_gil(|py| {
             let error = match client.stat(py, "s3://bucket/key") {

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use crate::{Error, ObjectEntry, ObjectId, ObjectStat, UriError, Version};
 use futures::stream::{FuturesUnordered, StreamExt};
-use talon_cache_client::{plan_read, BlockReader, CoordinatorClient, PlacementCache};
+use talon_cache_client::pool::{DEFAULT_IDLE_TTL, DEFAULT_MAX_IDLE_PER_ADDR};
+use talon_cache_client::{
+    plan_read, BlockReader, ConnectionPool, CoordinatorClient, PlacementCache,
+};
 
 const PLACEMENT_TTL_MS: u64 = 30_000;
 const REPLICAS_K: u8 = 1;
@@ -15,22 +18,88 @@ pub struct Client {
     block_size: u32,
 }
 
-impl Client {
-    /// Construct a client without creating or selecting a Tokio runtime.
-    pub fn new(coordinator: impl Into<String>, block_size: u32) -> Result<Self, Error> {
+/// Collects client configuration without allocating connection pools or caches.
+///
+/// Defaults to 256 MiB blocks and 8 idle connections per peer address.
+/// A coordinator address must be supplied before [`build`](Self::build).
+pub struct ClientBuilder {
+    coordinator: String,
+    block_size: u32,
+    max_idle_per_addr: usize,
+}
+
+impl Default for ClientBuilder {
+    fn default() -> Self {
+        Self {
+            coordinator: String::new(),
+            block_size: 256 << 20,
+            max_idle_per_addr: DEFAULT_MAX_IDLE_PER_ADDR,
+        }
+    }
+}
+
+impl ClientBuilder {
+    /// Set the coordinator address (`host:port`).
+    pub fn with_coordinator(mut self, coordinator: impl Into<String>) -> Self {
+        self.coordinator = coordinator.into();
+        self
+    }
+
+    /// Set the block size in bytes; it must match the workers' block size.
+    pub fn with_block_size(mut self, block_size: u32) -> Self {
+        self.block_size = block_size;
+        self
+    }
+
+    /// Set the idle connection limit per peer in both coordinator and worker pools.
+    /// This does not cap in-flight connections or change the idle TTL and timeouts.
+    pub fn with_max_idle_per_addr(mut self, max_idle_per_addr: usize) -> Self {
+        self.max_idle_per_addr = max_idle_per_addr;
+        self
+    }
+
+    /// Validate configuration and construct a client without selecting a Tokio runtime.
+    pub fn build(self) -> Result<Client, Error> {
+        let Self {
+            coordinator,
+            block_size,
+            max_idle_per_addr,
+        } = self;
+        if coordinator.is_empty() {
+            return Err(Error::InvalidArgument(
+                "coordinator must be non-empty".into(),
+            ));
+        }
         if block_size == 0 {
             return Err(Error::InvalidArgument("block_size must be non-zero".into()));
         }
-        let coordinator = CoordinatorClient::new(coordinator);
+        if max_idle_per_addr == 0 {
+            return Err(Error::InvalidArgument(
+                "max_idle_per_addr must be non-zero".into(),
+            ));
+        }
+        // Keep control and data connections in separate pools.
+        let coordinator = CoordinatorClient::with_pool(
+            coordinator,
+            Arc::new(ConnectionPool::with_limits(
+                max_idle_per_addr,
+                DEFAULT_IDLE_TTL,
+            )),
+        );
         let cache = Arc::new(PlacementCache::new(PLACEMENT_TTL_MS));
-        let reader = BlockReader::new(coordinator.clone(), cache, REPLICAS_K);
-        Ok(Self {
+        let reader =
+            BlockReader::new(coordinator.clone(), cache, REPLICAS_K).with_worker_pool(Arc::new(
+                ConnectionPool::with_limits(max_idle_per_addr, DEFAULT_IDLE_TTL),
+            ));
+        Ok(Client {
             coordinator,
             reader,
             block_size,
         })
     }
+}
 
+impl Client {
     /// Address of the coordinator used by this client.
     pub fn coordinator_addr(&self) -> &str {
         self.coordinator.addr()
@@ -457,7 +526,14 @@ mod tests {
         let worker = mock_worker().await;
         let stat_calls = Arc::new(AtomicUsize::new(0));
         let coordinator = mock_read_coordinator(worker, size, Arc::clone(&stat_calls)).await;
-        (Client::new(coordinator, 8).unwrap(), stat_calls)
+        (
+            ClientBuilder::default()
+                .with_coordinator(coordinator)
+                .with_block_size(8)
+                .build()
+                .unwrap(),
+            stat_calls,
+        )
     }
 
     #[test]
@@ -498,16 +574,166 @@ mod tests {
     }
 
     #[test]
+    fn build_requires_a_coordinator() {
+        let error = ClientBuilder::default()
+            .build()
+            .err()
+            .expect("a coordinator must be provided");
+        assert!(matches!(error, Error::InvalidArgument(_)));
+        assert!(error.to_string().contains("coordinator"));
+    }
+
+    #[test]
+    fn build_uses_defaults_and_final_overrides() {
+        let default_client = ClientBuilder::default()
+            .with_coordinator("127.0.0.1:7000")
+            .build()
+            .unwrap();
+        assert_eq!(default_client.coordinator_addr(), "127.0.0.1:7000");
+        assert_eq!(default_client.block_size(), 256 * 1024 * 1024);
+
+        // Setters only collect configuration; validation uses the final values.
+        let client = ClientBuilder::default()
+            .with_block_size(0)
+            .with_max_idle_per_addr(0)
+            .with_coordinator("127.0.0.1:7001")
+            .with_max_idle_per_addr(1)
+            .with_block_size(1024)
+            .build()
+            .unwrap();
+        assert_eq!(client.coordinator_addr(), "127.0.0.1:7001");
+        assert_eq!(client.block_size(), 1024);
+    }
+
+    #[test]
     fn rejects_zero_block_size() {
-        let error = Client::new("127.0.0.1:7000", 0)
+        let error = ClientBuilder::default()
+            .with_coordinator("127.0.0.1:7000")
+            .with_block_size(0)
+            .build()
             .err()
             .expect("zero block size must fail");
         assert!(matches!(error, Error::InvalidArgument(_)));
     }
 
+    #[test]
+    fn rejects_zero_max_idle_per_addr() {
+        let error = ClientBuilder::default()
+            .with_coordinator("127.0.0.1:7000")
+            .with_max_idle_per_addr(0)
+            .build()
+            .err()
+            .expect("zero idle connection limit must fail");
+        assert!(matches!(error, Error::InvalidArgument(_)));
+        assert!(error.to_string().contains("max_idle_per_addr"));
+    }
+
+    #[tokio::test]
+    async fn max_idle_per_addr_controls_coordinator_and_worker_connection_reuse() {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            for (limit, concurrent, second_batch_accepts) in
+                [(None, 10, 12), (Some(1), 3, 5), (Some(12), 14, 16)]
+            {
+                for worker in [false, true] {
+                    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+                    let addr = listener.local_addr().unwrap().to_string();
+                    let accepts = Arc::new(AtomicUsize::new(0));
+                    // Hold each batch until every request has its own connection.
+                    // The idle limit must not cap concurrent requests.
+                    let barrier = Arc::new(tokio::sync::Barrier::new(concurrent));
+                    let count = Arc::clone(&accepts);
+                    let server = tokio::spawn(async move {
+                        loop {
+                            let (mut socket, _) = listener.accept().await.unwrap();
+                            count.fetch_add(1, Ordering::SeqCst);
+                            let barrier = Arc::clone(&barrier);
+                            tokio::spawn(async move {
+                                loop {
+                                    let mut header_bytes = [0_u8; HEADER_LEN];
+                                    if socket.read_exact(&mut header_bytes).await.is_err() {
+                                        return;
+                                    }
+                                    let header = FrameHeader::decode(&header_bytes).unwrap();
+                                    let mut payload = vec![0_u8; header.length as usize];
+                                    socket.read_exact(&mut payload).await.unwrap();
+                                    let response = if worker {
+                                        let mut frame = header_bytes.to_vec();
+                                        frame.extend_from_slice(&payload);
+                                        let (_, request): (_, RangeRequest) =
+                                            decode_request(&frame).unwrap();
+                                        assert_eq!(request.len, 8);
+                                        let mut response = response_header_ok(0, 8).to_vec();
+                                        response.extend_from_slice(&[7; 8]);
+                                        response
+                                    } else {
+                                        talon_transport::encode(
+                                            0,
+                                            &ControlMessage::ObjectStat {
+                                                size: 8,
+                                                version: "test-version".into(),
+                                            },
+                                        )
+                                        .unwrap()
+                                    };
+                                    barrier.wait().await;
+                                    socket.write_all(&response).await.unwrap();
+                                }
+                            });
+                        }
+                    });
+                    let coordinator = if worker {
+                        mock_read_coordinator(addr, 8, Arc::new(AtomicUsize::new(0))).await
+                    } else {
+                        addr
+                    };
+                    let builder = ClientBuilder::default()
+                        .with_coordinator(coordinator)
+                        .with_block_size(1024);
+                    let builder = match limit {
+                        Some(limit) => builder.with_max_idle_per_addr(limit),
+                        None => builder,
+                    };
+                    let client = builder.build().unwrap();
+                    let object = parse_uri("s3://bucket/key").unwrap();
+                    let stat = ObjectStat {
+                        size: 8,
+                        version: "test-version".into(),
+                    };
+                    for (client, expected_accepts) in
+                        [(client.clone(), concurrent), (client, second_batch_accepts)]
+                    {
+                        futures::future::join_all((0..concurrent).map(|_| async {
+                            if worker {
+                                assert_eq!(
+                                    client.read(&object, 0, Some(8), Some(&stat)).await.unwrap(),
+                                    vec![7; 8]
+                                );
+                            } else {
+                                assert_eq!(client.stat(&object).await.unwrap().size, 8);
+                            }
+                        }))
+                        .await;
+                        assert_eq!(
+                            accepts.load(Ordering::SeqCst),
+                            expected_accepts,
+                            "worker={worker}, limit={limit:?}"
+                        );
+                    }
+                    server.abort();
+                }
+            }
+        })
+        .await
+        .expect("idle limit must not block concurrent requests");
+    }
+
     #[tokio::test]
     async fn stat_returns_coordinator_metadata() {
-        let client = Client::new(mock_coordinator().await, 1024).unwrap();
+        let client = ClientBuilder::default()
+            .with_coordinator(mock_coordinator().await)
+            .with_block_size(1024)
+            .build()
+            .unwrap();
 
         let stat = client
             .stat(&parse_uri("s3://bucket/key").unwrap())
@@ -520,7 +746,11 @@ mod tests {
 
     #[tokio::test]
     async fn list_returns_existing_object_entries() {
-        let client = Client::new(mock_coordinator().await, 1024).unwrap();
+        let client = ClientBuilder::default()
+            .with_coordinator(mock_coordinator().await)
+            .with_block_size(1024)
+            .build()
+            .unwrap();
 
         let entries = client.list("s3/bucket/data").await.unwrap();
 
@@ -567,7 +797,11 @@ mod tests {
 
     #[tokio::test]
     async fn allocating_read_rejects_length_above_vec_capacity() {
-        let client = Client::new("127.0.0.1:1", 8).unwrap();
+        let client = ClientBuilder::default()
+            .with_coordinator("127.0.0.1:1")
+            .with_block_size(8)
+            .build()
+            .unwrap();
         let object = parse_uri("s3://bucket/key").unwrap();
         let too_large = isize::MAX as u64 + 1;
         let stat = ObjectStat {
@@ -631,7 +865,11 @@ mod tests {
         .await;
         let stat_calls = Arc::new(AtomicUsize::new(0));
         let coordinator = mock_read_coordinator(worker, 16, stat_calls).await;
-        let client = Client::new(coordinator, 8).unwrap();
+        let client = ClientBuilder::default()
+            .with_coordinator(coordinator)
+            .with_block_size(8)
+            .build()
+            .unwrap();
         let object = parse_uri("s3://bucket/key").unwrap();
         let stat = ObjectStat {
             size: 16,
@@ -668,7 +906,11 @@ mod tests {
         .await;
         let stat_calls = Arc::new(AtomicUsize::new(0));
         let coordinator = mock_read_coordinator(worker, 16, stat_calls).await;
-        let client = Client::new(coordinator, 8).unwrap();
+        let client = ClientBuilder::default()
+            .with_coordinator(coordinator)
+            .with_block_size(8)
+            .build()
+            .unwrap();
         let object = parse_uri("s3://bucket/key").unwrap();
         let stat = ObjectStat {
             size: 16,
@@ -695,7 +937,11 @@ mod tests {
         let worker = mock_short_worker().await;
         let stat_calls = Arc::new(AtomicUsize::new(0));
         let coordinator = mock_read_coordinator(worker, 8, stat_calls).await;
-        let client = Client::new(coordinator, 8).unwrap();
+        let client = ClientBuilder::default()
+            .with_coordinator(coordinator)
+            .with_block_size(8)
+            .build()
+            .unwrap();
         let object = parse_uri("s3://bucket/key").unwrap();
         let stat = ObjectStat {
             size: 8,

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -3,7 +3,7 @@
 mod client;
 mod error;
 
-pub use client::{parse_uri, Client};
+pub use client::{parse_uri, Client, ClientBuilder};
 pub use error::{Error, UriError};
 pub use talon_cache_client::ObjectStat;
 pub use talon_core::{ObjectId, Version};

--- a/crates/talon-cache-client/src/block_reader.rs
+++ b/crates/talon-cache-client/src/block_reader.rs
@@ -125,30 +125,30 @@ impl BlockReader {
     /// Metrics are collected into a fresh [`ReadStats`]; use
     /// [`with_stats`](Self::with_stats) to share an existing one.
     pub fn new(coordinator: CoordinatorClient, cache: Arc<PlacementCache>, replicas_k: u8) -> Self {
-        Self::with_stats(coordinator, cache, replicas_k, ReadStats::new())
-    }
-
-    /// Like [`new`](Self::new) but records metrics into the provided
-    /// [`ReadStats`], so a caller (e.g. the mount layer) can observe the same
-    /// counters this reader bumps.
-    pub fn with_stats(
-        coordinator: CoordinatorClient,
-        cache: Arc<PlacementCache>,
-        replicas_k: u8,
-        stats: ReadStats,
-    ) -> Self {
         let membership = Arc::new(MembershipCache::new(cache.ttl_ms()));
         Self {
             coordinator,
             cache,
             replicas_k: replicas_k.max(1),
-            stats,
+            stats: ReadStats::new(),
             worker_pool: Arc::new(ConnectionPool::new()),
             membership,
             membership_refresh: Arc::new(tokio::sync::Mutex::new(())),
             zone: None,
             zone_observer: Arc::new(crate::metrics::NoopZoneReadObserver),
         }
+    }
+
+    /// Record metrics into the provided counters, shared by reader clones.
+    pub fn with_stats(mut self, stats: ReadStats) -> Self {
+        self.stats = stats;
+        self
+    }
+
+    /// Use the provided worker connection pool, shared by reader clones.
+    pub fn with_worker_pool(mut self, worker_pool: Arc<ConnectionPool>) -> Self {
+        self.worker_pool = worker_pool;
+        self
     }
 
     /// Configure zone-affine placement (ADR 0006).
@@ -1072,6 +1072,40 @@ mod tests {
             }
         });
         addr
+    }
+
+    #[tokio::test]
+    async fn stats_and_worker_pool_builders_are_independent() {
+        for stats_first in [false, true] {
+            let hits = Arc::new(std::sync::atomic::AtomicU32::new(0));
+            let worker_addr = mock_worker(hits).await;
+            let coordinator = mock_coordinator(worker_addr.clone()).await;
+            let stats = ReadStats::new();
+            let pool = Arc::new(ConnectionPool::with_limits(
+                1,
+                crate::pool::DEFAULT_IDLE_TTL,
+            ));
+            let reader = BlockReader::new(
+                CoordinatorClient::new(coordinator),
+                Arc::new(PlacementCache::new(10_000)),
+                1,
+            );
+            let reader = if stats_first {
+                reader
+                    .with_stats(stats.clone())
+                    .with_worker_pool(Arc::clone(&pool))
+            } else {
+                reader
+                    .with_worker_pool(Arc::clone(&pool))
+                    .with_stats(stats.clone())
+            };
+
+            let bytes = reader.clone().read_block(&block(), 0, 64, 0).await.unwrap();
+            assert_eq!(bytes.len(), 64);
+            assert_eq!(stats.snapshot().bytes_served, 64);
+            assert_eq!(stats.snapshot().worker_fetches, 1);
+            assert_eq!(pool.idle_count(&worker_addr), 1);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Make per-peer idle connection limits configurable across the Rust, C, Python, and Java SDKs, with a default of eight and no limit on in-flight request concurrency. Add connection reuse to the Java client, which previously opened a new TCP connection for every request.

## Related issues

No linked issue.

## Type of change

- [ ] Bug fix
- [x] New feature / functionality
- [ ] Refactor (no behavior change)
- [x] Performance
- [ ] Docs / tests / tooling

## Design alignment

Follows [DESIGN.md](DESIGN.md), **§1 — RPC / transport**, by keeping coordinator and worker connections in separate pools and preserving the existing framed TCP protocol. Connection management remains separate from placement and block-read planning, as described in **Runtime & I/O model**.

The native Rust client continues to leave Tokio runtime ownership to its caller. No wire-format, placement, or server-side design changes are introduced.

## Changes

- **Rust:** Introduce `ClientBuilder` to collect configuration and validate it during `build()`. Expose `max_idle_per_addr` with a default of eight, and keep `BlockReader` statistics and worker-pool configuration independent.
- **Python / C:** Expose the setting through the Python constructor and `talon_client_options`, forwarding it to the shared Rust client. Python requires a positive value; zero in C options selects the default.
- **Java:** Add `connect(coordinator, blockSize, maxIdlePerAddr)` while retaining the existing factory overloads. Add separate coordinator and worker pools that reuse healthy connections, discard expired idle entries on checkout after 30 seconds, retry disconnected reused sockets once, and close failed or excess connections. Client shutdown drains idle connections and prevents in-flight connections from returning to the pools.
- **API compatibility:** Native Rust callers migrate from `Client::new(...)` to `ClientBuilder`. C consumers must recompile against the extended options structure. Existing Python and Java constructor/factory calls remain valid.

## Test plan

- [x] Rust SDK, cache client, and C/Python bindings: **133 passed**.

  ```sh
  cargo test -p talon-c -p talon-python -p talon-rust-client -p talon-cache-client
  ```

- [x] Java compilation and conformance checks: **17 passed**, with no compiler warnings.

  ```sh
  mkdir -p /tmp/talon-java-precommit-classes
  javac --release 17 -Xlint:all -d /tmp/talon-java-precommit-classes \
    clients/java/src/main/java/io/milvus/talon/*.java \
    clients/java/src/test/java/io/milvus/talon/*.java
  java -cp /tmp/talon-java-precommit-classes io.milvus.talon.ConformanceTest
  ```

- [x] Changed Rust files pass `rustfmt --check`; C examples pass compiler syntax checks.
- [ ] `just ci` passes locally (fmt + clippy + test) — full workspace CI not run.
- [ ] Workspace compiles (`cargo build --workspace`) — not run.
- [x] Added/updated tests for new behavior.

## Performance impact

This changes the Java transport hot path from creating a socket per request to reusing idle sockets. It is expected to reduce repeated connection setup and teardown, while adding pool synchronization and retaining a bounded number of idle sockets per peer. Higher configured limits can retain more file descriptors and socket buffers.

Rust-backed clients already pooled connections; their default idle limit remains eight. The setting does not cap concurrent requests. Native Rust client construction still creates a default worker pool before replacing it with the configured pool; this is a temporary allocation during initialization, not additional per-read work.

No throughput or latency improvement is claimed from the functional results. `just bench-check` was not run, and no performance baseline was refreshed.

- [ ] Not performance-sensitive, OR
- [ ] `just bench-check` run; results below (baseline refreshed if the change is intentional)

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/): `feat(clients): make idle connection limits configurable`.
- [x] Public items are documented; new intra-doc links point to existing items.
- [x] No new dependencies without discussion — no dependencies added.
- [ ] Rebased on the latest `main` — the commit is based on locally recorded `origin/main` (`1e2482a`); remote freshness has not been checked.
